### PR TITLE
Specific nixos/nix:2.15.2

### DIFF
--- a/cloudbuild/README.md
+++ b/cloudbuild/README.md
@@ -15,7 +15,7 @@ There are several technologies to be aware of:
 The way that we run tests:
 
 - we have a `cloudbuild.yaml` file that specifies the build -- see `cloudbuild/build-test/cloudbuild.yaml`
-- the build runs the `nixos/nix` docker image -- this ensures that `nix` is installed
+- the build runs the `nixos/nix:2.15.2` docker image -- this ensures that `nix` is installed
 - we run the file `cloudbuild/build-test/build-test.sh` -- this _enters_ into a nix environment and runs `npm run build`, etc.
 
 ### Our Testing Architecture: Cloudbuild
@@ -38,7 +38,7 @@ If you need to add a dependency, see `default.nix`. `buildInputs = [ ... ]` is a
 
 You will notice that when a build runs, nix dependencies are installed.
 
-These both take a meaningful amount of time. We can reduce the amount of time this takes by creating a docker image based on `nixos/nix`, which pre-installs nix dependencies.
+These both take a meaningful amount of time. We can reduce the amount of time this takes by creating a docker image based on `nixos/nix:2.15.2`, which pre-installs nix dependencies.
 
 ## Our Testing Architecture: Future Directions: Pinning Nix Dependencies
 

--- a/cloudbuild/build-test/cloudbuild.yaml
+++ b/cloudbuild/build-test/cloudbuild.yaml
@@ -4,16 +4,16 @@ steps:
     args:
       - pull
       - "-q"
-      - nixos/nix
+      - nixos/nix:2.15.2
   - id: proxy-install
-    name: "nixos/nix"
+    name: "nixos/nix:2.15.2"
     entrypoint: sh
     args:
       - -c
       - "wget -q -O /workspace/cloud_sql_proxy https://dl.google.com/cloudsql/cloud_sql_proxy.linux.386 && chmod +x /workspace/cloud_sql_proxy"
     waitFor: ["nix-quiet-install"]
   - id: run-script
-    name: "nixos/nix"
+    name: "nixos/nix:2.15.2"
     entrypoint: sh
     args:
       - -c

--- a/cloudbuild/deploy/cloudbuild.yaml
+++ b/cloudbuild/deploy/cloudbuild.yaml
@@ -17,16 +17,16 @@ steps:
     args:
       - pull
       - "-q"
-      - nixos/nix
+      - nixos/nix:2.15.2
   - id: proxy-install
-    name: "nixos/nix"
+    name: "nixos/nix:2.15.2"
     entrypoint: sh
     args:
       - -c
       - "wget -q -O /workspace/cloud_sql_proxy https://dl.google.com/cloudsql/cloud_sql_proxy.linux.386 && chmod +x /workspace/cloud_sql_proxy"
     waitFor: ["nix-quiet-install"]
   - id: deploy-npm
-    name: "nixos/nix"
+    name: "nixos/nix:2.15.2"
     entrypoint: sh
     args:
       - -c


### PR DESCRIPTION
**tl;dr**: this ensures that the latest package definitions are fetched from `nixpkgs`

---

We change the image to `nixos/nix:2.15.2` to ensure that we pull this specific image from the cache, which is populated with a more recent version of `nixpkgs`.

Updating `nixos/nix` references was done with the following:

```bash
git grep --null --files-with-matches "nixos/nix" |
  xargs --null -I{} sed -i 's/nixos\/nix/nixos\/nix:2.15.2/' {}
```

This will allow us to use the latest official package references; for example https://search.nixos.org/packages?channel=23.05&show=nodejs_18.

---

For a concrete example of why this is helpful, see https://github.com/malloydata/malloy/pull/1314#discussion_r1309498349.