### PR TITLE
de-indent """ strings in expressions

### DIFF
--- a/packages/malloy/src/lang/malloy-to-ast.ts
+++ b/packages/malloy/src/lang/malloy-to-ast.ts
@@ -229,7 +229,9 @@ export class MalloyToAST
     sqlStr: ast.SQLString
   ): void {
     const allParts = getStringParts(pcx);
-    unIndent(allParts);
+    // Until SQL writer properly indents turducken, it actually looks better
+    // in the output to NOT de-indent the SQL sources
+    // unIndent(allParts);
     for (const part of allParts) {
       if (part instanceof ParserRuleContext) {
         sqlStr.push(this.visit(part));

--- a/packages/malloy/src/lang/malloy-to-ast.ts
+++ b/packages/malloy/src/lang/malloy-to-ast.ts
@@ -216,7 +216,30 @@ export class MalloyToAST
           safeParts.push(part);
         }
       }
-      return safeParts.join('');
+      let allText = safeParts.join('');
+      let minIndent = allText.length;
+      const lines: string[] = [];
+      while (allText.length > 0) {
+        const lineMatch = allText.match(/^.*?\r?\n/);
+        let nextLine: string;
+        if (lineMatch) {
+          nextLine = lineMatch[0];
+          lines.push(nextLine);
+        } else {
+          lines.push(allText);
+          nextLine = allText;
+        }
+        allText = allText.slice(nextLine.length);
+        // look for lines starting with spaces, that have a non blank character somewhere
+        const leadingMatch = nextLine.match(/^( *).*[^\s]/);
+        if (leadingMatch) {
+          const indentBy = leadingMatch[1].length;
+          if (indentBy < minIndent) {
+            minIndent = indentBy;
+          }
+        }
+      }
+      return lines.map(s => (s[0] === ' ' ? s.slice(minIndent) : s)).join('');
     }
     // string: shortString | sqlString; So this will never happen
     return '';

--- a/packages/malloy/src/lang/malloy-to-ast.ts
+++ b/packages/malloy/src/lang/malloy-to-ast.ts
@@ -228,17 +228,16 @@ export class MalloyToAST
     pcx: parse.SqlStringContext,
     sqlStr: ast.SQLString
   ): void {
-    const allParts = getStringParts(pcx);
-    // Until SQL writer properly indents turducken, it actually looks better
-    // in the output to NOT de-indent the SQL sources
-    // unIndent(allParts);
-    for (const part of allParts) {
+    for (const part of getStringParts(pcx)) {
       if (part instanceof ParserRuleContext) {
         sqlStr.push(this.visit(part));
       } else {
         sqlStr.push(part);
       }
     }
+    // Until SQL writer properly indents turducken, it actually looks better
+    // in the output to NOT de-indent the SQL sources
+    // unIndent(sqlStr.elements);
     sqlStr.complete();
     this.astAt(sqlStr, pcx);
   }

--- a/packages/malloy/src/lang/parse-utils.ts
+++ b/packages/malloy/src/lang/parse-utils.ts
@@ -59,25 +59,22 @@ export type HasString = ParserRuleContext & {
 };
 type StringPart = ParserRuleContext | string;
 
-export function getStringParts(cx: SqlStringContext): StringPart[] {
+export function* getStringParts(cx: SqlStringContext): Generator<StringPart> {
   if (cx) {
-    const strParts: StringPart[] = [];
     for (const part of cx.sqlInterpolation()) {
       const upToOpen = part.OPEN_CODE().text;
       if (upToOpen.length > 2) {
-        strParts.push(upToOpen.slice(0, upToOpen.length - 2));
+        yield upToOpen.slice(0, upToOpen.length - 2);
       }
       if (part.query()) {
-        strParts.push(part.query());
+        yield part.query();
       }
     }
     const lastChars = cx.SQL_END()?.text.slice(0, -3);
     if (lastChars && lastChars.length > 0) {
-      strParts.push(lastChars);
+      yield lastChars;
     }
-    return strParts;
   }
-  return [];
 }
 
 enum ParseState {

--- a/packages/malloy/src/lang/test/strings.spec.ts
+++ b/packages/malloy/src/lang/test/strings.spec.ts
@@ -25,7 +25,7 @@ import './parse-expects';
 import {parseString} from '../parse-utils';
 import {BetaExpression, TestTranslator} from './test-translator';
 
-describe('test internal string parsing', () => {
+describe('quote comprehension inside strings', () => {
   test('\\b', () => {
     expect(parseString('\\b')).toEqual('\b');
   });
@@ -61,8 +61,36 @@ describe('test internal string parsing', () => {
   });
 });
 
-describe('all strings are parsed in all places', () => {
+describe('string parsing in language', () => {
   const tz = 'America/Mexico_City';
+  test('multi-line indent increasing', () => {
+    const checking = new BetaExpression(`"""
+      left
+        mid
+          right
+    """`);
+    expect(checking).toTranslate();
+    const v = checking.generated().value[0];
+    expect(v).toMatchObject({literal: '\nleft\n  mid\n    right\n'});
+  });
+  test('multi-line indent decreasing', () => {
+    const checking = new BetaExpression(`"""
+          right
+        mid
+      left
+    """`);
+    expect(checking).toTranslate();
+    const v = checking.generated().value[0];
+    expect(v).toMatchObject({literal: '\n    right\n  mid\nleft\n'});
+  });
+  test('multi-line indent keep', () => {
+    const checking = new BetaExpression(`"""right
+        mid
+      left"""`);
+    expect(checking).toTranslate();
+    const v = checking.generated().value[0];
+    expect(v).toMatchObject({literal: 'right\n        mid\n      left'});
+  });
   test('timezone single quote', () => {
     const m = new TestTranslator(`run: a-> {timezone: '${tz}'; project: *}`);
     expect(m).toParse();


### PR DESCRIPTION
Since it is common to write these strings in the middle of indented code, it is nice to remove the extra indent
added to make the string line up with the code

```
source: a is b extend {
  dimension: poem is """
        hello
          to all
        and to all
          a good night
    """
    
Produces the string
    
hello
  to all
and to all
  a good night
```

This PR looks for the minimum space indent on any non blank line, and then deletes that many spaces on every line that starts with spaces

Descision was made NOT to de-indent sql blocks because

```
run: bigquery.sql("""
    SELECT
      *
    FROM (%{ bigquery.sql("""
      SELECT
        1 as one,
        2 as two
      """) -> { project: * } }%)
""") -> { project: * }
```

Reads better without indentation removal

```
SELECT 
   base.one as `one`,
   base.two as `two`
FROM (
    SELECT
      *
    FROM (SELECT 
   base.one as `one`,
   base.two as `two`
FROM (
      SELECT
        1 as one,
        2 as two
      ) as base
)
) as base
```

Once the query writer begins writing nicely formatted turduckens with indentation, making sql blocks de-indent so the query writer can indent them properly is as simple as un-commenting out one line of code.