### PR TITLE
Allow ' and " strings in CONNECTION.sql()

### DIFF
--- a/packages/malloy/src/lang/grammar/MalloyParser.g4
+++ b/packages/malloy/src/lang/grammar/MalloyParser.g4
@@ -164,11 +164,11 @@ explore
   ;
 
 exploreSource
-  : sourceID                                      # NamedSource
-  | exploreTable                                  # TableSource
-  | FROM OPAREN query CPAREN                      # QuerySource
-  | FROM_SQL OPAREN sqlExploreNameRef CPAREN      # SQLSourceName
-  | connectionId DOT SQL OPAREN sqlString CPAREN  # SQLSource
+  : sourceID                                                    # NamedSource
+  | exploreTable                                                # TableSource
+  | FROM OPAREN query CPAREN                                    # QuerySource
+  | FROM_SQL OPAREN sqlExploreNameRef CPAREN                    # SQLSourceName
+  | connectionId DOT SQL OPAREN (sqlString|shortString) CPAREN  # SQLSource
   ;
 
 sourceNameDef: id;

--- a/packages/malloy/src/lang/test/parse.spec.ts
+++ b/packages/malloy/src/lang/test/parse.spec.ts
@@ -3211,6 +3211,36 @@ describe('sql expressions', () => {
     }
   });
 
+  test('sql expression legal with single quote', () => {
+    const m = model`
+      source: na is bigquery.sql('SELECT 1 as one')
+    `;
+    expect(m).toParse();
+    const compileSql = m.translator.translate().compileSQL;
+    expect(compileSql).toBeDefined();
+    if (compileSql) {
+      m.translator.update({
+        compileSQL: {[compileSql.name]: getSelectOneStruct(compileSql)},
+      });
+      expect(m).toTranslate();
+    }
+  });
+
+  test('sql expression legal with double quote', () => {
+    const m = model`
+      source: na is bigquery.sql("SELECT 1 as one")
+    `;
+    expect(m).toParse();
+    const compileSql = m.translator.translate().compileSQL;
+    expect(compileSql).toBeDefined();
+    if (compileSql) {
+      m.translator.update({
+        compileSQL: {[compileSql.name]: getSelectOneStruct(compileSql)},
+      });
+      expect(m).toTranslate();
+    }
+  });
+
   test('reference to sql expression in extended source', () => {
     const m = model`
       source: na is bigquery.sql("""SELECT 1 as one""") {


### PR DESCRIPTION
This is different than allowing """ strings as literals because we do a different thing in the parse step.