### PR TITLE
Restore ability to compare timestamp and date values to NULL

### DIFF
--- a/packages/malloy/src/lang/ast/types/expression-def.ts
+++ b/packages/malloy/src/lang/ast/types/expression-def.ts
@@ -222,7 +222,11 @@ function timeCompare(
       return compose(lhs.value, op, rhs.value);
     }
   }
-  if (leftIsTime || rightIsTime) {
+  if (
+    (leftIsTime || rightIsTime) &&
+    lhs.dataType !== 'null' &&
+    rhs.dataType !== 'null'
+  ) {
     left.log(`Cannot compare a ${lhs.dataType} to a ${rhs.dataType}`);
     return ['false'];
   }

--- a/packages/malloy/src/lang/test/parse.spec.ts
+++ b/packages/malloy/src/lang/test/parse.spec.ts
@@ -1023,6 +1023,15 @@ describe('expressions', () => {
       }
     }
   });
+  test.each([
+    ['ats', 'timestamp'],
+    ['ad', 'date'],
+    ['ai', 'number'],
+    ['astr', 'string'],
+    ['abool', 'boolean'],
+  ])('Can compare field %s (type %s) to NULL', (name, _datatype) => {
+    expect(`${name} = NULL`).expressionCompiled();
+  });
 });
 describe('unspported fields in schema', () => {
   test('unsupported reference in result allowed', () => {


### PR DESCRIPTION
There was no test for this, and the timezone change broke it.
It is fixed and there is a test now