### PR TITLE
handle bare }%

### DIFF
--- a/packages/malloy/src/lang/test/parse.spec.ts
+++ b/packages/malloy/src/lang/test/parse.spec.ts
@@ -1561,6 +1561,11 @@ describe("error handling", () => {
     }
     `)
   );
+  test("popping out of embedding when not embedded", () => {
+    expect("}%").compileToFailWith(
+      "extraneous input '}%' expecting {<EOF>, EXPLORE, QUERY, SOURCE, SQL, IMPORT, ';'}"
+    );
+  });
 });
 
 function getSelectOneStruct(sqlBlock: SQLBlockSource): SQLBlockStructDef {


### PR DESCRIPTION
A bare `}%` in a file causes `Malloy.parse` to throw, which is two problems.

1) If the ANTLR generated code throws, we should catch it and report it as an error.
2) `}%` is a problem which we workaround here by ignoring a popMode if we are at the top level