### PR TITLE
Update getNamedQuery handling when requesting a named query that does not exist.

### DIFF
--- a/packages/malloy/src/malloy.ts
+++ b/packages/malloy/src/malloy.ts
@@ -627,7 +627,7 @@ export class Model {
    */
   public getPreparedQueryByName(queryName: string): PreparedQuery {
     const query = this.modelDef.contents[queryName];
-    if (query.type === 'query') {
+    if (query?.type === 'query') {
       return new PreparedQuery(query, this.modelDef, queryName);
     }
 

--- a/test/src/api.spec.ts
+++ b/test/src/api.spec.ts
@@ -76,4 +76,9 @@ describe('extendModel', () => {
     const twoState = await q2.run();
     expect(twoState.data.path(0, 'state').value).toBe('CA');
   });
+  test('returns helpful error message if named query does not exist', async () => {
+    await expect(runtime.getQueryByName('', 'Dummy Query')).rejects.toThrow(
+      'Given query name does not refer to a named query.'
+    );
+  });
 });


### PR DESCRIPTION
- Fix unsafe property access of a returned record that could be undefined.
- Add test to verify new behavior.