### PR TITLE
Accept table read functions in duckdb as tables

### DIFF
--- a/packages/malloy/src/dialect/duckdb.ts
+++ b/packages/malloy/src/dialect/duckdb.ts
@@ -163,6 +163,11 @@ export class DuckDBDialect extends Dialect {
   }
 
   quoteTablePath(tableName: string): string {
+    // If this looks like a function call, don't quote, this lets you
+    // specify read_json_auto(...) for example, as if it were a table name
+    if (tableName.match(/^[a-z_]+\(.*\)$)/)) {
+      return tableName;
+    }
     return tableName.match(/\//) ? `'${tableName}'` : tableName;
   }
 


### PR DESCRIPTION
If we just turn off quoting, we gain the ability to treat a table read function in duckdb as a table ... enabling users to write

```
sql: user_from_json is { connection: "duckdb" select: """
   SELECT * from read_json_auto("some file", various options)
 """}
 
 source: users is from_sql(user_from_json) {
 ```
 
 as
 
 ```
 source: users is table('duckdb:read_json_auto("some file", various options)') {
 ```
 
 What we do is, if the table name starts with WORD OPEN_PAREN and ends with CLOSE PAREN, we just pass it through to duckdb to parse however it likes. This will let us read JSON, CSV and PARQUET files with all the options duckdb has, without having to have an SQL block