### PR TITLE
Allow unsupported types in schemas

### DIFF
--- a/packages/malloy-db-bigquery/src/bigquery_connection.ts
+++ b/packages/malloy-db-bigquery/src/bigquery_connection.ts
@@ -519,7 +519,8 @@ export class BigQueryConnection
         structDef.fields.push(innerStructDef);
       } else {
         const malloyType = this.bqToMalloyTypes[type] || {
-          "type": "unsupported"
+          "type": "unsupported",
+          "rawType": type.toLowerCase()
         };
         structDef.fields.push({ name, ...malloyType } as FieldTypeDef);
       }

--- a/packages/malloy-db-bigquery/src/bigquery_connection.ts
+++ b/packages/malloy-db-bigquery/src/bigquery_connection.ts
@@ -518,7 +518,9 @@ export class BigQueryConnection
         this.addFieldsToStructDef(innerStructDef, field);
         structDef.fields.push(innerStructDef);
       } else {
-        const malloyType = this.bqToMalloyTypes[type] || "unsupported";
+        const malloyType = this.bqToMalloyTypes[type] || {
+          "type": "unsupported"
+        };
         structDef.fields.push({ name, ...malloyType } as FieldTypeDef);
       }
     }

--- a/packages/malloy-db-bigquery/src/bigquery_connection.ts
+++ b/packages/malloy-db-bigquery/src/bigquery_connection.ts
@@ -518,16 +518,8 @@ export class BigQueryConnection
         this.addFieldsToStructDef(innerStructDef, field);
         structDef.fields.push(innerStructDef);
       } else {
-        const malloyType = this.bqToMalloyTypes[type];
-        if (malloyType) {
-          structDef.fields.push({ name, ...malloyType } as FieldTypeDef);
-        } else {
-          structDef.fields.push({
-            name,
-            "type": "string",
-            "e": [`'BigQuery type "${type}" not supported by Malloy'`]
-          });
-        }
+        const malloyType = this.bqToMalloyTypes[type] || "unsupported";
+        structDef.fields.push({ name, ...malloyType } as FieldTypeDef);
       }
     }
   }

--- a/packages/malloy-db-duckdb/src/duckdb_common.ts
+++ b/packages/malloy-db-duckdb/src/duckdb_common.ts
@@ -268,7 +268,15 @@ export abstract class DuckDBCommon
           };
           structDef.fields.push(innerStructDef);
         } else {
-          structDef.fields.push({ "type": malloyType || "unsupported", name });
+          if (malloyType) {
+            structDef.fields.push({ "type": malloyType, name });
+          } else {
+            structDef.fields.push({
+              "type": "unsupported",
+              "rawType": duckDBType.toLowerCase(),
+              name
+            });
+          }
         }
       }
     }

--- a/packages/malloy-db-duckdb/src/duckdb_common.ts
+++ b/packages/malloy-db-duckdb/src/duckdb_common.ts
@@ -268,18 +268,7 @@ export abstract class DuckDBCommon
           };
           structDef.fields.push(innerStructDef);
         } else {
-          if (malloyType !== undefined) {
-            structDef.fields.push({
-              "type": malloyType,
-              name
-            });
-          } else {
-            structDef.fields.push({
-              name,
-              "type": "string",
-              "e": [`'DuckDB type "${duckDBType}" not supported by Malloy'`]
-            });
-          }
+          structDef.fields.push({ "type": malloyType || "unsupported", name });
         }
       }
     }

--- a/packages/malloy-db-postgres/src/postgres_connection.ts
+++ b/packages/malloy-db-postgres/src/postgres_connection.ts
@@ -307,18 +307,7 @@ export class PostgresConnection
         structDef.fields.push(s);
         name = "value";
       }
-      if (malloyType !== undefined) {
-        s.fields.push({
-          "type": malloyType,
-          name
-        });
-      } else {
-        s.fields.push({
-          name,
-          "type": "string",
-          "e": [`'Postgres type "${postgresDataType}" not supported by Malloy'`]
-        });
-      }
+      s.fields.push({ "type": malloyType || "unsupported", name });
     }
   }
 

--- a/packages/malloy-db-postgres/src/postgres_connection.ts
+++ b/packages/malloy-db-postgres/src/postgres_connection.ts
@@ -308,7 +308,15 @@ export class PostgresConnection
         structDef.fields.push(s);
         name = "value";
       }
