### PR TITLE
Allow null to be first branch value of pick statement

### DIFF
--- a/packages/malloy/src/lang/ast/expressions/expr-coalesce.ts
+++ b/packages/malloy/src/lang/ast/expressions/expr-coalesce.ts
@@ -21,7 +21,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import {maxExpressionType, mergeEvalSpaces, mkExpr} from '../../../model';
+import {maxExpressionType, mkExpr} from '../../../model';
 import {FT} from '../fragtype-utils';
 import {ExprValue} from '../types/expr-value';
 import {ExpressionDef} from '../types/expression-def';
@@ -55,7 +55,6 @@ export class ExprCoalesce extends ExpressionDef {
         whenNull.expressionType
       ),
       value: mkExpr`COALESCE(${maybeNull.value},${whenNull.value})`,
-      evalSpace: mergeEvalSpaces(maybeNull.evalSpace, whenNull.evalSpace),
     };
   }
 }

--- a/packages/malloy/src/lang/ast/expressions/expr-coalesce.ts
+++ b/packages/malloy/src/lang/ast/expressions/expr-coalesce.ts
@@ -21,7 +21,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import {maxExpressionType, mkExpr} from '../../../model';
+import {maxExpressionType, mergeEvalSpaces, mkExpr} from '../../../model';
 import {FT} from '../fragtype-utils';
 import {ExprValue} from '../types/expr-value';
 import {ExpressionDef} from '../types/expression-def';
@@ -55,6 +55,7 @@ export class ExprCoalesce extends ExpressionDef {
         whenNull.expressionType
       ),
       value: mkExpr`COALESCE(${maybeNull.value},${whenNull.value})`,
+      evalSpace: mergeEvalSpaces(maybeNull.evalSpace, whenNull.evalSpace),
     };
   }
 }

--- a/packages/malloy/src/lang/ast/expressions/pick-when.ts
+++ b/packages/malloy/src/lang/ast/expressions/pick-when.ts
@@ -41,7 +41,7 @@ interface Choice {
 }
 
 function typeCoalesce(ev1: ExprValue | undefined, ev2: ExprValue): ExprValue {
-  return (ev1 === undefined || ev1.dataType === 'null') ? ev2 : ev1;
+  return ev1 === undefined || ev1.dataType === 'null' ? ev2 : ev1;
 }
 
 export class Pick extends ExpressionDef {
@@ -85,9 +85,7 @@ export class Pick extends ExpressionDef {
       );
       if (returnType && !FT.typeEq(returnType, thenExpr, true)) {
         const whenType = FT.inspect(thenExpr);
-        this.log(
-          `pick type '${whenType}', expected '${returnType.dataType}'`
-        );
+        this.log(`pick type '${whenType}', expected '${returnType.dataType}'`);
         return errorFor('pick when type');
       }
       returnType = typeCoalesce(returnType, thenExpr);
@@ -152,7 +150,7 @@ export class Pick extends ExpressionDef {
         this.log(`pick type '${whenType}', expected '${returnType.dataType}'`);
         return errorFor('pick value type');
       }
-      returnType = typeCoalesce(returnType,aChoice.pick);
+      returnType = typeCoalesce(returnType, aChoice.pick);
       anyExpressionType = maxExpressionType(
         anyExpressionType,
         maxExpressionType(

--- a/packages/malloy/src/lang/test/parse.spec.ts
+++ b/packages/malloy/src/lang/test/parse.spec.ts
@@ -56,6 +56,15 @@ function exprOK(s: string): TestFunc {
   };
 }
 
+function exprType(s: string, t: string): TestFunc {
+  return () => {
+    const expr = new BetaExpression(s);
+    expect(expr).modelParsed();
+    expect(expr.generated().dataType).toBe(t);
+    return undefined;
+  };
+}
+
 function modelOK(s: string): TestFunc {
   return () => {
     const m = new TestTranslator(s);
@@ -916,6 +925,18 @@ describe('expressions', () => {
       exprOK(`
         astr ? pick 'missing value' when NULL
     `)
+    );
+    test(
+      'null branch with else',
+      exprType("astr ? pick null when = '42' else 3", 'number')
+    );
+    test(
+      'null branch no else',
+      exprType("astr ? pick null when = '42'", 'string')
+    );
+    test(
+      'null branch no apply',
+      exprType('pick null when 1 = 1 else 3', 'number')
     );
     test(
       'tiering',


### PR DESCRIPTION
Previously the following expressions all had a type of `null`, and therefore could not be used to define a field:
```malloy
my_string ? pick null when = 'bad_value'
my_string ? pick null when = 'bad_value' else my_string
pick null when my_string = 'bad_value' else my_string
```

Now all of those get type `string` and can be used to define a field.

Also added a new test function `exprType` in `parse.spec.ts` to check the type of an expression, not just that it parsed, as in this case, the expressions were already parsing, but just had a type of `null`. We may want to consider using this function in other tests, too.