### PR TITLE
Debounce yieldTask's creation of tasks to 100ms

### DIFF
--- a/packages/malloy-render/src/html/utils.ts
+++ b/packages/malloy-render/src/html/utils.ts
@@ -148,7 +148,16 @@ export function timeToString(
  * rendering / UI task. Sprinkling in `yieldTask`s into a long task allows other
  * tasks to run periodically.
  */
+let LAST_YIELD_TIME: number | undefined = undefined;
+const YIELD_DEBOUNCE = 100; // milliseconds
 export async function yieldTask(): Promise<void> {
+  const currentTime = Date.now();
+  // We don't actually yield every time the function is called, because that can add a lot of
+  // overhead in terms of new tasks. Instead, we debounce yielding to once every 100ms.
+  if (LAST_YIELD_TIME && currentTime < LAST_YIELD_TIME + YIELD_DEBOUNCE) {
+    return;
+  }
+  LAST_YIELD_TIME = currentTime;
   return new Promise((resolve) => {
     setTimeout(resolve, 0);
   });


### PR DESCRIPTION
`yieldTask` in the renderer was a nice win for responsiveness during slow renders, but was total overkill. This PR reduces the number of tasks to roughly one per 100ms, so we're not blowing up the task queue. This dramatically improves performance in renders of large tables.