### PR TITLE
Add new `lensRange` for `DocumentSymbol`s to move code lenses above tags

### DIFF
--- a/packages/malloy/src/lang/parse-tree-walkers/document-symbol-walker.ts
+++ b/packages/malloy/src/lang/parse-tree-walkers/document-symbol-walker.ts
@@ -34,9 +34,11 @@ export interface DocumentSymbol {
   type: string;
   name: string;
   children: DocumentSymbol[];
+  lensRange?: DocumentRange;
 }
 
 class DocumentSymbolWalker implements MalloyParserListener {
+  private blockRange: DocumentRange | undefined;
   constructor(
     readonly translator: MalloyTranslation,
     readonly tokens: CommonTokenStream,
@@ -52,13 +54,26 @@ class DocumentSymbolWalker implements MalloyParserListener {
     return this.scopes[this.scopes.length - 1];
   }
 
+  enterTopLevelQueryDefs(pcx: parser.TopLevelQueryDefsContext) {
+    const blockRange = this.translator.rangeFromContext(pcx);
+    const defs = pcx.topLevelQueryDef();
+    if (defs.length === 1) {
+      this.blockRange = blockRange;
+    }
+  }
+
   enterTopLevelQueryDef(pcx: parser.TopLevelQueryDefContext) {
     this.symbols.push({
       range: this.translator.rangeFromContext(pcx),
       name: pcx.queryName().text,
       type: 'query',
       children: [],
+      lensRange: this.blockRange,
     });
+  }
+
+  exitTopLevelQueryDefs(_pcx: parser.TopLevelQueryDefsContext) {
+    this.blockRange = undefined;
   }
 
   enterRunStatementDef(pcx: parser.RunStatementDefContext) {
@@ -67,6 +82,7 @@ class DocumentSymbolWalker implements MalloyParserListener {
       name: 'unnamed_query',
       type: 'unnamed_query',
       children: [],
+      lensRange: this.translator.rangeFromContext(pcx),
     });
   }
 
@@ -76,24 +92,43 @@ class DocumentSymbolWalker implements MalloyParserListener {
       name: pcx.queryName().id().text,
       type: 'query',
       children: [],
+      lensRange: this.translator.rangeFromContext(pcx),
     });
   }
 
-  enterTopLevelAnonQueryDef(pcx: parser.TopLevelAnonQueryDefContext) {
+  enterAnonymousQuery(pcx: parser.AnonymousQueryContext) {
     this.symbols.push({
-      range: this.translator.rangeFromContext(pcx),
+      range: this.translator.rangeFromContext(
+        pcx.topLevelAnonQueryDef().query()
+      ),
       name: 'unnamed_query',
       type: 'unnamed_query',
       children: [],
+      lensRange: this.translator.rangeFromContext(pcx),
     });
   }
 
+  enterDefineSourceStatement(pcx: parser.DefineSourceStatementContext) {
+    const blockRange = this.translator.rangeFromContext(pcx);
+    const sourcePl = pcx.sourcePropertyList();
+    const defs = sourcePl.sourceDefinition();
+    if (defs.length === 1) {
+      this.blockRange = blockRange;
+    }
+  }
+
+  exitDefineSourceStatement(_pcx: parser.DefineSourceStatementContext) {
+    this.blockRange = undefined;
+  }
+
   enterSourceDefinition(pcx: parser.SourceDefinitionContext) {
+    const range = this.translator.rangeFromContext(pcx);
     this.scopes.push({
-      range: this.translator.rangeFromContext(pcx),
+      range,
       name: pcx.sourceNameDef().id().text,
       type: 'explore',
       children: [],
+      lensRange: this.blockRange,
     });
   }
 
@@ -104,12 +139,21 @@ class DocumentSymbolWalker implements MalloyParserListener {
     }
   }
 
