### PR TITLE
Allow """ strings (almost) everywhere

### DIFF
--- a/packages/malloy/src/lang/grammar/MalloyParser.g4
+++ b/packages/malloy/src/lang/grammar/MalloyParser.g4
@@ -88,7 +88,7 @@ importStatement
   ;
 
 importURL
-  : shortString
+  : string
   ;
 
 docAnnotations
@@ -400,7 +400,7 @@ sampleStatement
   ;
 
 timezoneStatement
-  : TIMEZONE shortString
+  : TIMEZONE string
   ;
 
 queryAnnotation
@@ -418,6 +418,11 @@ aggregate: SUM | COUNT | AVG | MIN | MAX;
 malloyType: STRING | NUMBER | BOOLEAN | DATE | TIMESTAMP;
 compareOp: MATCH | NOT_MATCH | GT | LT | GTE | LTE | EQ | NE;
 
+string
+  : shortString
+  | sqlString
+  ;
+
 shortString
   : (SQ_STRING | DQ_STRING)
   ;
@@ -427,7 +432,7 @@ numericLiteral
   ;
 
 literal
-  : shortString                               # exprString
+  : string                                      # exprString
   | numericLiteral                              # exprNumber
   | dateLiteral                                 # exprTime
   | NULL                                        # exprNULL
@@ -446,8 +451,8 @@ dateLiteral
   | LITERAL_YEAR           # literalYear
   ;
 
-tablePath: shortString;
-tableURI: shortString;
+tablePath: string;
+tableURI: string;
 
 id
   : IDENTIFIER
@@ -548,4 +553,4 @@ justExpr: fieldExpr EOF;
 
 sqlExploreNameRef: id;
 nameSQLBlock: id;
-connectionName: shortString;
+connectionName: string;

--- a/packages/malloy/src/lang/malloy-to-ast.ts
+++ b/packages/malloy/src/lang/malloy-to-ast.ts
@@ -201,7 +201,7 @@ export class MalloyToAST
     throw this.internalError(pcx, `'${element.elementType}': illegal source`);
   }
 
-  protected getString(cx: HasString): string {
+  protected getPlainString(cx: HasString): string {
     const shortStr = getStringIfShort(cx);
     if (shortStr) {
       return shortStr;
@@ -313,7 +313,7 @@ export class MalloyToAST
   }
 
   visitTableFunction(pcx: parse.TableFunctionContext): ast.TableSource {
-    const tableURI = this.getString(pcx.tableURI());
+    const tableURI = this.getPlainString(pcx.tableURI());
     const el = this.astAt(new ast.TableFunctionSource(tableURI), pcx);
     if (ENABLE_M4_WARNINGS) {
       this.astError(
@@ -328,7 +328,7 @@ export class MalloyToAST
   visitTableMethod(pcx: parse.TableMethodContext): ast.TableSource {
     const connId = pcx.connectionId();
     const connectionName = this.astAt(this.getModelEntryName(connId), connId);
-    const tablePath = this.getString(pcx.tablePath());
+    const tablePath = this.getPlainString(pcx.tablePath());
     return this.astAt(
       new ast.TableMethodSource(connectionName, tablePath),
       pcx
@@ -639,7 +639,7 @@ export class MalloyToAST
   visitTimezoneStatement(
     cx: parse.TimezoneStatementContext
   ): ast.TimezoneStatement {
-    const timezone = this.getString(cx);
+    const timezone = this.getPlainString(cx);
     const timezoneStatement = this.astAt(
       new ast.TimezoneStatement(timezone),
       cx.string()
@@ -1116,7 +1116,7 @@ export class MalloyToAST
   }
 
   visitExprString(pcx: parse.ExprStringContext): ast.ExprString {
-    const str = this.getString(pcx);
+    const str = this.getPlainString(pcx);
     return new ast.ExprString(str);
   }
 
@@ -1427,7 +1427,7 @@ export class MalloyToAST
   }
 
   visitImportStatement(pcx: parse.ImportStatementContext): ast.ImportStatement {
-    const url = this.getString(pcx.importURL());
+    const url = this.getPlainString(pcx.importURL());
     return this.astAt(
       new ast.ImportStatement(url, this.parse.subTranslator.sourceURL),
       pcx
@@ -1451,7 +1451,7 @@ export class MalloyToAST
         if (connectionName) {
           this.contextError(nmCx, 'Cannot redefine connection');
         } else {
-          connectionName = this.getString(nmCx);
+          connectionName = this.getPlainString(nmCx);
         }
       }
       const selCx = blockEnt.sqlString();

--- a/packages/malloy/src/lang/malloy-to-ast.ts
+++ b/packages/malloy/src/lang/malloy-to-ast.ts
@@ -22,7 +22,7 @@
  */
 
 import {ParserRuleContext} from 'antlr4ts';
-import {ParseTree, TerminalNode} from 'antlr4ts/tree';
+import {ParseTree} from 'antlr4ts/tree';
 import {AbstractParseTreeVisitor} from 'antlr4ts/tree/AbstractParseTreeVisitor';
 import {MalloyParserVisitor} from './lib/Malloy/MalloyParserVisitor';
 import * as parse from './lib/Malloy/MalloyParser';
@@ -31,7 +31,17 @@ import {LogSeverity, MessageLogger} from './parse-log';
 import {MalloyParseRoot} from './parse-malloy';
 import {Interval as StreamInterval} from 'antlr4ts/misc/Interval';
 import {FieldDeclarationConstructor, TableSource} from './ast';
-import {parseString} from './string-parser';
+import {
+  getId,
+  getOptionalId,
+  getNotes,
+  getIsNotes,
+  HasString,
+  HasID,
+  getStringParts,
+  getShortString,
+  getStringIfShort,
+} from './parse-utils';
 
 const ENABLE_M4_WARNINGS = false;
 
@@ -41,79 +51,6 @@ class IgnoredElement extends ast.MalloyElement {
   constructor(src: string) {
     super();
     this.malloySrc = src;
-  }
-}
-
-/**
- * Get all the possibly missing annotations from this parse rule
- * @param cx Any parse context which has an ANNOTATION* rules
- * @returns Array of texts for the annotations
- */
-function getNotes(cx: {ANNOTATION: () => TerminalNode[]}): string[] {
-  return cx.ANNOTATION().map(a => a.text);
-}
-
-function getIsNotes(cx: parse.IsDefineContext): string[] {
-  const before = getNotes(cx._beforeIs);
-  return before.concat(getNotes(cx._afterIs));
-}
-
-type ContainsShortString = ParserRuleContext & {
-  shortString: () => parse.ShortStringContext;
-};
-
-/**
- * Take the text of a matched string, including the matching quote
- * characters, and return the actual contents of the string after
- * \ processing.
- * @param cx Any parse context which contains a string
- * @returns Decocded string
- */
-function getShortString(cx: ContainsShortString): string {
-  const scx = cx.shortString();
-  const str = scx.DQ_STRING()?.text || scx.SQ_STRING()?.text;
-  if (str) {
-    return parseString(str, str[0]);
-  }
-  // shortString: DQ_STRING | SQ_STRING; So this will never happen
-  return '';
-}
-
-export type ContainsString = ParserRuleContext & {
-  string: () => parse.StringContext;
-};
-
-export function getOptionalString(cx: ParserRuleContext): string | undefined {
-  function isShort(cx: ParserRuleContext): cx is ContainsShortString {
-    return 'shortString' in cx;
-  }
-  if (isShort(cx) && cx.shortString()) {
-    return getShortString(cx);
-  }
-}
-
-type ContainsID = ParserRuleContext & {id: () => parse.IdContext};
-
-/**
- * An identifier is either a sequence of id characters or a `quoted`
- * This parses either to simply the resulting text.
- * @param cx A context which has an identifier
- * @returns The indenftifier text
- */
-function getId(cx: ContainsID): string {
-  const quoted = cx.id().BQ_STRING();
-  if (quoted) {
-    return parseString(quoted.text, '`');
-  }
-  return cx.id().text;
-}
-
-function getOptionalId(cx: ParserRuleContext): string | undefined {
-  function containsID(cx: ParserRuleContext): cx is ContainsID {
-    return 'id' in cx;
-  }
-  if (containsID(cx) && cx.id()) {
-    return getId(cx);
   }
 }
 
@@ -193,11 +130,11 @@ export class MalloyToAST
     return Number.parseInt(term.text);
   }
 
-  protected getFieldName(cx: ContainsID): ast.FieldName {
+  protected getFieldName(cx: HasID): ast.FieldName {
     return this.astAt(new ast.FieldName(getId(cx)), cx);
   }
 
-  protected getModelEntryName(cx: ContainsID): ast.ModelEntryReference {
+  protected getModelEntryName(cx: HasID): ast.ModelEntryReference {
     return this.astAt(new ast.ModelEntryReference(getId(cx)), cx);
   }
 
@@ -264,26 +201,22 @@ export class MalloyToAST
     throw this.internalError(pcx, `'${element.elementType}': illegal source`);
   }
 
-  protected getString(cx: ContainsString): string {
-    const shortStr = getOptionalString(cx);
+  protected getString(cx: HasString): string {
+    const shortStr = getStringIfShort(cx);
     if (shortStr) {
       return shortStr;
     }
+    const safeParts: string[] = [];
     const multiLineStr = cx.string().sqlString();
     if (multiLineStr) {
-      const strParts: string[] = [];
-      for (const part of multiLineStr.sqlInterpolation()) {
-        const upToOpen = part.OPEN_CODE().text;
-        if (upToOpen.length > 2) {
-          strParts.push(upToOpen.slice(0, upToOpen.length - 2));
-        }
-        if (part.query()) {
+      for (const part of getStringParts(multiLineStr)) {
+        if (part instanceof ParserRuleContext) {
           this.contextError(part, '%{ query }% illegal in this string');
+        } else {
+          safeParts.push(part);
         }
       }
-      const lastChars = multiLineStr.SQL_END()?.text.slice(0, -3);
-      strParts.push(lastChars || '');
-      return strParts.join('');
+      return safeParts.join('');
     }
     // string: shortString | sqlString; So this will never happen
     return '';
@@ -293,15 +226,13 @@ export class MalloyToAST
     pcx: parse.SqlStringContext,
     sqlStr: ast.SQLString
   ): void {
-    for (const part of pcx.sqlInterpolation()) {
-      const upToOpen = part.OPEN_CODE().text;
-      if (upToOpen.length > 2) {
-        sqlStr.push(upToOpen.slice(0, upToOpen.length - 2));
+    for (const part of getStringParts(pcx)) {
+      if (part instanceof ParserRuleContext) {
+        sqlStr.push(this.visit(part));
+      } else {
+        sqlStr.push(part);
       }
-      sqlStr.push(this.visit(part.query()));
     }
-    const lastChars = pcx.SQL_END()?.text.slice(0, -3);
-    sqlStr.push(lastChars || '');
     sqlStr.complete();
     this.astAt(sqlStr, pcx);
   }
@@ -428,9 +359,9 @@ export class MalloyToAST
     if (selCx) {
       this.makeSqlString(selCx, sqlStr);
     }
-    const shortSelect = getOptionalString(pcx);
-    if (shortSelect) {
-      sqlStr.push(shortSelect);
+    const shortCX = pcx.shortString();
+    if (shortCX) {
+      sqlStr.push(getShortString(shortCX));
     }
     const expr = new ast.SQLSource(connectionName, sqlStr);
     return this.astAt(expr, pcx);

--- a/packages/malloy/src/lang/test/strings.spec.ts
+++ b/packages/malloy/src/lang/test/strings.spec.ts
@@ -23,6 +23,7 @@
 
 import './parse-expects';
 import {parseString} from '../parse-utils';
+import {BetaExpression, TestTranslator} from './test-translator';
 
 describe('test internal string parsing', () => {
   test('\\b', () => {
@@ -57,5 +58,74 @@ describe('test internal string parsing', () => {
   });
   test('quote stripping works', () => {
     expect(parseString('|42|', '|')).toEqual('42');
+  });
+});
+
+describe('all strings are parsed in all places', () => {
+  const tz = 'America/Mexico_City';
+  test('timezone single quote', () => {
+    const m = new TestTranslator(`run: a-> {timezone: '${tz}'; project: *}`);
+    expect(m).toParse();
+  });
+  test('timezone double quote', () => {
+    const m = new TestTranslator(`run: a-> {timezone: "${tz}"; project: *}`);
+    expect(m).toParse();
+  });
+  test('timezone triple quote', () => {
+    const m = new TestTranslator(`run: a->{timezone: """${tz}"""; project: *}`);
+    expect(m).toParse();
+  });
+  test('timezone with illegal query', () => {
+    expect(
+      `run: a->{timezone: """${tz}%{ab->aturtle}%"""; project: *}`
+    ).translationToFailWith('%{ query }% illegal in this string');
+  });
+  test('table single quote', () => {
+    const m = new TestTranslator("source: n is bigquery.table('n')");
+    expect(m).toParse();
+  });
+  test('table double quote', () => {
+    const m = new TestTranslator('source: n is bigquery.table("n")');
+    expect(m).toParse();
+  });
+  test('table triple quote', () => {
+    const m = new TestTranslator('source: n is bigquery.table("""n""")');
+    expect(m).toParse();
+  });
+  test('sql single quote', () => {
+    const m = new TestTranslator("source: n is bigquery.sql('n')");
+    expect(m).toParse();
+  });
+  test('sql double quote', () => {
+    const m = new TestTranslator('source: n is bigquery.sql("n")');
+    expect(m).toParse();
+  });
+  test('sql triple quote', () => {
+    const m = new TestTranslator('source: n is bigquery.sql("""n""")');
+    expect(m).toParse();
+  });
+  test('import single quote', () => {
+    const m = new TestTranslator("import 'a'");
+    expect(m).toParse();
+  });
+  test('import double quote', () => {
+    const m = new TestTranslator('import "a"');
+    expect(m).toParse();
+  });
+  test('import triple quote', () => {
+    const m = new TestTranslator('import """a"""');
+    expect(m).toParse();
+  });
+  test('literal single quote', () => {
+    const x = new BetaExpression("'x'");
+    expect(x).toParse();
+  });
+  test('literal double quote', () => {
+    const x = new BetaExpression('"x"');
+    expect(x).toParse();
+  });
+  test('literal triple quote', () => {
+    const x = new BetaExpression('"""x"""');
+    expect(x).toParse();
   });
 });

--- a/packages/malloy/src/lang/test/strings.spec.ts
+++ b/packages/malloy/src/lang/test/strings.spec.ts
@@ -22,7 +22,7 @@
  */
 
 import './parse-expects';
-import {parseString} from '../string-parser';
+import {parseString} from '../parse-utils';
 
 describe('test internal string parsing', () => {
   test('\\b', () => {


### PR DESCRIPTION
Legal in

```
timezone: """if you really want to"""
import: """foo:\\my\\server\\wants\\backslash"""
dimension: lyric is """
  i wonder wonder who
  who wrote the book of love
"""
source: flights is bigquerr.table("""flights""")
```

If the string contains a `%{ }%` query, there will be an error