### PR TITLE
Export DataStyles related types

### DIFF
--- a/packages/malloy-render/src/index.ts
+++ b/packages/malloy-render/src/index.ts
@@ -22,4 +22,4 @@
  */
 
 export {HTMLView, JSONView} from './html/html_view';
-export type {DataStyles} from './data_styles';
+export * from './data_styles';


### PR DESCRIPTION
DataStyles references all the other types in this file, so they should be exported, too.