+  enterDefExploreQuery(pcx: parser.DefExploreQueryContext) {
+    const blockRange = this.translator.rangeFromContext(pcx);
+    const defs = pcx.subQueryDefList().exploreQueryDef();
+    if (defs.length === 1) {
+      this.blockRange = blockRange;
+    }
+  }
+
   enterExploreQueryDef(pcx: parser.ExploreQueryDefContext) {
     const symbol = {
       range: this.translator.rangeFromContext(pcx),
       name: pcx.exploreQueryNameDef().id().text,
       type: 'query',
       children: [],
+      lensRange: this.blockRange,
     };
     const parent = this.peekScope();
     if (parent) {
@@ -120,6 +164,10 @@ class DocumentSymbolWalker implements MalloyParserListener {
 
   exitExploreQueryDef(_pcx: parser.ExploreQueryDefContext) {
     this.popScope();
+  }
+
+  exitDefExploreQuery(_pcx: parser.DefExploreQueryContext) {
+    this.blockRange = undefined;
   }
 
   handleNestEntry(pcx: parser.NestExistingContext | parser.NestDefContext) {

--- a/packages/malloy/src/lang/parse-tree-walkers/document-symbol-walker.ts
+++ b/packages/malloy/src/lang/parse-tree-walkers/document-symbol-walker.ts
@@ -212,11 +212,11 @@ class DocumentSymbolWalker implements MalloyParserListener {
   }
 
   enterDefineSQLStatement(pcx: parser.DefineSQLStatementContext) {
-    const name = pcx.nameSQLBlock()?.text;
+    const name = pcx.nameSQLBlock().text;
     const symbol = {
       range: this.translator.rangeFromContext(pcx),
-      name: name || 'unnamed_sql',
-      type: name === undefined ? 'unnamed_sql' : 'sql',
+      name: name,
+      type: 'sql',
       children: [],
     };
     this.symbols.push(symbol);

--- a/packages/malloy/src/lang/test/test-translator.ts
+++ b/packages/malloy/src/lang/test/test-translator.ts
@@ -516,7 +516,9 @@ export function markSource(
         end: {
           line: start.line + bitLines.length - 1,
           character:
-            bitLines.length === 1 ? start.character + mark.length : mark.length,
+            bitLines.length === 1
+              ? start.character + mark.length
+              : bitLines[bitLines.length - 1].length,
         },
       },
     };

--- a/packages/malloy/src/malloy.ts
+++ b/packages/malloy/src/malloy.ts
@@ -958,6 +958,19 @@ export class DocumentRange {
       end: this.end.toJSON(),
     };
   }
+
+  /**
+   * Construct a DocumentRange from JSON.
+   */
+  public static fromJSON(json: {
+    start: {line: number; character: number};
+    end: {line: number; character: number};
+  }): DocumentRange {
+    return new DocumentRange(
+      new DocumentPosition(json.start.line, json.start.character),
+      new DocumentPosition(json.end.line, json.end.character)
+    );
+  }
 }
 
 /**
@@ -1001,21 +1014,16 @@ export class DocumentPosition {
  */
 export class DocumentSymbol {
   private _range: DocumentRange;
+  private _lensRange: DocumentRange | undefined;
   private _type: string;
   private _name: string;
   private _children: DocumentSymbol[];
 
   constructor(documentSymbol: DocumentSymbolDefinition) {
-    this._range = new DocumentRange(
-      new DocumentPosition(
-        documentSymbol.range.start.line,
-        documentSymbol.range.start.character
-      ),
-      new DocumentPosition(
-        documentSymbol.range.end.line,
-        documentSymbol.range.end.character
-      )
-    );
+    this._range = DocumentRange.fromJSON(documentSymbol.range);
+    this._lensRange = documentSymbol.lensRange
+      ? DocumentRange.fromJSON(documentSymbol.lensRange)
+      : undefined;
     this._type = documentSymbol.type;
     this._name = documentSymbol.name;
     this._children = documentSymbol.children.map(
@@ -1028,6 +1036,15 @@ export class DocumentSymbol {
    */
   public get range(): DocumentRange {
     return this._range;
+  }
+
+  /**
+   * @return The range of characters in the source Malloy document that define this symbol,
+   * including tags. Note: "block tags" are included if there is exactly one
+   * definition in the block.
+   */
+  public get lensRange(): DocumentRange {
+    return this._lensRange ?? this._range;
   }
 
   /**


### PR DESCRIPTION
The rule is that the `lensRange` for a document symbol will start before the "block tags" (tags before the `type:`) unless there is more than one definition in the block, in which case it will start before the "individual tags" the tags before the `name is ...`. 

This is implemented for:
* Turtles
* Unnamed top level queries
* Top level queries
* Sources
As these are the only things with code lenses (except SQL blocks, see note below). If we add more code lenses, we will have to implement this for those things, too.

Note: SQL blocks are not included here, as we are phasing them out, and they currently don't support tags at all. Also, run "references" (`run: query_name` as opposed to `run: -> query_name`) are not included, as tags are not supported for those yet. 


Turtles:
<img width="640" alt="Screenshot 2023-06-26 at 10 57 45 AM" src="https://github.com/malloydata/malloy/assets/3538955/ccf0bf26-24c8-4fd7-b475-4086e2528b4e">
Unnamed queries:
<img width="525" alt="Screenshot 2023-06-26 at 10 57 39 AM" src="https://github.com/malloydata/malloy/assets/3538955/204f871c-e335-41d3-9722-a7d72c26f107">
Named queries:
<img width="501" alt="Screenshot 2023-06-26 at 10 57 28 AM" src="https://github.com/malloydata/malloy/assets/3538955/a761e0a4-e87e-427f-a29f-92940163c46e">
Sources:
<img width="518" alt="Screenshot 2023-06-26 at 10 57 10 AM" src="https://github.com/malloydata/malloy/assets/3538955/500e8fb1-2a4c-4cb1-aaec-30843b258f41">
