### PR TITLE
Allow import base url

### DIFF
--- a/packages/malloy/src/lang/malloy-parse-info.ts
+++ b/packages/malloy/src/lang/malloy-parse-info.ts
@@ -34,6 +34,7 @@ export interface MalloyParseInfo {
   tokenStream: CommonTokenStream;
   sourceStream: CodePointCharStream;
   sourceURL: string;
+  importBaseURL: string;
   rangeFromContext: (pcx: ParserRuleContext) => DocumentRange;
   malloyVersion: string;
 }

--- a/packages/malloy/src/lang/malloy-to-ast.ts
+++ b/packages/malloy/src/lang/malloy-to-ast.ts
@@ -1734,7 +1734,7 @@ export class MalloyToAST
   visitImportStatement(pcx: parse.ImportStatementContext): ast.ImportStatement {
     const url = this.getPlainString(pcx.importURL());
     const importStmt = this.astAt(
-      new ast.ImportStatement(url, this.parseInfo.sourceURL),
+      new ast.ImportStatement(url, this.parseInfo.importBaseURL),
       pcx
     );
     const selectCx = pcx.importSelect();

--- a/packages/malloy/src/lang/parse-malloy.ts
+++ b/packages/malloy/src/lang/parse-malloy.ts
@@ -668,10 +668,7 @@ export abstract class MalloyTranslation {
 
   addChild(url: string): void {
     if (!this.childTranslators.get(url)) {
-      this.childTranslators.set(
-        url,
-        new MalloyChildTranslator(url, this.importBaseURL, this.root)
-      );
+      this.childTranslators.set(url, new MalloyChildTranslator(url, this.root));
     }
   }
 
@@ -915,10 +912,9 @@ export abstract class MalloyTranslation {
 export class MalloyChildTranslator extends MalloyTranslation {
   constructor(
     rootURL: string,
-    importURL: string | null,
     readonly root: MalloyTranslator
   ) {
-    super(rootURL, importURL);
+    super(rootURL);
   }
 }
 

--- a/packages/malloy/src/lang/test/imports.spec.ts
+++ b/packages/malloy/src/lang/test/imports.spec.ts
@@ -37,6 +37,21 @@ describe('import:', () => {
     const aa = docParse.getSourceDef('aa');
     expect(aa).toBeDefined();
   });
+  test('simple source with importBaseURL', () => {
+    const docParse = new TestTranslator(
+      'import "child"',
+      'http://example.com/'
+    );
+    const xr = docParse.unresolved();
+    expect(docParse).toParse();
+    expect(xr).toEqual({urls: ['http://example.com/child']});
+    docParse.update({
+      urls: {'http://example.com/child': 'source: aa is a'},
+    });
+    expect(docParse).toTranslate();
+    const aa = docParse.getSourceDef('aa');
+    expect(aa).toBeDefined();
+  });
   test('simple query', () => {
     const docParse = new TestTranslator('import "child"');
     const xr = docParse.unresolved();

--- a/packages/malloy/src/lang/test/test-translator.ts
+++ b/packages/malloy/src/lang/test/test-translator.ts
@@ -220,7 +220,7 @@ export class TestChildTranslator extends MalloyChildTranslator {
 
   addChild(url: string): void {
     if (!this.childTranslators.get(url)) {
-      const child = new TestChildTranslator(url, this.importBaseURL, this.root);
+      const child = new TestChildTranslator(url, this.root);
       this.childTranslators.set(url, child);
     }
   }
@@ -312,7 +312,7 @@ export class TestTranslator extends MalloyTranslator {
 
   addChild(url: string): void {
     if (!this.childTranslators.get(url)) {
-      const child = new TestChildTranslator(url, this.importBaseURL, this);
+      const child = new TestChildTranslator(url, this);
       this.childTranslators.set(url, child);
     }
   }

--- a/packages/malloy/src/lang/test/test-translator.ts
+++ b/packages/malloy/src/lang/test/test-translator.ts
@@ -291,10 +291,11 @@ export class TestTranslator extends MalloyTranslator {
 
   constructor(
     readonly testSrc: string,
+    importBaseURL: string | null = null,
     rootRule = 'malloyDocument',
     internalModel?: ModelDef
   ) {
-    super(testURI);
+    super(testURI, importBaseURL);
     this.grammarRule = rootRule;
     this.importZone.define(testURI, testSrc);
     if (internalModel !== undefined) {
@@ -413,7 +414,7 @@ export class TestTranslator extends MalloyTranslator {
 export class BetaExpression extends TestTranslator {
   private compiled?: ExprValue;
   constructor(src: string) {
-    super(src, 'justExpr');
+    super(src, null, 'justExpr');
   }
 
   private testFS() {
@@ -541,6 +542,7 @@ export function makeModelFunc(options: {
       translator: new TestTranslator(
         (options.prefix ?? '') +
           (options.wrap ? options.wrap(ms.code) : ms.code),
+        null,
         undefined,
         options?.model
       ),

--- a/packages/malloy/src/lang/test/test-translator.ts
+++ b/packages/malloy/src/lang/test/test-translator.ts
@@ -220,7 +220,7 @@ export class TestChildTranslator extends MalloyChildTranslator {
 
   addChild(url: string): void {
     if (!this.childTranslators.get(url)) {
-      const child = new TestChildTranslator(url, this.root);
+      const child = new TestChildTranslator(url, this.importBaseURL, this.root);
       this.childTranslators.set(url, child);
     }
   }
@@ -312,7 +312,7 @@ export class TestTranslator extends MalloyTranslator {
 
   addChild(url: string): void {
     if (!this.childTranslators.get(url)) {
-      const child = new TestChildTranslator(url, this);
+      const child = new TestChildTranslator(url, this.importBaseURL, this);
       this.childTranslators.set(url, child);
     }
   }


### PR DESCRIPTION
There are a few use cases, like notebook cells, where the document URL is not ideal for importing, but we still want to be able to import from. There's a bunch of hackery in the VS Code extension that makes this work, but it would be cleaner to push this into the parser itself. This adds an optional parser parameter, `importBaseURL`, that can be used as the basis for importing.
