### PR TITLE
Change row limit of flaky test.

### DIFF
--- a/test/src/databases/bigquery/handexpr.spec.ts
+++ b/test/src/databases/bigquery/handexpr.spec.ts
@@ -496,7 +496,7 @@ describe("BigQuery hand-built expression test", () => {
           }
         ]
       })
-      .run();
+      .run({ "rowLimit": 15 });
     for (let i = 0; i < result.data.rowCount; i++) {
       expect(result.data.value[i].row_num).toBe(i + 1);
     }


### PR DESCRIPTION
Updating the row limit on occasionally failing test. Records 10-12 had the same aggregate value that was the order by column, so which row was returned as the 10th record was not guaranteed to be consistent.