### PR TITLE
Fix `run:` highlighting

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 build/
 packages/malloy-malloy-sql/src/grammar
+packages/malloy-syntax-highlight/**/*.monarch.ts

--- a/package-lock.json
+++ b/package-lock.json
@@ -4324,6 +4324,18 @@
         "node": "^4.5.0 || >= 5.9"
       }
     },
+    "node_modules/basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "5.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/before-after-hook": {
       "version": "2.2.3",
       "dev": true,
@@ -5422,6 +5434,15 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/corser": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/corser/-/corser-2.0.1.tgz",
+      "integrity": "sha512-utCYNzRSQIZNPIcGZdQc92UVJYAhtGAteCFg0yRaFm8f0P+CPtyGyHXJcGXnffjCybUCEx3FQ2G7U3/o9eIkVQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4.0"
       }
     },
     "node_modules/cosmiconfig": {
@@ -8351,6 +8372,15 @@
       "version": "2.0.1",
       "license": "ISC"
     },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "bin": {
+        "he": "bin/he"
+      }
+    },
     "node_modules/hosted-git-info": {
       "version": "2.8.9",
       "dev": true,
@@ -8424,6 +8454,45 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/http-server": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/http-server/-/http-server-14.1.1.tgz",
+      "integrity": "sha512-+cbxadF40UXd9T01zUHgA+rlo2Bg1Srer4+B4NwIHdaGxAGGv59nYRnGGDJ9LBk7alpS0US+J+bLLdQOOkJq4A==",
+      "dev": true,
+      "dependencies": {
+        "basic-auth": "^2.0.1",
+        "chalk": "^4.1.2",
+        "corser": "^2.0.1",
+        "he": "^1.2.0",
+        "html-encoding-sniffer": "^3.0.0",
+        "http-proxy": "^1.18.1",
+        "mime": "^1.6.0",
+        "minimist": "^1.2.6",
+        "opener": "^1.5.1",
+        "portfinder": "^1.0.28",
+        "secure-compare": "3.0.1",
+        "union": "~0.5.0",
+        "url-join": "^4.0.1"
+      },
+      "bin": {
+        "http-server": "bin/http-server"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/http-server/node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true,
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/https-proxy-agent": {
@@ -13582,6 +13651,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/opener": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
+      "dev": true,
+      "bin": {
+        "opener": "bin/opener-bin.js"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.3",
       "license": "MIT",
@@ -14302,6 +14380,50 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/portfinder": {
+      "version": "1.0.32",
+      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.32.tgz",
+      "integrity": "sha512-on2ZJVVDXRADWE6jnQaX0ioEylzgBpQk8r55NE4wjXW1ZxO+BgDlY6DXwj20i0V8eB4SenDQ00WEaxfiIQPcxg==",
+      "dev": true,
+      "dependencies": {
+        "async": "^2.6.4",
+        "debug": "^3.2.7",
+        "mkdirp": "^0.5.6"
+      },
+      "engines": {
+        "node": ">= 0.12.0"
+      }
+    },
+    "node_modules/portfinder/node_modules/async": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.17.14"
+      }
+    },
+    "node_modules/portfinder/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/portfinder/node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
       }
     },
     "node_modules/postcss": {
@@ -15193,6 +15315,12 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/secure-compare": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/secure-compare/-/secure-compare-3.0.1.tgz",
+      "integrity": "sha512-AckIIV90rPDcBcglUwXPF3kg0P0qmPsPXAj6BBEENQE1p5yA1xfmDJzfi1Tappj37Pv2mVbKpL3Z1T+Nn7k1Qw==",
+      "dev": true
     },
     "node_modules/semver": {
       "version": "7.5.3",
@@ -16799,6 +16927,18 @@
         "node": ">=4"
       }
     },
