### PR TITLE
Split out MalloySQL SQL parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@ packages/malloy/src/lang/lib
 packages/**/package-lock.json
 packages/**/.eslintcache
 packages/malloy/src/lang/grammar/.antlr
-packages/malloy-malloy-sql/src/grammar/malloySQL.js
 demo/**/build
 demo/**/dist
 demo/**/node_modules

--- a/packages/malloy-malloy-sql/.gitignore
+++ b/packages/malloy-malloy-sql/.gitignore
@@ -1,0 +1,2 @@
+src/grammar/malloySQL.js
+src/grammar/malloySQLSQL.js

--- a/packages/malloy-malloy-sql/package.json
+++ b/packages/malloy-malloy-sql/package.json
@@ -10,7 +10,9 @@
     "url": "https://github.com/malloydata/malloy"
   },
   "scripts": {
-    "build-grammar": "peggy -o src/grammar/malloySQL.js src/grammar/malloySQL.pegjs",
+    "build-malloysql-grammar": "peggy -o src/grammar/malloySQL.js src/grammar/malloySQL.pegjs",
+    "build-malloysqlsql-grammar": "peggy -o src/grammar/malloySQLSQL.js src/grammar/malloySQLSQL.pegjs",
+    "build-grammar": "npm run build-malloysql-grammar && npm run build-malloysqlsql-grammar",
     "lint": "eslint '**/*.ts{,x}'",
     "lint-fix": "eslint '**/*.ts{,x}' --fix",
     "test": "npm run build-grammar && jest --config=../../jest.config.js",

--- a/packages/malloy-malloy-sql/src/grammar/malloySQL.pegjs
+++ b/packages/malloy-malloy-sql/src/grammar/malloySQL.pegjs
@@ -1,43 +1,56 @@
-start = initial_comments delimiter_and_statement*
+start
+  = initial_comments delimiter_and_statement*
 
-delimiter_and_statement = c:delimiter s:statement {
+delimiter_and_statement
+  = c:delimiter s:statement {
   s["statementType"] = c.type;
   s["config"] = c.config
   s["delimiterRange"] = c.range
   return s
 }
 
-statement = p:(comment / embedded_malloy / other)* {
-  return {parts: p, range: location(), statementText: p.map((s) => { return s.text }).join('')}
+statement
+  = p:(comment / cell)* {
+  return {
+    parts: p,
+    range: location(),
+    statementText: p.map((s) => { return s.text }).join('')
+  }
 }
 
-other "query string" = s:$(!delimiter_start !comment !embedded_malloy .)+ {
-  return {type: "other", text: s, range:location()}
-}
-
-embedded_malloy = parenthized_embedded_malloy / plain_embedded_malloy
-parenthized_embedded_malloy = '(' __ em:plain_embedded_malloy __ ')' {
-  return {type: "malloy", text:text(), malloy:em.malloy, malloyRange: em.malloyRange, range:location(), parenthized: true}
-}
-plain_embedded_malloy = '%{' m:malloy '}%' {
-  return {type: "malloy", text:text(), malloy:m.text, malloyRange: m.malloyRange, range:location(), parenthized: false}
-}
-malloy = (!'}%' .)* {
-  return {malloyRange: location(), text:text()}
+cell "cell" = s:$(!delimiter_start !comment .)+ {
+  return {
+    type: "other",
+    text: s,
+    range:location()
+  }
 }
 
 delimiter =
   delimiter_start t:statement_type c:(_ oc:optional_config {return oc})? __ (single_comment / EOL / EOF) {
-    return {type: t, config: c ? c.trim() : '', range:location()}
+    return {
+      type: t,
+      config: c ? c.trim() : '',
+      range:location()
   }
+}
+
 delimiter_start = '>>>'
+
 statement_type = 'sql' / 'malloy' / 'markdown'
+
 optional_config = $(!comment !EOL .)*
 
 initial_comments "initial comments" = $(_ / EOL / comment)*
+
 comment "comment" = c:(single_comment / multi_comment) {
-  return {type: "comment", text:c, range:location()}
+  return {
+    type: "comment",
+    text:c,
+    range:location()
+  }
 }
+
 single_comment = $(('//' / '--') (!EOL .)* __ (EOL / EOF))
 multi_comment = $("/*" (!"*/" .)* "*/")
 

--- a/packages/malloy-malloy-sql/src/grammar/malloySQLSQL.pegjs
+++ b/packages/malloy-malloy-sql/src/grammar/malloySQLSQL.pegjs
@@ -1,0 +1,65 @@
+start = statement
+
+statement = p:(comment / embedded_malloy / other)* {
+  return {
+    parts: p,
+    range: location(),
+    statementText: p.map((s) => { return s.text }).join('')
+  }
+}
+
+other "query string" = s:$(!comment !embedded_malloy .)+ {
+  return {
+    type: "other",
+    text: s,
+    range:location()
+  }
+}
+
+embedded_malloy
+  = parenthized_embedded_malloy / plain_embedded_malloy
+parenthized_embedded_malloy
+  = '(' __ em:plain_embedded_malloy __ ')' {
+  return {
+    type: "malloy",
+    text:text(),
+    malloy:em.malloy,
+    malloyRange: em.malloyRange,
+    range:location(),
+    parenthized: true
+  }
+}
+plain_embedded_malloy
+  = '%{' m:malloy '}%' {
+  return {
+    type: "malloy",
+    text:text(),
+    malloy:m.text,
+    malloyRange: m.malloyRange,
+    range:location(),
+    parenthized: false
+  }
+}
+malloy
+  = (!'}%' .)* {
+  return {
+    malloyRange: location(),
+    text:text()
+  }
+}
+
+comment "comment"
+  = c:(single_comment / multi_comment) {
+  return {
+    type: "comment",
+    text:c,
+    range:location()
+  }
+}
+single_comment = $(('//' / '--') (!EOL .)* __ (EOL / EOF))
+multi_comment = $("/*" (!"*/" .)* "*/")
+
+__ = _*
+_ = [ \t]
+EOL "end of line" = [\n\r]
+EOF = !.

--- a/packages/malloy-malloy-sql/src/grammar/test/parse.spec.ts
+++ b/packages/malloy-malloy-sql/src/grammar/test/parse.spec.ts
@@ -191,8 +191,6 @@ SELECT 1
 >>>malloy
 import "airports.malloy"`);
 
-      console.log(JSON.stringify(parse.statements, null, 2));
-
       expect(parse.statements).toHaveLength(4);
 
       expect(parse.statements[0].type).toBe(MalloySQLStatementType.MARKDOWN);

--- a/packages/malloy-malloy-sql/src/index.ts
+++ b/packages/malloy-malloy-sql/src/index.ts
@@ -21,7 +21,9 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 export {MalloySQLParser, MalloySQLParseError} from './malloySQLParser';
+export {MalloySQLSQLParser} from './malloySQLSQLParser';
 export type {MalloySQLParse} from './malloySQLParser';
+export type {MalloySQLSQLParse} from './malloySQLSQLParser';
 export type {
   MalloySQLMalloyStatement,
   MalloySQLSQLStatement,

--- a/packages/malloy-malloy-sql/src/malloySQLErrors.ts
+++ b/packages/malloy-malloy-sql/src/malloySQLErrors.ts
@@ -20,15 +20,28 @@
  * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-export {MalloySQLParser} from './malloySQLParser';
-export {MalloySQLParseError} from './malloySQLErrors';
-export {MalloySQLSQLParser} from './malloySQLSQLParser';
-export type {MalloySQLParse} from './malloySQLParser';
-export type {MalloySQLSQLParse} from './malloySQLSQLParser';
-export type {
-  MalloySQLMalloyStatement,
-  MalloySQLSQLStatement,
-  MalloySQLStatement,
-  MalloySQLParseErrorExpected,
-} from './types';
-export {MalloySQLStatementType} from './types';
+
+import {LogMessage, MalloyError} from '@malloydata/malloy';
+import {MalloySQLParseErrorExpected} from './types';
+
+export class MalloySQLParseError extends MalloyError {
+  constructor(message: string, problems: LogMessage[] = []) {
+    super(message, problems);
+  }
+}
+
+export class MalloySQLSyntaxError extends MalloySQLParseError {
+  public expected: MalloySQLParseErrorExpected[];
+  public found: string;
+
+  constructor(
+    message: string,
+    log: LogMessage[],
+    expected: MalloySQLParseErrorExpected[],
+    found: string
+  ) {
+    super(message, log);
+    this.expected = expected;
+    this.found = found;
+  }
+}

--- a/packages/malloy-malloy-sql/src/malloySQLParser.ts
+++ b/packages/malloy-malloy-sql/src/malloySQLParser.ts
@@ -21,12 +21,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import {
-  LogMessage,
-  MalloyError,
-  DocumentRange,
-  DocumentPosition,
-} from '@malloydata/malloy';
+import {LogMessage, DocumentRange, DocumentPosition} from '@malloydata/malloy';
 import * as parser from './grammar/malloySQL';
 import {
   MalloySQLStatmentConfig,
@@ -35,32 +30,10 @@ import {
   MalloySQLParseResults,
   MalloySQLStatementType,
   MalloySQLParseRange,
-  MalloySQLParseErrorExpected,
   MalloySQLParseLocation,
 } from './types';
 import {MalloySQLSQLParser} from './malloySQLSQLParser';
-
-export class MalloySQLParseError extends MalloyError {
-  constructor(message: string, problems: LogMessage[] = []) {
-    super(message, problems);
-  }
-}
-
-export class MalloySQLSyntaxError extends MalloySQLParseError {
-  public expected: MalloySQLParseErrorExpected[];
-  public found: string;
-
-  constructor(
-    message: string,
-    log: LogMessage[],
-    expected: MalloySQLParseErrorExpected[],
-    found: string
-  ) {
-    super(message, log);
-    this.expected = expected;
-    this.found = found;
-  }
-}
+import {MalloySQLParseError, MalloySQLSyntaxError} from './malloySQLErrors';
 
 export class MalloySQLParser {
   private static convertLocation(

--- a/packages/malloy-malloy-sql/src/malloySQLParser.ts
+++ b/packages/malloy-malloy-sql/src/malloySQLParser.ts
@@ -34,11 +34,11 @@ import {
   MalloySQLStatement,
   MalloySQLParseResults,
   MalloySQLStatementType,
-  ParsedMalloySQLMalloyStatementPart,
   MalloySQLParseRange,
   MalloySQLParseErrorExpected,
   MalloySQLParseLocation,
 } from './types';
+import {MalloySQLSQLParser} from './malloySQLSQLParser';
 
 export class MalloySQLParseError extends MalloyError {
   constructor(message: string, problems: LogMessage[] = []) {
@@ -196,19 +196,14 @@ export class MalloySQLParser {
         }
 
         previousConnection = config.connection;
-        const embeddedMalloyQueries = parsedStatement.parts
-          .filter((part): part is ParsedMalloySQLMalloyStatementPart => {
-            return part.type === 'malloy';
-          })
-          .map(part => {
-            return {
-              query: part.malloy,
-              parenthized: part.parenthized,
-              range: this.convertRange(part.range),
-              text: part.text,
-              malloyRange: this.convertRange(part.malloyRange),
-            };
-          });
+
+        const parsedMalloySQLSQL = MalloySQLSQLParser.parse(
+          parsedStatement.statementText,
+          url,
+          parsedStatement.range.start
+        );
+
+        const embeddedMalloyQueries = parsedMalloySQLSQL.embeddedMalloyQueries;
 
         statements.push({
           ...base,

--- a/packages/malloy-malloy-sql/src/malloySQLSQLParser.ts
+++ b/packages/malloy-malloy-sql/src/malloySQLSQLParser.ts
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files
+ * (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import {DocumentRange, DocumentPosition} from '@malloydata/malloy';
+import * as parser from './grammar/malloySQLSQL';
+import {
+  MalloySQLSQLParseResults,
+  ParsedMalloySQLMalloyStatementPart,
+  MalloySQLParseRange,
+  MalloySQLParseLocation,
+  EmbeddedMalloyQuery,
+} from './types';
+import {MalloySQLParseError, MalloySQLSyntaxError} from './malloySQLParser';
+
+export class MalloySQLSQLParser {
+  private static convertLocation(
+    location: MalloySQLParseLocation,
+    start: MalloySQLParseLocation | null
+  ): DocumentPosition {
+    // VSCode expects line/character numbers to be zero-based
+    const result = {
+      character: location.column - 1,
+      line: location.line - 1,
+    };
+    if (start) {
+      result.line += start.line - 1;
+    }
+
+    return result;
+  }
+  private static convertRange(
+    range: MalloySQLParseRange,
+    start: MalloySQLParseLocation | null
+  ): DocumentRange {
+    return {
+      start: this.convertLocation(range.start, start),
+      end: this.convertLocation(range.end, start),
+    };
+  }
+
+  // passing a URL returns the URL in MalloyError.log entries
+  public static parse(
+    document: string,
+    url = '.',
+    start: MalloySQLParseLocation | null = null
+  ): MalloySQLSQLParse {
+    let parsed: MalloySQLSQLParseResults;
+
+    try {
+      parsed = parser.parse(document);
+    } catch (e) {
+      return {
+        embeddedMalloyQueries: [],
+        errors: [
+          new MalloySQLSyntaxError(
+            e.message,
+            [
+              {
+                message: e.message,
+                at: {url, range: this.convertRange(e.location, start)},
+                severity: 'error',
+              },
+            ],
+            e.expected,
+            e.found
+          ),
+        ],
+      };
+    }
+
+    if (!parsed.parts) return {embeddedMalloyQueries: [], errors: []};
+
+    const embeddedMalloyQueries = parsed.parts
+      .filter((part): part is ParsedMalloySQLMalloyStatementPart => {
+        return part.type === 'malloy';
+      })
+      .map(part => {
+        return {
+          query: part.malloy,
+          parenthized: part.parenthized,
+          range: this.convertRange(part.range, start),
+          text: part.text,
+          malloyRange: this.convertRange(part.malloyRange, start),
+        };
+      });
+
+    return {
+      embeddedMalloyQueries,
+      errors: [],
+    };
+  }
+}
+
+export interface MalloySQLSQLParse {
+  embeddedMalloyQueries: EmbeddedMalloyQuery[];
+  errors: MalloySQLParseError[];
+}

--- a/packages/malloy-malloy-sql/src/malloySQLSQLParser.ts
+++ b/packages/malloy-malloy-sql/src/malloySQLSQLParser.ts
@@ -30,7 +30,7 @@ import {
   MalloySQLParseLocation,
   EmbeddedMalloyQuery,
 } from './types';
-import {MalloySQLParseError, MalloySQLSyntaxError} from './malloySQLParser';
+import {MalloySQLParseError, MalloySQLSyntaxError} from './malloySQLErrors';
 
 export class MalloySQLSQLParser {
   private static convertLocation(

--- a/packages/malloy-malloy-sql/src/types.ts
+++ b/packages/malloy-malloy-sql/src/types.ts
@@ -72,6 +72,10 @@ export interface MalloySQLParseResults {
   statements: ParsedMalloySQLStatement[];
 }
 
+export interface MalloySQLSQLParseResults {
+  parts: ParsedMalloySQLMalloyStatementPart[];
+}
+
 export interface MalloySQLStatmentConfig {
   connection?: string;
 }


### PR DESCRIPTION
Use two parsers, one to split up the MalloySQL document, the second to handle MalloySQL SQL cells, so that it can be used separately for notebook cells.

I tried to just modify the original parser to handle both scenarios but peggy didn't want to play along.
