### PR TITLE
Fix extendModel with queries

### DIFF
--- a/packages/malloy/src/lang/ast/types/malloy-element.ts
+++ b/packages/malloy/src/lang/ast/types/malloy-element.ts
@@ -384,11 +384,10 @@ export class Document extends MalloyElement implements NameSpace {
     this.queryList = [];
     this.sqlBlocks = [];
     if (extendingModelDef) {
-      for (const inName in extendingModelDef.contents) {
-        const modelEntry = extendingModelDef.contents[inName];
-        if (modelEntry.type === 'struct' || modelEntry.type === 'query') {
-          const exported = extendingModelDef.exports.includes(inName);
-          this.setEntry(inName, {entry: modelEntry, exported});
+      for (const [nm, entry] of Object.entries(extendingModelDef.contents)) {
+        if (entry.type === 'struct' || entry.type === 'query') {
+          const exported = extendingModelDef.exports.includes(nm);
+          this.setEntry(nm, {entry, exported});
         }
       }
     }

--- a/packages/malloy/src/lang/ast/types/malloy-element.ts
+++ b/packages/malloy/src/lang/ast/types/malloy-element.ts
@@ -384,10 +384,15 @@ export class Document extends MalloyElement implements NameSpace {
     this.queryList = [];
     this.sqlBlocks = [];
     if (extendingModelDef) {
-      for (const [nm, entry] of Object.entries(extendingModelDef.contents)) {
+      for (const [nm, orig] of Object.entries(extendingModelDef.contents)) {
+        const entry = cloneDeep(orig);
         if (entry.type === 'struct' || entry.type === 'query') {
           const exported = extendingModelDef.exports.includes(nm);
-          this.setEntry(nm, {entry, exported});
+          const sqlType = entry.type === 'struct' && isSQLBlock(entry);
+          if (sqlType) {
+            this.sqlBlocks.push(entry);
+          }
+          this.setEntry(nm, {entry, exported, sqlType});
         }
       }
     }

--- a/packages/malloy/src/lang/ast/types/malloy-element.ts
+++ b/packages/malloy/src/lang/ast/types/malloy-element.ts
@@ -385,10 +385,10 @@ export class Document extends MalloyElement implements NameSpace {
     this.sqlBlocks = [];
     if (extendingModelDef) {
       for (const inName in extendingModelDef.contents) {
-        const struct = extendingModelDef.contents[inName];
-        if (struct.type === 'struct') {
+        const modelEntry = extendingModelDef.contents[inName];
+        if (modelEntry.type === 'struct' || modelEntry.type === 'query') {
           const exported = extendingModelDef.exports.includes(inName);
-          this.setEntry(inName, {entry: struct, exported});
+          this.setEntry(inName, {entry: modelEntry, exported});
         }
       }
     }

--- a/test/src/api.spec.ts
+++ b/test/src/api.spec.ts
@@ -64,4 +64,16 @@ describe('extendModel', () => {
     const twoState = await q2.run();
     expect(twoState.data.path(0, 'state').value).toBe('CA');
   });
+  test('can reference sql from previous section ', async () => {
+    const model = runtime.loadModel(`
+      sql: q1 is { connection: "duckdb" select: """SELECT 'CA' as state""" }
+    `);
+
+    const extended = model.extendModel(
+      'query: q2 is from_sql(q1)->{project: *}'
+    );
+    const q2 = extended.loadQueryByName('q2');
+    const twoState = await q2.run();
+    expect(twoState.data.path(0, 'state').value).toBe('CA');
+  });
 });

--- a/test/src/api.spec.ts
+++ b/test/src/api.spec.ts
@@ -1,0 +1,67 @@
+/* eslint-disable no-console */
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files
+ * (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import {runtimeFor} from './runtimes';
+
+const runtime = runtimeFor('duckdb');
+
+describe('extendModel', () => {
+  test('can run query in extend section', async () => {
+    const model = runtime.loadModel(`
+      query: q1 is table('malloytest.aircraft')->{
+        where: state = 'CA'
+        group_by: state
+      }
+    `);
+    const q1 = model.loadQueryByName('q1');
+    const oneState = await q1.run();
+    expect(oneState.data.path(0, 'state').value).toBe('CA');
+
+    const extended = model.extendModel(`
+      query: q2 is table('malloytest.aircraft')->{
+        where: state = 'NV'
+        group_by: state
+      }
+    `);
+    const q2 = extended.loadQueryByName('q2');
+    const twoState = await q2.run();
+    expect(twoState.data.path(0, 'state').value).toBe('NV');
+  });
+  test('can reference query from previous section ', async () => {
+    const model = runtime.loadModel(`
+      query: q1 is table('malloytest.aircraft')->{
+        where: state = 'CA'
+        group_by: state
+      }
+    `);
+    const q1 = model.loadQueryByName('q1');
+    const oneState = await q1.run();
+    expect(oneState.data.path(0, 'state').value).toBe('CA');
+
+    const extended = model.extendModel('query: q2 is ->q1 -> { project: * }');
+    const q2 = extended.loadQueryByName('q2');
+    const twoState = await q2.run();
+    expect(twoState.data.path(0, 'state').value).toBe('CA');
+  });
+});


### PR DESCRIPTION
It turns out compiling a model from a pre-existing model, which has been around since the beginning of time because it was the basis for all my compiler tests, doesn't take anything from the pre-existing model except sources.

Not any more :)