### PR TITLE
Fix  - no model was present error.

### DIFF
--- a/packages/malloy/src/model/malloy_query.ts
+++ b/packages/malloy/src/model/malloy_query.ts
@@ -89,6 +89,16 @@ function generateSQLStringLiteral(sourceString: string): string {
   return `'${sourceString}'`;
 }
 
+/** Parent from QueryStruct. */
+export declare interface ParentQueryStruct {
+  struct: QueryStruct;
+}
+
+/** Parent from QueryModel. */
+export declare interface ParentQueryModel {
+  model: QueryModel;
+}
+
 // Storage for SQL code for multi stage turtle pipelines that don't support UNNEST(ARRAY_AGG)
 interface OutputPipelinedSQL {
   sqlFieldName: string;
@@ -3440,10 +3450,8 @@ class QueryStruct extends QueryNode {
   constructor(
     fieldDef: StructDef,
     parent:
-      | {struct: QueryStruct}
-      | {
-          model: QueryModel;
-        }
+      | ParentQueryStruct
+      | ParentQueryModel
   ) {
     super(fieldDef);
     this.setParent(parent);
@@ -3710,7 +3718,7 @@ class QueryStruct extends QueryNode {
     }
   }
 
-  setParent(parent: {struct: QueryStruct} | {model: QueryModel}) {
+  setParent(parent: ParentQueryStruct | ParentQueryModel) {
     if ('struct' in parent) {
       this.parent = parent.struct;
     }

--- a/packages/malloy/src/model/malloy_query.ts
+++ b/packages/malloy/src/model/malloy_query.ts
@@ -3449,9 +3449,7 @@ class QueryStruct extends QueryNode {
 
   constructor(
     fieldDef: StructDef,
-    parent:
-      | ParentQueryStruct
-      | ParentQueryModel
+    parent: ParentQueryStruct | ParentQueryModel
   ) {
     super(fieldDef);
     this.setParent(parent);


### PR DESCRIPTION
Fix the "'Expected this query struct to have a parent, as no model was present.'" error is closure compilers.