### PR TITLE
Flag inherited connections

### DIFF
--- a/packages/malloy-malloy-sql/src/grammar/test/parse.spec.ts
+++ b/packages/malloy-malloy-sql/src/grammar/test/parse.spec.ts
@@ -156,7 +156,26 @@ import "foo"
 -- connection:bigquery
 SELECT 1`);
       expect(parse.statements[1].config?.connection).toBe('bigquery');
-      expect(parse.statements[1].config?.fromDelimiter).not.toBe(true);
+      expect(parse.statements[1].config?.fromDelimiter).toBeFalsy();
+      expect(parse.statements[1].config?.inheritedConnection).toBeFalsy();
+    });
+
+    test('Should mark a connection as inherited', () => {
+      const parse = MalloySQLParser.parse(`\
+>>>malloy
+import "foo"
+>>>sql
+-- connection:bigquery
+SELECT 1
+>>>sql
+SELECT 2
+`);
+      expect(parse.statements[1].config?.connection).toBe('bigquery');
+      expect(parse.statements[1].config?.fromDelimiter).toBeFalsy();
+      expect(parse.statements[1].config?.inheritedConnection).toBeFalsy();
+      expect(parse.statements[2].config?.connection).toBe('bigquery');
+      expect(parse.statements[2].config?.fromDelimiter).toBeFalsy();
+      expect(parse.statements[2].config?.inheritedConnection).toBe(true);
     });
   });
 

--- a/packages/malloy-malloy-sql/src/malloySQLParser.ts
+++ b/packages/malloy-malloy-sql/src/malloySQLParser.ts
@@ -175,6 +175,7 @@ export class MalloySQLParser {
               )
             );
           config.connection = previousConnection;
+          config.inheritedConnection = true;
         }
 
         previousConnection = config.connection;

--- a/packages/malloy-malloy-sql/src/types.ts
+++ b/packages/malloy-malloy-sql/src/types.ts
@@ -79,6 +79,7 @@ export interface MalloySQLSQLParseResults {
 export interface MalloySQLStatementConfig {
   connection?: string;
   fromDelimiter?: boolean;
+  inheritedConnection?: boolean;
 }
 
 export enum MalloySQLStatementType {


### PR DESCRIPTION
In order to be able to easily re-serialize a parsed document we need a hint whether the connection was directly or indirectly assigned.