### PR TITLE
Nested pipelines are busted in DuckDB

### DIFF
--- a/packages/malloy/src/dialect/dialect.ts
+++ b/packages/malloy/src/dialect/dialect.ts
@@ -146,7 +146,8 @@ export abstract class Dialect {
     alias: string,
     fieldList: DialectFieldList,
     needDistinctKey: boolean,
-    isArray: boolean
+    isArray: boolean,
+    isInNestedPipeline: boolean
   ): string;
 
   abstract sqlSumDistinctHashedKey(sqlDistinctKey: string): string;

--- a/packages/malloy/src/dialect/postgres.ts
+++ b/packages/malloy/src/dialect/postgres.ts
@@ -196,7 +196,8 @@ export class PostgresDialect extends Dialect {
     alias: string,
     fieldList: DialectFieldList,
     needDistinctKey: boolean,
-    isArray: boolean
+    isArray: boolean,
+    _isInNestedPipeline: boolean
   ): string {
     if (isArray) {
       if (needDistinctKey) {

--- a/packages/malloy/src/dialect/standardsql.ts
+++ b/packages/malloy/src/dialect/standardsql.ts
@@ -163,7 +163,8 @@ export class StandardSQLDialect extends Dialect {
     alias: string,
     fieldList: DialectFieldList,
     needDistinctKey: boolean,
-    isArray: boolean
+    isArray: boolean,
+    _isInNestedPipeline: boolean
   ): string {
     if (isArray) {
       if (needDistinctKey) {

--- a/packages/malloy/src/model/malloy_query.ts
+++ b/packages/malloy/src/model/malloy_query.ts
@@ -1657,6 +1657,13 @@ class QueryQuery extends QueryField {
     }
   }
 
+  inNestedPipeline(): boolean {
+    return (
+      this.parent.fieldDef.structSource.type === 'sql' &&
+      this.parent.fieldDef.structSource.method === 'nested'
+    );
+  }
+
   getFieldList(): QueryFieldDef[] {
     switch (this.firstSegment.type) {
       // case "index":
@@ -2337,12 +2344,14 @@ class QueryQuery extends QueryField {
           this.parent.fieldDef.structRelationship.isArray
       );
       // we need to generate primary key.  If parent has a primary key combine
+      // console.log(ji.alias, fieldExpression, this.inNestedPipeline());
       s += `${this.parent.dialect.sqlUnnestAlias(
         fieldExpression,
         ji.alias,
         ji.getDialectFieldList(),
         ji.makeUniqueKey,
-        structRelationship.isArray
+        structRelationship.isArray,
+        this.inNestedPipeline()
       )}\n`;
     } else if (structRelationship.type === 'inline') {
       throw new Error(

--- a/test/src/databases/bigquery-duckdb/nested_source_table.spec.ts
+++ b/test/src/databases/bigquery-duckdb/nested_source_table.spec.ts
@@ -205,7 +205,7 @@ describe.each(runtimes.runtimeList)(
     });
 
     test(`autobin - ${databaseName}`, async () => {
-      const result = await runtime
+      const _result = await runtime
         .loadQuery(
           `
           source: airports is table('malloytest.airports') + {
@@ -233,6 +233,7 @@ describe.each(runtimes.runtimeList)(
         `
         )
         .run();
+      // console.log(result.sql);
       // console.log(result.data.toObject());
       // expect(result.data.path(0, 'fieldName').value).toBe('channelGrouping');
       // expect(result.data.path(0, 'fieldValue').value).toBe('Organic Search');

--- a/test/src/databases/bigquery-duckdb/nested_source_table.spec.ts
+++ b/test/src/databases/bigquery-duckdb/nested_source_table.spec.ts
@@ -203,6 +203,41 @@ describe.each(runtimes.runtimeList)(
       // expect(result.data.path(0, "fieldValue").value).toBe("Organic Search");
       // expect(result.data.path(0, "weight").value).toBe(18);
     });
+
+    test(`autobin - ${databaseName}`, async () => {
+      const result = await runtime
+        .loadQuery(
+          `
+          source: airports is table('malloytest.airports') + {
+            measure:
+              airport_count is count()
+            query: by_elevation is {
+              aggregate: bin_size is NULLIF((max(elevation) - min(elevation))/30,0)
+              nest: data is {
+                group_by: elevation
+                aggregate: row_count is count()
+              }
+            }
+            -> {
+              group_by: elevation is floor(data.elevation/bin_size)*bin_size + bin_size/2
+              aggregate: airport_count is data.row_count.sum()
+              order_by: elevation
+            }
+          }
+
+          query: airports -> {
+            group_by: state is state
+            aggregate: airport_count
+            nest: by_elevation_bar_chart is by_elevation
+          }
+        `
+        )
+        .run();
+      // console.log(result.data.toObject());
+      // expect(result.data.path(0, 'fieldName').value).toBe('channelGrouping');
+      // expect(result.data.path(0, 'fieldValue').value).toBe('Organic Search');
+      // expect(result.data.path(0, "weight").value).toBe(18);
+    });
   }
 );
 


### PR DESCRIPTION
Aparently they didn't implement 

> Binder Error: Nested lateral joins or lateral joins in correlated subqueries are not (yet) supported

May have to revert to using array indexes :(