### PR TITLE
apparently you cant export as type and use as value in another projec…

### DIFF
--- a/packages/malloy-malloy-sql/src/index.ts
+++ b/packages/malloy-malloy-sql/src/index.ts
@@ -24,8 +24,8 @@ export {MalloySQLParser, MalloySQLParseError} from './malloySQLParser';
 export type {MalloySQLParse} from './malloySQLParser';
 export type {
   MalloySQLMalloyStatement,
-  MalloySQLStatementType,
   MalloySQLSQLStatement,
   MalloySQLStatement,
   MalloySQLParseErrorExpected,
 } from './types';
+export {MalloySQLStatementType} from './types';


### PR DESCRIPTION
…t..IF the project isnt being run locally? but it works locally with npm-link. i got no idea.