### PR TITLE
Update npm jest-expect-message

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "fs-extra": "^10.1.0",
         "jest": "^29.0.3",
         "jest-diff": "^27.0.6",
-        "jest-expect-message": "^1.0.2",
+        "jest-expect-message": "^1.1.3",
         "jest-silent-reporter": "^0.5.0",
         "jsdom": "^19.0.0",
         "lerna": "^5.4.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9177,9 +9177,10 @@
       }
     },
     "node_modules/jest-expect-message": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT"
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/jest-expect-message/-/jest-expect-message-1.1.3.tgz",
+      "integrity": "sha512-bTK77T4P+zto+XepAX3low8XVQxDgaEqh3jSTQOG8qvPpD69LsIdyJTa+RmnJh3HNSzJng62/44RPPc7OIlFxg==",
+      "dev": true
     },
     "node_modules/jest-get-type": {
       "version": "26.3.0",
@@ -21620,7 +21621,9 @@
       }
     },
     "jest-expect-message": {
-      "version": "1.0.2",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/jest-expect-message/-/jest-expect-message-1.1.3.tgz",
+      "integrity": "sha512-bTK77T4P+zto+XepAX3low8XVQxDgaEqh3jSTQOG8qvPpD69LsIdyJTa+RmnJh3HNSzJng62/44RPPc7OIlFxg==",
       "dev": true
     },
     "jest-get-type": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "fs-extra": "^10.1.0",
     "jest": "^29.0.3",
     "jest-diff": "^27.0.6",
-    "jest-expect-message": "^1.0.2",
+    "jest-expect-message": "^1.1.3",
     "jest-silent-reporter": "^0.5.0",
     "jsdom": "^19.0.0",
     "lerna": "^5.4.3",


### PR DESCRIPTION
Custom matchers which failed were throwing inside jest instead of reporting their error messages, due to a bug which has been fixed.