### PR TITLE
in malloySQL, send the entire text of an embedded malloy query along …

### DIFF
--- a/packages/malloy-malloy-sql/src/grammar/test/parse.spec.ts
+++ b/packages/malloy-malloy-sql/src/grammar/test/parse.spec.ts
@@ -172,9 +172,9 @@ describe('MalloySQL parse', () => {
       );
       expect(parse.statements).toHaveLength(1);
       expect(parse.statements[0].type).toBe(MalloySQLStatementType.SQL);
-      expect(parse.statements[0].statementText).toBe('SELECT 1');
+      expect(parse.statements[0].text).toBe('SELECT 1');
       expect(parse.statements[0].config?.connection).toBe('bigquery');
-      expect(parse.statements[0].statementIndex).toBe(0);
+      expect(parse.statements[0].index).toBe(0);
       expect(parse.statements[0].range.start.line).toBe(1);
       expect(parse.statements[0].range.start.character).toBe(0);
       expect(parse.statements[0].range.end.character).toBe(8);
@@ -186,18 +186,16 @@ describe('MalloySQL parse', () => {
       );
       expect(parse.statements).toHaveLength(2);
       expect(parse.statements[0].type).toBe(MalloySQLStatementType.SQL);
-      expect(parse.statements[0].statementText).toBe('SELECT 1\n');
+      expect(parse.statements[0].text).toBe('SELECT 1\n');
       expect(parse.statements[0].config?.connection).toBe('bigquery');
-      expect(parse.statements[0].statementIndex).toBe(0);
+      expect(parse.statements[0].index).toBe(0);
       expect(parse.statements[0].range.start.line).toBe(1);
       expect(parse.statements[0].range.start.character).toBe(0);
       expect(parse.statements[0].range.end.character).toBe(0);
 
       expect(parse.statements[1].type).toBe(MalloySQLStatementType.MALLOY);
-      expect(parse.statements[1].statementText).toBe(
-        'import "airports.malloy"'
-      );
-      expect(parse.statements[1].statementIndex).toBe(1);
+      expect(parse.statements[1].text).toBe('import "airports.malloy"');
+      expect(parse.statements[1].index).toBe(1);
       expect(parse.statements[1].range.start.line).toBe(3);
       expect(parse.statements[1].range.start.character).toBe(0);
       expect(parse.statements[1].range.end.character).toBe(24);
@@ -209,11 +207,11 @@ describe('MalloySQL parse', () => {
       );
       expect(parse.statements).toHaveLength(2);
       expect(parse.statements[0].type).toBe(MalloySQLStatementType.SQL);
-      expect(parse.statements[0].statementText).toBe(
+      expect(parse.statements[0].text).toBe(
         'SELECT 1 FROM %{ malloy-here }%;\n'
       );
       expect(parse.statements[0].config?.connection).toBe('bigquery');
-      expect(parse.statements[0].statementIndex).toBe(0);
+      expect(parse.statements[0].index).toBe(0);
       expect(parse.statements[0].range.start.line).toBe(1);
       expect(parse.statements[0].range.start.character).toBe(0);
       expect(parse.statements[0].range.end.character).toBe(0);
@@ -223,14 +221,13 @@ describe('MalloySQL parse', () => {
       expect(embeddedMalloy).toHaveLength(1);
       expect(embeddedMalloy[0].parenthized).toBeFalsy();
       expect(embeddedMalloy[0].query).toBe(' malloy-here ');
+      expect(embeddedMalloy[0].text).toBe('%{ malloy-here }%');
       expect(embeddedMalloy[0].range.start.line).toBe(1);
       expect(embeddedMalloy[0].range.start.character).toBe(14);
 
       expect(parse.statements[1].type).toBe(MalloySQLStatementType.MALLOY);
-      expect(parse.statements[1].statementText).toBe(
-        'import "airports.malloy"'
-      );
-      expect(parse.statements[1].statementIndex).toBe(1);
+      expect(parse.statements[1].text).toBe('import "airports.malloy"');
+      expect(parse.statements[1].index).toBe(1);
       expect(parse.statements[1].range.start.line).toBe(3);
       expect(parse.statements[1].range.start.character).toBe(0);
       expect(parse.statements[1].range.end.character).toBe(24);

--- a/packages/malloy-malloy-sql/src/malloySQLParser.ts
+++ b/packages/malloy-malloy-sql/src/malloySQLParser.ts
@@ -161,8 +161,8 @@ export class MalloySQLParser {
       }
 
       const base: MalloySQLStatementBase = {
-        statementIndex,
-        statementText: parsedStatement.statementText,
+        index: statementIndex,
+        text: parsedStatement.statementText,
         range: this.convertRange(parsedStatement.range),
         delimiterRange: this.convertRange(parsedStatement.delimiterRange),
       };
@@ -197,6 +197,7 @@ export class MalloySQLParser {
               query: part.malloy,
               parenthized: part.parenthized,
               range: this.convertRange(part.range),
+              text: part.text,
               malloyRange: this.convertRange(part.malloyRange),
             };
           });

--- a/packages/malloy-malloy-sql/src/types.ts
+++ b/packages/malloy-malloy-sql/src/types.ts
@@ -82,15 +82,16 @@ export enum MalloySQLStatementType {
 }
 
 export interface MalloySQLStatementBase {
-  statementIndex: number;
-  statementText: string;
+  index: number;
+  text: string;
   config?: MalloySQLStatmentConfig;
   range: DocumentRange;
   delimiterRange: DocumentRange;
 }
 
 export interface EmbeddedMalloyQuery {
-  query: string;
+  query: string; // the malloy part only
+  text: string; // the entire wrapped embedded malloy text i.e. "(%{ malloy }%)"
   range: DocumentRange; // the entire wrapped embedded malloy, i.e. "(%{ malloy }%)"
   malloyRange: DocumentRange; // the malloy text only, i.e. " malloy "
   parenthized: boolean;
@@ -102,7 +103,7 @@ export interface MalloySQLMalloyStatement extends MalloySQLStatementBase {
 
 export interface MalloySQLSQLStatement extends MalloySQLStatementBase {
   type: MalloySQLStatementType.SQL;
-  statementIndex: number;
+  index: number;
   embeddedMalloyQueries: EmbeddedMalloyQuery[];
 }
 


### PR DESCRIPTION
…with the query-only text. This enables simpler string replacement without having to start passing offsets. standardize property names a bit as well