### PR TITLE
Typescript 5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "prettier": "^2.3.2",
         "ts-jest": "^29.0.3",
         "ts-node": "^10.9.1",
-        "typescript": "4.8.4",
+        "typescript": "^5.1.6",
         "unified": "^10.1.2",
         "uuid": "^8.3.2"
       },
@@ -2915,8 +2915,9 @@
       }
     },
     "node_modules/@types/geojson": {
-      "version": "7946.0.10",
-      "license": "MIT"
+      "version": "7946.0.4",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.4.tgz",
+      "integrity": "sha512-MHmwBtCb7OCv1DSivz2UNJXPGU/1btAWRKlqJ2saEhVJkpkvqHMMaOpKg0v4sAbDWSQekHGvPVMM8nQ+Jen03Q=="
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.5",
@@ -3780,13 +3781,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/array-flat-polyfill": {
-      "version": "1.0.1",
-      "license": "CC0-1.0",
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/array-ify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
@@ -4332,6 +4326,7 @@
     },
     "node_modules/cliui": {
       "version": "7.0.4",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
@@ -5022,7 +5017,8 @@
     },
     "node_modules/d3-dispatch": {
       "version": "3.0.1",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
       "engines": {
         "node": ">=12"
       }
@@ -5069,7 +5065,8 @@
     },
     "node_modules/d3-force": {
       "version": "3.0.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
       "dependencies": {
         "d3-dispatch": "1 - 3",
         "d3-quadtree": "1 - 3",
@@ -5148,7 +5145,8 @@
     },
     "node_modules/d3-quadtree": {
       "version": "3.0.1",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
       "engines": {
         "node": ">=12"
       }
@@ -15368,14 +15366,15 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.8.4",
-      "license": "Apache-2.0",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/typical": {
@@ -15628,32 +15627,33 @@
       }
     },
     "node_modules/vega": {
-      "version": "5.23.0",
-      "license": "BSD-3-Clause",
+      "version": "5.25.0",
+      "resolved": "https://registry.npmjs.org/vega/-/vega-5.25.0.tgz",
+      "integrity": "sha512-lr+uj0mhYlSN3JOKbMNp1RzZBenWp9DxJ7kR3lha58AFNCzzds7pmFa7yXPbtbaGhB7Buh/t6n+Bzk3Y0VnF5g==",
       "dependencies": {
         "vega-crossfilter": "~4.1.1",
         "vega-dataflow": "~5.7.5",
-        "vega-encode": "~4.9.1",
+        "vega-encode": "~4.9.2",
         "vega-event-selector": "~3.0.1",
-        "vega-expression": "~5.0.1",
-        "vega-force": "~4.1.1",
+        "vega-expression": "~5.1.0",
+        "vega-force": "~4.2.0",
         "vega-format": "~1.1.1",
-        "vega-functions": "~5.13.1",
+        "vega-functions": "~5.13.2",
         "vega-geo": "~4.4.1",
         "vega-hierarchy": "~4.1.1",
         "vega-label": "~1.2.1",
         "vega-loader": "~4.5.1",
         "vega-parser": "~6.2.0",
         "vega-projection": "~1.6.0",
-        "vega-regression": "~1.1.1",
+        "vega-regression": "~1.2.0",
         "vega-runtime": "~6.1.4",
         "vega-scale": "~7.3.0",
         "vega-scenegraph": "~4.10.2",
-        "vega-statistics": "~1.8.1",
+        "vega-statistics": "~1.9.0",
         "vega-time": "~2.1.1",
-        "vega-transforms": "~4.10.1",
-        "vega-typings": "~0.23.0",
-        "vega-util": "~1.17.1",
+        "vega-transforms": "~4.10.2",
+        "vega-typings": "~0.24.0",
+        "vega-util": "~1.17.2",
         "vega-view": "~5.11.1",
         "vega-view-transforms": "~4.5.9",
         "vega-voronoi": "~4.2.1",
@@ -15683,8 +15683,9 @@
       }
     },
     "node_modules/vega-encode": {
-      "version": "4.9.1",
-      "license": "BSD-3-Clause",
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/vega-encode/-/vega-encode-4.9.2.tgz",
+      "integrity": "sha512-c3J0LYkgYeXQxwnYkEzL15cCFBYPRaYUon8O2SZ6O4PhH4dfFTXBzSyT8+gh8AhBd572l2yGDfxpEYA6pOqdjg==",
       "dependencies": {
         "d3-array": "^3.2.2",
         "d3-interpolate": "^3.0.1",
@@ -15698,16 +15699,18 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/vega-expression": {
-      "version": "5.0.1",
-      "license": "BSD-3-Clause",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-5.1.0.tgz",
+      "integrity": "sha512-u8Rzja/cn2PEUkhQN3zUj3REwNewTA92ExrcASNKUJPCciMkHJEjESwFYuI6DWMCq4hQElQ92iosOAtwzsSTqA==",
       "dependencies": {
         "@types/estree": "^1.0.0",
         "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-force": {
-      "version": "4.1.1",
-      "license": "BSD-3-Clause",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/vega-force/-/vega-force-4.2.0.tgz",
+      "integrity": "sha512-aE2TlP264HXM1r3fl58AvZdKUWBNOGkIvn4EWyqeJdgO2vz46zSU7x7TzPG4ZLuo44cDRU5Ng3I1eQk23Asz6A==",
       "dependencies": {
         "d3-force": "^3.0.0",
         "vega-dataflow": "^5.7.5",
@@ -15726,14 +15729,15 @@
       }
     },
     "node_modules/vega-functions": {
-      "version": "5.13.1",
-      "license": "BSD-3-Clause",
+      "version": "5.13.2",
+      "resolved": "https://registry.npmjs.org/vega-functions/-/vega-functions-5.13.2.tgz",
+      "integrity": "sha512-YE1Xl3Qi28kw3vdXVYgKFMo20ttd3+SdKth1jUNtBDGGdrOpvPxxFhZkVqX+7FhJ5/1UkDoAYs/cZY0nRKiYgA==",
       "dependencies": {
         "d3-array": "^3.2.2",
         "d3-color": "^3.1.0",
         "d3-geo": "^3.1.0",
         "vega-dataflow": "^5.7.5",
-        "vega-expression": "^5.0.1",
+        "vega-expression": "^5.1.0",
         "vega-scale": "^7.3.0",
         "vega-scenegraph": "^4.10.2",
         "vega-selections": "^5.4.1",
@@ -15776,20 +15780,20 @@
       }
     },
     "node_modules/vega-lite": {
-      "version": "5.2.0",
-      "license": "BSD-3-Clause",
+      "version": "5.14.1",
+      "resolved": "https://registry.npmjs.org/vega-lite/-/vega-lite-5.14.1.tgz",
+      "integrity": "sha512-VFvi0QtUoLQqwfAXTGjo0Acw/OTjiK3zOrcO/HyksGnnNDBHWM1GTcFryiWZYoAi99ehvv7tI/q94O46+fGRSQ==",
       "dependencies": {
         "@types/clone": "~2.1.1",
-        "array-flat-polyfill": "^1.0.1",
         "clone": "~2.1.2",
         "fast-deep-equal": "~3.1.3",
         "fast-json-stable-stringify": "~2.1.0",
         "json-stringify-pretty-compact": "~3.0.0",
-        "tslib": "~2.3.1",
-        "vega-event-selector": "~3.0.0",
-        "vega-expression": "~5.0.0",
-        "vega-util": "~1.17.0",
-        "yargs": "~17.2.1"
+        "tslib": "~2.5.0",
+        "vega-event-selector": "~3.0.1",
+        "vega-expression": "~5.1.0",
+        "vega-util": "~1.17.2",
+        "yargs": "~17.7.2"
       },
       "bin": {
         "vl2pdf": "bin/vl2pdf",
@@ -15798,28 +15802,51 @@
         "vl2vg": "bin/vl2vg"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=16"
       },
       "peerDependencies": {
-        "vega": "^5.21.0"
+        "vega": "^5.24.0"
+      }
+    },
+    "node_modules/vega-lite/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/vega-lite/node_modules/tslib": {
-      "version": "2.3.1",
-      "license": "0BSD"
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
+      "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
     },
     "node_modules/vega-lite/node_modules/yargs": {
-      "version": "17.2.1",
-      "license": "MIT",
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
       "dependencies": {
-        "cliui": "^7.0.2",
+        "cliui": "^8.0.1",
         "escalade": "^3.1.1",
         "get-caller-file": "^2.0.5",
         "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
+        "string-width": "^4.2.3",
         "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
+        "yargs-parser": "^21.1.1"
       },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vega-lite/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "engines": {
         "node": ">=12"
       }
@@ -15856,12 +15883,13 @@
       }
     },
     "node_modules/vega-regression": {
-      "version": "1.1.1",
-      "license": "BSD-3-Clause",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/vega-regression/-/vega-regression-1.2.0.tgz",
+      "integrity": "sha512-6TZoPlhV/280VbxACjRKqlE0Nv48z5g4CSNf1FmGGTWS1rQtElPTranSoVW4d7ET5eVQ6f9QLxNAiALptvEq+g==",
       "dependencies": {
         "d3-array": "^3.2.2",
         "vega-dataflow": "^5.7.3",
-        "vega-statistics": "^1.7.9",
+        "vega-statistics": "^1.9.0",
         "vega-util": "^1.15.2"
       }
     },
@@ -15916,8 +15944,9 @@
       }
     },
     "node_modules/vega-statistics": {
-      "version": "1.8.1",
-      "license": "BSD-3-Clause",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/vega-statistics/-/vega-statistics-1.9.0.tgz",
+      "integrity": "sha512-GAqS7mkatpXcMCQKWtFu1eMUKLUymjInU0O8kXshWaQrVWjPIO2lllZ1VNhdgE0qGj4oOIRRS11kzuijLshGXQ==",
       "dependencies": {
         "d3-array": "^3.2.2"
       }
@@ -15932,8 +15961,9 @@
       }
     },
     "node_modules/vega-transforms": {
-      "version": "4.10.1",
-      "license": "BSD-3-Clause",
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/vega-transforms/-/vega-transforms-4.10.2.tgz",
+      "integrity": "sha512-sJELfEuYQ238PRG+GOqQch8D69RYnJevYSGLsRGQD2LxNz3j+GlUX6Pid+gUEH5HJy22Q5L0vsTl2ZNhIr4teQ==",
       "dependencies": {
         "d3-array": "^3.2.2",
         "vega-dataflow": "^5.7.5",
@@ -15943,18 +15973,20 @@
       }
     },
     "node_modules/vega-typings": {
-      "version": "0.23.0",
-      "license": "BSD-3-Clause",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/vega-typings/-/vega-typings-0.24.2.tgz",
+      "integrity": "sha512-fW02GElYoqweCCaPqH6iH44UZnzXiX9kbm1qyecjU3k5s0vtufLI7Yuz/a/uL37mEAqTMQplBBAlk0T9e2e1Dw==",
       "dependencies": {
-        "@types/geojson": "^7946.0.10",
+        "@types/geojson": "7946.0.4",
         "vega-event-selector": "^3.0.1",
         "vega-expression": "^5.0.1",
         "vega-util": "^1.17.1"
       }
     },
     "node_modules/vega-util": {
-      "version": "1.17.1",
-      "license": "BSD-3-Clause"
+      "version": "1.17.2",
+      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.17.2.tgz",
+      "integrity": "sha512-omNmGiZBdjm/jnHjZlywyYqafscDdHaELHx1q96n5UOz/FlO9JO99P4B3jZg391EFG8dqhWjQilSf2JH6F1mIw=="
     },
     "node_modules/vega-view": {
       "version": "5.11.1",
@@ -16391,6 +16423,7 @@
     },
     "node_modules/yargs-parser": {
       "version": "20.2.4",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"
@@ -16502,8 +16535,7 @@
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/utils": "^5.59.1",
-        "tsutils": "^3.21.0",
-        "typescript": "^4.8.4"
+        "typescript": "^5.1.6"
       }
     },
     "packages/malloy-lint/node_modules/@typescript-eslint/scope-manager": {
@@ -17309,6 +17341,18 @@
       },
       "engines": {
         "node": ">=14"
+      }
+    },
+    "test/node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
       }
     },
     "test/node_modules/w3c-xmlserializer": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "jest-silent-reporter": "^0.5.0",
         "lerna": "^7.1.0",
         "prettier": "^2.3.2",
-        "ts-jest": "^29.0.3",
+        "ts-jest": "^29.1.1",
         "ts-node": "^10.9.1",
         "typescript": "^5.1.6",
         "unified": "^10.1.2",
