### PR TITLE
Attach document level tags on model

### DIFF
--- a/packages/malloy/src/malloy.ts
+++ b/packages/malloy/src/malloy.ts
@@ -582,7 +582,7 @@ export class MalloyError extends Error {
 /**
  * A compiled Malloy document.
  */
-export class Model {
+export class Model implements Taggable {
   private modelDef: ModelDef;
   private queryList: InternalQuery[];
   private sqlBlocks: SQLBlockStructDef[];
@@ -605,6 +605,10 @@ export class Model {
     this.sqlBlocks = sqlBlocks;
     this._referenceAt = referenceAt;
     this.problems = problems;
+  }
+
+  getTags(): Tags {
+    return new Tags(this.modelDef.annotation);
   }
 
   /**

--- a/packages/malloy/src/tags.ts
+++ b/packages/malloy/src/tags.ts
@@ -95,10 +95,12 @@ function parseTag(
   src: string,
   tagProp: MalloyTagProperties
 ): MalloyTag | undefined {
-  if (src.startsWith('#" ')) {
-    return {docString: src.slice(3)};
+  const docMatch = src.match(/^##?" /);
+  if (docMatch) {
+    return {docString: src.slice(docMatch[0].length)};
   }
-  if (!src.startsWith('# ')) {
+  const propMatch = src.match(/^##? /);
+  if (!propMatch) {
     return;
   }
   /*
@@ -108,7 +110,7 @@ function parseTag(
    *
    * Seems wrong to be writing a parser though.
    */
-  const tokens = tokenize(src.slice(2));
+  const tokens = tokenize(src.slice(propMatch[0].length));
   let tn = 0;
   const lastToken = tokens.length - 1;
   while (tn <= lastToken) {

--- a/test/src/tags.spec.ts
+++ b/test/src/tags.spec.ts
@@ -116,6 +116,19 @@ import {runtimeFor} from './runtimes';
 
 const runtime = runtimeFor('duckdb');
 
+describe('## top level', () => {
+  test.skip('top level tags are available in the model def', async () => {
+    // const model = await runtime.loadModel(`
+    //   ## propertyTag
+    //   ##" Doc String
+    // `);
+    // const modelDesc = model.getTags().getMalloyTags();
+    // expect(modelDesc).toEqual({
+    //   properties: {propertyTag: true},
+    //   docStrings: [ '##" Doc String\n'],
+    // });
+  });
+});
 describe('tags in results', () => {
   test('nameless query', async () => {
     const loaded = runtime.loadQuery(

--- a/test/src/tags.spec.ts
+++ b/test/src/tags.spec.ts
@@ -117,16 +117,20 @@ import {runtimeFor} from './runtimes';
 const runtime = runtimeFor('duckdb');
 
 describe('## top level', () => {
-  test.skip('top level tags are available in the model def', async () => {
-    // const model = await runtime.loadModel(`
-    //   ## propertyTag
-    //   ##" Doc String
-    // `);
-    // const modelDesc = model.getTags().getMalloyTags();
-    // expect(modelDesc).toEqual({
-    //   properties: {propertyTag: true},
-    //   docStrings: [ '##" Doc String\n'],
-    // });
+  test('top level tags are available in the model def', async () => {
+    const model = await runtime
+      .loadModel(
+        `
+      ## propertyTag
+      ##" Doc String
+    `
+      )
+      .getModel();
+    const modelDesc = model.getTags().getMalloyTags();
+    expect(modelDesc).toEqual({
+      properties: {propertyTag: true},
+      docStrings: ['Doc String\n'],
+    });
   });
 });
 describe('tags in results', () => {


### PR DESCRIPTION
We use special comments in files to tell the renderer where to find the json file which describes the render parameters.

Those should be in the "model" tags, which I implemented, but then forgot to provide an API for.

Fixed.

* Tags starting with `##` are file/document/model tags ( as they always were )
* `await XXX.getModel().getTags().getMalloyTags()` will now get you the tag parse for a model