### PR TITLE
DO NOT MERGE: change the way DuckDB deals with Nested data.

### DIFF
--- a/packages/malloy/src/dialect/duckdb/duckdb.ts
+++ b/packages/malloy/src/dialect/duckdb/duckdb.ts
@@ -62,7 +62,7 @@ export class DuckDBDialect extends Dialect {
   stringTypeName = 'VARCHAR';
   divisionIsInteger = true;
   supportsSumDistinctFunction = true;
-  unnestWithNumbers = true;
+  unnestWithNumbers = false;
   defaultSampling = {rows: 50000};
   supportUnnestArrayAgg = true;
   supportsAggDistinct = true;


### PR DESCRIPTION
When DuckDB 0.9.0 releases it should support lateral joins in nested queries.  This should fix the failure in the nested_source_table.spec.ts and then it should be safe to switch mechanisms.

