### PR TITLE
Fix duckdb malloy version

### DIFF
--- a/packages/malloy-db-duckdb/package.json
+++ b/packages/malloy-db-duckdb/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@malloydata/duckdb-wasm": "0.0.2",
-    "@malloydata/malloy": "^0.0.40",
+    "@malloydata/malloy": "^0.0.47",
     "apache-arrow": "^11.0.0",
     "duckdb": "0.8.1",
     "web-worker": "^1.2.0"


### PR DESCRIPTION
A bad merge accidentally pinned the duckdb package's malloy version to 0.0.40, and that has cause it to diverge.