### PR TITLE
Corrects path to dot malloy files for examples

### DIFF
--- a/docs/_src/examples/ecommerce.md
+++ b/docs/_src/examples/ecommerce.md
@@ -1,5 +1,5 @@
 # eCommerce Walkthrough: An Intro to Malloy Syntax & the VSCode Plugin
-_The following walk-through covers similar concepts to the [Quick Start](https://github.com/malloydata/malloy/#quick-start-videos) videos in the README. You can find the complete source code for this model [here](https://github.com/malloydata/malloy/blob/docs-release/samples/ecommerce/ecommerce.malloy)._
+_The following walk-through covers similar concepts to the [Quick Start](https://github.com/malloydata/malloy/#quick-start-videos) videos in the README. You can find the complete source code for this model [here](https://github.com/malloydata/malloy/blob/main/samples/bigquery/ecommerce/ecommerce.malloy)._
 
 Malloy queries compile to SQL. As Malloy queries become more complex, the SQL complexity expands dramatically, while the Malloy query remains concise and easier to read.
 

--- a/docs/_src/examples/faa/bigquery.md
+++ b/docs/_src/examples/faa/bigquery.md
@@ -1,6 +1,6 @@
 # NTSB Flight Database Examples
 
-_The follow examples all run against the model at the bottom of this page OR you can find the source code [here](https://github.com/malloydata/malloy/blob/docs-release/samples/faa/flights.malloy)._
+_The follow examples all run against the model at the bottom of this page OR you can find the source code [here](https://github.com/malloydata/malloy/blob/main/samples/bigquery/faa/flights.malloy)._
 
 ## Airport Dashboard
 Where can you fly from SJC? For each destination; Which carriers?  How long have they been flying there?

--- a/docs/_src/examples/ga_sessions.md
+++ b/docs/_src/examples/ga_sessions.md
@@ -1,6 +1,6 @@
 # Google Analytics
 
-_You can find the complete source code for this model [here](https://github.com/malloydata/malloy/blob/docs-release/samples/ga_sessions/ga_sessions.malloy)._
+_You can find the complete source code for this model [here](https://github.com/malloydata/malloy/blob/main/samples/bigquery/ga_sessions/ga_sessions.malloy)._
 
 Start by defining a source based on a query.
 

--- a/docs/_src/examples/iowa/iowa.md
+++ b/docs/_src/examples/iowa/iowa.md
@@ -3,7 +3,7 @@ Liquor sales in Iowa are state-controlled, with all liquor wholesale run by the 
 
 All data here is stored in BigQuery, in the table `'bigquery-public-data.iowa_liquor_sales.sales'`.
 
-_The [Malloy data model](source.md) can be reviewed in examples under ['iowa'](https://github.com/malloydata/malloy/blob/docs-release/samples/iowa/iowa.malloy)._
+_The [Malloy data model](source.md) can be reviewed in examples under ['iowa'](https://github.com/malloydata/malloy/blob/main/samples/bigquery/iowa/iowa.malloy)._
 
 ## A quick overview of the dataset:
 

--- a/docs/_src/examples/names.md
+++ b/docs/_src/examples/names.md
@@ -1,6 +1,6 @@
 # Name Game
 
-_You can find the complete source code for this model [here](https://github.com/malloydata/malloy/blob/docs-release/samples/names/names.malloy)._
+_You can find the complete source code for this model [here](https://github.com/malloydata/malloy/blob/main/samples/bigquery/names/names.malloy)._
 
 The Data set consists of name, gender, state and year with the number of people that
 were born with that name in that gender, state and year.


### PR DESCRIPTION
The current "this model _here_" link resolves to a non-existent GitHub location resulting in 404 errors.  The new links correct this.