### PR TITLE
Support httpfs in duckdb

### DIFF
--- a/packages/malloy-db-duckdb/src/duckdb_connection.ts
+++ b/packages/malloy-db-duckdb/src/duckdb_connection.ts
@@ -19,7 +19,7 @@ import { QueryDataRow, RunSQLOptions } from "@malloydata/malloy";
 export class DuckDBConnection extends DuckDBCommon {
   protected connection;
   protected database;
-  protected isSetup = false;
+  protected isSetup: Promise<void> | undefined;
 
   constructor(
     public readonly name: string,
@@ -42,28 +42,21 @@ export class DuckDBConnection extends DuckDBCommon {
   }
 
   protected async setup(): Promise<void> {
-    if (!this.isSetup) {
+    const doSetup = async () => {
       if (this.workingDirectory) {
-        this.runDuckDBQuery(`SET FILE_SEARCH_PATH='${this.workingDirectory}'`);
+        await this.runDuckDBQuery(
+          `SET FILE_SEARCH_PATH='${this.workingDirectory}'`
+        );
       }
-      // TODO: This is where we will load extensions once we figure
-      // out how to better support them.
-      // await this.runDuckDBQuery("INSTALL 'json'");
-      // await this.runDuckDBQuery("LOAD 'json'");
-      // await this.runDuckDBQuery("INSTALL 'httpfs'");
-      // await this.runDuckDBQuery("LOAD 'httpfs'");
-      //   await this.runDuckDBQuery("DROP MACRO sum_distinct");
-      //   try {
-      //     await this.runDuckDBQuery(
-      //       `
-      //       create macro sum_distinct(l) as  (
-      //         select sum(x.val) as value FROM (select unnest(l)) x
-      //       )
-      //       `
-      //     );
-      //   } catch (e) {}
+      await this.runDuckDBQuery("INSTALL 'json'");
+      await this.runDuckDBQuery("LOAD 'json'");
+      await this.runDuckDBQuery("INSTALL 'httpfs'");
+      await this.runDuckDBQuery("LOAD 'httpfs'");
+    };
+    if (!this.isSetup) {
+      this.isSetup = doSetup();
     }
-    this.isSetup = true;
+    await this.isSetup;
   }
 
   protected async runDuckDBQuery(

--- a/packages/malloy/src/malloy.ts
+++ b/packages/malloy/src/malloy.ts
@@ -750,11 +750,12 @@ export function parseTableURI(tableURI: string): {
   connectionName?: string;
   tablePath: string;
 } {
-  const [firstPart, secondPart] = tableURI.split(":");
-  if (secondPart) {
+  const parts = tableURI.match(/^([^:]*):(.*)$/);
+  if (parts) {
+    const [, firstPart, secondPart] = parts;
     return { connectionName: firstPart, tablePath: secondPart };
   } else {
-    return { tablePath: firstPart };
+    return { tablePath: tableURI };
   }
 }
 


### PR DESCRIPTION
* Load duckdb httpfs and json extensions so remote parquet files can be loaded. 
* Fix table name parsing to only split on the first ':' so table names can be URLs.
* Cache table schema for duckdb now that it can be a non-trivial operation