### PR TITLE
infer sql block connection from turducken source

### DIFF
--- a/packages/malloy/src/lang/test/parse.spec.ts
+++ b/packages/malloy/src/lang/test/parse.spec.ts
@@ -31,7 +31,7 @@ import {
   expressionIsCalculation,
   isFieldTypeDef,
   isFilteredAliasedName,
-  isSQLFragment,
+  phraseIsSQLFragment,
 } from '../../model';
 import {makeSQLBlock} from '../../model/sql_block';
 import {
@@ -1181,7 +1181,7 @@ describe('sql:', () => {
       const star = compileSql.select[1];
       const where = compileSql.select[2];
       expect(select).toEqual({sql: 'SELECT * FROM '});
-      expect(isSQLFragment(star)).toBeFalsy();
+      expect(phraseIsSQLFragment(star)).toBeFalsy();
       expect(where).toEqual({sql: ' WHERE 1=1'});
     }
   });
@@ -1358,7 +1358,7 @@ describe('error handling', () => {
 
 function getSelectOneStruct(sqlBlock: SQLBlockSource): SQLBlockStructDef {
   const selectThis = sqlBlock.select[0];
-  if (!isSQLFragment(selectThis)) {
+  if (!phraseIsSQLFragment(selectThis)) {
     throw new Error('weird test support error sorry');
   }
   return {

--- a/packages/malloy/src/malloy.ts
+++ b/packages/malloy/src/malloy.ts
@@ -60,7 +60,7 @@ import {
   expressionIsCalculation,
   flattenQuery,
   isSQLBlock,
-  isSQLFragment,
+  phraseIsSQLFragment,
   FieldUnsupportedDef,
 } from './model';
 import {
@@ -304,7 +304,7 @@ export class Malloy {
   ): SQLBlock {
     let queryModel: QueryModel;
     const sqlStrings = toCompile.select.map(segment => {
-      if (isSQLFragment(segment)) {
+      if (phraseIsSQLFragment(segment)) {
         return segment.sql;
       } else {
         // TODO catch exceptions and throw errors ...

--- a/packages/malloy/src/model/malloy_types.ts
+++ b/packages/malloy/src/model/malloy_types.ts
@@ -743,8 +743,11 @@ export interface SQLFragment {
   sql: string;
 }
 export type SQLPhrase = Query | SQLFragment;
-export function isSQLFragment(f: SQLPhrase): f is SQLFragment {
+export function phraseIsSQLFragment(f: SQLPhrase): f is SQLFragment {
   return (f as SQLFragment).sql !== undefined;
+}
+export function phraseIsQuery(f: SQLPhrase): f is Query {
+  return (f as Query).type === 'query';
 }
 /**
  * A source reference to an SQL block. The compiler uses these to request

--- a/packages/malloy/src/model/sql_block.ts
+++ b/packages/malloy/src/model/sql_block.ts
@@ -21,7 +21,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import {SQLBlockSource, SQLPhrase, isSQLFragment} from './malloy_types';
+import {SQLBlockSource, SQLPhrase, phraseIsSQLFragment} from './malloy_types';
 import {generateHash} from './utils';
 
 /**
@@ -53,7 +53,7 @@ export function makeSQLBlock(
 // algorithm needs to change
 function nameFor(select: SQLPhrase[]): string {
   const phrases = select.map(el =>
-    isSQLFragment(el) ? el.sql : JSON.stringify(el)
+    phraseIsSQLFragment(el) ? el.sql : JSON.stringify(el)
   );
   return generateHash(phrases.join(';'));
 }


### PR DESCRIPTION
This is an attempt to fix #1008.

If an SQL block has no connection, and it can find a connection in a turducken inside the block, use that as the connection for the sql block.

Not sure how to write a test for this.