### PR TITLE
Add missing mod (%) operator

### DIFF
--- a/packages/malloy/src/lang/ast/apply-expr.ts
+++ b/packages/malloy/src/lang/ast/apply-expr.ts
@@ -59,7 +59,7 @@ export function applyBinary(
   if (oneOf(op, "+", "-")) {
     return delta(fs, left, op, right);
   }
-  if (oneOf(op, "*")) {
+  if (oneOf(op, "*", "%")) {
     return numeric(fs, left, op, right);
   }
   if (oneOf(op, "/")) {

--- a/packages/malloy/src/lang/ast/ast-expr.ts
+++ b/packages/malloy/src/lang/ast/ast-expr.ts
@@ -546,8 +546,8 @@ export class ExprAddSub extends BinaryNumeric<"+" | "-"> {
   elementType = "+-";
 }
 
-export class ExprMulDiv extends BinaryNumeric<"*" | "/"> {
-  elementType = "*/";
+export class ExprMulDiv extends BinaryNumeric<"*" | "/" | "%"> {
+  elementType = "*/%";
 }
 
 export class ExprAlternationTree extends BinaryBoolean<"|" | "&"> {

--- a/packages/malloy/src/lang/grammar/MalloyLexer.g4
+++ b/packages/malloy/src/lang/grammar/MalloyLexer.g4
@@ -145,6 +145,7 @@ BAR: '|' ;
 SEMI: ';' ;
 NOT_MATCH: '!~' ;
 MATCH: '~' ;
+PERCENT: '%';
 
 fragment F_YEAR: DIGIT DIGIT DIGIT DIGIT;
 fragment F_DD: DIGIT DIGIT;

--- a/packages/malloy/src/lang/grammar/MalloyParser.g4
+++ b/packages/malloy/src/lang/grammar/MalloyParser.g4
@@ -379,7 +379,7 @@ fieldExpr
   | fieldExpr timeframe                                    # exprDuration
   | fieldExpr DOT timeframe                                # exprTimeTrunc
   | fieldExpr DOUBLECOLON malloyType                       # exprSafeCast
-  | fieldExpr ( STAR | SLASH ) fieldExpr                   # exprMulDiv
+  | fieldExpr ( STAR | SLASH | PERCENT ) fieldExpr         # exprMulDiv
   | fieldExpr ( PLUS | MINUS ) fieldExpr                   # exprAddSub
   | fieldExpr TO fieldExpr                                 # exprRange
   | startAt=fieldExpr FOR duration=fieldExpr timeframe     # exprForRange

--- a/packages/malloy/src/lang/parse-to-ast.ts
+++ b/packages/malloy/src/lang/parse-to-ast.ts
@@ -899,9 +899,10 @@ export class MalloyToAST
   }
 
   visitExprMulDiv(pcx: parse.ExprMulDivContext): ast.ExprMulDiv {
+    const op = pcx.STAR() ? "*" : pcx.SLASH() ? "/" : "%";
     return new ast.ExprMulDiv(
       this.getFieldExpr(pcx.fieldExpr(0)),
-      pcx.STAR() ? "*" : "/",
+      op,
       this.getFieldExpr(pcx.fieldExpr(1))
     );
   }

--- a/packages/malloy/src/lang/test/parse.spec.ts
+++ b/packages/malloy/src/lang/test/parse.spec.ts
@@ -1146,6 +1146,7 @@ describe("expressions", () => {
     test("addition", exprOK("42 + 7"));
     test("subtraction", exprOK("42 - 7"));
     test("multiplication", exprOK("42 * 7"));
+    test("mod", exprOK("42 % 7"));
     test("division", exprOK("42 / 7"));
     test("unary negation", exprOK("- ai"));
     test("equal", exprOK("42 = 7"));


### PR DESCRIPTION
OK, we don't support `even is (num %2 == 0)` because ... I never wrote the `%` operator into the grammar.