### PR TITLE
Return defined renderer

### DIFF
--- a/packages/malloy-render/src/html/html_view.ts
+++ b/packages/malloy-render/src/html/html_view.ts
@@ -177,6 +177,7 @@ function getRendererOptions(
       return updateOrCreateRenderer(suffix, label, suffixMap, renderer);
     }
   }
+  return renderer;
 }
 
 function updateOrCreateRenderer(


### PR DESCRIPTION
Fix case where dataStyles specifies a renderer and there are no tag or magic name overrides.