### PR TITLE
Remove special casing for UUID in postgres

### DIFF
--- a/packages/malloy-db-postgres/src/postgres_connection.ts
+++ b/packages/malloy-db-postgres/src/postgres_connection.ts
@@ -72,7 +72,6 @@ const postgresToMalloyTypes: {[key: string]: AtomicFieldTypeInner} = {
   numeric: 'number',
   bytea: 'string',
   pg_ndistinct: 'number',
-  uuid: 'string',
 };
 
 interface PostgresQueryConfiguration {


### PR DESCRIPTION
Malloy code was augmented to make any unknown types cause failures.
The special casing for UUID in postgres can now be removed.

fixes #1021