### PR TITLE
Cleanup Strings

### DIFF
--- a/packages/malloy/src/lang/ast/expressions/expr-string.ts
+++ b/packages/malloy/src/lang/ast/expressions/expr-string.ts
@@ -31,9 +31,7 @@ export class ExprString extends ExpressionDef {
   value: string;
   constructor(src: string) {
     super();
-    const bareStr = src.slice(1, -1);
-    const val = bareStr.replace(/\\(.)/g, '$1');
-    this.value = val;
+    this.value = src;
   }
 
   getExpression(_fs: FieldSpace): ExprValue {

--- a/packages/malloy/src/lang/grammar/DeltaMalloy.g4
+++ b/packages/malloy/src/lang/grammar/DeltaMalloy.g4
@@ -46,7 +46,7 @@ scalarValue
   | scalarValue ARROW scalarValue
   | scalarValue refinement
   | refinement
-  | TABLE STRING_LITERAL
+  | TABLE SQ_STRING
   | OPAREN scalarValue CPAREN
   ;
 
@@ -73,7 +73,7 @@ malloyType: STRING | NUMBER | BOOLEAN | DATE | TIMESTAMP;
 compareOp: MATCH | NOT_MATCH | GT | LT | GTE | LTE | EQ | NE;
 
 literal
-  : STRING_LITERAL                              # exprString
+  : SQ_STRING                              # exprString
   | (NUMERIC_LITERAL | INTEGER_LITERAL)         # exprNumber
   | dateLiteral                                 # exprTime
   | NULL                                        # exprNULL
@@ -207,7 +207,7 @@ STRING_ESCAPE
   | '\\' '\\'
   | '\\' .;
 HACKY_REGEX: ('/' | [rR]) '\'' (STRING_ESCAPE | ~('\\' | '\''))* '\'';
-STRING_LITERAL: '\'' (STRING_ESCAPE | ~('\\' | '\''))* '\'';
+SQ_STRING: '\'' (STRING_ESCAPE | ~('\\' | '\''))* '\'';
 
 fragment SPACE_CHAR: [ \u000B\t\r\n];
 

--- a/packages/malloy/src/lang/grammar/MalloyLexer.g4
+++ b/packages/malloy/src/lang/grammar/MalloyLexer.g4
@@ -23,7 +23,7 @@
 
 lexer grammar MalloyLexer;
 
-JSON_STRING: '"' (ESC | SAFECODEPOINT)* '"';
+DQ_STRING: '"' (ESC | SAFECODEPOINT)* '"';
 
 fragment ESC: '\\' (["\\/bfnrt] | UNICODE);
 fragment UNICODE: 'u' HEX HEX HEX HEX;
@@ -128,7 +128,7 @@ STRING_ESCAPE
   ;
 
 HACKY_REGEX: ('/' | [rR]) '\'' (STRING_ESCAPE | ~('\\' | '\''))* '\'';
-STRING_LITERAL: '\'' (STRING_ESCAPE | ~('\\' | '\''))* '\'';
+SQ_STRING: '\'' (STRING_ESCAPE | ~('\\' | '\''))* '\'';
 fragment F_TO_EOL: ~[\r\n]* (('\r'? '\n') | EOF);
 DOC_ANNOTATION: '##' F_TO_EOL;
 ANNOTATION: '#' F_TO_EOL;

--- a/packages/malloy/src/lang/grammar/MalloyLexer.g4
+++ b/packages/malloy/src/lang/grammar/MalloyLexer.g4
@@ -122,14 +122,13 @@ STRING_ESCAPE
   ;
 HACKY_REGEX: ('/' | [rR]) '\'' (STRING_ESCAPE | ~('\\' | '\''))* '\'';
 
-fragment ESC: '\\' (["\\/bfnrt] | UNICODE);
-fragment UNICODE: 'u' HEX HEX HEX HEX;
 fragment HEX: [0-9a-fA-F];
-fragment SAFECODEPOINT: ~ ["\\\u0000-\u001F];
-fragment ESC2: '\\' (['\\/bfnrt] | UNICODE);
-fragment SAFECODEPOINT2: ~ ['\\\u0000-\u001F];
-DQ_STRING: '"'  (ESC | SAFECODEPOINT)* '"';
-SQ_STRING: '\'' (ESC2 | SAFECODEPOINT2)* '\'';
+fragment UNICODE: '\\u' HEX HEX HEX HEX;
+fragment SAFE_NON_QUOTE: ~ ['"`\\\u0000-\u001F];
+fragment ESCAPED: '\\' .;
+SQ_STRING: '\'' (UNICODE | ESCAPED | SAFE_NON_QUOTE | ["`])* '\'';
+DQ_STRING: '"' (UNICODE | ESCAPED | SAFE_NON_QUOTE | ['`])* '"';
+BQ_STRING: '`' (UNICODE | ESCAPED | SAFE_NON_QUOTE | ['"])* '`';
 
 fragment F_TO_EOL: ~[\r\n]* (('\r'? '\n') | EOF);
 DOC_ANNOTATION: '##' F_TO_EOL;
@@ -196,8 +195,6 @@ NUMERIC_LITERAL
   : DIGIT+ ( DOT DIGIT* ) ?
   | DOT DIGIT+ (E [-+]? DIGIT+)?
   ;
-
-OBJECT_NAME_LITERAL: '`' ~[`]+ '`';
 
 fragment ID_CHAR: [\p{Alphabetic}_] ;
 fragment DIGIT: [0-9];

--- a/packages/malloy/src/lang/grammar/MalloyLexer.g4
+++ b/packages/malloy/src/lang/grammar/MalloyLexer.g4
@@ -23,12 +23,6 @@
 
 lexer grammar MalloyLexer;
 
-DQ_STRING: '"' (ESC | SAFECODEPOINT)* '"';
-
-fragment ESC: '\\' (["\\/bfnrt] | UNICODE);
-fragment UNICODE: 'u' HEX HEX HEX HEX;
-fragment HEX: [0-9a-fA-F];
-fragment SAFECODEPOINT: ~ ["\\\u0000-\u001F];
 fragment SPACE_CHAR: [ \u000B\t\r\n];
 
 // colon keywords ...
@@ -126,9 +120,15 @@ STRING_ESCAPE
   | '\\' '\\'
   | '\\' .
   ;
-
 HACKY_REGEX: ('/' | [rR]) '\'' (STRING_ESCAPE | ~('\\' | '\''))* '\'';
-SQ_STRING: '\'' (STRING_ESCAPE | ~('\\' | '\''))* '\'';
+
+fragment ESC: '\\' (["\\/bfnrt] | UNICODE);
+fragment UNICODE: 'u' HEX HEX HEX HEX;
+fragment HEX: [0-9a-fA-F];
+fragment SAFECODEPOINT: ~ ["\\\u0000-\u001F];
+DQ_STRING: '"'  (ESC | SAFECODEPOINT)* '"';
+SQ_STRING: '\'' (ESC | SAFECODEPOINT)* '\'';
+
 fragment F_TO_EOL: ~[\r\n]* (('\r'? '\n') | EOF);
 DOC_ANNOTATION: '##' F_TO_EOL;
 ANNOTATION: '#' F_TO_EOL;

--- a/packages/malloy/src/lang/grammar/MalloyLexer.g4
+++ b/packages/malloy/src/lang/grammar/MalloyLexer.g4
@@ -126,8 +126,10 @@ fragment ESC: '\\' (["\\/bfnrt] | UNICODE);
 fragment UNICODE: 'u' HEX HEX HEX HEX;
 fragment HEX: [0-9a-fA-F];
 fragment SAFECODEPOINT: ~ ["\\\u0000-\u001F];
+fragment ESC2: '\\' (['\\/bfnrt] | UNICODE);
+fragment SAFECODEPOINT2: ~ ['\\\u0000-\u001F];
 DQ_STRING: '"'  (ESC | SAFECODEPOINT)* '"';
-SQ_STRING: '\'' (ESC | SAFECODEPOINT)* '\'';
+SQ_STRING: '\'' (ESC2 | SAFECODEPOINT2)* '\'';
 
 fragment F_TO_EOL: ~[\r\n]* (('\r'? '\n') | EOF);
 DOC_ANNOTATION: '##' F_TO_EOL;

--- a/packages/malloy/src/lang/grammar/MalloyParser.g4
+++ b/packages/malloy/src/lang/grammar/MalloyParser.g4
@@ -84,11 +84,11 @@ sqlInterpolation
   ;
 
 importStatement
-  : IMPORT shortString
+  : IMPORT importURL
   ;
 
 importURL
-  : DQ_STRING
+  : shortString
   ;
 
 docAnnotations
@@ -399,11 +399,7 @@ sampleStatement
   ;
 
 timezoneStatement
-  : TIMEZONE timezoneName
-  ;
-
-timezoneName
-  : SQ_STRING
+  : TIMEZONE shortString
   ;
 
 queryAnnotation

--- a/packages/malloy/src/lang/grammar/MalloyParser.g4
+++ b/packages/malloy/src/lang/grammar/MalloyParser.g4
@@ -445,15 +445,12 @@ dateLiteral
   | LITERAL_YEAR           # literalYear
   ;
 
-tablePath
-  : SQ_STRING;
-
-tableURI
-  : SQ_STRING;
+tablePath: shortString;
+tableURI: shortString;
 
 id
   : IDENTIFIER
-  | OBJECT_NAME_LITERAL
+  | BQ_STRING
   ;
 
 
@@ -550,4 +547,4 @@ justExpr: fieldExpr EOF;
 
 sqlExploreNameRef: id;
 nameSQLBlock: id;
-connectionName: DQ_STRING;
+connectionName: shortString;

--- a/packages/malloy/src/lang/grammar/MalloyParser.g4
+++ b/packages/malloy/src/lang/grammar/MalloyParser.g4
@@ -84,7 +84,7 @@ sqlInterpolation
   ;
 
 importStatement
-  : IMPORT importURL
+  : IMPORT shortString
   ;
 
 importURL
@@ -421,18 +421,16 @@ aggregate: SUM | COUNT | AVG | MIN | MAX;
 malloyType: STRING | NUMBER | BOOLEAN | DATE | TIMESTAMP;
 compareOp: MATCH | NOT_MATCH | GT | LT | GTE | LTE | EQ | NE;
 
-stringLiteral
-  : SQ_STRING
-  | DQ_STRING
+shortString
+  : (SQ_STRING | DQ_STRING)
   ;
 
 numericLiteral
-  : NUMERIC_LITERAL
-  | INTEGER_LITERAL
+  : (NUMERIC_LITERAL | INTEGER_LITERAL)
   ;
 
 literal
-  : stringLiteral                               # exprString
+  : shortString                               # exprString
   | numericLiteral                              # exprNumber
   | dateLiteral                                 # exprTime
   | NULL                                        # exprNULL

--- a/packages/malloy/src/lang/grammar/MalloyParser.g4
+++ b/packages/malloy/src/lang/grammar/MalloyParser.g4
@@ -88,7 +88,7 @@ importStatement
   ;
 
 importURL
-  : JSON_STRING
+  : DQ_STRING
   ;
 
 docAnnotations
@@ -403,7 +403,7 @@ timezoneStatement
   ;
 
 timezoneName
-  : STRING_LITERAL
+  : SQ_STRING
   ;
 
 queryAnnotation
@@ -421,9 +421,19 @@ aggregate: SUM | COUNT | AVG | MIN | MAX;
 malloyType: STRING | NUMBER | BOOLEAN | DATE | TIMESTAMP;
 compareOp: MATCH | NOT_MATCH | GT | LT | GTE | LTE | EQ | NE;
 
+stringLiteral
+  : SQ_STRING
+  | DQ_STRING
+  ;
+
+numericLiteral
+  : NUMERIC_LITERAL
+  | INTEGER_LITERAL
+  ;
+
 literal
-  : STRING_LITERAL                              # exprString
-  | (NUMERIC_LITERAL | INTEGER_LITERAL)         # exprNumber
+  : stringLiteral                               # exprString
+  | numericLiteral                              # exprNumber
   | dateLiteral                                 # exprTime
   | NULL                                        # exprNULL
   | (TRUE | FALSE)                              # exprBool
@@ -442,10 +452,10 @@ dateLiteral
   ;
 
 tablePath
-  : STRING_LITERAL;
+  : SQ_STRING;
 
 tableURI
-  : STRING_LITERAL;
+  : SQ_STRING;
 
 id
   : IDENTIFIER
@@ -544,35 +554,6 @@ fieldName: id;
 
 justExpr: fieldExpr EOF;
 
-json
-  : jsonValue
-  ;
-
-jsonValue
-   : JSON_STRING
-   | INTEGER_LITERAL
-   | NUMERIC_LITERAL
-   | jsonObject
-   | jsonArray
-   | TRUE
-   | FALSE
-   | NULL
-   ;
-
-jsonObject
-   : OCURLY jsonProperty (COMMA jsonProperty)* CCURLY
-   | OCURLY CCURLY
-   ;
-
-jsonProperty
-   : JSON_STRING COLON jsonValue
-   ;
-
-jsonArray
-   : OBRACK jsonValue (COMMA jsonValue)* CBRACK
-   | OBRACK CBRACK
-   ;
-
 sqlExploreNameRef: id;
 nameSQLBlock: id;
-connectionName: JSON_STRING;
+connectionName: DQ_STRING;

--- a/packages/malloy/src/lang/malloy-to-ast.ts
+++ b/packages/malloy/src/lang/malloy-to-ast.ts
@@ -61,10 +61,14 @@ function getIsNotes(cx: parse.IsDefineContext): string[] {
 type ContainsString = ParserRuleContext & {
   shortString: () => parse.ShortStringContext;
 };
-// function constainsString(cx: ParserRuleContext): cx is ContainsString {
-//   return 'shortString' in cx;
-// }
 
+/**
+ * Take the text of a matched string, including the matching quote
+ * characters, and return the actual contents of the string after
+ * \ processing.
+ * @param cx Any parse context which contains a string
+ * @returns Decocded string
+ */
 function getShortString(cx: ContainsString): string {
   const scx = cx.shortString();
   const str = scx.DQ_STRING()?.text || scx.SQ_STRING()?.text;
@@ -74,17 +78,18 @@ function getShortString(cx: ContainsString): string {
   // shortString: DQ_STRING | SQ_STRING; So this will never happen
   return '';
 }
-// function getOptionalString(cx: ParserRuleContext): string | undefined {
-//   if (cx && constainsString(cx)) {
-//     return getShortString(cx);
-//   }
-// }
 
 type ContainsID = ParserRuleContext & {id: () => parse.IdContext};
 function containsID(cx: ParserRuleContext): cx is ContainsID {
   return 'id' in cx;
 }
 
+/**
+ * An identifier is either a sequence of id characters or a `quoted`
+ * This parses either to simply the resulting text.
+ * @param cx A context which has an identifier
+ * @returns The indenftifier text
+ */
 function getId(cx: ContainsID): string {
   const quoted = cx.id().BQ_STRING();
   if (quoted) {

--- a/packages/malloy/src/lang/malloy-to-ast.ts
+++ b/packages/malloy/src/lang/malloy-to-ast.ts
@@ -646,10 +646,9 @@ export class MalloyToAST
   visitTimezoneStatement(
     cx: parse.TimezoneStatementContext
   ): ast.TimezoneStatement {
-    const tz = cx.timezoneName();
     const timezoneStatement = this.astAt(
-      new ast.TimezoneStatement(this.stripQuotes(tz.SQ_STRING().text)),
-      tz
+      new ast.TimezoneStatement(getShortString(cx) || 'UTC'),
+      cx.shortString()
     );
 
     if (!timezoneStatement.isValid) {
@@ -1446,7 +1445,7 @@ export class MalloyToAST
   }
 
   visitImportStatement(pcx: parse.ImportStatementContext): ast.ImportStatement {
-    const url = getShortString(pcx) || 'BAD_URL_FOR_IMPORT';
+    const url = getShortString(pcx.importURL()) || 'BAD_URL_FOR_IMPORT';
     return this.astAt(
       new ast.ImportStatement(url, this.parse.subTranslator.sourceURL),
       pcx

--- a/packages/malloy/src/lang/malloy-to-ast.ts
+++ b/packages/malloy/src/lang/malloy-to-ast.ts
@@ -58,13 +58,44 @@ function getIsNotes(cx: parse.IsDefineContext): string[] {
   return before.concat(getNotes(cx._afterIs));
 }
 
-function getShortString(cx: {
+type ContainsString = ParserRuleContext & {
   shortString: () => parse.ShortStringContext;
-}): string | undefined {
+};
+// function constainsString(cx: ParserRuleContext): cx is ContainsString {
+//   return 'shortString' in cx;
+// }
+
+function getShortString(cx: ContainsString): string {
   const scx = cx.shortString();
   const str = scx.DQ_STRING()?.text || scx.SQ_STRING()?.text;
   if (str) {
     return parseString(str, str[0]);
+  }
+  // shortString: DQ_STRING | SQ_STRING; So this will never happen
+  return '';
+}
+// function getOptionalString(cx: ParserRuleContext): string | undefined {
+//   if (cx && constainsString(cx)) {
+//     return getShortString(cx);
+//   }
+// }
+
+type ContainsID = ParserRuleContext & {id: () => parse.IdContext};
+function containsID(cx: ParserRuleContext): cx is ContainsID {
+  return 'id' in cx;
+}
+
+function getId(cx: ContainsID): string {
+  const quoted = cx.id().BQ_STRING();
+  if (quoted) {
+    return parseString(quoted.text, '`');
+  }
+  return cx.id().text;
+}
+
+function getOptionalId(cx: ParserRuleContext): string | undefined {
+  if (containsID(cx) && cx.id()) {
+    return getId(cx);
   }
 }
 
@@ -144,41 +175,12 @@ export class MalloyToAST
     return Number.parseInt(term.text);
   }
 
-  protected optionalString(
-    fromTerm: ParseTree | undefined
-  ): string | undefined {
-    if (fromTerm) {
-      return this.stripQuotes(fromTerm.text);
-    }
-    return undefined;
+  protected getFieldName(cx: ContainsID): ast.FieldName {
+    return this.astAt(new ast.FieldName(getId(cx)), cx);
   }
 
-  protected getIdText(fromTerm: ParseTree): string {
-    return this.stripQuotes(fromTerm.text);
-  }
-
-  protected getFieldName(cx: ParserRuleContext): ast.FieldName {
-    return this.astAt(new ast.FieldName(this.getIdText(cx)), cx);
-  }
-
-  protected getModelEntryName(cx: ParserRuleContext): ast.ModelEntryReference {
-    return this.astAt(new ast.ModelEntryReference(this.getIdText(cx)), cx);
-  }
-
-  protected stripQuotes(s: string): string {
-    if (s[0] === '`' || s[0] === "'" || s[0] === '"') {
-      if (s[0] === s[s.length - 1]) {
-        return s.slice(1, -1);
-      }
-    }
-    return s;
-  }
-
-  protected optionalText(idCx: ParseTree | undefined): string | undefined {
-    if (idCx) {
-      return this.getIdText(idCx);
-    }
-    return undefined;
+  protected getModelEntryName(cx: ContainsID): ast.ModelEntryReference {
+    return this.astAt(new ast.ModelEntryReference(getId(cx)), cx);
   }
 
   defaultResult(): ast.MalloyElement {
@@ -299,7 +301,7 @@ export class MalloyToAST
 
   visitSourceDefinition(pcx: parse.SourceDefinitionContext): ast.DefineSource {
     const exploreDef = new ast.DefineSource(
-      this.getIdText(pcx.sourceNameDef()),
+      getId(pcx.sourceNameDef()),
       this.visitExplore(pcx.explore()),
       true,
       []
@@ -336,7 +338,7 @@ export class MalloyToAST
   }
 
   visitTableFunction(pcx: parse.TableFunctionContext): ast.TableSource {
-    const tableURI = this.stripQuotes(pcx.tableURI().text);
+    const tableURI = getShortString(pcx.tableURI());
     const el = this.astAt(new ast.TableFunctionSource(tableURI), pcx);
     if (ENABLE_M4_WARNINGS) {
       this.astError(
@@ -351,7 +353,7 @@ export class MalloyToAST
   visitTableMethod(pcx: parse.TableMethodContext): ast.TableSource {
     const connId = pcx.connectionId();
     const connectionName = this.astAt(this.getModelEntryName(connId), connId);
-    const tablePath = this.stripQuotes(pcx.tablePath().text);
+    const tablePath = getShortString(pcx.tablePath());
     return this.astAt(
       new ast.TableMethodSource(connectionName, tablePath),
       pcx
@@ -496,7 +498,7 @@ export class MalloyToAST
     makeFieldDef: ast.FieldDeclarationConstructor
   ): ast.FieldDeclaration {
     const defCx = pcx.fieldExpr();
-    const fieldName = this.getIdText(pcx.fieldNameDef());
+    const fieldName = getId(pcx.fieldNameDef());
     const valExpr = this.getFieldExpr(defCx);
     const def = new makeFieldDef(valExpr, fieldName, this.getSourceCode(defCx));
     const notes = getNotes(pcx.tags()).concat(getIsNotes(pcx.isDefine()));
@@ -562,10 +564,10 @@ export class MalloyToAST
   }
 
   visitExploreRenameDef(pcx: parse.ExploreRenameDefContext): ast.RenameField {
-    const newName = pcx.fieldName(0).id();
-    const oldName = pcx.fieldName(1).id();
+    const newName = pcx.fieldName(0);
+    const oldName = pcx.fieldName(1);
     const rename = new ast.RenameField(
-      this.getIdText(newName),
+      getId(newName),
       this.getFieldName(oldName)
     );
     return this.astAt(rename, pcx);
@@ -647,7 +649,7 @@ export class MalloyToAST
     cx: parse.TimezoneStatementContext
   ): ast.TimezoneStatement {
     const timezoneStatement = this.astAt(
-      new ast.TimezoneStatement(getShortString(cx) || 'UTC'),
+      new ast.TimezoneStatement(getShortString(cx)),
       cx.shortString()
     );
 
@@ -898,8 +900,7 @@ export class MalloyToAST
   }
 
   visitSourceID(pcx: parse.SourceIDContext): ast.NamedSource {
-    const name = this.getModelEntryName(pcx.id());
-    return this.astAt(new ast.NamedSource(name), pcx);
+    return this.astAt(new ast.NamedSource(getId(pcx)), pcx);
   }
 
   protected buildPipelineFromName(
@@ -955,7 +956,7 @@ export class MalloyToAST
   }
 
   visitTopLevelQueryDef(pcx: parse.TopLevelQueryDefContext): ast.DefineQuery {
-    const queryName = this.getIdText(pcx.queryName());
+    const queryName = getId(pcx.queryName());
     const queryExpr = this.visit(pcx.query());
     if (ast.isQueryElement(queryExpr)) {
       const notes = getNotes(pcx.tags()).concat(getIsNotes(pcx.isDefine()));
@@ -1045,7 +1046,7 @@ export class MalloyToAST
   }
 
   visitNestDef(pcx: parse.NestDefContext): ast.NestDefinition {
-    const name = this.getIdText(pcx.queryName());
+    const name = getId(pcx.queryName());
     const nestDef = new ast.NestDefinition(name);
     this.buildPipelineFromName(nestDef, pcx.pipelineFromName());
     nestDef.extendNote({
@@ -1055,7 +1056,7 @@ export class MalloyToAST
   }
 
   visitExploreQueryDef(pcx: parse.ExploreQueryDefContext): ast.TurtleDecl {
-    const name = this.getIdText(pcx.exploreQueryNameDef());
+    const name = getId(pcx.exploreQueryNameDef());
     const queryDef = new ast.TurtleDecl(name);
     const notes = getNotes(pcx).concat(getIsNotes(pcx.isDefine()));
     queryDef.extendNote({notes});
@@ -1123,17 +1124,12 @@ export class MalloyToAST
   }
 
   visitExprString(pcx: parse.ExprStringContext): ast.ExprString {
-    const str = getShortString(pcx);
-    if (str !== undefined) {
-      return new ast.ExprString(str);
-    }
-    this.contextError(pcx, 'Illegal string');
-    return new ast.ExprString('');
+    return new ast.ExprString(getShortString(pcx));
   }
 
   visitExprRegex(pcx: parse.ExprRegexContext): ast.ExprRegEx {
     const malloyRegex = pcx.HACKY_REGEX().text;
-    return new ast.ExprRegEx(this.stripQuotes(malloyRegex.slice(1)));
+    return new ast.ExprRegEx(malloyRegex.slice(2, -1));
   }
 
   visitExprNow(_pcx: parse.ExprNowContext): ast.ExprNow {
@@ -1202,7 +1198,7 @@ export class MalloyToAST
 
   visitExprUngroup(pcx: parse.ExprUngroupContext): ast.ExprUngroup {
     const flist = pcx.fieldName().map(fcx => this.getFieldName(fcx));
-    const kw = this.getIdText(pcx.ungroup()).toLocaleLowerCase();
+    const kw = pcx.ungroup().text.toLowerCase();
     return this.astAt(
       new ast.ExprUngroup(
         kw === 'all' ? kw : 'exclude',
@@ -1316,8 +1312,7 @@ export class MalloyToAST
     const argsCx = pcx.argumentList();
     const args = argsCx ? this.allFieldExpressions(argsCx.fieldExpr()) : [];
 
-    const idCx = pcx.id();
-    const fn = this.getIdText(idCx);
+    const fn = getId(pcx);
 
     const pathCx = pcx.fieldPath();
     const path = pathCx
@@ -1353,15 +1348,9 @@ export class MalloyToAST
       }
     }
 
-    const idCx = pcx.id();
-    const dCx = pcx.timeframe();
-    let fn: string;
-    if (idCx) {
-      fn = this.getIdText(idCx);
-    } else if (dCx) {
-      fn = dCx.text;
-    } else {
-      this.contextError(pcx, 'Funciton name error');
+    let fn = getOptionalId(pcx) || pcx.timeframe()?.text;
+    if (fn === undefined) {
+      this.contextError(pcx, 'Function name error');
       fn = 'FUNCTION_NAME_ERROR';
     }
 
@@ -1445,7 +1434,7 @@ export class MalloyToAST
   }
 
   visitImportStatement(pcx: parse.ImportStatementContext): ast.ImportStatement {
-    const url = getShortString(pcx.importURL()) || 'BAD_URL_FOR_IMPORT';
+    const url = getShortString(pcx.importURL());
     return this.astAt(
       new ast.ImportStatement(url, this.parse.subTranslator.sourceURL),
       pcx
@@ -1469,7 +1458,7 @@ export class MalloyToAST
         if (connectionName) {
           this.contextError(nmCx, 'Cannot redefine connection');
         } else {
-          connectionName = this.getIdText(nmCx);
+          connectionName = getShortString(nmCx);
         }
       }
       const selCx = blockEnt.sqlString();

--- a/packages/malloy/src/lang/malloy-to-ast.ts
+++ b/packages/malloy/src/lang/malloy-to-ast.ts
@@ -1124,7 +1124,7 @@ export class MalloyToAST
 
   visitExprString(pcx: parse.ExprStringContext): ast.ExprString {
     const str = getShortString(pcx);
-    if (str) {
+    if (str !== undefined) {
       return new ast.ExprString(str);
     }
     this.contextError(pcx, 'Illegal string');

--- a/packages/malloy/src/lang/malloy-to-ast.ts
+++ b/packages/malloy/src/lang/malloy-to-ast.ts
@@ -637,7 +637,7 @@ export class MalloyToAST
   ): ast.TimezoneStatement {
     const tz = cx.timezoneName();
     const timezoneStatement = this.astAt(
-      new ast.TimezoneStatement(this.stripQuotes(tz.STRING_LITERAL().text)),
+      new ast.TimezoneStatement(this.stripQuotes(tz.SQ_STRING().text)),
       tz
     );
 
@@ -1113,7 +1113,7 @@ export class MalloyToAST
   }
 
   visitExprString(pcx: parse.ExprStringContext): ast.ExprString {
-    return new ast.ExprString(pcx.STRING_LITERAL().text);
+    return new ast.ExprString(pcx.SQ_STRING().text);
   }
 
   visitExprRegex(pcx: parse.ExprRegexContext): ast.ExprRegEx {

--- a/packages/malloy/src/lang/parse-tree-walkers/document-highlight-walker.ts
+++ b/packages/malloy/src/lang/parse-tree-walkers/document-highlight-walker.ts
@@ -224,8 +224,8 @@ export function passForHighlights(
       case MalloyParser.FROM_SQL:
         register(token, HighlightType.Call.FromSQL);
         break;
-      case MalloyParser.STRING_LITERAL:
-      case MalloyParser.JSON_STRING:
+      case MalloyParser.SQ_STRING:
+      case MalloyParser.DQ_STRING:
         register(token, HighlightType.Literal.String);
         break;
       case MalloyParser.NUMERIC_LITERAL:

--- a/packages/malloy/src/lang/parse-tree-walkers/document-highlight-walker.ts
+++ b/packages/malloy/src/lang/parse-tree-walkers/document-highlight-walker.ts
@@ -312,7 +312,7 @@ export function passForHighlights(
         register(token, HighlightType.Call.Aggregate);
         break;
       case MalloyParser.IDENTIFIER:
-      case MalloyParser.OBJECT_NAME_LITERAL:
+      case MalloyParser.BQ_STRING:
         register(token, HighlightType.Identifier);
         break;
       case MalloyParser.STRING:

--- a/packages/malloy/src/lang/parse-tree-walkers/find-external-references.ts
+++ b/packages/malloy/src/lang/parse-tree-walkers/find-external-references.ts
@@ -80,7 +80,7 @@ class FindExternalReferences implements MalloyParserListener {
   }
 
   enterImportURL(pcx: parser.ImportURLContext) {
-    const url = JSON.parse(pcx.DQ_STRING().text);
+    const url = JSON.parse(pcx.shortString().text);
     if (!this.needImports[url]) {
       this.needImports[url] = this.trans.rangeFromContext(pcx);
     }

--- a/packages/malloy/src/lang/parse-tree-walkers/find-external-references.ts
+++ b/packages/malloy/src/lang/parse-tree-walkers/find-external-references.ts
@@ -80,7 +80,7 @@ class FindExternalReferences implements MalloyParserListener {
   }
 
   enterImportURL(pcx: parser.ImportURLContext) {
-    const url = JSON.parse(pcx.JSON_STRING().text);
+    const url = JSON.parse(pcx.DQ_STRING().text);
     if (!this.needImports[url]) {
       this.needImports[url] = this.trans.rangeFromContext(pcx);
     }

--- a/packages/malloy/src/lang/string-parser.ts
+++ b/packages/malloy/src/lang/string-parser.ts
@@ -41,7 +41,7 @@ export function parseString(str: string, surround = ''): string {
   let inner = str.slice(surround.length);
   let state = ParseState.Normal;
   if (surround.length) {
-    inner = inner.slice(-surround.length);
+    inner = inner.slice(0, -surround.length);
   }
   let out = '';
   let unicode = '';

--- a/packages/malloy/src/lang/string-parser.ts
+++ b/packages/malloy/src/lang/string-parser.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files
+ * (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+enum ParseState {
+  Normal,
+  ReverseVirgule,
+  Unicode,
+}
+
+/**
+ * Parses the interior of a string, doing all \ substitutions. In most cases
+ * a lexical analyzer has already recognized this as a string. As a convenience,
+ * strip off the quoting outer chartacters if asked, then parse the interior of
+ * the string. The intention is to be compatible with JSON strings, in terms
+ * of which \X substitutions are processed.
+ * @param str is the string to parse
+ * @param surround is the quoting character, default means quotes already stripped
+ * @returns a string with the \ processing completed
+ */
+export function parseString(str: string, surround = ''): string {
+  let inner = str.slice(surround.length);
+  let state = ParseState.Normal;
+  if (surround.length) {
+    inner = inner.slice(-surround.length);
+  }
+  let out = '';
+  let unicode = '';
+  for (const c of inner) {
+    switch (state) {
+      case ParseState.Normal: {
+        if (c === '\\') {
+          state = ParseState.ReverseVirgule;
+        } else {
+          out += c;
+        }
+        break;
+      }
+      case ParseState.ReverseVirgule: {
+        let outc = c;
+        if (c === 'u') {
+          state = ParseState.Unicode;
+          unicode = '';
+          continue;
+        }
+        if (c === 'b') {
+          outc = '\b';
+        } else if (c === 'f') {
+          outc = '\f';
+        } else if (c === 'n') {
+          outc = '\n';
+        } else if (c === 'r') {
+          outc = '\r';
+        } else if (c === 't') {
+          outc = '\t';
+        }
+        out += outc;
+        state = ParseState.Normal;
+        break;
+      }
+      case ParseState.Unicode: {
+        if ('ABCDEFabcdef0123456789'.includes(c)) {
+          unicode += c;
+          if (unicode.length === 4) {
+            out += String.fromCharCode(parseInt(unicode, 16));
+            state = ParseState.Normal;
+          }
+        } else {
+          // Don't think we ever get here ...
+          state = ParseState.Normal;
+        }
+      }
+    }
+  }
+  return out;
+}

--- a/packages/malloy/src/lang/test/parse.spec.ts
+++ b/packages/malloy/src/lang/test/parse.spec.ts
@@ -1345,8 +1345,12 @@ describe('literals', () => {
     expect(expr`42`).toTranslate();
   });
   test('string', () => {
-    expect(expr`'fortywo-two'`).toTranslate();
+    const m = new BetaExpression("'forty two'");
+    expect(m).toTranslate();
+    const m42 = m.generated().value[0];
+    expect(m42).toMatchObject({literal: 'forty two'});
   });
+
   test('string with quoted quote', () => {
     const str = "'Isn" + '\\' + "'t this nice'";
     expect(new BetaExpression(str)).toTranslate();

--- a/packages/malloy/src/lang/test/strings.spec.ts
+++ b/packages/malloy/src/lang/test/strings.spec.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files
+ * (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import './parse-expects';
+import {parseString} from '../string-parser';
+
+describe('test internal string parsing', () => {
+  test('\\b', () => {
+    expect(parseString('\\b')).toEqual('\b');
+  });
+  test('\\f', () => {
+    expect(parseString('\\f')).toEqual('\f');
+  });
+  test('\\n', () => {
+    expect(parseString('\\n')).toEqual('\n');
+  });
+  test('\\r', () => {
+    expect(parseString('\\r')).toEqual('\r');
+  });
+  test('\\t', () => {
+    expect(parseString('\\t')).toEqual('\t');
+  });
+  test('unicode ?', () => {
+    expect(parseString('\\u003f')).toEqual('?');
+    expect(parseString('\\u003F')).toEqual('?');
+  });
+  test('normal stuff', () => {
+    expect(parseString('normal stuff')).toEqual('normal stuff');
+  });
+  test('stuff & nonsense', () => {
+    expect(parseString('stuff \\u0026 nonsense')).toEqual('stuff & nonsense');
+  });
+  test('one thing\\nnext thing', () => {
+    expect(parseString('one thing\\nnext thing')).toEqual(
+      'one thing\nnext thing'
+    );
+  });
+});

--- a/packages/malloy/src/lang/test/strings.spec.ts
+++ b/packages/malloy/src/lang/test/strings.spec.ts
@@ -55,4 +55,7 @@ describe('test internal string parsing', () => {
       'one thing\nnext thing'
     );
   });
+  test('quote stripping works', () => {
+    expect(parseString('|42|', '|')).toEqual('42');
+  });
 });

--- a/test/src/databases/all/expr.spec.ts
+++ b/test/src/databases/all/expr.spec.ts
@@ -630,6 +630,7 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
   });
 
   describe('string literal quoting', () => {
+    const dq = '"';
     const tick = "'";
     const back = '\\';
     test('quote single character', async () => {
@@ -637,6 +638,16 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
     });
     test('quote single quote', async () => {
       expect(await sqlEq(`'${back}${tick}'`, tick)).isSqlEq();
+    });
+    test('quote double quote', async () => {
+      await expect(runtime).queryMatches(
+        `sql: x is {connection:"${databaseName}" select:"""SELECT 1 as x"""}
+        query: from_sql(x) -> {
+          project: double_quote is "${back}${dq}"
+        }
+      `,
+        {double_quote: '"'}
+      );
     });
     test('quote backslash', async () => {
       expect(await sqlEq(`'${back}${back}'`, back)).isSqlEq();

--- a/test/src/util/index.ts
+++ b/test/src/util/index.ts
@@ -87,7 +87,10 @@ interface InitValues {
 }
 
 function sqlSafe(str: string): string {
-  return str.replace(/'/g, '{single-quote}').replace(/\\/g, '{backslash}');
+  return str
+    .replace(/'/g, '{single-quote}')
+    .replace(/\\/g, '{backslash}')
+    .replace(/"/g, '{double-quote}');
 }
 export function mkSqlEqWith(runtime: Runtime, initV?: InitValues) {
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types


### PR DESCRIPTION
This PR makes ' ` and " strings all behave the same. The can all contain \ escapes for bfrnt and uXXXX for unicode.

Also, every place in the language where a string is legal, a ' or " string is legal. The only difference in the two
is which quote character you have to use \ on