### PR TITLE
to properly shift malloy parse errors, need to know where embedded ma…

### DIFF
--- a/packages/malloy-malloy-sql/src/grammar/malloySQL.pegjs
+++ b/packages/malloy-malloy-sql/src/grammar/malloySQL.pegjs
@@ -16,11 +16,14 @@ other "query string" = s:$(!delimiter_start !comment !embedded_malloy .)+ {
 }
 
 embedded_malloy = parenthized_embedded_malloy / plain_embedded_malloy
-parenthized_embedded_malloy = '(' __ '%{' m:$((!'}%' .)*) '}%' __ ')' {
-  return {type: "malloy", text:text(), malloy:m, range:location(), parenthized: true}
+parenthized_embedded_malloy = '(' __ em:plain_embedded_malloy __ ')' {
+  return {type: "malloy", text:text(), malloy:em.malloy, malloyRange: em.malloyRange, range:location(), parenthized: true}
 }
-plain_embedded_malloy = '%{' m:$((!'}%' .)*) '}%' {
-  return {type: "malloy", text:text(), malloy:m, range:location(), parenthized: false}
+plain_embedded_malloy = '%{' m:malloy '}%' {
+  return {type: "malloy", text:text(), malloy:m.text, malloyRange: m.malloyRange, range:location(), parenthized: false}
+}
+malloy = (!'}%' .)* {
+  return {malloyRange: location(), text:text()}
 }
 
 delimiter =

--- a/packages/malloy-malloy-sql/src/grammar/test/parse.spec.ts
+++ b/packages/malloy-malloy-sql/src/grammar/test/parse.spec.ts
@@ -144,28 +144,24 @@ describe('MalloySQL parse', () => {
       const parse = MalloySQLParser.parse(
         '>>>sql connection:bigquery\nSELECT (  %{ malloy }%  )'
       );
-      expect(
-        (parse.statements[0] as MalloySQLSQLStatement).embeddedMalloyQueries[0]
-          .query
-      ).toBe(' malloy ');
-      expect(
-        (parse.statements[0] as MalloySQLSQLStatement).embeddedMalloyQueries[0]
-          .parenthized
-      ).toBeTruthy();
+      const stmt = parse.statements[0] as MalloySQLSQLStatement;
+      const embeddedMalloy = stmt.embeddedMalloyQueries[0];
+      expect(embeddedMalloy.query).toBe(' malloy ');
+      expect(embeddedMalloy.parenthized).toBeTruthy();
+      expect(embeddedMalloy.range.start.character).toBe(8);
+      expect(embeddedMalloy.malloyRange.start.character).toBe(13);
     });
 
     test('Non-parenthized embedded malloy', () => {
       const parse = MalloySQLParser.parse(
         '>>>sql connection:bigquery\nSELECT %{ malloy }%'
       );
-      expect(
-        (parse.statements[0] as MalloySQLSQLStatement).embeddedMalloyQueries[0]
-          .query
-      ).toBe(' malloy ');
-      expect(
-        (parse.statements[0] as MalloySQLSQLStatement).embeddedMalloyQueries[0]
-          .parenthized
-      ).toBeFalsy();
+      const stmt = parse.statements[0] as MalloySQLSQLStatement;
+      const embeddedMalloy = stmt.embeddedMalloyQueries[0];
+      expect(embeddedMalloy.query).toBe(' malloy ');
+      expect(embeddedMalloy.parenthized).toBeFalsy();
+      expect(embeddedMalloy.range.start.character).toBe(8);
+      expect(embeddedMalloy.malloyRange.start.character).toBe(10);
     });
   });
 

--- a/packages/malloy-malloy-sql/src/malloySQLParser.ts
+++ b/packages/malloy-malloy-sql/src/malloySQLParser.ts
@@ -196,6 +196,7 @@ export class MalloySQLParser {
               query: part.malloy,
               parenthized: part.parenthized,
               range: this.convertRange(part.range),
+              malloyRange: this.convertRange(part.malloyRange),
             };
           });
 

--- a/packages/malloy-malloy-sql/src/types.ts
+++ b/packages/malloy-malloy-sql/src/types.ts
@@ -53,6 +53,7 @@ export interface ParsedMalloySQLMalloyStatementPart {
   text: string;
   malloy: string;
   range: MalloySQLParseRange;
+  malloyRange: MalloySQLParseRange;
   parenthized: boolean;
 }
 
@@ -90,7 +91,8 @@ export interface MalloySQLStatementBase {
 
 export interface EmbeddedMalloyQuery {
   query: string;
-  range: DocumentRange;
+  range: DocumentRange; // the entire wrapped embedded malloy, i.e. "(%{ malloy }%)"
+  malloyRange: DocumentRange; // the malloy text only, i.e. " malloy "
   parenthized: boolean;
 }
 


### PR DESCRIPTION
…lloy starts (there might be space like SELECT (   %{ malloy %}  ))