### PR TITLE
add * { except: } for wildcard expansion in select: *

### DIFF
--- a/packages/malloy/src/lang/ast/field-space/query-spaces.ts
+++ b/packages/malloy/src/lang/ast/field-space/query-spaces.ts
@@ -132,6 +132,9 @@ export abstract class QuerySpace
     }
     const dialect = this.dialectObj();
     for (const [name, entry] of current.entries()) {
+      if (wild.except.has(name)) {
+        continue;
+      }
       if (this.entry(name)) {
         const conflict = this.expandedWild[name]?.join('.');
         wild.log(

--- a/packages/malloy/src/lang/ast/query-items/field-references.ts
+++ b/packages/malloy/src/lang/ast/query-items/field-references.ts
@@ -184,6 +184,7 @@ export class WildcardFieldReference extends MalloyElement implements Noteable {
   note?: Annotation;
   readonly isNoteableObj = true;
   extendNote = extendNoteMethod;
+  except = new Set<string>();
   constructor(readonly joinPath: FieldReference | undefined) {
     super();
     this.has({joinPath: joinPath});

--- a/packages/malloy/src/lang/grammar/MalloyParser.g4
+++ b/packages/malloy/src/lang/grammar/MalloyParser.g4
@@ -572,7 +572,14 @@ fieldCollection
   ;
 
 collectionWildCard
-  : (fieldPath DOT)? STAR
+  : (fieldPath DOT)? STAR starQualified?
+  ;
+
+starQualified
+  : OCURLY (
+      (EXCEPT fieldNameList)
+    | COMMA
+  )+ CCURLY
   ;
 
 taggedRef

--- a/packages/malloy/src/lang/malloy-to-ast.ts
+++ b/packages/malloy/src/lang/malloy-to-ast.ts
@@ -1064,7 +1064,14 @@ export class MalloyToAST
     const join = nameCx
       ? this.getFieldPath(nameCx, ast.ProjectFieldReference)
       : undefined;
-    return this.astAt(new ast.WildcardFieldReference(join), pcx);
+    const wild = this.astAt(new ast.WildcardFieldReference(join), pcx);
+    const exceptStmts = pcx.starQualified()?.fieldNameList() || [];
+    for (const except of exceptStmts) {
+      for (const exceptThis of except.fieldName()) {
+        wild.except.add(getId(exceptThis));
+      }
+    }
+    return wild;
   }
 
   visitIndexFields(pcx: parse.IndexFieldsContext): ast.FieldReferences {

--- a/packages/malloy/src/lang/test/query.spec.ts
+++ b/packages/malloy/src/lang/test/query.spec.ts
@@ -806,6 +806,17 @@ describe('query:', () => {
       const fields = query!.pipeline[0].fields;
       expect(fields.sort()).toEqual(afields.map(f => `b.${f}`));
     });
+    test('expands star with exclusions', () => {
+      const selstar = model`run: ab->{select: * { except: ai, except: aun, aweird }}`;
+      const filterdFields = afields.filter(
+        f => f !== 'ai' && f !== 'aun' && f !== 'aweird'
+      );
+      expect(selstar).toTranslate();
+      const query = selstar.translator.getQuery(0);
+      expect(query).toBeDefined();
+      const fields = query!.pipeline[0].fields;
+      expect(fields.sort()).toEqual(filterdFields);
+    });
     test('star error checking', () => {
       expect(markSource`run: a->{select: ${'zzz'}.*}`).translationToFailWith(
         "No such field as 'zzz'"


### PR DESCRIPTION
On the way to towards a more full featured star.

`select: * { except: badThing, otherBadThing }`

What's missing is "*" in index doesn't use this, and the user request was also to have rename, which is more code to implement

* [x] @lloydtabb 
* [x] @christopherswenson 
* [x] @carlineng 