### PR TITLE
Bump Node.js to v18 per Pending v16 EOL

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,1 +1,1 @@
-with import <nixpkgs> {}; stdenv.mkDerivation { name = "malloy"; buildInputs = [ nodejs-16_x jdk8 google-cloud-sdk postgresql git cacert openssh jq fakeroot]; }
+with import <nixpkgs> {}; stdenv.mkDerivation { name = "malloy"; buildInputs = [ nodejs-18_x jdk8 google-cloud-sdk postgresql git cacert openssh jq fakeroot]; }


### PR DESCRIPTION
Node.js 16.x will leave maintenance status 2022-09-11. Source: https://github.com/nodejs/release#release-schedule.

Per the OpenJS foundation, the 18.x series is currently recommended. Source: https://nodejs.org/en.

Resolves https://github.com/malloydata/malloy/issues/1313