### PR TITLE
Deprecate `top:N by`

### DIFF
--- a/packages/malloy/src/lang/malloy-to-ast.ts
+++ b/packages/malloy/src/lang/malloy-to-ast.ts
@@ -1069,6 +1069,13 @@ export class MalloyToAST
     const topN = this.getNumber(pcx.INTEGER_LITERAL());
     let top: ast.Top | undefined;
     if (byCx) {
+      if (this.m4WarningsEnabled()) {
+        this.contextError(
+          byCx,
+          'by clause of top statement unupported. Use order_by instead',
+          'warn'
+        );
+      }
       const nameCx = byCx.fieldName();
       if (nameCx) {
         const name = this.getFieldName(nameCx);


### PR DESCRIPTION
`top: N` will still be legal, but the `by` clause is going away in m4.
This PR adds it to the m4 warning list.