@@ -14928,17 +14928,18 @@
       }
     },
     "node_modules/ts-jest": {
-      "version": "29.0.3",
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.1.1.tgz",
+      "integrity": "sha512-D6xjnnbP17cC85nliwGiL+tpoKN0StpgE0TeOjXQTU6MVCfsB4v7aW05CgQ/1OywGb0x/oy9hHFnN+sczTiRaA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "bs-logger": "0.x",
         "fast-json-stable-stringify": "2.x",
         "jest-util": "^29.0.0",
-        "json5": "^2.2.1",
+        "json5": "^2.2.3",
         "lodash.memoize": "4.x",
         "make-error": "1.x",
-        "semver": "7.x",
+        "semver": "^7.5.3",
         "yargs-parser": "^21.0.1"
       },
       "bin": {
@@ -14952,7 +14953,7 @@
         "@jest/types": "^29.0.0",
         "babel-jest": "^29.0.0",
         "jest": "^29.0.0",
-        "typescript": ">=4.3"
+        "typescript": ">=4.3 <6"
       },
       "peerDependenciesMeta": {
         "@babel/core": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "jest-silent-reporter": "^0.5.0",
     "lerna": "^7.1.0",
     "prettier": "^2.3.2",
-    "ts-jest": "^29.0.3",
+    "ts-jest": "^29.1.1",
     "ts-node": "^10.9.1",
     "typescript": "^5.1.6",
     "unified": "^10.1.2",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "prettier": "^2.3.2",
     "ts-jest": "^29.0.3",
     "ts-node": "^10.9.1",
-    "typescript": "4.8.4",
+    "typescript": "^5.1.6",
     "unified": "^10.1.2",
     "uuid": "^8.3.2"
   },

--- a/packages/malloy-lint/package.json
+++ b/packages/malloy-lint/package.json
@@ -17,7 +17,6 @@
   },
   "dependencies": {
     "@typescript-eslint/utils": "^5.59.1",
-    "tsutils": "^3.21.0",
-    "typescript": "^4.8.4"
+    "typescript": "^5.1.6"
   }
 }

--- a/packages/malloy-lint/src/quote_string_properties.ts
+++ b/packages/malloy-lint/src/quote_string_properties.ts
@@ -28,7 +28,6 @@ import {
   ParserServices,
 } from '@typescript-eslint/utils';
 import ts from 'typescript';
