### PR TITLE
Align typescript versions

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -39,7 +39,7 @@ module.exports = {
     "prettier/prettier": "error",
     "sort-keys": "off",
     "no-duplicate-imports": "error",
-    "no-unsafe-any": true,
+    "no-unsafe-any": "error",
     "no-restricted-imports": [
       "error",
       { patterns: ["@malloydata/malloy/src/*"] },

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -39,6 +39,7 @@ module.exports = {
     "prettier/prettier": "error",
     "sort-keys": "off",
     "no-duplicate-imports": "error",
+    "no-unsafe-any": true,
     "no-restricted-imports": [
       "error",
       { patterns: ["@malloydata/malloy/src/*"] },

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -39,7 +39,6 @@ module.exports = {
     "prettier/prettier": "error",
     "sort-keys": "off",
     "no-duplicate-imports": "error",
-    "no-unsafe-any": "error",
     "no-restricted-imports": [
       "error",
       { patterns: ["@malloydata/malloy/src/*"] },

--- a/docs/_scripts/build_docs/page.ts
+++ b/docs/_scripts/build_docs/page.ts
@@ -62,7 +62,7 @@ function enrichTableOfContents(sections: Section[]): EnrichedSection[] {
 }
 
 function extractItems(sections: (Section | SectionItem)[]): SectionItem[] {
-  const items = [];
+  const items: SectionItem[] = [];
   const stack = [...sections].reverse();
   while (stack.length) {
     const section = stack.pop() as Section | SectionItem;

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "tar-stream": "^2.2.0",
         "ts-jest": "^26.4.4",
         "ts-node": "^10.9.1",
-        "typescript": "4.7.4",
+        "typescript": "4.8.4",
         "unified": "^10.1.2",
         "wait-on": "^6.0.0"
       },
@@ -15913,9 +15913,10 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.7.4",
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
       "dev": true,
-      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -28767,7 +28768,9 @@
       }
     },
     "typescript": {
-      "version": "4.7.4",
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
       "dev": true
     },
     "typical": {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "tar-stream": "^2.2.0",
     "ts-jest": "^26.4.4",
     "ts-node": "^10.9.1",
-    "typescript": "4.7.4",
+    "typescript": "4.8.4",
     "unified": "^10.1.2",
     "wait-on": "^6.0.0"
   },

--- a/packages/malloy-db-duckdb/src/duckdb_common.ts
+++ b/packages/malloy-db-duckdb/src/duckdb_common.ts
@@ -168,7 +168,7 @@ export abstract class DuckDBCommon
    * @returns Array of column type declarations
    */
   private splitColumns(s: string) {
-    const columns = [];
+    const columns: string[] = [];
     let parens = 0;
     let column = "";
     let eatSpaces = true;

--- a/packages/malloy-render/src/drill.ts
+++ b/packages/malloy-render/src/drill.ts
@@ -41,7 +41,7 @@ function timestampToDateFilter(
 }
 
 function getTableFilters(table: DataArray): FilterItem[] {
-  const filters = [];
+  const filters: FilterItem[] = [];
   for (const f of table.field.filters || []) {
     if (!f.aggregate) {
       filters.push({ key: f.code, value: undefined });
@@ -51,7 +51,7 @@ function getTableFilters(table: DataArray): FilterItem[] {
 }
 
 function getRowFilters(row: DataRecord): FilterItem[] {
-  const filters = [];
+  const filters: FilterItem[] = [];
   const dimensions = row.field.intrinsicFields.filter(
     (field) => field.isAtomicField() && field.sourceWasDimension()
   );

--- a/packages/malloy-render/src/html/chart.ts
+++ b/packages/malloy-render/src/html/chart.ts
@@ -17,6 +17,8 @@ import { DataArray, DataColumn, Field } from "@malloydata/malloy";
 import { Renderer } from "../renderer";
 import { ChartRenderOptions, StyleDefaults } from "../data_styles";
 
+type MappedRow = { [p: string]: string | number | Date | undefined | null };
+
 export abstract class HTMLChartRenderer implements Renderer {
   size: string;
   abstract getDataType(
@@ -27,10 +29,8 @@ export abstract class HTMLChartRenderer implements Renderer {
     value: DataColumn
   ): Date | string | number | null | undefined;
 
-  mapData(
-    data: DataArray
-  ): { [p: string]: string | number | Date | undefined | null }[] {
-    const mappedRows = [];
+  mapData(data: DataArray): MappedRow[] {
+    const mappedRows: MappedRow[] = [];
     for (const row of data) {
       const mappedRow: {
         [p: string]: string | number | Date | undefined | null;

--- a/packages/malloy/src/lang/ast/ast-types.ts
+++ b/packages/malloy/src/lang/ast/ast-types.ts
@@ -186,7 +186,7 @@ function term(f: Fragment[]): Fragment[] {
 
 export function compressExpr(expr: Expr): Expr {
   // compress all adjacent strings
-  const compressValue = [];
+  const compressValue: Array<string | Fragment> = [];
   let buildString;
   for (const fragment of expr.flat()) {
     if (typeof fragment === "string") {

--- a/packages/malloy/src/lang/zone.ts
+++ b/packages/malloy/src/lang/zone.ts
@@ -97,7 +97,7 @@ export class Zone<TValue> {
    * @returns A list of all symbols which have references but not definitions
    */
   getUndefined(): string[] | undefined {
-    const allUndefined = [];
+    const allUndefined: string[] = [];
     for (const [name, val] of this.zone) {
       if (val.status === "reference") {
         allUndefined.push(name);

--- a/packages/malloy/src/malloy.ts
+++ b/packages/malloy/src/malloy.ts
@@ -1207,7 +1207,7 @@ abstract class Entity {
   }
 
   public get sourceClasses(): string[] {
-    const sourceClasses = [];
+    const sourceClasses: string[] = [];
     if (this.source) {
       sourceClasses.push(this.source.name);
     }

--- a/packages/malloy/src/model/malloy_query.ts
+++ b/packages/malloy/src/model/malloy_query.ts
@@ -1048,7 +1048,7 @@ class FieldInstanceResult implements FieldInstance {
   fieldNames(
     fn: undefined | ((field: FieldInstanceField) => boolean)
   ): string[] {
-    const ret = [];
+    const ret: string[] = [];
     for (const [name, fi] of this.allFields) {
       if (fi instanceof FieldInstanceField) {
         if (fn === undefined || fn(fi)) {
@@ -1628,7 +1628,7 @@ class QueryQuery extends QueryField {
     filter: ((qf: QueryNode) => boolean) | undefined = undefined
   ): string[] {
     let fieldNames: string[] = [];
-    const structs = [];
+    const structs: QueryStruct[] = [];
 
     for (const [_name, f] of struct.nameMap) {
       if (
@@ -2167,7 +2167,7 @@ class QueryQuery extends QueryField {
         onCondition = "1=1";
       }
       let filters = "";
-      let conditions = undefined;
+      let conditions: string[] | undefined = undefined;
       if (ji.joinFilterConditions) {
         conditions = ji.joinFilterConditions.map((qf) =>
           qf.generateExpression(this.rootResult)
@@ -2281,7 +2281,7 @@ class QueryQuery extends QueryField {
       return ""; // No default ordering for project.
     }
     const orderBy = queryDef.orderBy || resultStruct.calculateDefaultOrderBy();
-    const o = [];
+    const o: string[] = [];
     for (const f of orderBy) {
       if (typeof f.field === "string") {
         // convert name to an index
@@ -2304,7 +2304,7 @@ class QueryQuery extends QueryField {
   generateSimpleSQL(stageWriter: StageWriter): string {
     let s = "";
     s += "SELECT \n";
-    const fields = [];
+    const fields: string[] = [];
 
     for (const [name, field] of this.rootResult.allFields) {
       const fi = field as FieldInstanceField;
@@ -2322,7 +2322,7 @@ class QueryQuery extends QueryField {
 
     // group by
     if (this.firstSegment.type === "reduce") {
-      const n = [];
+      const n: string[] = [];
       for (const field of this.rootResult.fields()) {
         const fi = field as FieldInstanceField;
         if (fi.fieldUsage.type === "result" && isScalarField(fi.f)) {
@@ -2496,7 +2496,7 @@ class QueryQuery extends QueryField {
     stageWriter: StageWriter,
     lastStageName: string
   ): string {
-    const fields = [];
+    const fields: string[] = [];
     const resultsWithHaving = this.rootResult.selectStructs(
       [],
       (result: FieldInstanceResult) => result.hasHaving
@@ -2505,7 +2505,7 @@ class QueryQuery extends QueryField {
     if (resultsWithHaving.length > 0) {
       for (const result of resultsWithHaving) {
         // find all the parent dimension names.
-        const dimensions = [];
+        const dimensions: string[] = [];
         let r: FieldInstanceResult | undefined = result;
         while (r) {
           for (const name of r.fieldNames((fi) => isScalarField(fi.f))) {
@@ -2601,7 +2601,7 @@ class QueryQuery extends QueryField {
     output: StageOutputContext,
     stageWriter: StageWriter
   ) {
-    const groupsToMap = [];
+    const groupsToMap: number[] = [];
     for (const [name, fi] of resultSet.allFields) {
       const sqlFieldName = this.parent.dialect.sqlMaybeQuoteIdentifier(
         `${name}__${resultSet.groupSet}`
@@ -2696,10 +2696,10 @@ class QueryQuery extends QueryField {
     stage0Name: string
   ): string {
     let s = "SELECT\n";
-    const fieldsSQL = [];
+    const fieldsSQL: string[] = [];
     let fieldIndex = 1;
     const outputPipelinedSQL: OutputPipelinedSQL[] = [];
-    const dimensionIndexes = [];
+    const dimensionIndexes: number[] = [];
     for (const [name, fi] of this.rootResult.allFields) {
       const sqlName = this.parent.dialect.sqlMaybeQuoteIdentifier(name);
       if (fi instanceof FieldInstanceField) {
@@ -2789,7 +2789,7 @@ class QueryQuery extends QueryField {
     const limit: number | undefined = resultStruct.firstSegment.limit;
 
     // calculate the ordering.
-    const obSQL = [];
+    const obSQL: string[] = [];
     let orderingField;
     const orderByDef =
       (resultStruct.firstSegment as QuerySegment).orderBy ||
@@ -3091,7 +3091,8 @@ class QueryQueryIndexStage extends QueryQuery {
         .f.generateExpression(this.rootResult);
     }
 
-    const fields = [];
+    const fields: Array<{ name: string; type: string; expression: string }> =
+      [];
     for (const [name, field] of this.rootResult.allFields) {
       const fi = field as FieldInstanceField;
       if (fi.fieldUsage.type === "result" && isScalarField(fi.f)) {

--- a/test/src/databases/bigquery-postgres/streaming.spec.ts
+++ b/test/src/databases/bigquery-postgres/streaming.spec.ts
@@ -11,7 +11,12 @@
  * GNU General Public License for more details.
  */
 
-import { CSVWriter, JSONWriter, WriteStream } from "@malloydata/malloy";
+import {
+  CSVWriter,
+  DataRecord,
+  JSONWriter,
+  WriteStream,
+} from "@malloydata/malloy";
 import { RuntimeList } from "../../runtimes";
 import { describeIfDatabaseAvailable } from "../../util";
 
@@ -45,7 +50,7 @@ describe("Streaming tests", () => {
         .loadModel(`source: airports is table('malloytest.airports') {}`)
         .loadQuery("query: airports -> { project: code }")
         .runStream({ rowLimit: 10 });
-      const rows = [];
+      const rows: DataRecord[] = [];
       for await (const row of stream) {
         rows.push(row);
       }

--- a/tsconfig.packages.json
+++ b/tsconfig.packages.json
@@ -4,6 +4,7 @@
     "declaration": true,
     "composite": true,
     "strict": true,
+    "noImplicitAny": false,
     "skipLibCheck": true,
     "resolveJsonModule": true,
     "lib": [
@@ -21,6 +22,6 @@
     "experimentalDecorators": true,
     "sourceMap": true,
     "useUnknownInCatchVariables": false,
-    "forceConsistentCasingInFileNames": true,
+    "forceConsistentCasingInFileNames": true
   }
 }


### PR DESCRIPTION
Confusingly, turning off `noImplicitAny` generates a lot of errors because before, arrays initialized without types like 
```typescript
const x = [];
``` 
were implicitly giving `any[]` types.

😕 