### PR TITLE
query: statement should error on redefine

### DIFF
--- a/packages/malloy/src/lang/ast/elements/define-query.ts
+++ b/packages/malloy/src/lang/ast/elements/define-query.ts
@@ -41,15 +41,18 @@ export class DefineQuery extends MalloyElement implements DocStatement {
   }
 
   execute(doc: Document): ModelDataRequest {
+    const existing = doc.getEntry(this.name);
+    if (existing) {
+      this.log(`Query '${this.name}' is already defined, cannot redefine`);
+      return;
+    }
     const entry: NamedQuery = {
       ...this.queryDetails.query(),
       type: 'query',
       name: this.name,
       location: this.location,
     };
-    const exported = true;
-    doc.setEntry(this.name, {entry, exported});
-    return undefined;
+    doc.setEntry(this.name, {entry, exported: true});
   }
 }
 

--- a/packages/malloy/src/lang/test/parse.spec.ts
+++ b/packages/malloy/src/lang/test/parse.spec.ts
@@ -295,6 +295,11 @@ describe('model statements', () => {
       `)
     );
   });
+  test('errors on redefinition of query', () => {
+    expect(
+      'query: q1 is a -> { project: * }, q1 is a -> { project: * }'
+    ).compileToFailWith("Query 'q1' is already defined, cannot redefine");
+  });
 });
 
 describe('explore properties', () => {


### PR DESCRIPTION
Fixes #1112 