### PR TITLE
Support Explore object serialization with JSON

### DIFF
--- a/packages/malloy/src/index.ts
+++ b/packages/malloy/src/index.ts
@@ -93,9 +93,9 @@ export {
   JSONWriter,
   Parse,
   DataWriter,
+  Explore,
 } from './malloy';
 export type {
-  Explore,
   Model,
   PreparedQuery,
   PreparedResult,
@@ -115,6 +115,7 @@ export type {
   SQLBlockMaterializer,
   ExploreMaterializer,
   WriteStream,
+  SerializedExplore,
 } from './malloy';
 export type {RunSQLOptions} from './run_sql_options';
 export type {

--- a/packages/malloy/src/lang/test/model_serialization.spec.ts
+++ b/packages/malloy/src/lang/test/model_serialization.spec.ts
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files
+ * (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import {StructDef} from '../../model/malloy_types';
+import {Explore} from '../../malloy';
+
+export const CHILD_EXPLORE: StructDef = {
+  type: 'struct',
+  name: 'some_ns.child',
+  as: 'child',
+  dialect: 'standardsql',
+  structSource: {
+    type: 'table',
+    tablePath: 'some_ns.child',
+  },
+  structRelationship: {type: 'basetable', connectionName: 'bigquery'},
+  primaryKey: 'id1',
+  fields: [
+    {type: 'string', name: 'carrier'},
+    {
+      type: 'number',
+      name: 'flight_count',
+      expressionType: 'aggregate',
+      e: [{type: 'aggregate', function: 'count', e: []}],
+    },
+  ],
+};
+
+export const PARENT_EXPLORE: StructDef = {
+  type: 'struct',
+  name: 'some_ns.parent',
+  as: 'parent',
+  dialect: 'standardsql',
+  structSource: {
+    type: 'table',
+    tablePath: 'some_ns.parent',
+  },
+  structRelationship: {type: 'basetable', connectionName: 'bigquery'},
+  primaryKey: 'id2',
+  fields: [
+    {type: 'string', name: 'name'},
+    {
+      type: 'number',
+      name: 'some_parent_count',
+      expressionType: 'aggregate',
+      e: [{type: 'aggregate', function: 'count', e: []}],
+    },
+  ],
+};
+
+export const GRADPARENT_EXPLORE: StructDef = {
+  type: 'struct',
+  name: 'some_ns.gradparent',
+  as: 'parent',
+  dialect: 'standardsql',
+  structSource: {
+    type: 'table',
+    tablePath: 'some_ns.gradparent',
+  },
+  structRelationship: {type: 'basetable', connectionName: 'bigquery'},
+  primaryKey: 'id3',
+  fields: [
+    {type: 'string', name: 'name'},
+    {
+      type: 'number',
+      name: 'some_gradparent_count',
+      expressionType: 'aggregate',
+      e: [{type: 'aggregate', function: 'count', e: []}],
+    },
+  ],
+};
+
+export const SOURCE_EXPLORE: StructDef = {
+  type: 'struct',
+  name: 'some_ns.source',
+  as: 'source',
+  dialect: 'standardsql',
+  structSource: {
+    type: 'table',
+    tablePath: 'some_ns.source',
+  },
+  structRelationship: {type: 'basetable', connectionName: 'bigquery'},
+  primaryKey: 'id4',
+  fields: [
+    {type: 'string', name: 'name'},
+    {
+      type: 'number',
+      name: 'some_child_count',
+      expressionType: 'aggregate',
+      e: [{type: 'aggregate', function: 'count', e: []}],
+    },
+  ],
+};
+
+describe('serializeModel', () => {
+  test('Stringify on an `explore` with no parent nor source explore', async () => {
+    const parent_explore = new Explore(PARENT_EXPLORE);
+    expect(JSON.stringify(parent_explore)).toStrictEqual(
+      '{"_structDef":{"type":"struct","name":"some_ns.parent","as":"parent","dialect":"standardsql","structSource":{"type":"table","tablePath":"some_ns.parent"},"structRelationship":{"type":"basetable","connectionName":"bigquery"},"primaryKey":"id2","fields":[{"type":"string","name":"name"},{"type":"number","name":"some_parent_count","expressionType":"aggregate","e":[{"type":"aggregate","function":"count","e":[]}]}]}}'
+    );
+  });
+
+  test('No parent nor source explore', async () => {
+    const parent_explore = new Explore(PARENT_EXPLORE);
+    expect(Explore.fromJSON(parent_explore.toJSON())).toStrictEqual(
+      parent_explore
+    );
+  });
+
+  test('Having parent and source explores', async () => {
+    const gradparent_explore = new Explore(GRADPARENT_EXPLORE);
+    const parent_explore = new Explore(PARENT_EXPLORE, gradparent_explore);
+    const source_explore = new Explore(SOURCE_EXPLORE);
+    const child_explore = new Explore(
+      CHILD_EXPLORE,
+      parent_explore,
+      source_explore
+    );
+    expect(Explore.fromJSON(child_explore.toJSON())).toStrictEqual(
+      child_explore
+    );
+  });
+});

--- a/packages/malloy/src/malloy.ts
+++ b/packages/malloy/src/malloy.ts
@@ -1241,6 +1241,11 @@ abstract class Entity {
 }
 
 export type Field = AtomicField | QueryField | ExploreField;
+export type SerializedExplore = {
+  _structDef: StructDef;
+  sourceExplore?: SerializedExplore;
+  _parentExplore?: SerializedExplore;
+};
 
 export class Explore extends Entity {
   protected readonly _structDef: StructDef;
@@ -1408,6 +1413,26 @@ export class Explore extends Entity {
 
   public get structDef(): StructDef {
     return this._structDef;
+  }
+
+  public toJSON(): SerializedExplore {
+    return {
+      _structDef: this._structDef,
+      sourceExplore: this.sourceExplore?.toJSON(),
+      _parentExplore: this._parentExplore?.toJSON(),
+    };
+  }
+
+  public static fromJSON(main_explore: SerializedExplore): Explore {
+    const parentExplore =
+      main_explore._parentExplore !== undefined
+        ? Explore.fromJSON(main_explore._parentExplore)
+        : undefined;
+    const sourceExplore =
+      main_explore.sourceExplore !== undefined
+        ? Explore.fromJSON(main_explore.sourceExplore)
+        : undefined;
+    return new Explore(main_explore._structDef, parentExplore, sourceExplore);
   }
 }
 


### PR DESCRIPTION
This patch supports the `Explore` object serialization with JSON:
- encapsulated structDef in an Explore and all its parents, sources into a struct for JSON serialization.
- leave the server side optimization of `_fieldMap` field to future, as it contains self references.