### PR TITLE
Top-level build now builds all workspaces

### DIFF
--- a/cloudbuild/build-test/test.sh
+++ b/cloudbuild/build-test/test.sh
@@ -2,6 +2,7 @@
 set -euxo pipefail
 
 nix-shell --quiet --pure --command "$(cat <<NIXCMD
+  set -euxo pipefail
   export PGHOST=127.0.0.1
   export PGDATABASE=postgres
   export PGUSER=673673622326@cloudbuild

--- a/package.json
+++ b/package.json
@@ -5,7 +5,11 @@
   "name": "malloy",
   "workspaces": {
     "packages": [
-      "packages/*",
+      "packages/malloy",
+      "packages/malloy-db-bigquery",
+      "packages/malloy-db-duckdb",
+      "packages/malloy-db-postgres",
+      "packages/malloy-render",
       "test"
     ]
   },
@@ -17,8 +21,8 @@
     "npm": ">=8"
   },
   "scripts": {
-    "clean": "npm run -w @malloydata/malloy clean && tsc --build --clean",
-    "build": "npm run -w @malloydata/malloy build-parser && tsc --build",
+    "clean": "npm run -ws clean",
+    "build": "npm run -ws build",
     "lint": "eslint --quiet '**/*.ts{,x}'",
     "lint-fix": "eslint --quiet '**/*.ts{,x}' --fix",
     "test": "jest --runInBand",

--- a/packages/malloy-db-bigquery/package.json
+++ b/packages/malloy-db-bigquery/package.json
@@ -14,6 +14,7 @@
     "lint-fix": "eslint '**/*.ts{,x}' --fix",
     "test": "jest --config=../../jest.config.js",
     "build": "tsc --build",
+    "clean": "tsc --build --clean",
     "malloyc": "ts-node ../../scripts/malloy-to-json",
     "prepublishOnly": "npm run build"
   },

--- a/packages/malloy-db-duckdb/package.json
+++ b/packages/malloy-db-duckdb/package.json
@@ -32,6 +32,7 @@
     "lint-fix": "eslint '**/*.ts{,x}' --fix",
     "test": "jest --config=../../jest.config.js",
     "build": "tsc --build",
+    "clean": "tsc --build --clean",
     "malloyc": "ts-node ../../scripts/malloy-to-json",
     "prepublishOnly": "npm run build"
   },

--- a/packages/malloy-db-postgres/package.json
+++ b/packages/malloy-db-postgres/package.json
@@ -14,6 +14,7 @@
     "lint-fix": "eslint '**/*.ts{,x}' --fix",
     "test": "jest --config=../../jest.config.js",
     "build": "tsc --build",
+    "clean": "tsc --build --clean",
     "malloyc": "ts-node ../../scripts/malloy-to-json",
     "prepublishOnly": "npm run build"
   },

--- a/packages/malloy-render/package.json
+++ b/packages/malloy-render/package.json
@@ -14,6 +14,7 @@
     "lint-fix": "eslint '**/*.ts{,x}' --fix",
     "test": "jest --config=../../jest.config.js",
     "build": "tsc --build",
+    "clean": "tsc --build --clean",
     "prepublishOnly": "npm run build"
   },
   "dependencies": {

--- a/packages/malloy/package.json
+++ b/packages/malloy/package.json
@@ -13,7 +13,7 @@
     "test": "jest --config=../../jest.config.js",
     "build-parser": "node src/lang/grammar/build_parser.js",
     "testLang": "npm run test --testPathPattern=packages/malloy/src/lang",
-    "clean": "rm -rf src/lang/lib",
+    "clean": "tsc --build --clean && rm -rf src/lang/lib dist",
     "build": "npm run build-parser && tsc --build",
     "malloyc": "ts-node ../../scripts/malloy-to-json",
     "prepublishOnly": "npm run clean && npm run build"

--- a/test/package.json
+++ b/test/package.json
@@ -6,6 +6,7 @@
     "lint-fix": "eslint '**/*.ts{,x}' --fix",
     "test": "jest --config=../jest.config.js",
     "build": "tsc --build",
+    "clean": "tsc --build --clean",
     "malloyc": "ts-node ../scripts/malloy-to-json"
   },
   "dependencies": {


### PR DESCRIPTION
Top level build was only building malloy, and malloy wasn't cleaning its tsc build cache on clean. And hilarity ensued...