-import * as tsutils from 'tsutils';
 
 const createRule = ESLintUtils.RuleCreator(
   () => 'https://github.com/malloydata/malloy/main/package/malloy-lint'
@@ -94,10 +93,10 @@ const rule: ReturnType<typeof createRule> = createRule({
           const originalNode = parserServices.esTreeNodeToTSNodeMap.get(parent);
           const nodeType = checker.getTypeAtLocation(originalNode);
 
-          if (tsutils.isPropertyDeclaration(originalNode)) {
+          if (originalNode.kind === ts.SyntaxKind.PropertyDeclaration) {
             return nodeType;
           }
-          if (tsutils.isVariableDeclaration(originalNode)) {
+          if (originalNode.kind === ts.SyntaxKind.VariableDeclaration) {
             return nodeType;
           }
           return undefined;
@@ -114,7 +113,7 @@ const rule: ReturnType<typeof createRule> = createRule({
             ts.IndexKind.String
           )?.keyType;
           if (keyType) {
-            return tsutils.isTypeFlagSet(keyType, ts.TypeFlags.String);
+            return Boolean(keyType.getFlags() & ts.TypeFlags.String);
           }
           return false;
         }

--- a/packages/malloy-render/src/html/vega_spec.ts
+++ b/packages/malloy-render/src/html/vega_spec.ts
@@ -111,7 +111,7 @@ const sizeLarge = {
 
 // bar with text in the bars.
 const bar_SM: lite.TopLevelSpec = {
-  ...DEFAULT_SPEC,
+  config: {...DEFAULT_SPEC.config},
   encoding: {
     y: {field: '#{1}', type: 'nominal', axis: null, sort: null},
   },

--- a/test/src/render/__snapshots__/render.spec.ts.snap
+++ b/test/src/render/__snapshots__/render.spec.ts.snap
@@ -1122,15 +1122,15 @@ exports[`rendering results html renderer complex query with tags regular table 1
             class="marks"
             height="217"
             version="1.1"
-            viewBox="0 0 309 217"
-            width="309"
+            viewBox="0 0 293 217"
+            width="293"
             xmlns="http://www.w3.org/2000/svg"
             xmlns:xlink="http://www.w3.org/1999/xlink"
           >
             <g
               fill="none"
               stroke-miterlimit="10"
-              transform="translate(53,5)"
+              transform="translate(37,5)"
             >
               <g
                 aria-roledescription="group mark container"
@@ -1278,7 +1278,7 @@ exports[`rendering results html renderer complex query with tags regular table 1
                               opacity="1"
                               stroke="#888"
                               stroke-width="1"
-                              transform="translate(0,135)"
+                              transform="translate(0,136)"
                               x2="250"
                               y2="0"
                             />
@@ -1286,7 +1286,7 @@ exports[`rendering results html renderer complex query with tags regular table 1
                               opacity="1"
                               stroke="#888"
                               stroke-width="1"
-                              transform="translate(0,95)"
+                              transform="translate(0,97)"
                               x2="250"
                               y2="0"
                             />
@@ -1294,7 +1294,7 @@ exports[`rendering results html renderer complex query with tags regular table 1
                               opacity="1"
                               stroke="#888"
                               stroke-width="1"
-                              transform="translate(0,56)"
+                              transform="translate(0,58)"
                               x2="250"
                               y2="0"
                             />
@@ -1302,7 +1302,7 @@ exports[`rendering results html renderer complex query with tags regular table 1
                               opacity="1"
                               stroke="#888"
                               stroke-width="1"
-                              transform="translate(0,16)"
+                              transform="translate(0,19)"
                               x2="250"
                               y2="0"
                             />
@@ -1545,7 +1545,7 @@ exports[`rendering results html renderer complex query with tags regular table 1
                       </g>
                     </g>
                     <g
-                      aria-label="Y-axis titled 'wt' for a linear scale with values from 2.0 to 4.2"
+                      aria-label="Y-axis titled 'wt' for a linear scale with values from 0 to 5"
                       aria-roledescription="axis"
                       class="mark-group role-axis"
                       role="graphics-symbol"
@@ -1576,7 +1576,7 @@ exports[`rendering results html renderer complex query with tags regular table 1
                               opacity="1"
                               stroke="#ddd"
                               stroke-width="1"
-                              transform="translate(0,135)"
+                              transform="translate(0,136)"
                               x2="-5"
                               y2="0"
                             />
@@ -1584,7 +1584,7 @@ exports[`rendering results html renderer complex query with tags regular table 1
                               opacity="1"
                               stroke="#ddd"
                               stroke-width="1"
-                              transform="translate(0,95)"
+                              transform="translate(0,97)"
                               x2="-5"
                               y2="0"
                             />
@@ -1592,7 +1592,7 @@ exports[`rendering results html renderer complex query with tags regular table 1
                               opacity="1"
                               stroke="#ddd"
                               stroke-width="1"
-                              transform="translate(0,56)"
+                              transform="translate(0,58)"
                               x2="-5"
                               y2="0"
                             />
@@ -1600,7 +1600,7 @@ exports[`rendering results html renderer complex query with tags regular table 1
                               opacity="1"
                               stroke="#ddd"
                               stroke-width="1"
-                              transform="translate(0,16)"
+                              transform="translate(0,19)"
                               x2="-5"
                               y2="0"
                             />
@@ -1617,7 +1617,7 @@ exports[`rendering results html renderer complex query with tags regular table 1
                               text-anchor="end"
                               transform="translate(-7,178)"
                             >
-                              2.0
+                              0
                             </text>
                             <text
                               fill="var(--malloy-label-color, #505050)"
@@ -1625,9 +1625,9 @@ exports[`rendering results html renderer complex query with tags regular table 1
                               font-size="10px"
                               opacity="1"
                               text-anchor="end"
-                              transform="translate(-7,138.22727272727272)"
+                              transform="translate(-7,139.11111111111111)"
                             >
-                              2.5
+                              1
                             </text>
                             <text
                               fill="var(--malloy-label-color, #505050)"
@@ -1635,9 +1635,9 @@ exports[`rendering results html renderer complex query with tags regular table 1
                               font-size="10px"
                               opacity="1"
                               text-anchor="end"
-                              transform="translate(-7,98.45454545454545)"
+                              transform="translate(-7,100.22222222222223)"
                             >
-                              3.0
+                              2
                             </text>
                             <text
                               fill="var(--malloy-label-color, #505050)"
@@ -1645,9 +1645,9 @@ exports[`rendering results html renderer complex query with tags regular table 1
                               font-size="10px"
                               opacity="1"
                               text-anchor="end"
-                              transform="translate(-7,58.681818181818194)"
+                              transform="translate(-7,61.33333333333334)"
                             >
-                              3.5
+                              3
                             </text>
                             <text
                               fill="var(--malloy-label-color, #505050)"
@@ -1655,9 +1655,9 @@ exports[`rendering results html renderer complex query with tags regular table 1
                               font-size="10px"
                               opacity="1"
                               text-anchor="end"
-                              transform="translate(-7,18.909090909090914)"
+                              transform="translate(-7,22.444444444444454)"
                             >
-                              4.0
+                              4
                             </text>
                           </g>
                           <g
@@ -1684,7 +1684,7 @@ exports[`rendering results html renderer complex query with tags regular table 1
                               font-weight="500"
                               opacity="1"
                               text-anchor="middle"
-                              transform="translate(-35,87.5) rotate(-90) translate(0,-3)"
+                              transform="translate(-19,87.5) rotate(-90) translate(0,-3)"
                             >
                               wt
                             </text>
@@ -1707,28 +1707,28 @@ exports[`rendering results html renderer complex query with tags regular table 1
                       <path
                         aria-label="monthy: 1; wt: 2"
                         aria-roledescription="bar"
-                        d="M28.75,175h5v0h-5Z"
+                        d="M28.75,97.22222222222223h5v77.77777777777777h-5Z"
                         fill="#4285F4"
                         role="graphics-symbol"
                       />
                       <path
                         aria-label="monthy: 2; wt: 2.6"
                         aria-roledescription="bar"
-                        d="M91.25,127.27272727272728h5v47.72727272727272h-5Z"
+                        d="M91.25,73.88888888888889h5v101.11111111111111h-5Z"
                         fill="#4285F4"
                         role="graphics-symbol"
                       />
                       <path
                         aria-label="monthy: 3; wt: 3.6"
                         aria-roledescription="bar"
-                        d="M153.75,47.72727272727273h5v127.27272727272728h-5Z"
+                        d="M153.75,34.99999999999999h5v140h-5Z"
                         fill="#4285F4"
                         role="graphics-symbol"
                       />
                       <path
                         aria-label="monthy: 4; wt: 4.2"
                         aria-roledescription="bar"
-                        d="M216.25,0h5v175h-5Z"
+                        d="M216.25,11.666666666666664h5v163.33333333333334h-5Z"
                         fill="#4285F4"
                         role="graphics-symbol"
                       />
@@ -2363,15 +2363,15 @@ exports[`rendering results html renderer complex query with tags regular table 1
             class="marks"
             height="222"
             version="1.1"
-            viewBox="0 0 309 222"
-            width="309"
+            viewBox="0 0 293 222"
+            width="293"
             xmlns="http://www.w3.org/2000/svg"
             xmlns:xlink="http://www.w3.org/1999/xlink"
           >
             <g
               fill="none"
               stroke-miterlimit="10"
-              transform="translate(53,10)"
+              transform="translate(37,10)"
             >
               <g
                 aria-roledescription="group mark container"
@@ -2519,7 +2519,7 @@ exports[`rendering results html renderer complex query with tags regular table 1
                               opacity="1"
                               stroke="#888"
                               stroke-width="1"
-                              transform="translate(0,150)"
+                              transform="translate(0,131)"
                               x2="250"
                               y2="0"
                             />
@@ -2527,7 +2527,7 @@ exports[`rendering results html renderer complex query with tags regular table 1
                               opacity="1"
                               stroke="#888"
                               stroke-width="1"
-                              transform="translate(0,125)"
+                              transform="translate(0,88)"
                               x2="250"
                               y2="0"
                             />
@@ -2535,31 +2535,7 @@ exports[`rendering results html renderer complex query with tags regular table 1
                               opacity="1"
                               stroke="#888"
                               stroke-width="1"
-                              transform="translate(0,100)"
-                              x2="250"
-                              y2="0"
-                            />
-                            <line
-                              opacity="1"
-                              stroke="#888"
-                              stroke-width="1"
-                              transform="translate(0,75)"
-                              x2="250"
-                              y2="0"
-                            />
-                            <line
-                              opacity="1"
-                              stroke="#888"
-                              stroke-width="1"
-                              transform="translate(0,50)"
-                              x2="250"
-                              y2="0"
-                            />
-                            <line
-                              opacity="1"
-                              stroke="#888"
-                              stroke-width="1"
-                              transform="translate(0,25)"
+                              transform="translate(0,44)"
                               x2="250"
                               y2="0"
                             />
@@ -2810,7 +2786,7 @@ exports[`rendering results html renderer complex query with tags regular table 1
                       </g>
                     </g>
                     <g
-                      aria-label="Y-axis titled 'wt' for a linear scale with values from 3.0 to 3.7"
+                      aria-label="Y-axis titled 'wt' for a linear scale with values from 0 to 4"
                       aria-roledescription="axis"
                       class="mark-group role-axis"
                       role="graphics-symbol"
@@ -2841,7 +2817,7 @@ exports[`rendering results html renderer complex query with tags regular table 1
                               opacity="1"
                               stroke="#ddd"
                               stroke-width="1"
-                              transform="translate(0,150)"
+                              transform="translate(0,131)"
                               x2="-5"
                               y2="0"
                             />
@@ -2849,7 +2825,7 @@ exports[`rendering results html renderer complex query with tags regular table 1
                               opacity="1"
                               stroke="#ddd"
                               stroke-width="1"
-                              transform="translate(0,125)"
+                              transform="translate(0,88)"
                               x2="-5"
                               y2="0"
                             />
@@ -2857,31 +2833,7 @@ exports[`rendering results html renderer complex query with tags regular table 1
                               opacity="1"
                               stroke="#ddd"
                               stroke-width="1"
-                              transform="translate(0,100)"
-                              x2="-5"
-                              y2="0"
-                            />
-                            <line
-                              opacity="1"
-                              stroke="#ddd"
-                              stroke-width="1"
-                              transform="translate(0,75)"
-                              x2="-5"
-                              y2="0"
-                            />
-                            <line
-                              opacity="1"
-                              stroke="#ddd"
-                              stroke-width="1"
-                              transform="translate(0,50)"
-                              x2="-5"
-                              y2="0"
-                            />
-                            <line
-                              opacity="1"
-                              stroke="#ddd"
-                              stroke-width="1"
-                              transform="translate(0,25)"
+                              transform="translate(0,44)"
                               x2="-5"
                               y2="0"
                             />
@@ -2906,7 +2858,7 @@ exports[`rendering results html renderer complex query with tags regular table 1
                               text-anchor="end"
                               transform="translate(-7,178)"
                             >
-                              3.0
+                              0
                             </text>
                             <text
                               fill="var(--malloy-label-color, #505050)"
@@ -2914,9 +2866,9 @@ exports[`rendering results html renderer complex query with tags regular table 1
                               font-size="10px"
                               opacity="1"
                               text-anchor="end"
-                              transform="translate(-7,152.99999999999997)"
+                              transform="translate(-7,134.25)"
                             >
-                              3.1
+                              1
                             </text>
                             <text
                               fill="var(--malloy-label-color, #505050)"
@@ -2924,9 +2876,9 @@ exports[`rendering results html renderer complex query with tags regular table 1
                               font-size="10px"
                               opacity="1"
                               text-anchor="end"
-                              transform="translate(-7,127.99999999999996)"
+                              transform="translate(-7,90.5)"
                             >
-                              3.2
+                              2
                             </text>
                             <text
                               fill="var(--malloy-label-color, #505050)"
@@ -2934,39 +2886,9 @@ exports[`rendering results html renderer complex query with tags regular table 1
                               font-size="10px"
                               opacity="1"
                               text-anchor="end"
-                              transform="translate(-7,103.00000000000007)"
+                              transform="translate(-7,46.75)"
                             >
-                              3.3
-                            </text>
-                            <text
-                              fill="var(--malloy-label-color, #505050)"
-                              font-family="var(--malloy-font-family, 'Roboto')"
-                              font-size="10px"
-                              opacity="1"
-                              text-anchor="end"
-                              transform="translate(-7,78.00000000000004)"
-                            >
-                              3.4
-                            </text>
-                            <text
-                              fill="var(--malloy-label-color, #505050)"
-                              font-family="var(--malloy-font-family, 'Roboto')"
-                              font-size="10px"
-                              opacity="1"
-                              text-anchor="end"
-                              transform="translate(-7,53.000000000000036)"
-                            >
-                              3.5
-                            </text>
-                            <text
-                              fill="var(--malloy-label-color, #505050)"
-                              font-family="var(--malloy-font-family, 'Roboto')"
-                              font-size="10px"
-                              opacity="1"
-                              text-anchor="end"
-                              transform="translate(-7,28.000000000000007)"
-                            >
-                              3.6
+                              3
                             </text>
                             <text
                               fill="var(--malloy-label-color, #505050)"
@@ -2976,7 +2898,7 @@ exports[`rendering results html renderer complex query with tags regular table 1
                               text-anchor="end"
                               transform="translate(-7,3)"
                             >
-                              3.7
+                              4
                             </text>
                           </g>
                           <g
@@ -3003,7 +2925,7 @@ exports[`rendering results html renderer complex query with tags regular table 1
                               font-weight="500"
                               opacity="1"
                               text-anchor="middle"
-                              transform="translate(-35,87.5) rotate(-90) translate(0,-3)"
+                              transform="translate(-19,87.5) rotate(-90) translate(0,-3)"
                             >
                               wt
                             </text>
@@ -3026,28 +2948,28 @@ exports[`rendering results html renderer complex query with tags regular table 1
                       <path
                         aria-label="monthy: 1; wt: 3"
                         aria-roledescription="bar"
-                        d="M28.75,175h5v0h-5Z"
+                        d="M28.75,43.75h5v131.25h-5Z"
                         fill="#4285F4"
                         role="graphics-symbol"
                       />
                       <path
                         aria-label="monthy: 2; wt: 3.4"
                         aria-roledescription="bar"
-                        d="M91.25,75.00000000000004h5v99.99999999999996h-5Z"
+                        d="M91.25,26.250000000000004h5v148.75h-5Z"
                         fill="#4285F4"
                         role="graphics-symbol"
                       />
                       <path
                         aria-label="monthy: 3; wt: 3.6"
                         aria-roledescription="bar"
-                        d="M153.75,25.000000000000007h5v150h-5Z"
+                        d="M153.75,17.499999999999996h5v157.5h-5Z"
                         fill="#4285F4"
                         role="graphics-symbol"
                       />
                       <path
                         aria-label="monthy: 4; wt: 3.7"
                         aria-roledescription="bar"
-                        d="M216.25,0h5v175h-5Z"
+                        d="M216.25,13.124999999999993h5v161.875h-5Z"
                         fill="#4285F4"
                         role="graphics-symbol"
                       />
@@ -3804,7 +3726,7 @@ exports[`rendering results html renderer complex query with tags regular table 1
                               opacity="1"
                               stroke="#888"
                               stroke-width="1"
-                              transform="translate(0,156)"
+                              transform="translate(0,175)"
                               x2="250"
                               y2="0"
                             />
@@ -3812,7 +3734,7 @@ exports[`rendering results html renderer complex query with tags regular table 1
                               opacity="1"
                               stroke="#888"
                               stroke-width="1"
-                              transform="translate(0,117)"
+                              transform="translate(0,150)"
                               x2="250"
                               y2="0"
                             />
@@ -3820,7 +3742,7 @@ exports[`rendering results html renderer complex query with tags regular table 1
                               opacity="1"
                               stroke="#888"
                               stroke-width="1"
-                              transform="translate(0,78)"
+                              transform="translate(0,125)"
                               x2="250"
                               y2="0"
                             />
@@ -3828,7 +3750,31 @@ exports[`rendering results html renderer complex query with tags regular table 1
                               opacity="1"
                               stroke="#888"
                               stroke-width="1"
-                              transform="translate(0,39)"
+                              transform="translate(0,100)"
+                              x2="250"
+                              y2="0"
+                            />
+                            <line
+                              opacity="1"
+                              stroke="#888"
+                              stroke-width="1"
+                              transform="translate(0,75)"
+                              x2="250"
+                              y2="0"
+                            />
+                            <line
+                              opacity="1"
+                              stroke="#888"
+                              stroke-width="1"
+                              transform="translate(0,50)"
+                              x2="250"
+                              y2="0"
+                            />
+                            <line
+                              opacity="1"
+                              stroke="#888"
+                              stroke-width="1"
+                              transform="translate(0,25)"
                               x2="250"
                               y2="0"
                             />
@@ -4079,7 +4025,7 @@ exports[`rendering results html renderer complex query with tags regular table 1
                       </g>
                     </g>
                     <g
-                      aria-label="Y-axis titled 'wt' for a linear scale with values from 2.5 to 3.4"
+                      aria-label="Y-axis titled 'wt' for a linear scale with values from 0.0 to 3.5"
                       aria-roledescription="axis"
                       class="mark-group role-axis"
                       role="graphics-symbol"
@@ -4102,7 +4048,7 @@ exports[`rendering results html renderer complex query with tags regular table 1
                               opacity="1"
                               stroke="#ddd"
                               stroke-width="1"
-                              transform="translate(0,156)"
+                              transform="translate(0,175)"
                               x2="-5"
                               y2="0"
                             />
@@ -4110,7 +4056,7 @@ exports[`rendering results html renderer complex query with tags regular table 1
                               opacity="1"
                               stroke="#ddd"
                               stroke-width="1"
-                              transform="translate(0,117)"
+                              transform="translate(0,150)"
                               x2="-5"
                               y2="0"
                             />
@@ -4118,7 +4064,7 @@ exports[`rendering results html renderer complex query with tags regular table 1
                               opacity="1"
                               stroke="#ddd"
                               stroke-width="1"
-                              transform="translate(0,78)"
+                              transform="translate(0,125)"
                               x2="-5"
                               y2="0"
                             />
@@ -4126,7 +4072,31 @@ exports[`rendering results html renderer complex query with tags regular table 1
                               opacity="1"
                               stroke="#ddd"
                               stroke-width="1"
-                              transform="translate(0,39)"
+                              transform="translate(0,100)"
+                              x2="-5"
+                              y2="0"
+                            />
+                            <line
+                              opacity="1"
+                              stroke="#ddd"
+                              stroke-width="1"
+                              transform="translate(0,75)"
+                              x2="-5"
+                              y2="0"
+                            />
+                            <line
+                              opacity="1"
+                              stroke="#ddd"
+                              stroke-width="1"
+                              transform="translate(0,50)"
+                              x2="-5"
+                              y2="0"
+                            />
+                            <line
+                              opacity="1"
+                              stroke="#ddd"
+                              stroke-width="1"
+                              transform="translate(0,25)"
                               x2="-5"
                               y2="0"
                             />
@@ -4149,9 +4119,9 @@ exports[`rendering results html renderer complex query with tags regular table 1
                               font-size="10px"
                               opacity="1"
                               text-anchor="end"
-                              transform="translate(-7,158.55555555555554)"
+                              transform="translate(-7,178)"
                             >
-                              2.6
+                              0.0
                             </text>
                             <text
                               fill="var(--malloy-label-color, #505050)"
@@ -4159,9 +4129,9 @@ exports[`rendering results html renderer complex query with tags regular table 1
                               font-size="10px"
                               opacity="1"
                               text-anchor="end"
-                              transform="translate(-7,119.6666666666667)"
+                              transform="translate(-7,153)"
                             >
-                              2.8
+                              0.5
                             </text>
                             <text
                               fill="var(--malloy-label-color, #505050)"
@@ -4169,7 +4139,47 @@ exports[`rendering results html renderer complex query with tags regular table 1
                               font-size="10px"
                               opacity="1"
                               text-anchor="end"
-                              transform="translate(-7,80.77777777777777)"
+                              transform="translate(-7,128)"
+                            >
+                              1.0
+                            </text>
+                            <text
+                              fill="var(--malloy-label-color, #505050)"
+                              font-family="var(--malloy-font-family, 'Roboto')"
+                              font-size="10px"
+                              opacity="1"
+                              text-anchor="end"
+                              transform="translate(-7,103)"
+                            >
+                              1.5
+                            </text>
+                            <text
+                              fill="var(--malloy-label-color, #505050)"
+                              font-family="var(--malloy-font-family, 'Roboto')"
+                              font-size="10px"
+                              opacity="1"
+                              text-anchor="end"
+                              transform="translate(-7,78)"
+                            >
+                              2.0
+                            </text>
+                            <text
+                              fill="var(--malloy-label-color, #505050)"
+                              font-family="var(--malloy-font-family, 'Roboto')"
+                              font-size="10px"
+                              opacity="1"
+                              text-anchor="end"
+                              transform="translate(-7,53)"
+                            >
+                              2.5
+                            </text>
+                            <text
+                              fill="var(--malloy-label-color, #505050)"
+                              font-family="var(--malloy-font-family, 'Roboto')"
+                              font-size="10px"
+                              opacity="1"
+                              text-anchor="end"
+                              transform="translate(-7,28.000000000000007)"
                             >
                               3.0
                             </text>
@@ -4179,19 +4189,9 @@ exports[`rendering results html renderer complex query with tags regular table 1
                               font-size="10px"
                               opacity="1"
                               text-anchor="end"
-                              transform="translate(-7,41.88888888888885)"
-                            >
-                              3.2
-                            </text>
-                            <text
-                              fill="var(--malloy-label-color, #505050)"
-                              font-family="var(--malloy-font-family, 'Roboto')"
-                              font-size="10px"
-                              opacity="1"
-                              text-anchor="end"
                               transform="translate(-7,3)"
                             >
-                              3.4
+                              3.5
                             </text>
                           </g>
                           <g
@@ -4241,28 +4241,28 @@ exports[`rendering results html renderer complex query with tags regular table 1
                       <path
                         aria-label="monthy: 1; wt: 2.5"
                         aria-roledescription="bar"
-                        d="M28.75,175h5v0h-5Z"
+                        d="M28.75,50h5v125h-5Z"
                         fill="#4285F4"
                         role="graphics-symbol"
                       />
                       <path
                         aria-label="monthy: 2; wt: 3"
                         aria-roledescription="bar"
-                        d="M91.25,77.77777777777777h5v97.22222222222223h-5Z"
+                        d="M91.25,25.000000000000007h5v150h-5Z"
                         fill="#4285F4"
                         role="graphics-symbol"
                       />
                       <path
                         aria-label="monthy: 3; wt: 3.2"
                         aria-roledescription="bar"
-                        d="M153.75,38.88888888888885h5v136.11111111111114h-5Z"
+                        d="M153.75,14.999999999999986h5v160h-5Z"
                         fill="#4285F4"
                         role="graphics-symbol"
                       />
                       <path
                         aria-label="monthy: 4; wt: 3.4"
                         aria-roledescription="bar"
-                        d="M216.25,0h5v175h-5Z"
+                        d="M216.25,5.000000000000002h5v170h-5Z"
                         fill="#4285F4"
                         role="graphics-symbol"
                       />
@@ -4869,17 +4869,17 @@ exports[`rendering results html renderer complex query with tags regular table 1
         <div>
           <svg
             class="marks"
-            height="222"
+            height="217"
             version="1.1"
-            viewBox="0 0 317 222"
-            width="317"
+            viewBox="0 0 293 217"
+            width="293"
             xmlns="http://www.w3.org/2000/svg"
             xmlns:xlink="http://www.w3.org/1999/xlink"
           >
             <g
               fill="none"
               stroke-miterlimit="10"
-              transform="translate(61,10)"
+              transform="translate(37,5)"
             >
               <g
                 aria-roledescription="group mark container"
@@ -5027,7 +5027,7 @@ exports[`rendering results html renderer complex query with tags regular table 1
                               opacity="1"
                               stroke="#888"
                               stroke-width="1"
-                              transform="translate(0,146)"
+                              transform="translate(0,136)"
                               x2="250"
                               y2="0"
                             />
@@ -5035,15 +5035,7 @@ exports[`rendering results html renderer complex query with tags regular table 1
                               opacity="1"
                               stroke="#888"
                               stroke-width="1"
-                              transform="translate(0,117)"
-                              x2="250"
-                              y2="0"
-                            />
-                            <line
-                              opacity="1"
-                              stroke="#888"
-                              stroke-width="1"
-                              transform="translate(0,87)"
+                              transform="translate(0,97)"
                               x2="250"
                               y2="0"
                             />
@@ -5059,15 +5051,7 @@ exports[`rendering results html renderer complex query with tags regular table 1
                               opacity="1"
                               stroke="#888"
                               stroke-width="1"
-                              transform="translate(0,29)"
-                              x2="250"
-                              y2="0"
-                            />
-                            <line
-                              opacity="1"
-                              stroke="#888"
-                              stroke-width="1"
-                              transform="translate(0,0)"
+                              transform="translate(0,19)"
                               x2="250"
                               y2="0"
                             />
@@ -5310,7 +5294,7 @@ exports[`rendering results html renderer complex query with tags regular table 1
                       </g>
                     </g>
                     <g
-                      aria-label="Y-axis titled 'wt' for a linear scale with values from 4.00 to 4.30"
+                      aria-label="Y-axis titled 'wt' for a linear scale with values from 0 to 5"
                       aria-roledescription="axis"
                       class="mark-group role-axis"
                       role="graphics-symbol"
@@ -5341,7 +5325,7 @@ exports[`rendering results html renderer complex query with tags regular table 1
                               opacity="1"
                               stroke="#ddd"
                               stroke-width="1"
-                              transform="translate(0,146)"
+                              transform="translate(0,136)"
                               x2="-5"
                               y2="0"
                             />
@@ -5349,15 +5333,7 @@ exports[`rendering results html renderer complex query with tags regular table 1
                               opacity="1"
                               stroke="#ddd"
                               stroke-width="1"
-                              transform="translate(0,117)"
-                              x2="-5"
-                              y2="0"
-                            />
-                            <line
-                              opacity="1"
-                              stroke="#ddd"
-                              stroke-width="1"
-                              transform="translate(0,87)"
+                              transform="translate(0,97)"
                               x2="-5"
                               y2="0"
                             />
@@ -5373,15 +5349,7 @@ exports[`rendering results html renderer complex query with tags regular table 1
                               opacity="1"
                               stroke="#ddd"
                               stroke-width="1"
-                              transform="translate(0,29)"
-                              x2="-5"
-                              y2="0"
-                            />
-                            <line
-                              opacity="1"
-                              stroke="#ddd"
-                              stroke-width="1"
-                              transform="translate(0,0)"
+                              transform="translate(0,19)"
                               x2="-5"
                               y2="0"
                             />
@@ -5398,7 +5366,7 @@ exports[`rendering results html renderer complex query with tags regular table 1
                               text-anchor="end"
                               transform="translate(-7,178)"
                             >
-                              4.00
+                              0
                             </text>
                             <text
                               fill="var(--malloy-label-color, #505050)"
@@ -5406,9 +5374,9 @@ exports[`rendering results html renderer complex query with tags regular table 1
                               font-size="10px"
                               opacity="1"
                               text-anchor="end"
-                              transform="translate(-7,148.83333333333343)"
+                              transform="translate(-7,139.11111111111111)"
                             >
-                              4.05
+                              1
                             </text>
                             <text
                               fill="var(--malloy-label-color, #505050)"
@@ -5416,9 +5384,9 @@ exports[`rendering results html renderer complex query with tags regular table 1
                               font-size="10px"
                               opacity="1"
                               text-anchor="end"
-                              transform="translate(-7,119.66666666666684)"
+                              transform="translate(-7,100.22222222222223)"
                             >
-                              4.10
+                              2
                             </text>
                             <text
                               fill="var(--malloy-label-color, #505050)"
@@ -5426,9 +5394,9 @@ exports[`rendering results html renderer complex query with tags regular table 1
                               font-size="10px"
                               opacity="1"
                               text-anchor="end"
-                              transform="translate(-7,90.49999999999974)"
+                              transform="translate(-7,61.33333333333334)"
                             >
-                              4.15
+                              3
                             </text>
                             <text
                               fill="var(--malloy-label-color, #505050)"
@@ -5436,29 +5404,9 @@ exports[`rendering results html renderer complex query with tags regular table 1
                               font-size="10px"
                               opacity="1"
                               text-anchor="end"
-                              transform="translate(-7,61.333333333333165)"
+                              transform="translate(-7,22.444444444444454)"
                             >
-                              4.20
-                            </text>
-                            <text
-                              fill="var(--malloy-label-color, #505050)"
-                              font-family="var(--malloy-font-family, 'Roboto')"
-                              font-size="10px"
-                              opacity="1"
-                              text-anchor="end"
-                              transform="translate(-7,32.166666666666586)"
-                            >
-                              4.25
-                            </text>
-                            <text
-                              fill="var(--malloy-label-color, #505050)"
-                              font-family="var(--malloy-font-family, 'Roboto')"
-                              font-size="10px"
-                              opacity="1"
-                              text-anchor="end"
-                              transform="translate(-7,3)"
-                            >
-                              4.30
+                              4
                             </text>
                           </g>
                           <g
@@ -5485,7 +5433,7 @@ exports[`rendering results html renderer complex query with tags regular table 1
                               font-weight="500"
                               opacity="1"
                               text-anchor="middle"
-                              transform="translate(-43,87.5) rotate(-90) translate(0,-3)"
+                              transform="translate(-19,87.5) rotate(-90) translate(0,-3)"
                             >
                               wt
                             </text>
@@ -5508,28 +5456,28 @@ exports[`rendering results html renderer complex query with tags regular table 1
                       <path
                         aria-label="monthy: 1; wt: 4"
                         aria-roledescription="bar"
-                        d="M28.75,175h5v0h-5Z"
+                        d="M28.75,19.444444444444454h5v155.55555555555554h-5Z"
                         fill="#4285F4"
                         role="graphics-symbol"
                       />
                       <path
                         aria-label="monthy: 2; wt: 4.1"
                         aria-roledescription="bar"
-                        d="M91.25,116.66666666666684h5v58.33333333333316h-5Z"
+                        d="M91.25,15.555555555555578h5v159.44444444444443h-5Z"
                         fill="#4285F4"
                         role="graphics-symbol"
                       />
                       <path
                         aria-label="monthy: 3; wt: 4.2"
                         aria-roledescription="bar"
-                        d="M153.75,58.333333333333165h5v116.66666666666683h-5Z"
+                        d="M153.75,11.666666666666664h5v163.33333333333334h-5Z"
                         fill="#4285F4"
                         role="graphics-symbol"
                       />
                       <path
                         aria-label="monthy: 4; wt: 4.3"
                         aria-roledescription="bar"
-                        d="M216.25,0h5v175h-5Z"
+                        d="M216.25,7.777777777777789h5v167.2222222222222h-5Z"
                         fill="#4285F4"
                         role="graphics-symbol"
                       />
@@ -7895,15 +7843,15 @@ exports[`rendering results html renderer complex query with tags transposed tabl
             class="marks"
             height="217"
             version="1.1"
-            viewBox="0 0 309 217"
-            width="309"
+            viewBox="0 0 293 217"
+            width="293"
             xmlns="http://www.w3.org/2000/svg"
             xmlns:xlink="http://www.w3.org/1999/xlink"
           >
             <g
               fill="none"
               stroke-miterlimit="10"
-              transform="translate(53,5)"
+              transform="translate(37,5)"
             >
               <g
                 aria-roledescription="group mark container"
@@ -8051,7 +7999,7 @@ exports[`rendering results html renderer complex query with tags transposed tabl
                               opacity="1"
                               stroke="#888"
                               stroke-width="1"
-                              transform="translate(0,135)"
+                              transform="translate(0,136)"
                               x2="250"
                               y2="0"
                             />
@@ -8059,7 +8007,7 @@ exports[`rendering results html renderer complex query with tags transposed tabl
                               opacity="1"
                               stroke="#888"
                               stroke-width="1"
-                              transform="translate(0,95)"
+                              transform="translate(0,97)"
                               x2="250"
                               y2="0"
                             />
@@ -8067,7 +8015,7 @@ exports[`rendering results html renderer complex query with tags transposed tabl
                               opacity="1"
                               stroke="#888"
                               stroke-width="1"
-                              transform="translate(0,56)"
+                              transform="translate(0,58)"
                               x2="250"
                               y2="0"
                             />
@@ -8075,7 +8023,7 @@ exports[`rendering results html renderer complex query with tags transposed tabl
                               opacity="1"
                               stroke="#888"
                               stroke-width="1"
-                              transform="translate(0,16)"
+                              transform="translate(0,19)"
                               x2="250"
                               y2="0"
                             />
@@ -8318,7 +8266,7 @@ exports[`rendering results html renderer complex query with tags transposed tabl
                       </g>
                     </g>
                     <g
-                      aria-label="Y-axis titled 'wt' for a linear scale with values from 2.0 to 4.2"
+                      aria-label="Y-axis titled 'wt' for a linear scale with values from 0 to 5"
                       aria-roledescription="axis"
                       class="mark-group role-axis"
                       role="graphics-symbol"
@@ -8349,7 +8297,7 @@ exports[`rendering results html renderer complex query with tags transposed tabl
                               opacity="1"
                               stroke="#ddd"
                               stroke-width="1"
-                              transform="translate(0,135)"
+                              transform="translate(0,136)"
                               x2="-5"
                               y2="0"
                             />
@@ -8357,7 +8305,7 @@ exports[`rendering results html renderer complex query with tags transposed tabl
                               opacity="1"
                               stroke="#ddd"
                               stroke-width="1"
-                              transform="translate(0,95)"
+                              transform="translate(0,97)"
                               x2="-5"
                               y2="0"
                             />
@@ -8365,7 +8313,7 @@ exports[`rendering results html renderer complex query with tags transposed tabl
                               opacity="1"
                               stroke="#ddd"
                               stroke-width="1"
-                              transform="translate(0,56)"
+                              transform="translate(0,58)"
                               x2="-5"
                               y2="0"
                             />
@@ -8373,7 +8321,7 @@ exports[`rendering results html renderer complex query with tags transposed tabl
                               opacity="1"
                               stroke="#ddd"
                               stroke-width="1"
-                              transform="translate(0,16)"
+                              transform="translate(0,19)"
                               x2="-5"
                               y2="0"
                             />
@@ -8390,7 +8338,7 @@ exports[`rendering results html renderer complex query with tags transposed tabl
                               text-anchor="end"
                               transform="translate(-7,178)"
                             >
-                              2.0
+                              0
                             </text>
                             <text
                               fill="var(--malloy-label-color, #505050)"
@@ -8398,9 +8346,9 @@ exports[`rendering results html renderer complex query with tags transposed tabl
                               font-size="10px"
                               opacity="1"
                               text-anchor="end"
-                              transform="translate(-7,138.22727272727272)"
+                              transform="translate(-7,139.11111111111111)"
                             >
-                              2.5
+                              1
                             </text>
                             <text
                               fill="var(--malloy-label-color, #505050)"
@@ -8408,9 +8356,9 @@ exports[`rendering results html renderer complex query with tags transposed tabl
                               font-size="10px"
                               opacity="1"
                               text-anchor="end"
-                              transform="translate(-7,98.45454545454545)"
+                              transform="translate(-7,100.22222222222223)"
                             >
-                              3.0
+                              2
                             </text>
                             <text
                               fill="var(--malloy-label-color, #505050)"
@@ -8418,9 +8366,9 @@ exports[`rendering results html renderer complex query with tags transposed tabl
                               font-size="10px"
                               opacity="1"
                               text-anchor="end"
-                              transform="translate(-7,58.681818181818194)"
+                              transform="translate(-7,61.33333333333334)"
                             >
-                              3.5
+                              3
                             </text>
                             <text
                               fill="var(--malloy-label-color, #505050)"
@@ -8428,9 +8376,9 @@ exports[`rendering results html renderer complex query with tags transposed tabl
                               font-size="10px"
                               opacity="1"
                               text-anchor="end"
-                              transform="translate(-7,18.909090909090914)"
+                              transform="translate(-7,22.444444444444454)"
                             >
-                              4.0
+                              4
                             </text>
                           </g>
                           <g
@@ -8457,7 +8405,7 @@ exports[`rendering results html renderer complex query with tags transposed tabl
                               font-weight="500"
                               opacity="1"
                               text-anchor="middle"
-                              transform="translate(-35,87.5) rotate(-90) translate(0,-3)"
+                              transform="translate(-19,87.5) rotate(-90) translate(0,-3)"
                             >
                               wt
                             </text>
@@ -8480,28 +8428,660 @@ exports[`rendering results html renderer complex query with tags transposed tabl
                       <path
                         aria-label="monthy: 1; wt: 2"
                         aria-roledescription="bar"
-                        d="M28.75,175h5v0h-5Z"
+                        d="M28.75,97.22222222222223h5v77.77777777777777h-5Z"
                         fill="#4285F4"
                         role="graphics-symbol"
                       />
                       <path
                         aria-label="monthy: 2; wt: 2.6"
                         aria-roledescription="bar"
-                        d="M91.25,127.27272727272728h5v47.72727272727272h-5Z"
+                        d="M91.25,73.88888888888889h5v101.11111111111111h-5Z"
                         fill="#4285F4"
                         role="graphics-symbol"
                       />
                       <path
                         aria-label="monthy: 3; wt: 3.6"
                         aria-roledescription="bar"
-                        d="M153.75,47.72727272727273h5v127.27272727272728h-5Z"
+                        d="M153.75,34.99999999999999h5v140h-5Z"
                         fill="#4285F4"
                         role="graphics-symbol"
                       />
                       <path
                         aria-label="monthy: 4; wt: 4.2"
                         aria-roledescription="bar"
-                        d="M216.25,0h5v175h-5Z"
+                        d="M216.25,11.666666666666664h5v163.33333333333334h-5Z"
+                        fill="#4285F4"
+                        role="graphics-symbol"
+                      />
+                    </g>
+                  </g>
+                  <path
+                    aria-hidden="true"
+                    class="foreground"
+                    d=""
+                    display="none"
+                  />
+                </g>
+              </g>
+            </g>
+          </svg>
+        </div>
+      </td>
+      <td
+        style="padding: 8px; vertical-align: top; text-align: right;"
+      >
+        <div>
+          <svg
+            class="marks"
+            height="222"
+            version="1.1"
+            viewBox="0 0 293 222"
+            width="293"
+            xmlns="http://www.w3.org/2000/svg"
+            xmlns:xlink="http://www.w3.org/1999/xlink"
+          >
+            <g
+              fill="none"
+              stroke-miterlimit="10"
+              transform="translate(37,10)"
+            >
+              <g
+                aria-roledescription="group mark container"
+                class="mark-group role-frame root"
+                role="graphics-object"
+              >
+                <g
+                  transform="translate(0,0)"
+                >
+                  <path
+                    aria-hidden="true"
+                    class="background"
+                    d="M0.5,0.5h250v175h-250Z"
+                    stroke="#888"
+                  />
+                  <g>
+                    <g
+                      aria-hidden="true"
+                      class="mark-group role-axis"
+                    >
+                      <g
+                        transform="translate(0.5,175.5)"
+                      >
+                        <path
+                          aria-hidden="true"
+                          class="background"
+                          d="M0,0h0v0h0Z"
+                          pointer-events="none"
+                        />
+                        <g>
+                          <g
+                            class="mark-rule role-axis-grid"
+                            pointer-events="none"
+                          >
+                            <line
+                              opacity="1"
+                              stroke="#888"
+                              stroke-width="1"
+                              transform="translate(0,-175)"
+                              x2="0"
+                              y2="175"
+                            />
+                            <line
+                              opacity="1"
+                              stroke="#888"
+                              stroke-width="1"
+                              transform="translate(31,-175)"
+                              x2="0"
+                              y2="175"
+                            />
+                            <line
+                              opacity="1"
+                              stroke="#888"
+                              stroke-width="1"
+                              transform="translate(63,-175)"
+                              x2="0"
+                              y2="175"
+                            />
+                            <line
+                              opacity="1"
+                              stroke="#888"
+                              stroke-width="1"
+                              transform="translate(94,-175)"
+                              x2="0"
+                              y2="175"
+                            />
+                            <line
+                              opacity="1"
+                              stroke="#888"
+                              stroke-width="1"
+                              transform="translate(125,-175)"
+                              x2="0"
+                              y2="175"
+                            />
+                            <line
+                              opacity="1"
+                              stroke="#888"
+                              stroke-width="1"
+                              transform="translate(156,-175)"
+                              x2="0"
+                              y2="175"
+                            />
+                            <line
+                              opacity="1"
+                              stroke="#888"
+                              stroke-width="1"
+                              transform="translate(188,-175)"
+                              x2="0"
+                              y2="175"
+                            />
+                            <line
+                              opacity="1"
+                              stroke="#888"
+                              stroke-width="1"
+                              transform="translate(219,-175)"
+                              x2="0"
+                              y2="175"
+                            />
+                            <line
+                              opacity="1"
+                              stroke="#888"
+                              stroke-width="1"
+                              transform="translate(250,-175)"
+                              x2="0"
+                              y2="175"
+                            />
+                          </g>
+                        </g>
+                        <path
+                          aria-hidden="true"
+                          class="foreground"
+                          d=""
+                          display="none"
+                          pointer-events="none"
+                        />
+                      </g>
+                    </g>
+                    <g
+                      aria-hidden="true"
+                      class="mark-group role-axis"
+                    >
+                      <g
+                        transform="translate(0.5,0.5)"
+                      >
+                        <path
+                          aria-hidden="true"
+                          class="background"
+                          d="M0,0h0v0h0Z"
+                          pointer-events="none"
+                        />
+                        <g>
+                          <g
+                            class="mark-rule role-axis-grid"
+                            pointer-events="none"
+                          >
+                            <line
+                              opacity="1"
+                              stroke="#888"
+                              stroke-width="1"
+                              transform="translate(0,175)"
+                              x2="250"
+                              y2="0"
+                            />
+                            <line
+                              opacity="1"
+                              stroke="#888"
+                              stroke-width="1"
+                              transform="translate(0,131)"
+                              x2="250"
+                              y2="0"
+                            />
+                            <line
+                              opacity="1"
+                              stroke="#888"
+                              stroke-width="1"
+                              transform="translate(0,88)"
+                              x2="250"
+                              y2="0"
+                            />
+                            <line
+                              opacity="1"
+                              stroke="#888"
+                              stroke-width="1"
+                              transform="translate(0,44)"
+                              x2="250"
+                              y2="0"
+                            />
+                            <line
+                              opacity="1"
+                              stroke="#888"
+                              stroke-width="1"
+                              transform="translate(0,0)"
+                              x2="250"
+                              y2="0"
+                            />
+                          </g>
+                        </g>
+                        <path
+                          aria-hidden="true"
+                          class="foreground"
+                          d=""
+                          display="none"
+                          pointer-events="none"
+                        />
+                      </g>
+                    </g>
+                    <g
+                      aria-label="X-axis titled 'monthy' for a linear scale with values from 1 to 5"
+                      aria-roledescription="axis"
+                      class="mark-group role-axis"
+                      role="graphics-symbol"
+                    >
+                      <g
+                        transform="translate(0.5,175.5)"
+                      >
+                        <path
+                          aria-hidden="true"
+                          class="background"
+                          d="M0,0h0v0h0Z"
+                          pointer-events="none"
+                        />
+                        <g>
+                          <g
+                            class="mark-rule role-axis-tick"
+                            pointer-events="none"
+                          >
+                            <line
+                              opacity="1"
+                              stroke="#ddd"
+                              stroke-width="1"
+                              transform="translate(0,0)"
+                              x2="0"
+                              y2="5"
+                            />
+                            <line
+                              opacity="1"
+                              stroke="#ddd"
+                              stroke-width="1"
+                              transform="translate(31,0)"
+                              x2="0"
+                              y2="5"
+                            />
+                            <line
+                              opacity="1"
+                              stroke="#ddd"
+                              stroke-width="1"
+                              transform="translate(63,0)"
+                              x2="0"
+                              y2="5"
+                            />
+                            <line
+                              opacity="1"
+                              stroke="#ddd"
+                              stroke-width="1"
+                              transform="translate(94,0)"
+                              x2="0"
+                              y2="5"
+                            />
+                            <line
+                              opacity="1"
+                              stroke="#ddd"
+                              stroke-width="1"
+                              transform="translate(125,0)"
+                              x2="0"
+                              y2="5"
+                            />
+                            <line
+                              opacity="1"
+                              stroke="#ddd"
+                              stroke-width="1"
+                              transform="translate(156,0)"
+                              x2="0"
+                              y2="5"
+                            />
+                            <line
+                              opacity="1"
+                              stroke="#ddd"
+                              stroke-width="1"
+                              transform="translate(188,0)"
+                              x2="0"
+                              y2="5"
+                            />
+                            <line
+                              opacity="1"
+                              stroke="#ddd"
+                              stroke-width="1"
+                              transform="translate(219,0)"
+                              x2="0"
+                              y2="5"
+                            />
+                            <line
+                              opacity="1"
+                              stroke="#ddd"
+                              stroke-width="1"
+                              transform="translate(250,0)"
+                              x2="0"
+                              y2="5"
+                            />
+                          </g>
+                          <g
+                            class="mark-text role-axis-label"
+                            pointer-events="none"
+                          >
+                            <text
+                              fill="var(--malloy-label-color, #505050)"
+                              font-family="var(--malloy-font-family, 'Roboto')"
+                              font-size="10px"
+                              opacity="1"
+                              text-anchor="start"
+                              transform="translate(0,15)"
+                            >
+                              0.5
+                            </text>
+                            <text
+                              fill="var(--malloy-label-color, #505050)"
+                              font-family="var(--malloy-font-family, 'Roboto')"
+                              font-size="10px"
+                              opacity="0"
+                              text-anchor="middle"
+                              transform="translate(31.25,15)"
+                            >
+                              1.0
+                            </text>
+                            <text
+                              fill="var(--malloy-label-color, #505050)"
+                              font-family="var(--malloy-font-family, 'Roboto')"
+                              font-size="10px"
+                              opacity="1"
+                              text-anchor="middle"
+                              transform="translate(62.5,15)"
+                            >
+                              1.5
+                            </text>
+                            <text
+                              fill="var(--malloy-label-color, #505050)"
+                              font-family="var(--malloy-font-family, 'Roboto')"
+                              font-size="10px"
+                              opacity="0"
+                              text-anchor="middle"
+                              transform="translate(93.75,15)"
+                            >
+                              2.0
+                            </text>
+                            <text
+                              fill="var(--malloy-label-color, #505050)"
+                              font-family="var(--malloy-font-family, 'Roboto')"
+                              font-size="10px"
+                              opacity="1"
+                              text-anchor="middle"
+                              transform="translate(125,15)"
+                            >
+                              2.5
+                            </text>
+                            <text
+                              fill="var(--malloy-label-color, #505050)"
+                              font-family="var(--malloy-font-family, 'Roboto')"
+                              font-size="10px"
+                              opacity="0"
+                              text-anchor="middle"
+                              transform="translate(156.25,15)"
+                            >
+                              3.0
+                            </text>
+                            <text
+                              fill="var(--malloy-label-color, #505050)"
+                              font-family="var(--malloy-font-family, 'Roboto')"
+                              font-size="10px"
+                              opacity="1"
+                              text-anchor="middle"
+                              transform="translate(187.5,15)"
+                            >
+                              3.5
+                            </text>
+                            <text
+                              fill="var(--malloy-label-color, #505050)"
+                              font-family="var(--malloy-font-family, 'Roboto')"
+                              font-size="10px"
+                              opacity="0"
+                              text-anchor="middle"
+                              transform="translate(218.75,15)"
+                            >
+                              4.0
+                            </text>
+                            <text
+                              fill="var(--malloy-label-color, #505050)"
+                              font-family="var(--malloy-font-family, 'Roboto')"
+                              font-size="10px"
+                              opacity="1"
+                              text-anchor="end"
+                              transform="translate(250,15)"
+                            >
+                              4.5
+                            </text>
+                          </g>
+                          <g
+                            class="mark-rule role-axis-domain"
+                            pointer-events="none"
+                          >
+                            <line
+                              opacity="1"
+                              stroke="#ddd"
+                              stroke-width="1"
+                              transform="translate(0,0)"
+                              x2="250"
+                              y2="0"
+                            />
+                          </g>
+                          <g
+                            class="mark-text role-axis-title"
+                            pointer-events="none"
+                          >
+                            <text
+                              fill="var(--malloy-title-color, #505050)"
+                              font-family="var(--malloy-font-family, 'Roboto')"
+                              font-size="12px"
+                              font-weight="500"
+                              opacity="1"
+                              text-anchor="middle"
+                              transform="translate(125,30)"
+                            >
+                              monthy
+                            </text>
+                          </g>
+                        </g>
+                        <path
+                          aria-hidden="true"
+                          class="foreground"
+                          d=""
+                          display="none"
+                          pointer-events="none"
+                        />
+                      </g>
+                    </g>
+                    <g
+                      aria-label="Y-axis titled 'wt' for a linear scale with values from 0 to 4"
+                      aria-roledescription="axis"
+                      class="mark-group role-axis"
+                      role="graphics-symbol"
+                    >
+                      <g
+                        transform="translate(0.5,0.5)"
+                      >
+                        <path
+                          aria-hidden="true"
+                          class="background"
+                          d="M0,0h0v0h0Z"
+                          pointer-events="none"
+                        />
+                        <g>
+                          <g
+                            class="mark-rule role-axis-tick"
+                            pointer-events="none"
+                          >
+                            <line
+                              opacity="1"
+                              stroke="#ddd"
+                              stroke-width="1"
+                              transform="translate(0,175)"
+                              x2="-5"
+                              y2="0"
+                            />
+                            <line
+                              opacity="1"
+                              stroke="#ddd"
+                              stroke-width="1"
+                              transform="translate(0,131)"
+                              x2="-5"
+                              y2="0"
+                            />
+                            <line
+                              opacity="1"
+                              stroke="#ddd"
+                              stroke-width="1"
+                              transform="translate(0,88)"
+                              x2="-5"
+                              y2="0"
+                            />
+                            <line
+                              opacity="1"
+                              stroke="#ddd"
+                              stroke-width="1"
+                              transform="translate(0,44)"
+                              x2="-5"
+                              y2="0"
+                            />
+                            <line
+                              opacity="1"
+                              stroke="#ddd"
+                              stroke-width="1"
+                              transform="translate(0,0)"
+                              x2="-5"
+                              y2="0"
+                            />
+                          </g>
+                          <g
+                            class="mark-text role-axis-label"
+                            pointer-events="none"
+                          >
+                            <text
+                              fill="var(--malloy-label-color, #505050)"
+                              font-family="var(--malloy-font-family, 'Roboto')"
+                              font-size="10px"
+                              opacity="1"
+                              text-anchor="end"
+                              transform="translate(-7,178)"
+                            >
+                              0
+                            </text>
+                            <text
+                              fill="var(--malloy-label-color, #505050)"
+                              font-family="var(--malloy-font-family, 'Roboto')"
+                              font-size="10px"
+                              opacity="1"
+                              text-anchor="end"
+                              transform="translate(-7,134.25)"
+                            >
+                              1
+                            </text>
+                            <text
+                              fill="var(--malloy-label-color, #505050)"
+                              font-family="var(--malloy-font-family, 'Roboto')"
+                              font-size="10px"
+                              opacity="1"
+                              text-anchor="end"
+                              transform="translate(-7,90.5)"
+                            >
+                              2
+                            </text>
+                            <text
+                              fill="var(--malloy-label-color, #505050)"
+                              font-family="var(--malloy-font-family, 'Roboto')"
+                              font-size="10px"
+                              opacity="1"
+                              text-anchor="end"
+                              transform="translate(-7,46.75)"
+                            >
+                              3
+                            </text>
+                            <text
+                              fill="var(--malloy-label-color, #505050)"
+                              font-family="var(--malloy-font-family, 'Roboto')"
+                              font-size="10px"
+                              opacity="1"
+                              text-anchor="end"
+                              transform="translate(-7,3)"
+                            >
+                              4
+                            </text>
+                          </g>
+                          <g
+                            class="mark-rule role-axis-domain"
+                            pointer-events="none"
+                          >
+                            <line
+                              opacity="1"
+                              stroke="#ddd"
+                              stroke-width="1"
+                              transform="translate(0,175)"
+                              x2="0"
+                              y2="-175"
+                            />
+                          </g>
+                          <g
+                            class="mark-text role-axis-title"
+                            pointer-events="none"
+                          >
+                            <text
+                              fill="var(--malloy-title-color, #505050)"
+                              font-family="var(--malloy-font-family, 'Roboto')"
+                              font-size="12px"
+                              font-weight="500"
+                              opacity="1"
+                              text-anchor="middle"
+                              transform="translate(-19,87.5) rotate(-90) translate(0,-3)"
+                            >
+                              wt
+                            </text>
+                          </g>
+                        </g>
+                        <path
+                          aria-hidden="true"
+                          class="foreground"
+                          d=""
+                          display="none"
+                          pointer-events="none"
+                        />
+                      </g>
+                    </g>
+                    <g
+                      aria-roledescription="rect mark container"
+                      class="mark-rect role-mark marks"
+                      role="graphics-object"
+                    >
+                      <path
+                        aria-label="monthy: 1; wt: 3"
+                        aria-roledescription="bar"
+                        d="M28.75,43.75h5v131.25h-5Z"
+                        fill="#4285F4"
+                        role="graphics-symbol"
+                      />
+                      <path
+                        aria-label="monthy: 2; wt: 3.4"
+                        aria-roledescription="bar"
+                        d="M91.25,26.250000000000004h5v148.75h-5Z"
+                        fill="#4285F4"
+                        role="graphics-symbol"
+                      />
+                      <path
+                        aria-label="monthy: 3; wt: 3.6"
+                        aria-roledescription="bar"
+                        d="M153.75,17.499999999999996h5v157.5h-5Z"
+                        fill="#4285F4"
+                        role="graphics-symbol"
+                      />
+                      <path
+                        aria-label="monthy: 4; wt: 3.7"
+                        aria-roledescription="bar"
+                        d="M216.25,13.124999999999993h5v161.875h-5Z"
                         fill="#4285F4"
                         role="graphics-symbol"
                       />
@@ -8974,7 +9554,7 @@ exports[`rendering results html renderer complex query with tags transposed tabl
                       </g>
                     </g>
                     <g
-                      aria-label="Y-axis titled 'wt' for a linear scale with values from 3.0 to 3.7"
+                      aria-label="Y-axis titled 'wt' for a linear scale with values from 0.0 to 3.5"
                       aria-roledescription="axis"
                       class="mark-group role-axis"
                       role="graphics-symbol"
@@ -9070,7 +9650,7 @@ exports[`rendering results html renderer complex query with tags transposed tabl
                               text-anchor="end"
                               transform="translate(-7,178)"
                             >
-                              3.0
+                              0.0
                             </text>
                             <text
                               fill="var(--malloy-label-color, #505050)"
@@ -9078,9 +9658,9 @@ exports[`rendering results html renderer complex query with tags transposed tabl
                               font-size="10px"
                               opacity="1"
                               text-anchor="end"
-                              transform="translate(-7,152.99999999999997)"
+                              transform="translate(-7,153)"
                             >
-                              3.1
+                              0.5
                             </text>
                             <text
                               fill="var(--malloy-label-color, #505050)"
@@ -9088,9 +9668,9 @@ exports[`rendering results html renderer complex query with tags transposed tabl
                               font-size="10px"
                               opacity="1"
                               text-anchor="end"
-                              transform="translate(-7,127.99999999999996)"
+                              transform="translate(-7,128)"
                             >
-                              3.2
+                              1.0
                             </text>
                             <text
                               fill="var(--malloy-label-color, #505050)"
@@ -9098,9 +9678,9 @@ exports[`rendering results html renderer complex query with tags transposed tabl
                               font-size="10px"
                               opacity="1"
                               text-anchor="end"
-                              transform="translate(-7,103.00000000000007)"
+                              transform="translate(-7,103)"
                             >
-                              3.3
+                              1.5
                             </text>
                             <text
                               fill="var(--malloy-label-color, #505050)"
@@ -9108,9 +9688,9 @@ exports[`rendering results html renderer complex query with tags transposed tabl
                               font-size="10px"
                               opacity="1"
                               text-anchor="end"
-                              transform="translate(-7,78.00000000000004)"
+                              transform="translate(-7,78)"
                             >
-                              3.4
+                              2.0
                             </text>
                             <text
                               fill="var(--malloy-label-color, #505050)"
@@ -9118,9 +9698,9 @@ exports[`rendering results html renderer complex query with tags transposed tabl
                               font-size="10px"
                               opacity="1"
                               text-anchor="end"
-                              transform="translate(-7,53.000000000000036)"
+                              transform="translate(-7,53)"
                             >
-                              3.5
+                              2.5
                             </text>
                             <text
                               fill="var(--malloy-label-color, #505050)"
@@ -9130,7 +9710,7 @@ exports[`rendering results html renderer complex query with tags transposed tabl
                               text-anchor="end"
                               transform="translate(-7,28.000000000000007)"
                             >
-                              3.6
+                              3.0
                             </text>
                             <text
                               fill="var(--malloy-label-color, #505050)"
@@ -9139,640 +9719,8 @@ exports[`rendering results html renderer complex query with tags transposed tabl
                               opacity="1"
                               text-anchor="end"
                               transform="translate(-7,3)"
-                            >
-                              3.7
-                            </text>
-                          </g>
-                          <g
-                            class="mark-rule role-axis-domain"
-                            pointer-events="none"
-                          >
-                            <line
-                              opacity="1"
-                              stroke="#ddd"
-                              stroke-width="1"
-                              transform="translate(0,175)"
-                              x2="0"
-                              y2="-175"
-                            />
-                          </g>
-                          <g
-                            class="mark-text role-axis-title"
-                            pointer-events="none"
-                          >
-                            <text
-                              fill="var(--malloy-title-color, #505050)"
-                              font-family="var(--malloy-font-family, 'Roboto')"
-                              font-size="12px"
-                              font-weight="500"
-                              opacity="1"
-                              text-anchor="middle"
-                              transform="translate(-35,87.5) rotate(-90) translate(0,-3)"
-                            >
-                              wt
-                            </text>
-                          </g>
-                        </g>
-                        <path
-                          aria-hidden="true"
-                          class="foreground"
-                          d=""
-                          display="none"
-                          pointer-events="none"
-                        />
-                      </g>
-                    </g>
-                    <g
-                      aria-roledescription="rect mark container"
-                      class="mark-rect role-mark marks"
-                      role="graphics-object"
-                    >
-                      <path
-                        aria-label="monthy: 1; wt: 3"
-                        aria-roledescription="bar"
-                        d="M28.75,175h5v0h-5Z"
-                        fill="#4285F4"
-                        role="graphics-symbol"
-                      />
-                      <path
-                        aria-label="monthy: 2; wt: 3.4"
-                        aria-roledescription="bar"
-                        d="M91.25,75.00000000000004h5v99.99999999999996h-5Z"
-                        fill="#4285F4"
-                        role="graphics-symbol"
-                      />
-                      <path
-                        aria-label="monthy: 3; wt: 3.6"
-                        aria-roledescription="bar"
-                        d="M153.75,25.000000000000007h5v150h-5Z"
-                        fill="#4285F4"
-                        role="graphics-symbol"
-                      />
-                      <path
-                        aria-label="monthy: 4; wt: 3.7"
-                        aria-roledescription="bar"
-                        d="M216.25,0h5v175h-5Z"
-                        fill="#4285F4"
-                        role="graphics-symbol"
-                      />
-                    </g>
-                  </g>
-                  <path
-                    aria-hidden="true"
-                    class="foreground"
-                    d=""
-                    display="none"
-                  />
-                </g>
-              </g>
-            </g>
-          </svg>
-        </div>
-      </td>
-      <td
-        style="padding: 8px; vertical-align: top; text-align: right;"
-      >
-        <div>
-          <svg
-            class="marks"
-            height="222"
-            version="1.1"
-            viewBox="0 0 309 222"
-            width="309"
-            xmlns="http://www.w3.org/2000/svg"
-            xmlns:xlink="http://www.w3.org/1999/xlink"
-          >
-            <g
-              fill="none"
-              stroke-miterlimit="10"
-              transform="translate(53,10)"
-            >
-              <g
-                aria-roledescription="group mark container"
-                class="mark-group role-frame root"
-                role="graphics-object"
-              >
-                <g
-                  transform="translate(0,0)"
-                >
-                  <path
-                    aria-hidden="true"
-                    class="background"
-                    d="M0.5,0.5h250v175h-250Z"
-                    stroke="#888"
-                  />
-                  <g>
-                    <g
-                      aria-hidden="true"
-                      class="mark-group role-axis"
-                    >
-                      <g
-                        transform="translate(0.5,175.5)"
-                      >
-                        <path
-                          aria-hidden="true"
-                          class="background"
-                          d="M0,0h0v0h0Z"
-                          pointer-events="none"
-                        />
-                        <g>
-                          <g
-                            class="mark-rule role-axis-grid"
-                            pointer-events="none"
-                          >
-                            <line
-                              opacity="1"
-                              stroke="#888"
-                              stroke-width="1"
-                              transform="translate(0,-175)"
-                              x2="0"
-                              y2="175"
-                            />
-                            <line
-                              opacity="1"
-                              stroke="#888"
-                              stroke-width="1"
-                              transform="translate(31,-175)"
-                              x2="0"
-                              y2="175"
-                            />
-                            <line
-                              opacity="1"
-                              stroke="#888"
-                              stroke-width="1"
-                              transform="translate(63,-175)"
-                              x2="0"
-                              y2="175"
-                            />
-                            <line
-                              opacity="1"
-                              stroke="#888"
-                              stroke-width="1"
-                              transform="translate(94,-175)"
-                              x2="0"
-                              y2="175"
-                            />
-                            <line
-                              opacity="1"
-                              stroke="#888"
-                              stroke-width="1"
-                              transform="translate(125,-175)"
-                              x2="0"
-                              y2="175"
-                            />
-                            <line
-                              opacity="1"
-                              stroke="#888"
-                              stroke-width="1"
-                              transform="translate(156,-175)"
-                              x2="0"
-                              y2="175"
-                            />
-                            <line
-                              opacity="1"
-                              stroke="#888"
-                              stroke-width="1"
-                              transform="translate(188,-175)"
-                              x2="0"
-                              y2="175"
-                            />
-                            <line
-                              opacity="1"
-                              stroke="#888"
-                              stroke-width="1"
-                              transform="translate(219,-175)"
-                              x2="0"
-                              y2="175"
-                            />
-                            <line
-                              opacity="1"
-                              stroke="#888"
-                              stroke-width="1"
-                              transform="translate(250,-175)"
-                              x2="0"
-                              y2="175"
-                            />
-                          </g>
-                        </g>
-                        <path
-                          aria-hidden="true"
-                          class="foreground"
-                          d=""
-                          display="none"
-                          pointer-events="none"
-                        />
-                      </g>
-                    </g>
-                    <g
-                      aria-hidden="true"
-                      class="mark-group role-axis"
-                    >
-                      <g
-                        transform="translate(0.5,0.5)"
-                      >
-                        <path
-                          aria-hidden="true"
-                          class="background"
-                          d="M0,0h0v0h0Z"
-                          pointer-events="none"
-                        />
-                        <g>
-                          <g
-                            class="mark-rule role-axis-grid"
-                            pointer-events="none"
-                          >
-                            <line
-                              opacity="1"
-                              stroke="#888"
-                              stroke-width="1"
-                              transform="translate(0,156)"
-                              x2="250"
-                              y2="0"
-                            />
-                            <line
-                              opacity="1"
-                              stroke="#888"
-                              stroke-width="1"
-                              transform="translate(0,117)"
-                              x2="250"
-                              y2="0"
-                            />
-                            <line
-                              opacity="1"
-                              stroke="#888"
-                              stroke-width="1"
-                              transform="translate(0,78)"
-                              x2="250"
-                              y2="0"
-                            />
-                            <line
-                              opacity="1"
-                              stroke="#888"
-                              stroke-width="1"
-                              transform="translate(0,39)"
-                              x2="250"
-                              y2="0"
-                            />
-                            <line
-                              opacity="1"
-                              stroke="#888"
-                              stroke-width="1"
-                              transform="translate(0,0)"
-                              x2="250"
-                              y2="0"
-                            />
-                          </g>
-                        </g>
-                        <path
-                          aria-hidden="true"
-                          class="foreground"
-                          d=""
-                          display="none"
-                          pointer-events="none"
-                        />
-                      </g>
-                    </g>
-                    <g
-                      aria-label="X-axis titled 'monthy' for a linear scale with values from 1 to 5"
-                      aria-roledescription="axis"
-                      class="mark-group role-axis"
-                      role="graphics-symbol"
-                    >
-                      <g
-                        transform="translate(0.5,175.5)"
-                      >
-                        <path
-                          aria-hidden="true"
-                          class="background"
-                          d="M0,0h0v0h0Z"
-                          pointer-events="none"
-                        />
-                        <g>
-                          <g
-                            class="mark-rule role-axis-tick"
-                            pointer-events="none"
-                          >
-                            <line
-                              opacity="1"
-                              stroke="#ddd"
-                              stroke-width="1"
-                              transform="translate(0,0)"
-                              x2="0"
-                              y2="5"
-                            />
-                            <line
-                              opacity="1"
-                              stroke="#ddd"
-                              stroke-width="1"
-                              transform="translate(31,0)"
-                              x2="0"
-                              y2="5"
-                            />
-                            <line
-                              opacity="1"
-                              stroke="#ddd"
-                              stroke-width="1"
-                              transform="translate(63,0)"
-                              x2="0"
-                              y2="5"
-                            />
-                            <line
-                              opacity="1"
-                              stroke="#ddd"
-                              stroke-width="1"
-                              transform="translate(94,0)"
-                              x2="0"
-                              y2="5"
-                            />
-                            <line
-                              opacity="1"
-                              stroke="#ddd"
-                              stroke-width="1"
-                              transform="translate(125,0)"
-                              x2="0"
-                              y2="5"
-                            />
-                            <line
-                              opacity="1"
-                              stroke="#ddd"
-                              stroke-width="1"
-                              transform="translate(156,0)"
-                              x2="0"
-                              y2="5"
-                            />
-                            <line
-                              opacity="1"
-                              stroke="#ddd"
-                              stroke-width="1"
-                              transform="translate(188,0)"
-                              x2="0"
-                              y2="5"
-                            />
-                            <line
-                              opacity="1"
-                              stroke="#ddd"
-                              stroke-width="1"
-                              transform="translate(219,0)"
-                              x2="0"
-                              y2="5"
-                            />
-                            <line
-                              opacity="1"
-                              stroke="#ddd"
-                              stroke-width="1"
-                              transform="translate(250,0)"
-                              x2="0"
-                              y2="5"
-                            />
-                          </g>
-                          <g
-                            class="mark-text role-axis-label"
-                            pointer-events="none"
-                          >
-                            <text
-                              fill="var(--malloy-label-color, #505050)"
-                              font-family="var(--malloy-font-family, 'Roboto')"
-                              font-size="10px"
-                              opacity="1"
-                              text-anchor="start"
-                              transform="translate(0,15)"
-                            >
-                              0.5
-                            </text>
-                            <text
-                              fill="var(--malloy-label-color, #505050)"
-                              font-family="var(--malloy-font-family, 'Roboto')"
-                              font-size="10px"
-                              opacity="0"
-                              text-anchor="middle"
-                              transform="translate(31.25,15)"
-                            >
-                              1.0
-                            </text>
-                            <text
-                              fill="var(--malloy-label-color, #505050)"
-                              font-family="var(--malloy-font-family, 'Roboto')"
-                              font-size="10px"
-                              opacity="1"
-                              text-anchor="middle"
-                              transform="translate(62.5,15)"
-                            >
-                              1.5
-                            </text>
-                            <text
-                              fill="var(--malloy-label-color, #505050)"
-                              font-family="var(--malloy-font-family, 'Roboto')"
-                              font-size="10px"
-                              opacity="0"
-                              text-anchor="middle"
-                              transform="translate(93.75,15)"
-                            >
-                              2.0
-                            </text>
-                            <text
-                              fill="var(--malloy-label-color, #505050)"
-                              font-family="var(--malloy-font-family, 'Roboto')"
-                              font-size="10px"
-                              opacity="1"
-                              text-anchor="middle"
-                              transform="translate(125,15)"
-                            >
-                              2.5
-                            </text>
-                            <text
-                              fill="var(--malloy-label-color, #505050)"
-                              font-family="var(--malloy-font-family, 'Roboto')"
-                              font-size="10px"
-                              opacity="0"
-                              text-anchor="middle"
-                              transform="translate(156.25,15)"
-                            >
-                              3.0
-                            </text>
-                            <text
-                              fill="var(--malloy-label-color, #505050)"
-                              font-family="var(--malloy-font-family, 'Roboto')"
-                              font-size="10px"
-                              opacity="1"
-                              text-anchor="middle"
-                              transform="translate(187.5,15)"
                             >
                               3.5
-                            </text>
-                            <text
-                              fill="var(--malloy-label-color, #505050)"
-                              font-family="var(--malloy-font-family, 'Roboto')"
-                              font-size="10px"
-                              opacity="0"
-                              text-anchor="middle"
-                              transform="translate(218.75,15)"
-                            >
-                              4.0
-                            </text>
-                            <text
-                              fill="var(--malloy-label-color, #505050)"
-                              font-family="var(--malloy-font-family, 'Roboto')"
-                              font-size="10px"
-                              opacity="1"
-                              text-anchor="end"
-                              transform="translate(250,15)"
-                            >
-                              4.5
-                            </text>
-                          </g>
-                          <g
-                            class="mark-rule role-axis-domain"
-                            pointer-events="none"
-                          >
-                            <line
-                              opacity="1"
-                              stroke="#ddd"
-                              stroke-width="1"
-                              transform="translate(0,0)"
-                              x2="250"
-                              y2="0"
-                            />
-                          </g>
-                          <g
-                            class="mark-text role-axis-title"
-                            pointer-events="none"
-                          >
-                            <text
-                              fill="var(--malloy-title-color, #505050)"
-                              font-family="var(--malloy-font-family, 'Roboto')"
-                              font-size="12px"
-                              font-weight="500"
-                              opacity="1"
-                              text-anchor="middle"
-                              transform="translate(125,30)"
-                            >
-                              monthy
-                            </text>
-                          </g>
-                        </g>
-                        <path
-                          aria-hidden="true"
-                          class="foreground"
-                          d=""
-                          display="none"
-                          pointer-events="none"
-                        />
-                      </g>
-                    </g>
-                    <g
-                      aria-label="Y-axis titled 'wt' for a linear scale with values from 2.5 to 3.4"
-                      aria-roledescription="axis"
-                      class="mark-group role-axis"
-                      role="graphics-symbol"
-                    >
-                      <g
-                        transform="translate(0.5,0.5)"
-                      >
-                        <path
-                          aria-hidden="true"
-                          class="background"
-                          d="M0,0h0v0h0Z"
-                          pointer-events="none"
-                        />
-                        <g>
-                          <g
-                            class="mark-rule role-axis-tick"
-                            pointer-events="none"
-                          >
-                            <line
-                              opacity="1"
-                              stroke="#ddd"
-                              stroke-width="1"
-                              transform="translate(0,156)"
-                              x2="-5"
-                              y2="0"
-                            />
-                            <line
-                              opacity="1"
-                              stroke="#ddd"
-                              stroke-width="1"
-                              transform="translate(0,117)"
-                              x2="-5"
-                              y2="0"
-                            />
-                            <line
-                              opacity="1"
-                              stroke="#ddd"
-                              stroke-width="1"
-                              transform="translate(0,78)"
-                              x2="-5"
-                              y2="0"
-                            />
-                            <line
-                              opacity="1"
-                              stroke="#ddd"
-                              stroke-width="1"
-                              transform="translate(0,39)"
-                              x2="-5"
-                              y2="0"
-                            />
-                            <line
-                              opacity="1"
-                              stroke="#ddd"
-                              stroke-width="1"
-                              transform="translate(0,0)"
-                              x2="-5"
-                              y2="0"
-                            />
-                          </g>
-                          <g
-                            class="mark-text role-axis-label"
-                            pointer-events="none"
-                          >
-                            <text
-                              fill="var(--malloy-label-color, #505050)"
-                              font-family="var(--malloy-font-family, 'Roboto')"
-                              font-size="10px"
-                              opacity="1"
-                              text-anchor="end"
-                              transform="translate(-7,158.55555555555554)"
-                            >
-                              2.6
-                            </text>
-                            <text
-                              fill="var(--malloy-label-color, #505050)"
-                              font-family="var(--malloy-font-family, 'Roboto')"
-                              font-size="10px"
-                              opacity="1"
-                              text-anchor="end"
-                              transform="translate(-7,119.6666666666667)"
-                            >
-                              2.8
-                            </text>
-                            <text
-                              fill="var(--malloy-label-color, #505050)"
-                              font-family="var(--malloy-font-family, 'Roboto')"
-                              font-size="10px"
-                              opacity="1"
-                              text-anchor="end"
-                              transform="translate(-7,80.77777777777777)"
-                            >
-                              3.0
-                            </text>
-                            <text
-                              fill="var(--malloy-label-color, #505050)"
-                              font-family="var(--malloy-font-family, 'Roboto')"
-                              font-size="10px"
-                              opacity="1"
-                              text-anchor="end"
-                              transform="translate(-7,41.88888888888885)"
-                            >
-                              3.2
-                            </text>
-                            <text
-                              fill="var(--malloy-label-color, #505050)"
-                              font-family="var(--malloy-font-family, 'Roboto')"
-                              font-size="10px"
-                              opacity="1"
-                              text-anchor="end"
-                              transform="translate(-7,3)"
-                            >
-                              3.4
                             </text>
                           </g>
                           <g
@@ -9822,28 +9770,28 @@ exports[`rendering results html renderer complex query with tags transposed tabl
                       <path
                         aria-label="monthy: 1; wt: 2.5"
                         aria-roledescription="bar"
-                        d="M28.75,175h5v0h-5Z"
+                        d="M28.75,50h5v125h-5Z"
                         fill="#4285F4"
                         role="graphics-symbol"
                       />
                       <path
                         aria-label="monthy: 2; wt: 3"
                         aria-roledescription="bar"
-                        d="M91.25,77.77777777777777h5v97.22222222222223h-5Z"
+                        d="M91.25,25.000000000000007h5v150h-5Z"
                         fill="#4285F4"
                         role="graphics-symbol"
                       />
                       <path
                         aria-label="monthy: 3; wt: 3.2"
                         aria-roledescription="bar"
-                        d="M153.75,38.88888888888885h5v136.11111111111114h-5Z"
+                        d="M153.75,14.999999999999986h5v160h-5Z"
                         fill="#4285F4"
                         role="graphics-symbol"
                       />
                       <path
                         aria-label="monthy: 4; wt: 3.4"
                         aria-roledescription="bar"
-                        d="M216.25,0h5v175h-5Z"
+                        d="M216.25,5.000000000000002h5v170h-5Z"
                         fill="#4285F4"
                         role="graphics-symbol"
                       />
@@ -9867,17 +9815,17 @@ exports[`rendering results html renderer complex query with tags transposed tabl
         <div>
           <svg
             class="marks"
-            height="222"
+            height="217"
             version="1.1"
-            viewBox="0 0 317 222"
-            width="317"
+            viewBox="0 0 293 217"
+            width="293"
             xmlns="http://www.w3.org/2000/svg"
             xmlns:xlink="http://www.w3.org/1999/xlink"
           >
             <g
               fill="none"
               stroke-miterlimit="10"
-              transform="translate(61,10)"
+              transform="translate(37,5)"
             >
               <g
                 aria-roledescription="group mark container"
@@ -10025,7 +9973,7 @@ exports[`rendering results html renderer complex query with tags transposed tabl
                               opacity="1"
                               stroke="#888"
                               stroke-width="1"
-                              transform="translate(0,146)"
+                              transform="translate(0,136)"
                               x2="250"
                               y2="0"
                             />
@@ -10033,15 +9981,7 @@ exports[`rendering results html renderer complex query with tags transposed tabl
                               opacity="1"
                               stroke="#888"
                               stroke-width="1"
-                              transform="translate(0,117)"
-                              x2="250"
-                              y2="0"
-                            />
-                            <line
-                              opacity="1"
-                              stroke="#888"
-                              stroke-width="1"
-                              transform="translate(0,87)"
+                              transform="translate(0,97)"
                               x2="250"
                               y2="0"
                             />
@@ -10057,15 +9997,7 @@ exports[`rendering results html renderer complex query with tags transposed tabl
                               opacity="1"
                               stroke="#888"
                               stroke-width="1"
-                              transform="translate(0,29)"
-                              x2="250"
-                              y2="0"
-                            />
-                            <line
-                              opacity="1"
-                              stroke="#888"
-                              stroke-width="1"
-                              transform="translate(0,0)"
+                              transform="translate(0,19)"
                               x2="250"
                               y2="0"
                             />
@@ -10308,7 +10240,7 @@ exports[`rendering results html renderer complex query with tags transposed tabl
                       </g>
                     </g>
                     <g
-                      aria-label="Y-axis titled 'wt' for a linear scale with values from 4.00 to 4.30"
+                      aria-label="Y-axis titled 'wt' for a linear scale with values from 0 to 5"
                       aria-roledescription="axis"
                       class="mark-group role-axis"
                       role="graphics-symbol"
@@ -10339,7 +10271,7 @@ exports[`rendering results html renderer complex query with tags transposed tabl
                               opacity="1"
                               stroke="#ddd"
                               stroke-width="1"
-                              transform="translate(0,146)"
+                              transform="translate(0,136)"
                               x2="-5"
                               y2="0"
                             />
@@ -10347,15 +10279,7 @@ exports[`rendering results html renderer complex query with tags transposed tabl
                               opacity="1"
                               stroke="#ddd"
                               stroke-width="1"
-                              transform="translate(0,117)"
-                              x2="-5"
-                              y2="0"
-                            />
-                            <line
-                              opacity="1"
-                              stroke="#ddd"
-                              stroke-width="1"
-                              transform="translate(0,87)"
+                              transform="translate(0,97)"
                               x2="-5"
                               y2="0"
                             />
@@ -10371,15 +10295,7 @@ exports[`rendering results html renderer complex query with tags transposed tabl
                               opacity="1"
                               stroke="#ddd"
                               stroke-width="1"
-                              transform="translate(0,29)"
-                              x2="-5"
-                              y2="0"
-                            />
-                            <line
-                              opacity="1"
-                              stroke="#ddd"
-                              stroke-width="1"
-                              transform="translate(0,0)"
+                              transform="translate(0,19)"
                               x2="-5"
                               y2="0"
                             />
@@ -10396,7 +10312,7 @@ exports[`rendering results html renderer complex query with tags transposed tabl
                               text-anchor="end"
                               transform="translate(-7,178)"
                             >
-                              4.00
+                              0
                             </text>
                             <text
                               fill="var(--malloy-label-color, #505050)"
@@ -10404,9 +10320,9 @@ exports[`rendering results html renderer complex query with tags transposed tabl
                               font-size="10px"
                               opacity="1"
                               text-anchor="end"
-                              transform="translate(-7,148.83333333333343)"
+                              transform="translate(-7,139.11111111111111)"
                             >
-                              4.05
+                              1
                             </text>
                             <text
                               fill="var(--malloy-label-color, #505050)"
@@ -10414,9 +10330,9 @@ exports[`rendering results html renderer complex query with tags transposed tabl
                               font-size="10px"
                               opacity="1"
                               text-anchor="end"
-                              transform="translate(-7,119.66666666666684)"
+                              transform="translate(-7,100.22222222222223)"
                             >
-                              4.10
+                              2
                             </text>
                             <text
                               fill="var(--malloy-label-color, #505050)"
@@ -10424,9 +10340,9 @@ exports[`rendering results html renderer complex query with tags transposed tabl
                               font-size="10px"
                               opacity="1"
                               text-anchor="end"
-                              transform="translate(-7,90.49999999999974)"
+                              transform="translate(-7,61.33333333333334)"
                             >
-                              4.15
+                              3
                             </text>
                             <text
                               fill="var(--malloy-label-color, #505050)"
@@ -10434,29 +10350,9 @@ exports[`rendering results html renderer complex query with tags transposed tabl
                               font-size="10px"
                               opacity="1"
                               text-anchor="end"
-                              transform="translate(-7,61.333333333333165)"
+                              transform="translate(-7,22.444444444444454)"
                             >
-                              4.20
-                            </text>
-                            <text
-                              fill="var(--malloy-label-color, #505050)"
-                              font-family="var(--malloy-font-family, 'Roboto')"
-                              font-size="10px"
-                              opacity="1"
-                              text-anchor="end"
-                              transform="translate(-7,32.166666666666586)"
-                            >
-                              4.25
-                            </text>
-                            <text
-                              fill="var(--malloy-label-color, #505050)"
-                              font-family="var(--malloy-font-family, 'Roboto')"
-                              font-size="10px"
-                              opacity="1"
-                              text-anchor="end"
-                              transform="translate(-7,3)"
-                            >
-                              4.30
+                              4
                             </text>
                           </g>
                           <g
@@ -10483,7 +10379,7 @@ exports[`rendering results html renderer complex query with tags transposed tabl
                               font-weight="500"
                               opacity="1"
                               text-anchor="middle"
-                              transform="translate(-43,87.5) rotate(-90) translate(0,-3)"
+                              transform="translate(-19,87.5) rotate(-90) translate(0,-3)"
                             >
                               wt
                             </text>
@@ -10506,28 +10402,28 @@ exports[`rendering results html renderer complex query with tags transposed tabl
                       <path
                         aria-label="monthy: 1; wt: 4"
                         aria-roledescription="bar"
-                        d="M28.75,175h5v0h-5Z"
+                        d="M28.75,19.444444444444454h5v155.55555555555554h-5Z"
                         fill="#4285F4"
                         role="graphics-symbol"
                       />
                       <path
                         aria-label="monthy: 2; wt: 4.1"
                         aria-roledescription="bar"
-                        d="M91.25,116.66666666666684h5v58.33333333333316h-5Z"
+                        d="M91.25,15.555555555555578h5v159.44444444444443h-5Z"
                         fill="#4285F4"
                         role="graphics-symbol"
                       />
                       <path
                         aria-label="monthy: 3; wt: 4.2"
                         aria-roledescription="bar"
-                        d="M153.75,58.333333333333165h5v116.66666666666683h-5Z"
+                        d="M153.75,11.666666666666664h5v163.33333333333334h-5Z"
                         fill="#4285F4"
                         role="graphics-symbol"
                       />
                       <path
                         aria-label="monthy: 4; wt: 4.3"
                         aria-roledescription="bar"
-                        d="M216.25,0h5v175h-5Z"
+                        d="M216.25,7.777777777777789h5v167.2222222222222h-5Z"
                         fill="#4285F4"
                         role="graphics-symbol"
                       />


### PR DESCRIPTION
Update to Typescript 5. Mostly uneventful except for `tsutils` not having been updated to support Typescript 5 yet, but its functionality wasn't hard to replace. Main issue is that HTML table rendering snapshots are off, and it's fairly hard to determine why.