### PR TITLE
Revert "Update DuckDB to 0.7.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -681,9 +681,9 @@
       }
     },
     "node_modules/@duckdb/duckdb-wasm": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/@duckdb/duckdb-wasm/-/duckdb-wasm-1.21.0.tgz",
-      "integrity": "sha512-3HBqwAhkjGWUGY2zSk2YG9i6bjNeTO5tyhBTJC9asv4ChTjx4mY6j4PFpAgUNomLm+QEFx1XXZN/BjRfENLdZQ==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/@duckdb/duckdb-wasm/-/duckdb-wasm-1.20.0.tgz",
+      "integrity": "sha512-ZJG/yfCwqzjPPs63+y4nI3ICMsQO8kC7GKt3WmtM+JNceDayE2ahMoR8QbrQz/PXD8ggyE2hf46inQw4ACXVEA==",
       "dependencies": {
         "apache-arrow": "^9.0.0"
       }
@@ -6595,9 +6595,9 @@
       }
     },
     "node_modules/duckdb": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/duckdb/-/duckdb-0.7.0.tgz",
-      "integrity": "sha512-G5mCd5xk5HCbnhplpdz7Ej27uVRftvLRZqd+liQ3Cb3oEcLn8a0pJ7yF1WRjaUJVrTHTiu8mO68lO9aGeLe4bw==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/duckdb/-/duckdb-0.6.1.tgz",
+      "integrity": "sha512-lvSCKHL9jG9e5k1QS9AWx2qJblwPnqUEBlkJb3MYCuPP088kETEn9bkLfwFY2+4KAQIJFquyJWj2rYXxEoBjVQ==",
       "hasInstallScript": true,
       "dependencies": {
         "@mapbox/node-pre-gyp": "^1.0.0",
@@ -8167,9 +8167,8 @@
       "license": "MIT"
     },
     "node_modules/http-cache-semantics": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
-      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="
+      "version": "4.1.0",
+      "license": "BSD-2-Clause"
     },
     "node_modules/http-proxy-agent": {
       "version": "5.0.0",
@@ -16536,9 +16535,9 @@
       "version": "0.0.24",
       "license": "MIT",
       "dependencies": {
-        "@duckdb/duckdb-wasm": "^1.21.0",
+        "@duckdb/duckdb-wasm": "^1.20.0",
         "@malloydata/malloy": "^0.0.24",
-        "duckdb": "0.7.0",
+        "duckdb": "0.6.1",
         "web-worker": "^1.2.0"
       }
     },
@@ -16992,9 +16991,9 @@
       }
     },
     "@duckdb/duckdb-wasm": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/@duckdb/duckdb-wasm/-/duckdb-wasm-1.21.0.tgz",
-      "integrity": "sha512-3HBqwAhkjGWUGY2zSk2YG9i6bjNeTO5tyhBTJC9asv4ChTjx4mY6j4PFpAgUNomLm+QEFx1XXZN/BjRfENLdZQ==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/@duckdb/duckdb-wasm/-/duckdb-wasm-1.20.0.tgz",
+      "integrity": "sha512-ZJG/yfCwqzjPPs63+y4nI3ICMsQO8kC7GKt3WmtM+JNceDayE2ahMoR8QbrQz/PXD8ggyE2hf46inQw4ACXVEA==",
       "requires": {
         "apache-arrow": "^9.0.0"
       }
@@ -18725,9 +18724,9 @@
     "@malloydata/db-duckdb": {
       "version": "file:packages/malloy-db-duckdb",
       "requires": {
-        "@duckdb/duckdb-wasm": "^1.21.0",
+        "@duckdb/duckdb-wasm": "^1.20.0",
         "@malloydata/malloy": "^0.0.24",
-        "duckdb": "0.7.0",
+        "duckdb": "0.6.1",
         "web-worker": "^1.2.0"
       }
     },
@@ -21062,9 +21061,9 @@
       "dev": true
     },
     "duckdb": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/duckdb/-/duckdb-0.7.0.tgz",
-      "integrity": "sha512-G5mCd5xk5HCbnhplpdz7Ej27uVRftvLRZqd+liQ3Cb3oEcLn8a0pJ7yF1WRjaUJVrTHTiu8mO68lO9aGeLe4bw==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/duckdb/-/duckdb-0.6.1.tgz",
+      "integrity": "sha512-lvSCKHL9jG9e5k1QS9AWx2qJblwPnqUEBlkJb3MYCuPP088kETEn9bkLfwFY2+4KAQIJFquyJWj2rYXxEoBjVQ==",
       "requires": {
         "@mapbox/node-pre-gyp": "^1.0.0",
         "node-addon-api": "*",
@@ -22101,9 +22100,7 @@
       "dev": true
     },
     "http-cache-semantics": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
-      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="
+      "version": "4.1.0"
     },
     "http-proxy-agent": {
       "version": "5.0.0",

--- a/packages/malloy-db-duckdb/package.json
+++ b/packages/malloy-db-duckdb/package.json
@@ -37,9 +37,9 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@duckdb/duckdb-wasm": "^1.21.0",
+    "@duckdb/duckdb-wasm": "^1.20.0",
     "@malloydata/malloy": "^0.0.24",
-    "duckdb": "0.7.0",
+    "duckdb": "0.6.1",
     "web-worker": "^1.2.0"
   }
 }


### PR DESCRIPTION
0.7.0 shipped without binaries for darwin x86 and win32, backing back down until 0.7.1

Reverts malloydata/malloy#1026