+    "node_modules/union": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/union/-/union-0.5.0.tgz",
+      "integrity": "sha512-N6uOhuW6zO95P3Mel2I2zMsbsanvvtgn6jVqJv4vbVcz/JN0OkL9suomjQGmWtxJQXOCqUJvquc1sMeNz/IwlA==",
+      "dev": true,
+      "dependencies": {
+        "qs": "^6.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/uniq": {
       "version": "1.0.1",
       "license": "MIT"
@@ -16903,6 +17043,12 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/url-join": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
+      "dev": true
     },
     "node_modules/url-parse": {
       "version": "1.5.10",
@@ -17935,6 +18081,7 @@
       "license": "MIT",
       "devDependencies": {
         "@types/jasmine": "^4.3.5",
+        "http-server": "^14.1.1",
         "jasmine-core": "^5.1.1",
         "json5": "^2.2.3",
         "karma": "^6.4.2",

--- a/packages/malloy-syntax-highlight/.eslintignore
+++ b/packages/malloy-syntax-highlight/.eslintignore
@@ -1,1 +1,0 @@
-**/*.monarch.ts

--- a/packages/malloy-syntax-highlight/.eslintignore
+++ b/packages/malloy-syntax-highlight/.eslintignore
@@ -1,0 +1,1 @@
+**/*.monarch.ts

--- a/packages/malloy-syntax-highlight/grammars/malloy/malloy.monarch.ts
+++ b/packages/malloy-syntax-highlight/grammars/malloy/malloy.monarch.ts
@@ -24,11 +24,11 @@
 import {languages as Monaco} from 'monaco-editor';
 
 export const monarch: Monaco.IMonarchLanguage = {
-  'includeLF': true,
-  'defaultToken': '',
-  'tokenPostfix': '.malloy',
-  'ignoreCase': true,
-  'tokenizer': {
+  includeLF: true,
+  defaultToken: '',
+  tokenPostfix: '.malloy',
+  ignoreCase: true,
+  tokenizer: {
     root: [{include: '@malloy_language'}],
     malloy_language: [
       {include: '@sql_string'},
@@ -91,8 +91,8 @@ export const monarch: Monaco.IMonarchLanguage = {
     ],
     comment_block_end: [
       [/\*\//, {next: '@pop', token: 'comment.block'}],
-      [/[^*]+/, 'comment.block'],
-      [/[*]/, 'comment.block'],
+      [/[^\*]+/, 'comment.block'],
+      [/[\*]/, 'comment.block'],
     ],
     comment_line_double_slash_end: [
       [/\n/, {next: '@pop', token: 'comment.line.double.slash'}],
@@ -145,7 +145,7 @@ export const monarch: Monaco.IMonarchLanguage = {
       [/'/, {next: '@string_quoted_single_end', token: 'string.quoted'}],
       [/"/, {next: '@string_quoted_double_end', token: 'string.quoted'}],
       [/"""/, {next: '@string_quoted_triple_end', token: 'string.quoted'}],
-      [/[r|/]'/, {next: '@string_regexp_end', token: 'string.regexp'}],
+      [/[r|\/]'/, {next: '@string_regexp_end', token: 'string.regexp'}],
     ],
     string_quoted_single_end: [
       [/'/, {next: '@pop', token: 'string.quoted'}],
@@ -199,7 +199,7 @@ export const monarch: Monaco.IMonarchLanguage = {
       [/\bsql\b/, 'keyword.control.sql'],
       [/\bselect\b/, 'keyword.control.select'],
       [/\bconnection\b/, 'keyword.control.connection'],
-      [/\brun\b/, 'keyword'],
+      [/\brun\b/, 'keyword.control.run'],
       [/\bextend\b/, 'keyword.control.extend'],
       [/\brefine\b/, 'keyword.control.refine'],
       [/\baggregate\b/, 'keyword.control.aggregate'],
@@ -225,6 +225,7 @@ export const monarch: Monaco.IMonarchLanguage = {
       [/\bquery\b/, 'keyword.control.query'],
       [/\brename\b/, 'keyword.control.rename'],
       [/\btop\b/, 'keyword.control.top'],
+      [/\bview\b/, 'keyword.control.view'],
       [/\bwhere\b/, 'keyword.control.where'],
       [/\bdeclare\b/, 'keyword.control.declare'],
     ],
@@ -245,7 +246,7 @@ export const monarch: Monaco.IMonarchLanguage = {
     ],
     datetimes: [
       [
-        /@[0-9]{4}-[0-9]{2}-[0-9]{2}[ T][0-9]{2}:[0-9]{2}((:[0-9]{2})(([.,][0-9]+)(\[[A-Za-z_/]+\])?)?)?/,
+        /@[0-9]{4}-[0-9]{2}-[0-9]{2}[ T][0-9]{2}:[0-9]{2}((:[0-9]{2})(([\.,][0-9]+)(\[[A-Za-z_\/]+\])?)?)?/,
         'constant.numeric.timestamp',
       ],
       [

--- a/packages/malloy-syntax-highlight/grammars/malloy/malloy.tmGrammar.json
+++ b/packages/malloy-syntax-highlight/grammars/malloy/malloy.tmGrammar.json
@@ -364,7 +364,7 @@
         },
         {
           "match": "(?i)\\brun\\b",
-          "name": "keyword"
+          "name": "keyword.control.run"
         },
         {
           "match": "(?i)\\bextend\\b",

--- a/packages/malloy-syntax-highlight/grammars/malloy/tokenizations/darkPlus.ts
+++ b/packages/malloy-syntax-highlight/grammars/malloy/tokenizations/darkPlus.ts
@@ -1062,8 +1062,8 @@ export default [
       tokens: [
         {
           startIndex: 0,
-          type: ['source.malloy', 'keyword'],
-          color: '#569CD6',
+          type: ['source.malloy', 'keyword.control.run'],
+          color: '#C586C0',
         },
         {startIndex: 3, type: ['source.malloy'], color: '#000000'},
         {

--- a/packages/malloy-syntax-highlight/package.json
+++ b/packages/malloy-syntax-highlight/package.json
@@ -13,11 +13,13 @@
     "gen-malloy-tokens": "ts-node scripts/generateLanguageTokenizationFile grammars/malloy/tokenizations/darkPlus.ts",
     "test-monarch-grammars": "rimraf ./dist && tsc && karma start",
     "test-textmate-grammars": "jest",
-    "gen-monaco-darkplus": "ts-node scripts/generateMonarchTheme themes/textmate/dark_plus.json themes/monaco/darkPlus.ts"
+    "gen-monaco-darkplus": "ts-node scripts/generateMonarchTheme themes/textmate/dark_plus.json themes/monaco/darkPlus.ts",
+    "serve-visual": "http-server test/visual -p 2222"
   },
   "license": "MIT",
   "devDependencies": {
     "@types/jasmine": "^4.3.5",
+    "http-server": "^14.1.1",
     "jasmine-core": "^5.1.1",
     "json5": "^2.2.3",
     "karma": "^6.4.2",

--- a/packages/malloy-syntax-highlight/test/visual/index.html
+++ b/packages/malloy-syntax-highlight/test/visual/index.html
@@ -1,0 +1,76 @@
+<html>
+  <head>
+    <style>
+      body {
+        display: flex;
+        flex-direction: row;
+      }
+      .left {
+        width: 50%;
+        border: 1px solid #efefef;
+        margin: 10px;
+        border-radius: 10px;
+        overflow: hidden;
+        padding: 3px;
+      }
+      #input {
+        width: 100%;
+        height: 100%;
+        border: none;
+        resize: none;
+      }
+      #input:focus {
+        border: none;
+        outline: none;
+      }
+      .right {
+        padding: 3px;
+        width: 50%;
+        border: 1px solid #efefef;
+        margin: 10px;
+        border-radius: 10px;
+      }
+      pre {
+        white-space: pre-wrap;
+        margin: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="left"><textarea id="input">
+source: flights is duckdb.table('flights.parquet') extend {
+  dimension: foo is 1
+}
+    </textarea></div>
+    <div class="right"><div id="output"></div></div>
+    <script src="https://unpkg.com/shiki"></script>
+    <script>
+      fetch("./malloy.tmGrammar.json").then(response => {
+        const malloyGrammar = response.json();
+        const update = (el) => {
+          shiki
+          .getHighlighter({
+            theme: 'light-plus',
+            langs: [
+              "sql",
+              "json",
+              {
+                id: "malloy",
+                scopeName: "source.malloy",
+                embeddedLangs: ["sql"],
+                grammar: malloyGrammar,
+              },
+            ],
+          })
+          .then(highlighter => {
+            const code = highlighter.codeToHtml(el.value, { lang: 'malloy' })
+            document.getElementById('output').innerHTML = code
+          })
+        }
+        const inp = document.getElementById("input");
+        inp.addEventListener('input', (ev) => update(ev.target));
+        update(inp);
+      });
+    </script>
+  </body>
+</html>

--- a/packages/malloy-syntax-highlight/test/visual/malloy.tmGrammar.json
+++ b/packages/malloy-syntax-highlight/test/visual/malloy.tmGrammar.json
@@ -1,0 +1,1 @@
+../../grammars/malloy/malloy.tmGrammar.json


### PR DESCRIPTION
Old:
<img width="558" alt="Screenshot 2023-09-26 at 8 45 37 AM" src="https://github.com/malloydata/malloy/assets/3538955/57cf4463-442b-4192-8683-6916c6e228a3">
New:
<img width="488" alt="Screenshot 2023-09-26 at 9 33 35 AM" src="https://github.com/malloydata/malloy/assets/3538955/786ea2a9-3aaf-468e-9fcd-cce5c140bbc1">


Also add a super simple visual tester for the textmate grammar with `npm run serve-visual`
<img width="1111" alt="Screenshot 2023-09-26 at 10 15 05 AM" src="https://github.com/malloydata/malloy/assets/3538955/8239cf76-a7dd-4bd5-a17e-0e96cf55a50e">