-      s.fields.push({ "type": malloyType || "unsupported", name });
+      if (malloyType) {
+        structDef.fields.push({ "type": malloyType, name });
+      } else {
+        structDef.fields.push({
+          "type": "unsupported",
+          "rawType": postgresDataType.toLowerCase(),
+          name
+        });
+      }
     }
   }
 

--- a/packages/malloy-db-postgres/src/postgres_connection.ts
+++ b/packages/malloy-db-postgres/src/postgres_connection.ts
@@ -309,9 +309,9 @@ export class PostgresConnection
         name = "value";
       }
       if (malloyType) {
-        structDef.fields.push({ "type": malloyType, name });
+        s.fields.push({ "type": malloyType, name });
       } else {
-        structDef.fields.push({
+        s.fields.push({
           "type": "unsupported",
           "rawType": postgresDataType.toLowerCase(),
           name

--- a/packages/malloy/src/lang/ast/expressions/expr-id-reference.ts
+++ b/packages/malloy/src/lang/ast/expressions/expr-id-reference.ts
@@ -44,10 +44,8 @@ export class ExprIdReference extends ExpressionDef {
     const def = this.fieldReference.getField(fs);
     if (def.found) {
       const value = [{ "type": def.found.refType, "path": this.refString }];
-      return {
-        ...def.found.typeDesc(),
-        value
-      };
+      const td = def.found.typeDesc();
+      return { ...td, value };
     }
     this.log(def.error);
     return errorFor(def.error);

--- a/packages/malloy/src/lang/ast/expressions/expr-not.ts
+++ b/packages/malloy/src/lang/ast/expressions/expr-not.ts
@@ -21,7 +21,6 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import { errorFor } from "../ast-utils";
 import { FT } from "../fragtype-utils";
 import { ExprValue } from "../types/expr-value";
 import { ExpressionDef } from "../types/expression-def";
@@ -38,13 +37,11 @@ export class ExprNot extends Unary {
 
   getExpression(fs: FieldSpace): ExprValue {
     const notThis = this.expr.getExpression(fs);
-    if (this.typeCheck(this.expr, notThis)) {
-      return {
-        ...notThis,
-        "dataType": "boolean",
-        "value": nullsafeNot(notThis.value)
-      };
-    }
-    return errorFor("not requires boolean");
+    const doNot = this.typeCheck(this.expr, notThis);
+    return {
+      ...notThis,
+      "dataType": "boolean",
+      "value": doNot ? nullsafeNot(notThis.value) : ["false"]
+    };
   }
 }

--- a/packages/malloy/src/lang/ast/types/expression-def.ts
+++ b/packages/malloy/src/lang/ast/types/expression-def.ts
@@ -249,10 +249,16 @@ function equality(
   const rhs = right.getExpression(fs);
 
   // Unsupported types can be compare with null
-  if (lhs.dataType !== "null" && rhs.dataType !== "null") {
-    const noGo = unsupportError(left, lhs, right, rhs);
-    if (noGo) {
-      return { ...noGo, "dataType": "boolean" };
+  const checkUnsupport =
+    lhs.dataType === "unsupported" || rhs.dataType === "unsupported";
+  if (checkUnsupport) {
+    const oneNull = lhs.dataType === "null" || rhs.dataType === "null";
+    const rawMatch = lhs.rawType && lhs.rawType === rhs.rawType;
+    if (!(oneNull || rawMatch)) {
+      const noGo = unsupportError(left, lhs, right, rhs);
+      if (noGo) {
+        return { ...noGo, "dataType": "boolean" };
+      }
     }
   }
   let value = timeCompare(lhs, op, rhs) || compose(lhs.value, op, rhs.value);
@@ -459,6 +465,9 @@ export function applyBinary(
   return errorFor("applybinary bad operator");
 }
 
+/**
+ * Return an error if an binary operation includes unsupported types.
+ */
 function unsupportError(
   l: ExpressionDef,
   lhs: ExprValue,

--- a/packages/malloy/src/lang/ast/types/space-field.ts
+++ b/packages/malloy/src/lang/ast/types/space-field.ts
@@ -38,6 +38,13 @@ export abstract class SpaceField extends SpaceEntry {
     if (isFieldTypeDef(def) && def.expressionType) {
       ref.expressionType = def.expressionType;
     }
+    if (
+      ref.dataType === "unsupported" &&
+      def.type === "unsupported" &&
+      def.rawType
+    ) {
+      ref.rawType = def.rawType;
+    }
     return ref;
   }
 

--- a/packages/malloy/src/lang/ast/types/type-desc.ts
+++ b/packages/malloy/src/lang/ast/types/type-desc.ts
@@ -35,4 +35,5 @@ export type FieldValueType = ExpressionValueType | "turtle" | "struct";
 export interface TypeDesc {
   dataType: FieldValueType;
   expressionType: ExpressionType;
+  rawType?: string;
 }

--- a/packages/malloy/src/lang/test/field-symbols.spec.ts
+++ b/packages/malloy/src/lang/test/field-symbols.spec.ts
@@ -99,6 +99,18 @@ describe("structdef comprehension", () => {
     expect(oField).toEqual(field);
   });
 
+  test(`import unsupported field`, () => {
+    const field: model.FieldDef = {
+      "name": "t",
+      "type": "unsupported"
+    };
+    const struct = mkStructDef(field);
+    const space = new StaticSpace(struct);
+    expect(space.lookup(fieldRef("t")).found).toBeInstanceOf(ColumnSpaceField);
+    const oField = space.structDef().fields[0];
+    expect(oField).toEqual(field);
+  });
+
   test(`import nested field`, () => {
     const field: model.FieldDef = {
       "name": "t",

--- a/packages/malloy/src/lang/test/parse.spec.ts
+++ b/packages/malloy/src/lang/test/parse.spec.ts
@@ -1336,6 +1336,8 @@ describe("expressions", () => {
       }
     }
   });
+});
+describe("unspported fields in schema", () => {
   test("unsupported reference in result allowed", () => {
     const uModel = new BetaModel(`query: a->{ group_by: aun }`);
     expect(uModel).modelCompiled();
@@ -1363,6 +1365,12 @@ describe("expressions", () => {
     expect(uModel).compileToFailWith(
       "Unsupported type not allowed in expression"
     );
+  });
+  test("allow unsupported equality when raw types match", () => {
+    const uModel = new BetaModel(
+      `query: ab->{ where: aweird = b.aweird  project: * }`
+    );
+    expect(uModel).modelCompiled();
   });
   test("flag not applied to unsupported", () => {
     const uModel = new BetaModel(

--- a/packages/malloy/src/lang/test/parse.spec.ts
+++ b/packages/malloy/src/lang/test/parse.spec.ts
@@ -1336,6 +1336,22 @@ describe("expressions", () => {
       }
     }
   });
+  test("unsupported reference in result allowed", () => {
+    const uModel = new BetaModel(`query: a->{ group_by: aun }`);
+    expect(uModel).modelCompiled();
+  });
+  test("unsupported reference can be compared to NULL", () => {
+    const uModel = new BetaModel(
+      `query: a->{ where: aun != NULL; project: * }`
+    );
+    expect(uModel).modelCompiled();
+  });
+  test("unsupported comparison illegal", () => {
+    const uModel = new BetaModel(
+      `query: ab->{ where: aun = b.aun  project: * }`
+    );
+    expect(uModel).compileToFailWith("Cannot operate with unsupported type");
+  });
 });
 
 describe("sql:", () => {

--- a/packages/malloy/src/lang/test/parse.spec.ts
+++ b/packages/malloy/src/lang/test/parse.spec.ts
@@ -1370,6 +1370,12 @@ describe("expressions", () => {
     );
     expect(uModel).compileToFailWith("'not' Can't use type unsupported");
   });
+  test("allow unsupported to be cast", () => {
+    const uModel = new BetaModel(
+      `source: x is a { dimension: notUn is aun::string }`
+    );
+    expect(uModel).modelCompiled();
+  });
 });
 
 describe("sql:", () => {

--- a/packages/malloy/src/lang/test/parse.spec.ts
+++ b/packages/malloy/src/lang/test/parse.spec.ts
@@ -1346,11 +1346,29 @@ describe("expressions", () => {
     );
     expect(uModel).modelCompiled();
   });
-  test("unsupported comparison illegal", () => {
+  test("flag unsupported equality", () => {
+    // because we don't know if the two unsupported types are comparable
     const uModel = new BetaModel(
       `query: ab->{ where: aun = b.aun  project: * }`
     );
-    expect(uModel).compileToFailWith("Cannot operate with unsupported type");
+    expect(uModel).compileToFailWith(
+      "Unsupported type not allowed in expression"
+    );
+  });
+  test("flag unsupported compare", () => {
+    // because we don't know if the two unsupported types are comparable
+    const uModel = new BetaModel(
+      `query: ab->{ where: aun > b.aun  project: * }`
+    );
+    expect(uModel).compileToFailWith(
+      "Unsupported type not allowed in expression"
+    );
+  });
+  test("flag not applied to unsupported", () => {
+    const uModel = new BetaModel(
+      `source: x is a { dimension: notUn is not aun }`
+    );
+    expect(uModel).compileToFailWith("'not' Can't use type unsupported");
   });
 });
 

--- a/packages/malloy/src/lang/test/test-translator.ts
+++ b/packages/malloy/src/lang/test/test-translator.ts
@@ -58,7 +58,8 @@ const mockSchema: Record<string, StructDef> = {
       { "type": "number", "name": "ai", "numberType": "integer" },
       { "type": "date", "name": "ad" },
       { "type": "boolean", "name": "abool" },
-      { "type": "timestamp", "name": "ats" }
+      { "type": "timestamp", "name": "ats" },
+      { "type": "unsupported", "name": "aun" }
     ]
   },
   "malloytest.carriers": {

--- a/packages/malloy/src/lang/test/test-translator.ts
+++ b/packages/malloy/src/lang/test/test-translator.ts
@@ -59,7 +59,8 @@ const mockSchema: Record<string, StructDef> = {
       { "type": "date", "name": "ad" },
       { "type": "boolean", "name": "abool" },
       { "type": "timestamp", "name": "ats" },
-      { "type": "unsupported", "name": "aun" }
+      { "type": "unsupported", "name": "aun" },
+      { "type": "unsupported", "name": "aweird", "rawType": "weird" }
     ]
   },
   "malloytest.carriers": {

--- a/packages/malloy/src/malloy.ts
+++ b/packages/malloy/src/malloy.ts
@@ -1414,7 +1414,8 @@ export enum AtomicFieldType {
   Boolean = "boolean",
   Date = "date",
   Timestamp = "timestamp",
-  Json = "json"
+  Json = "json",
+  Unsupported = "unsupported"
 }
 
 export class AtomicField extends Entity {
@@ -1445,6 +1446,8 @@ export class AtomicField extends Entity {
         return AtomicFieldType.Number;
       case "json":
         return AtomicFieldType.Json;
+      case "unsupported":
+        return AtomicFieldType.Unsupported;
     }
   }
 

--- a/packages/malloy/src/model/malloy_query.ts
+++ b/packages/malloy/src/model/malloy_query.ts
@@ -794,6 +794,7 @@ class QueryFieldString extends QueryAtomicField {}
 class QueryFieldNumber extends QueryAtomicField {}
 class QueryFieldBoolean extends QueryAtomicField {}
 class QueryFieldJSON extends QueryAtomicField {}
+class QueryFieldUnsupported extends QueryAtomicField {}
 
 // in a query a struct can be referenced.  The struct will
 //  emit the primary key field in the actual result set and
@@ -2219,6 +2220,9 @@ class QueryQuery extends QueryField {
                 resultMetadata,
                 location
               });
+              break;
+            case "unsupported":
+              fields.push({ ...fi.f.fieldDef, resultMetadata, location });
               break;
             default:
               throw new Error(
@@ -3734,6 +3738,8 @@ class QueryStruct extends QueryNode {
         return new QueryFieldBoolean(field, this);
       case "json":
         return new QueryFieldJSON(field, this);
+      case "unsupported":
+        return new QueryFieldUnsupported(field, this);
       // case "reduce":
       // case "project":
       // case "index":

--- a/packages/malloy/src/model/malloy_types.ts
+++ b/packages/malloy/src/model/malloy_types.ts
@@ -546,6 +546,7 @@ export interface FieldJSONDef extends FieldAtomicDef {
 /** Scalar unsupported Field */
 export interface FieldUnsupportedDef extends FieldAtomicDef {
   type: "unsupported";
+  rawType?: string;
 }
 export type DateUnit = "day" | "week" | "month" | "quarter" | "year";
 export function isDateUnit(str: string): str is DateUnit {

--- a/packages/malloy/src/model/malloy_types.ts
+++ b/packages/malloy/src/model/malloy_types.ts
@@ -484,11 +484,18 @@ export type AtomicFieldType =
   | "number"
   | TimeFieldType
   | "boolean"
+  | "unsupported"
   | "json";
 export function isAtomicFieldType(s: string): s is AtomicFieldType {
-  return ["string", "number", "date", "timestamp", "boolean", "json"].includes(
-    s
-  );
+  return [
+    "string",
+    "number",
+    "date",
+    "timestamp",
+    "boolean",
+    "json",
+    "unsupported"
+  ].includes(s);
 }
 
 /** All scalars can have an optional expression */
@@ -536,6 +543,10 @@ export interface FieldJSONDef extends FieldAtomicDef {
   type: "json";
 }
 
+/** Scalar unsupported Field */
+export interface FieldUnsupportedDef extends FieldAtomicDef {
+  type: "unsupported";
+}
 export type DateUnit = "day" | "week" | "month" | "quarter" | "year";
 export function isDateUnit(str: string): str is DateUnit {
   return ["day", "week", "month", "quarter", "year"].includes(str);
@@ -804,7 +815,8 @@ export type FieldTypeDef =
   | FieldTimestampDef
   | FieldNumberDef
   | FieldBooleanDef
-  | FieldJSONDef;
+  | FieldJSONDef
+  | FieldUnsupportedDef;
 
 export function isFieldTypeDef(f: FieldDef): f is FieldTypeDef {
   return (

--- a/test/src/databases/bigquery/malloy_query.spec.ts
+++ b/test/src/databases/bigquery/malloy_query.spec.ts
@@ -1025,8 +1025,10 @@ describe("sql injection tests", () => {
     );
     expect(result.data.value[0].test).toBe("foo \\");
   });
+});
 
-  it("passes test which should be deleted when type support improves", async () => {
+describe("unsupported type tests", () => {
+  it("can read unsupported types in schema", async () => {
     const result = await runtime
       .loadQuery(
         `
@@ -1037,8 +1039,6 @@ describe("sql injection tests", () => {
       `
       )
       .run();
-    expect(result.data.value[0].geo).toBe(
-      'BigQuery type "GEOGRAPHY" not supported by Malloy'
-    );
+    expect(result.data.value[0].geo).toBeDefined();
   });
 });

--- a/test/src/databases/postgres/postgres.spec.ts
+++ b/test/src/databases/postgres/postgres.spec.ts
@@ -213,7 +213,7 @@ describe("Postgres tests", () => {
     expect(result.data.value[0].one).toBe(1);
   });
 
-  it("passes test which should be deleted when type support improves", async () => {
+  it("passes unsupported data", async () => {
     const result = await runtime
       .loadQuery(
         `
@@ -222,8 +222,6 @@ describe("Postgres tests", () => {
       `
       )
       .run();
-    expect(result.data.value[0].ranger).toBe(
-      'Postgres type "int4range" not supported by Malloy'
-    );
+    expect(result.data.value[0].ranger).toBeDefined();
   });
 });


### PR DESCRIPTION
OId behavior was the create a string expression with the value "this field has an unsupported type in it"

This should allow unsupported types to be passed to functions, and to be type cast. Beyond that they would still be unsupported.

* `query: x -> { project: * }` with unsupported fields works
* `query: x -> { group_by: unsupportedTypeField }` also works
* `query: x -> { where: unsupportedTypeField != NULL; ... }` also works
* `source: { dimension: x is` _any other expression with unsupported fields_ `}` will error
* `source: { dimension: xOk is(` _unsupported expression_ `)::__any malloy_type__ }` will compile, it may fail when you run the SQL (like you can't cast a GEOGRAPHY to a STRING in BigQuery)

- [x] Add an "unsupported" type in the schema
- [x] Don't allow unsupported field expressions in compiler
- [x] Tests updated
- [ ] Figure out what to do about the existing hack  #1018
- [ ] Make a plan to fix composer(s) and VSCode for unsupported data in the results.

