### PR TITLE
Language config schemas

### DIFF
--- a/packages/malloy-syntax-highlight/grammars/malloy-notebook/malloy-notebook-language.json
+++ b/packages/malloy-syntax-highlight/grammars/malloy-notebook/malloy-notebook-language.json
@@ -1,7 +1,7 @@
 {
   "$schema": "vscode://schemas/language-configuration",
   "comments": {
-    "lineComment": ["--", "//"],
+    "lineComment": "//",
     "blockComment": ["/*", "*/"]
   },
   "brackets": [

--- a/packages/malloy-syntax-highlight/grammars/malloy-notebook/malloy-notebook-language.json
+++ b/packages/malloy-syntax-highlight/grammars/malloy-notebook/malloy-notebook-language.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "vscode://schemas/language-configuration",
   "comments": {
     "lineComment": ["--", "//"],
     "blockComment": ["/*", "*/"]

--- a/packages/malloy-syntax-highlight/grammars/malloy-sql/malloy-sql-language.json
+++ b/packages/malloy-syntax-highlight/grammars/malloy-sql/malloy-sql-language.json
@@ -1,7 +1,7 @@
 {
   "$schema": "vscode://schemas/language-configuration",
   "comments": {
-    "lineComment": ["--", "//"],
+    "lineComment": "//",
     "blockComment": ["/*", "*/"]
   },
   "brackets": [

--- a/packages/malloy-syntax-highlight/grammars/malloy-sql/malloy-sql-language.json
+++ b/packages/malloy-syntax-highlight/grammars/malloy-sql/malloy-sql-language.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "vscode://schemas/language-configuration",
   "comments": {
     "lineComment": ["--", "//"],
     "blockComment": ["/*", "*/"]

--- a/packages/malloy-syntax-highlight/grammars/malloy/malloy-language.json
+++ b/packages/malloy-syntax-highlight/grammars/malloy/malloy-language.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "vscode://schemas/language-configuration",
   "comments": {
     "lineComment": "//",
     "blockComment": ["/*", "*/"]


### PR DESCRIPTION
Add a schema to our language config, and then fix the issues it highlights - `lineComment` is meant to be a single string used to comment out a line, not an array of potential lineComment starts. VS Code was falling back to multi-line commenting for single lines as a result.