### PR TITLE
Add label render tag

### DIFF
--- a/packages/malloy-render/src/html/utils.ts
+++ b/packages/malloy-render/src/html/utils.ts
@@ -245,7 +245,8 @@ export function formatTitle(
   renderDef?: RenderDef | undefined,
   timezone?: string
 ) {
-  const label = renderDef?.data?.label || field.name;
+  const label =
+    field.tagParse().tag.text('label') ?? renderDef?.data?.label ?? field.name;
   let title = options.titleCase ? startCase(label) : label;
   if (
     field.isAtomicField() &&


### PR DESCRIPTION
WIP

Adds `label` render tag, e.g. `# label="Some Human Readable Name"`.

Currently only works in the table renderer, not the dashboard or chart renderers.