### PR TITLE
Fix joins with multiple filters

### DIFF
--- a/packages/malloy/src/model/malloy_query.ts
+++ b/packages/malloy/src/model/malloy_query.ts
@@ -1460,8 +1460,8 @@ class JoinInstance {
     // convert the filter list into a list of boolean fields so we can
     //  generate dependancies and code for them.
     if (this.queryStruct.fieldDef.filterList) {
+      this.joinFilterConditions = [];
       for (const filter of this.queryStruct.fieldDef.filterList) {
-        this.joinFilterConditions = [];
         const qf = new QueryFieldBoolean(
           {
             type: "boolean",

--- a/test/src/databases/bigquery/joined_filters.spec.ts
+++ b/test/src/databases/bigquery/joined_filters.spec.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files
+ * (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { RuntimeList } from "../../runtimes";
+import { describeIfDatabaseAvailable } from "../../util";
+
+function sourceCodeWithFilter(filter: string) {
+  return `
+  source: aircraft_models is table('malloy-data.faa.aircraft_models') {
+    primary_key: aircraft_model_code
+    where: ${filter}
+  }
+
+  source: aircraft is table('malloy-data.faa.aircraft') {
+    primary_key: tail_num
+    measure: aircraft_count is count()
+    join_one: aircraft_models with aircraft_model_code
+  }
+
+  query: aircraft -> {
+    group_by: aircraft_models.aircraft_model_code
+  }
+`;
+}
+
+const [describe, databases] = describeIfDatabaseAvailable(["bigquery"]);
+describe("Joined filters", () => {
+  const runtimes = new RuntimeList(databases);
+
+  afterAll(async () => {
+    await runtimes.closeAll();
+  });
+
+  test("work with comma", async () => {
+    const runtime = runtimes.runtimeMap.get("bigquery");
+    expect(runtime).toBeDefined();
+    if (runtime) {
+      const src = sourceCodeWithFilter("1 = 1, 2 = 2");
+      const result = await runtime.loadQuery(src).run();
+      expect(result.sql).toContain("1=1");
+      expect(result.sql).toContain("2=2");
+    }
+  });
+
+  test("work with and", async () => {
+    const runtime = runtimes.runtimeMap.get("bigquery");
+    expect(runtime).toBeDefined();
+    if (runtime) {
+      const src = sourceCodeWithFilter("1 = 1 and 2 = 2");
+      const result = await runtime.loadQuery(src).run();
+      expect(result.sql).toContain("1=1");
+      expect(result.sql).toContain("2=2");
+    }
+  });
+});


### PR DESCRIPTION
Fixes a bug where a join of a source with multiple filters (with commas, not `and`) only uses the last one.

We were just resetting the list of filters to `[]` before processing each filter, rather than only at the start.