### PR TITLE
Fix extending models with from_sql based sources

### DIFF
--- a/packages/malloy/src/lang/ast/sources/named-source.ts
+++ b/packages/malloy/src/lang/ast/sources/named-source.ts
@@ -22,6 +22,7 @@
  */
 
 import {
+  isSQLBlockStruct,
   isValueParameter,
   paramHasValue,
   StructDef,
@@ -89,7 +90,7 @@ export class NamedSource extends Source {
     if (entry.type === 'query') {
       this.log(`Must use 'from()' for query source '${this.refName}`);
       return;
-    } else if (modelEnt.sqlType) {
+    } else if (isSQLBlockStruct(entry) && entry.declaredSQLBlock) {
       this.log(`Must use 'from_sql()' for sql source '${this.refName}`);
       return;
     }

--- a/packages/malloy/src/lang/ast/sources/sql-source.ts
+++ b/packages/malloy/src/lang/ast/sources/sql-source.ts
@@ -21,7 +21,11 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import {StructDef, StructRef} from '../../../model/malloy_types';
+import {
+  StructDef,
+  StructRef,
+  isSQLBlockStruct,
+} from '../../../model/malloy_types';
 import {NamedSource} from './named-source';
 
 export class SQLSource extends NamedSource {
@@ -29,6 +33,7 @@ export class SQLSource extends NamedSource {
   structRef(): StructRef {
     return this.structDef();
   }
+
   modelStruct(): StructDef | undefined {
     const modelEnt = this.modelEntry(this.ref);
     const entry = modelEnt?.entry;
@@ -39,10 +44,11 @@ export class SQLSource extends NamedSource {
     if (entry.type === 'query') {
       this.log(`Cannot use 'from_sql()' to explore query '${this.refName}'`);
       return;
-    } else if (!modelEnt.sqlType) {
-      this.log(`Cannot use 'from_sql()' to explore '${this.refName}'`);
-      return;
+    } else if (isSQLBlockStruct(entry) && entry.declaredSQLBlock) {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const {declaredSQLBlock, ...newEntry} = entry;
+      return newEntry;
     }
-    return entry;
+    this.log(`Cannot use 'from_sql()' to explore '${this.refName}'`);
   }
 }

--- a/packages/malloy/src/lang/ast/types/malloy-element.ts
+++ b/packages/malloy/src/lang/ast/types/malloy-element.ts
@@ -117,7 +117,7 @@ export abstract class MalloyElement {
           location: reference.location,
         });
       } else if (result?.entry.type === 'struct') {
-        if (isSQLBlockStruct(result.entry)) {
+        if (isSQLBlockStruct(result.entry) && result.entry.declaredSQLBlock) {
           this.addReference({
             type: 'sqlBlockReference',
             text: key,

--- a/packages/malloy/src/lang/ast/types/malloy-element.ts
+++ b/packages/malloy/src/lang/ast/types/malloy-element.ts
@@ -25,7 +25,7 @@ import cloneDeep from 'lodash/cloneDeep';
 import {
   DocumentLocation,
   DocumentReference,
-  isSQLBlock,
+  isSQLBlockStruct,
   ModelDef,
   Query,
   SQLBlockStructDef,
@@ -117,7 +117,7 @@ export abstract class MalloyElement {
           location: reference.location,
         });
       } else if (result?.entry.type === 'struct') {
-        if (isSQLBlock(result.entry)) {
+        if (isSQLBlockStruct(result.entry)) {
           this.addReference({
             type: 'sqlBlockReference',
             text: key,
@@ -421,13 +421,17 @@ export class Document extends MalloyElement implements NameSpace {
   }
 
   defineSQL(sql: SQLBlockStructDef, name?: string): boolean {
-    const ret = {...sql, as: `$${this.sqlBlocks.length}`};
+    const ret = {
+      ...sql,
+      as: `$${this.sqlBlocks.length}`,
+      declaredSQLBlock: true,
+    };
     if (name) {
       if (this.getEntry(name)) {
         return false;
       }
       ret.as = name;
-      this.setEntry(name, {entry: ret, sqlType: true});
+      this.setEntry(name, {entry: ret});
     }
     this.sqlBlocks.push(ret);
     return true;

--- a/packages/malloy/src/lang/ast/types/malloy-element.ts
+++ b/packages/malloy/src/lang/ast/types/malloy-element.ts
@@ -388,11 +388,7 @@ export class Document extends MalloyElement implements NameSpace {
         const entry = cloneDeep(orig);
         if (entry.type === 'struct' || entry.type === 'query') {
           const exported = extendingModelDef.exports.includes(nm);
-          const sqlType = entry.type === 'struct' && isSQLBlock(entry);
-          if (sqlType) {
-            this.sqlBlocks.push(entry);
-          }
-          this.setEntry(nm, {entry, exported, sqlType});
+          this.setEntry(nm, {entry, exported});
         }
       }
     }

--- a/packages/malloy/src/lang/ast/types/model-entry.ts
+++ b/packages/malloy/src/lang/ast/types/model-entry.ts
@@ -26,5 +26,4 @@ import {NamedModelObject} from '../../../model/malloy_types';
 export interface ModelEntry {
   entry: NamedModelObject;
   exported?: boolean;
-  sqlType?: boolean;
 }

--- a/packages/malloy/src/lang/test/parse-expects.ts
+++ b/packages/malloy/src/lang/test/parse-expects.ts
@@ -22,7 +22,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import {TranslateResponse} from '..';
+import {MalloyTranslator, TranslateResponse} from '..';
 import {DocumentLocation} from '../../model';
 import {MarkedSource, pretty, TestTranslator} from './test-translator';
 import {inspect} from 'util';
@@ -42,7 +42,7 @@ declare global {
   }
 }
 
-function checkForErrors(trans: TestTranslator) {
+function checkForErrors(trans: MalloyTranslator) {
   if (trans.logger === undefined) {
     throw new Error('JESTERY BROKEN, CANT FIND ERORR LOG');
   }
@@ -138,7 +138,7 @@ expect.extend({
     x.translate();
     return checkForNeededs(x);
   },
-  toBeErrorless: function (trans: TestTranslator) {
+  toBeErrorless: function (trans: MalloyTranslator) {
     return checkForErrors(trans);
   },
   toReturnType: function (functionCall: string, returnType: string) {

--- a/packages/malloy/src/lang/test/parse.spec.ts
+++ b/packages/malloy/src/lang/test/parse.spec.ts
@@ -27,17 +27,14 @@ import {
   DocumentPosition,
   SQLBlockSource,
   SQLBlockStructDef,
-  StructDef,
   expressionIsCalculation,
   isFieldTypeDef,
   isFilteredAliasedName,
   isSQLFragment,
 } from '../../model';
-import {makeSQLBlock} from '../../model/sql_block';
 import {
   MarkedSource,
   TestTranslator,
-  aTableDef,
   getExplore,
   getField,
   getJoinField,
@@ -49,17 +46,6 @@ import {
 import isEqual from 'lodash/isEqual';
 import {isGranularResult} from '../ast/types/granular-result';
 import './parse-expects';
-
-function unlocatedStructDef(sd: StructDef): StructDef {
-  const ret = {...sd};
-  ret.fields = sd.fields.map(f => {
-    const nf = {...f};
-    delete nf.location;
-    return nf;
-  });
-  delete ret.location;
-  return ret;
-}
 
 type TestFunc = () => undefined;
 
@@ -1076,130 +1062,6 @@ describe('unspported fields in schema', () => {
       'source: x is a { dimension: notUn is aun::string }'
     );
     expect(uModel).modelCompiled();
-  });
-});
-
-describe('sql:', () => {
-  function makeSchemaResponse(sql: SQLBlockSource): SQLBlockStructDef {
-    const cname = sql.connection || 'bigquery';
-    return {
-      type: 'struct',
-      name: sql.name,
-      dialect: "standardsql'",
-      structSource: {
-        type: 'sql',
-        method: 'subquery',
-        sqlBlock: {
-          type: 'sqlBlock',
-          ...sql,
-          selectStr: sql.select.filter(s => typeof s === 'string').join(''),
-        },
-      },
-      structRelationship: {type: 'basetable', connectionName: cname},
-      fields: aTableDef.fields,
-    };
-  }
-  test('definition', () => {
-    const selStmt = 'SELECT * FROM aTable';
-    const model = new TestTranslator(`
-      sql: users IS {
-        select: """${selStmt}"""
-        connection: "aConnection"
-      }
-    `);
-    const needReq = model.translate();
-    expect(model).modelParsed();
-    const needs = needReq?.compileSQL;
-    expect(needs).toBeDefined();
-    if (needs) {
-      const sql = makeSQLBlock([{sql: selStmt}], 'aConnection');
-      expect(needs).toMatchObject(sql);
-      const refKey = needs.name;
-      expect(refKey).toBeDefined();
-      if (refKey) {
-        const sr = makeSchemaResponse(sql);
-        model.update({compileSQL: {[refKey]: sr}});
-        expect(model).modelCompiled();
-        expect(unlocatedStructDef(model.sqlBlocks[0])).toEqual(
-          unlocatedStructDef({...sr, as: 'users'})
-        );
-      }
-    }
-  });
-  test('source from sql', () => {
-    const selStmt = 'SELECT * FROM aTable';
-    const model = new TestTranslator(`
-      sql: users IS { select: """${selStmt}""" }
-      source: malloyUsers is from_sql(users) { primary_key: ai }
-    `);
-    expect(model).modelParsed();
-    const needReq = model.translate();
-    const needs = needReq?.compileSQL;
-    expect(needs).toBeDefined();
-    if (needs) {
-      const sql = makeSQLBlock([{sql: selStmt}], 'aConnection');
-      const refKey = needs.name;
-      model.update({compileSQL: {[refKey]: makeSchemaResponse(sql)}});
-      expect(model).modelCompiled();
-      const users = model.getSourceDef('malloyUsers');
-      expect(users).toBeDefined();
-    }
-  });
-  test('explore from imported sql-based-source', () => {
-    const selStmt = 'SELECT * FROM aTable';
-    const createModel = `
-      sql: users IS { select: """${selStmt}""" }
-      source: malloyUsers is from_sql(users) { primary_key: ai }
-    `;
-    const model = new TestTranslator(`
-      import "createModel.malloy"
-      source: importUsers is malloyUsers
-    `);
-    model.importZone.define(
-      'internal://test/langtests/createModel.malloy',
-      createModel
-    );
-    expect(model).modelParsed();
-    const needReq = model.translate();
-    const needs = needReq?.compileSQL;
-    expect(needs).toBeDefined();
-    const sql = makeSQLBlock([{sql: selStmt}]);
-    model.update({compileSQL: {[sql.name]: makeSchemaResponse(sql)}});
-    expect(model).modelCompiled();
-  });
-  it('turducken', () => {
-    const m = new TestTranslator(`
-      sql: someSql is {
-        select: """SELECT * FROM %{ a -> { group_by: astr } }% WHERE 1=1"""
-      }
-    `);
-    expect(m).modelParsed();
-    const compileSql = m.translate().compileSQL;
-    expect(compileSql).toBeDefined();
-    if (compileSql) {
-      const select = compileSql.select[0];
-      const star = compileSql.select[1];
-      const where = compileSql.select[2];
-      expect(select).toEqual({sql: 'SELECT * FROM '});
-      expect(isSQLFragment(star)).toBeFalsy();
-      expect(where).toEqual({sql: ' WHERE 1=1'});
-    }
-  });
-  it('model preserved', () => {
-    const selStmt = 'SELECT * FROM aTable';
-    const shouldBeOK = `
-      source: newa is a
-      sql: someSql is { select: """${selStmt}""" }
-      source: newaa is newa
-    `;
-    const model = new TestTranslator(shouldBeOK);
-    expect(model).modelParsed();
-    const needReq = model.translate();
-    const needs = needReq?.compileSQL;
-    expect(needs).toBeDefined();
-    const sql = makeSQLBlock([{sql: selStmt}]);
-    model.update({compileSQL: {[sql.name]: makeSchemaResponse(sql)}});
-    expect(model).modelCompiled();
   });
 });
 

--- a/packages/malloy/src/lang/test/sql-block.spec.ts
+++ b/packages/malloy/src/lang/test/sql-block.spec.ts
@@ -1,0 +1,191 @@
+/* eslint-disable no-console */
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files
+ * (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import {
+  SQLBlockSource,
+  SQLBlockStructDef,
+  StructDef,
+  isSQLFragment,
+} from '../../model';
+import {makeSQLBlock} from '../../model/sql_block';
+import {TestTranslator, aTableDef} from './test-translator';
+import './parse-expects';
+import {MalloyTranslator} from '../parse-malloy';
+
+function unlocatedStructDef(sd: StructDef): StructDef {
+  const ret = {...sd};
+  ret.fields = sd.fields.map(f => {
+    const nf = {...f};
+    delete nf.location;
+    return nf;
+  });
+  delete ret.location;
+  return ret;
+}
+
+describe('sql:', () => {
+  const selStmt = 'SELECT * FROM aTable';
+  function makeSchemaResponse(sql: SQLBlockSource): SQLBlockStructDef {
+    const cname = sql.connection || 'bigquery';
+    return {
+      type: 'struct',
+      name: sql.name,
+      dialect: 'standardsql',
+      structSource: {
+        type: 'sql',
+        method: 'subquery',
+        sqlBlock: {
+          type: 'sqlBlock',
+          ...sql,
+          selectStr: sql.select.filter(s => typeof s === 'string').join(''),
+        },
+      },
+      structRelationship: {type: 'basetable', connectionName: cname},
+      fields: aTableDef.fields,
+    };
+  }
+
+  test('definition', () => {
+    const model = new TestTranslator(`
+      sql: users IS {
+        select: """${selStmt}"""
+        connection: "aConnection"
+      }
+    `);
+    const needReq = model.translate();
+    expect(model).modelParsed();
+    const needs = needReq?.compileSQL;
+    expect(needs).toBeDefined();
+    if (needs) {
+      const sql = makeSQLBlock([{sql: selStmt}], 'aConnection');
+      expect(needs).toMatchObject(sql);
+      const refKey = needs.name;
+      expect(refKey).toBeDefined();
+      if (refKey) {
+        const sr = makeSchemaResponse(sql);
+        model.update({compileSQL: {[refKey]: sr}});
+        expect(model).modelCompiled();
+        expect(unlocatedStructDef(model.sqlBlocks[0])).toEqual(
+          unlocatedStructDef({...sr, as: 'users'})
+        );
+      }
+    }
+  });
+
+  test('source from sql', () => {
+    const model = new TestTranslator(`
+      sql: users IS { select: """${selStmt}""" }
+      source: malloyUsers is from_sql(users) { primary_key: ai }
+    `);
+    expect(model).modelParsed();
+    const needReq = model.translate();
+    const needs = needReq?.compileSQL;
+    expect(needs).toBeDefined();
+    if (needs) {
+      const sql = makeSQLBlock([{sql: selStmt}], 'aConnection');
+      const refKey = needs.name;
+      model.update({compileSQL: {[refKey]: makeSchemaResponse(sql)}});
+      expect(model).modelCompiled();
+      const users = model.getSourceDef('malloyUsers');
+      expect(users).toBeDefined();
+    }
+  });
+
+  test('explore from imported sql-based-source', () => {
+    const createModel = `
+      sql: users IS { select: """${selStmt}""" }
+      source: malloyUsers is from_sql(users) { primary_key: ai }
+    `;
+    const model = new TestTranslator(`
+      import "createModel.malloy"
+      source: importUsers is malloyUsers
+      query: malloyUsers -> { project: * }
+      query: importUsers -> { project: * }
+    `);
+    model.importZone.define(
+      'internal://test/langtests/createModel.malloy',
+      createModel
+    );
+    expect(model).modelParsed();
+    const needReq = model.translate();
+    const needs = needReq?.compileSQL;
+    expect(needs).toBeDefined();
+    const sql = makeSQLBlock([{sql: selStmt}]);
+    model.update({compileSQL: {[sql.name]: makeSchemaResponse(sql)}});
+    expect(model).modelCompiled();
+  });
+
+  it('turducken', () => {
+    const m = new TestTranslator(`
+      sql: someSql is {
+        select: """SELECT * FROM %{ a -> { group_by: astr } }% WHERE 1=1"""
+      }
+    `);
+    expect(m).modelParsed();
+    const compileSql = m.translate().compileSQL;
+    expect(compileSql).toBeDefined();
+    if (compileSql) {
+      const select = compileSql.select[0];
+      const star = compileSql.select[1];
+      const where = compileSql.select[2];
+      expect(select).toEqual({sql: 'SELECT * FROM '});
+      expect(isSQLFragment(star)).toBeFalsy();
+      expect(where).toEqual({sql: ' WHERE 1=1'});
+    }
+  });
+  it('model preserved', () => {
+    const shouldBeOK = `
+      source: newa is a
+      sql: someSql is { select: """${selStmt}""" }
+      source: newaa is newa
+    `;
+    const model = new TestTranslator(shouldBeOK);
+    expect(model).modelParsed();
+    const needReq = model.translate();
+    const needs = needReq?.compileSQL;
+    expect(needs).toBeDefined();
+    const sql = makeSQLBlock([{sql: selStmt}]);
+    model.update({compileSQL: {[sql.name]: makeSchemaResponse(sql)}});
+    expect(model).modelCompiled();
+  });
+
+  test('explore from extended sql-based-source', () => {
+    const model = new TestTranslator(`
+      sql: sql_block IS { select: """${selStmt}""" }
+      source: malloy_source is from_sql(sql_block) { primary_key: ai }
+`);
+    const sql = makeSQLBlock([{sql: selStmt}]);
+    model.update({compileSQL: {[sql.name]: makeSchemaResponse(sql)}});
+    expect(model).modelCompiled();
+    const modelDef = model?.translate()?.translated?.modelDef;
+
+    const extModel = new MalloyTranslator('sqlblocktest://main');
+    extModel.importZone.define(
+      'sqlblocktest://main',
+      'query: malloy_source -> { project: * }'
+    );
+    extModel.translate(modelDef);
+    expect(extModel).toBeErrorless();
+  });
+});

--- a/packages/malloy/src/lang/test/sql-block.spec.ts
+++ b/packages/malloy/src/lang/test/sql-block.spec.ts
@@ -26,6 +26,7 @@ import {
   SQLBlockSource,
   SQLBlockStructDef,
   StructDef,
+  isSQLBlockStruct,
   isSQLFragment,
 } from '../../model';
 import {makeSQLBlock} from '../../model/sql_block';
@@ -86,9 +87,11 @@ describe('sql:', () => {
         const sr = makeSchemaResponse(sql);
         model.update({compileSQL: {[refKey]: sr}});
         expect(model).modelCompiled();
-        expect(unlocatedStructDef(model.sqlBlocks[0])).toEqual(
-          unlocatedStructDef({...sr, as: 'users'})
-        );
+        const expectThis = unlocatedStructDef({...sr, as: 'users'});
+        if (isSQLBlockStruct(expectThis)) {
+          expectThis.declaredSQLBlock = true;
+        }
+        expect(unlocatedStructDef(model.sqlBlocks[0])).toEqual(expectThis);
       }
     }
   });
@@ -109,6 +112,9 @@ describe('sql:', () => {
       expect(model).modelCompiled();
       const users = model.getSourceDef('malloyUsers');
       expect(users).toBeDefined();
+      if (users && isSQLBlockStruct(users)) {
+        expect(users.declaredSQLBlock).toBeUndefined();
+      }
     }
   });
 

--- a/packages/malloy/src/malloy.ts
+++ b/packages/malloy/src/malloy.ts
@@ -59,7 +59,7 @@ import {
   TurtleDef,
   expressionIsCalculation,
   flattenQuery,
-  isSQLBlock,
+  isSQLBlockStruct,
   isSQLFragment,
   FieldUnsupportedDef,
 } from './model';
@@ -282,7 +282,7 @@ export class Malloy {
               });
             }
             if (resolved.structDef) {
-              if (isSQLBlock(resolved.structDef)) {
+              if (isSQLBlockStruct(resolved.structDef)) {
                 translator.update({
                   compileSQL: {[expanded.name]: resolved.structDef},
                 });

--- a/packages/malloy/src/model/malloy_types.ts
+++ b/packages/malloy/src/model/malloy_types.ts
@@ -795,7 +795,11 @@ export interface StructDef extends NamedObject, ResultStructMetadata, Filtered {
 
 export interface SQLBlockStructDef extends StructDef {
   structSource: SubquerySource;
-  declaredSQLBlock?: boolean; // This is kind of a hack and should go
+  // This was added to that errors for structdefs created in sql: but NOT used in
+  // from_sql could error properly. This is kind of non-sensical, and once
+  // we decide if SQL blocks are StructDefs or Queries or Something Else
+  // this should go away.
+  declaredSQLBlock?: boolean;
 }
 
 export function isSQLBlockStruct(sd: StructDef): sd is SQLBlockStructDef {

--- a/packages/malloy/src/model/malloy_types.ts
+++ b/packages/malloy/src/model/malloy_types.ts
@@ -795,9 +795,10 @@ export interface StructDef extends NamedObject, ResultStructMetadata, Filtered {
 
 export interface SQLBlockStructDef extends StructDef {
   structSource: SubquerySource;
+  declaredSQLBlock?: boolean; // This is kind of a hack and should go
 }
 
-export function isSQLBlock(sd: StructDef): sd is SQLBlockStructDef {
+export function isSQLBlockStruct(sd: StructDef): sd is SQLBlockStructDef {
   const src = sd.structSource;
   return src.type === 'sql' && src.method === 'subquery';
 }


### PR DESCRIPTION
Fixes #1076 

StructDefs which resulted from an `sql:` statement now have a bit on them, in the structdef.

We clear that bit when we alias them into a `source:`

This allows us to treat sql blocks as if they were a thing which is neither a query nor structdef, and properly error when people forget to use from_sql (and not erroneously error when people do)

KInd of a lot of work to maintain a distinction which none of us believe in, but this is the most peaceful thing for me, given that there is no guarantee we are actually going to get to source/query, this PR correctly implements the current intended semantics for SQL blocks.

We will undo this when we do source/query, and that's OK with me too.