### PR TITLE
Make understandable sql errors in blocks

### DIFF
--- a/packages/malloy/src/lang/ast/ast-main.ts
+++ b/packages/malloy/src/lang/ast/ast-main.ts
@@ -2393,7 +2393,8 @@ export class SQLStatement extends MalloyElement implements DocStatement {
     sqlDefEntry.reference(sql.name, this.location);
     const lookup = sqlDefEntry.getEntry(sql.name);
     if (lookup.status == "error") {
-      this.select.log(`'Schema error: ${lookup.message}`);
+      const msgLines = lookup.message.split(/\r?\n/);
+      this.select.log("Invalid SQL, " + msgLines.join("\n    "));
       return undefined;
     }
     if (lookup.status == "present") {

--- a/packages/malloy/src/lang/test/parse.spec.ts
+++ b/packages/malloy/src/lang/test/parse.spec.ts
@@ -1583,6 +1583,23 @@ describe("error handling", () => {
       "extraneous input '}%' expecting {<EOF>, EXPLORE, QUERY, SOURCE, SQL, IMPORT, ';'}"
     );
   });
+
+  test("bad sql in sql block", () => {
+    const badModel = new BetaModel(`sql: { select: """)""" }`);
+    expect(badModel).modelParsed();
+    const needSchema = badModel.translate();
+    expect(needSchema.compileSQL).toBeDefined();
+    if (needSchema.compileSQL) {
+      badModel.update({
+        errors: {
+          compileSQL: {
+            [needSchema.compileSQL.name]: "ZZZZ",
+          },
+        },
+      });
+    }
+    expect(badModel).compileToFailWith("Invalid SQL, ZZZZ");
+  });
 });
 
 function getSelectOneStruct(sqlBlock: SQLBlockSource): SQLBlockStructDef {


### PR DESCRIPTION
`Schema Error: Syntax Error:` is a little confusing. The word schema there is related to an internal detail, that the error occured when requesting the schema for a block.

Decided to drop the `:`, and emphasize that this error is in the SQL, not in the Malloy.

Fixes #967 

```
Invalid SQL, Syntax error: Unexpected string literal 'bigquery-public-data.san_francisco.`sfpd_incidents
```

Or in the case where there are multiple lines in the server error message

```
Invalid SQL, FIRST LINE
  SECOND LINE
  THIRD LINE
```