### PR TITLE
Fix cells with only comments

### DIFF
--- a/packages/malloy-malloy-sql/src/grammar/malloySQL.pegjs
+++ b/packages/malloy-malloy-sql/src/grammar/malloySQL.pegjs
@@ -10,15 +10,15 @@ delimiter_and_statement
 }
 
 statement
-  = p:(comment / cell)* {
+  = p:cell {
   return {
     parts: p,
     range: location(),
-    statementText: p.map((s) => { return s.text }).join('')
+    statementText: p.text
   }
 }
 
-cell "cell" = s:$(!(EOL delimiter_start) !comment .)+ {
+cell "cell" = s:$(!(EOL delimiter_start) .)* {
   return {
     type: "other",
     text: s,

--- a/packages/malloy-malloy-sql/src/grammar/test/parse.spec.ts
+++ b/packages/malloy-malloy-sql/src/grammar/test/parse.spec.ts
@@ -338,5 +338,31 @@ SELECT 1
       expect(parse.statements[1].range.start.character).toBe(0);
       expect(parse.statements[1].range.end.character).toBe(25);
     });
+
+    test('Should provide correct output for cells that contain only comments', () => {
+      const parse = MalloySQLParser.parse(`\
+>>>sql connection:bigquery
+-- Nothing to see here, move along
+>>>markdown
+# I'm my own cell`);
+      expect(parse.statements).toHaveLength(2);
+
+      expect(parse.statements[0].type).toBe(MalloySQLStatementType.SQL);
+      expect(parse.statements[0].text).toBe(
+        '-- Nothing to see here, move along'
+      );
+      expect(parse.statements[0].config?.connection).toBe('bigquery');
+      expect(parse.statements[0].index).toBe(0);
+      expect(parse.statements[0].range.start.line).toBe(1);
+      expect(parse.statements[0].range.start.character).toBe(0);
+      expect(parse.statements[0].range.end.character).toBe(34);
+
+      expect(parse.statements[1].type).toBe(MalloySQLStatementType.MARKDOWN);
+      expect(parse.statements[1].text).toBe(`# I'm my own cell`);
+      expect(parse.statements[1].index).toBe(1);
+      expect(parse.statements[1].range.start.line).toBe(3);
+      expect(parse.statements[1].range.start.character).toBe(0);
+      expect(parse.statements[1].range.end.character).toBe(17);
+    });
   });
 });


### PR DESCRIPTION
Comment parsing can be done by the MalloySQLSQL parser, does not need to confuse things here.