### PR TITLE
Require targeted lodash imports

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -42,7 +42,7 @@ module.exports = {
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
     "warnOnUnsupportedTypeScriptVersion": false,
-    "project": ['./tsconfig.packages.json']
+    "project": ["./tsconfig.packages.json"]
   },
   "plugins": ["@typescript-eslint", "prettier"],
   "rules": {
@@ -52,7 +52,15 @@ module.exports = {
     "no-duplicate-imports": "error",
     "no-restricted-imports": [
       "error",
-      { "patterns": ["@malloydata/malloy/src/*"] }
+      {
+        patterns: ["@malloydata/malloy/src/*"],
+        paths: [
+          {
+            name: "lodash",
+            message: "Import [module] from lodash/[module] instead"
+          }
+        ]
+      }
     ],
     "no-use-before-define": "off",
     "no-throw-literal": "error",

--- a/packages/malloy-render/src/html/vega_spec.ts
+++ b/packages/malloy-render/src/html/vega_spec.ts
@@ -24,7 +24,7 @@
 import * as lite from "vega-lite";
 import { DataColumn, Explore, Field } from "@malloydata/malloy";
 import { HTMLChartRenderer } from "./chart";
-import { cloneDeep } from "lodash";
+import cloneDeep from "lodash/cloneDeep";
 import { getColorScale } from "./utils";
 import { StyleDefaults } from "../data_styles";
 

--- a/packages/malloy/src/lang/ast/elements/refined-source.ts
+++ b/packages/malloy/src/lang/ast/elements/refined-source.ts
@@ -21,7 +21,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import { cloneDeep } from "lodash";
+import cloneDeep from "lodash/cloneDeep";
 
 import {
   StructDef,

--- a/packages/malloy/src/lang/ast/field-space/dynamic-space.ts
+++ b/packages/malloy/src/lang/ast/field-space/dynamic-space.ts
@@ -21,7 +21,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import { cloneDeep } from "lodash";
+import cloneDeep from "lodash/cloneDeep";
 import * as model from "../../../model/malloy_types";
 import { nameOf } from "../../field-utils";
 import { SpaceEntry } from "../types/space-entry";

--- a/packages/malloy/src/lang/ast/types/malloy-element.ts
+++ b/packages/malloy/src/lang/ast/types/malloy-element.ts
@@ -20,7 +20,7 @@
  * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-import { cloneDeep } from "lodash";
+import cloneDeep from "lodash/cloneDeep";
 
 import {
   DocumentLocation,

--- a/packages/malloy/src/lang/test/parse.spec.ts
+++ b/packages/malloy/src/lang/test/parse.spec.ts
@@ -51,7 +51,7 @@ import {
   markSource,
   pretty
 } from "./test-translator";
-import { isEqual } from "lodash";
+import isEqual from "lodash/isEqual";
 import { inspect } from "util";
 
 const inspectCompile = false;

--- a/packages/malloy/src/model/malloy_query.ts
+++ b/packages/malloy/src/model/malloy_query.ts
@@ -21,7 +21,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import { cloneDeep } from "lodash";
+import cloneDeep from "lodash/cloneDeep";
 import { Dialect, DialectFieldList, getDialect } from "../dialect";
 import { StandardSQLDialect } from "../dialect/standardsql";
 import {


### PR DESCRIPTION
Importing directly from `"lodash"` causes `_` to be defined globally and can lead to conflicts with other versions or underscore, so as a library we should only import the methods we need directly.