### PR TITLE
Expose model imports

### DIFF
--- a/packages/malloy/src/lang/parse-malloy.ts
+++ b/packages/malloy/src/lang/parse-malloy.ts
@@ -610,6 +610,7 @@ class TranslateStep implements TranslationStep {
           modelDef: that.modelDef,
           queryList: that.queryList,
           sqlBlocks: that.sqlBlocks,
+          imports: that.imports,
         },
         ...that.problemResponse(),
         final: true,

--- a/packages/malloy/src/lang/translate-response.ts
+++ b/packages/malloy/src/lang/translate-response.ts
@@ -22,6 +22,7 @@
  */
 
 import {
+  ImportLocation,
   ModelDef,
   Query,
   SQLBlockSource,
@@ -95,6 +96,7 @@ interface TranslatedResponseData
     modelDef: ModelDef;
     queryList: Query[];
     sqlBlocks: SQLBlockStructDef[];
+    imports: ImportLocation[];
   };
 }
 

--- a/packages/malloy/src/malloy.ts
+++ b/packages/malloy/src/malloy.ts
@@ -222,6 +222,7 @@ export class Malloy {
             result.translated.modelDef,
             result.translated.queryList,
             result.translated.sqlBlocks,
+            result.translated.imports,
             result.problems || [],
             (position: ModelDocumentPosition) =>
               translator.referenceAt(position),
@@ -622,6 +623,7 @@ export class Model implements Taggable {
     private modelDef: ModelDef,
     private queryList: InternalQuery[],
     private sqlBlocks: SQLBlockStructDef[],
+    readonly imports: ImportLocation[],
     readonly problems: LogMessage[],
     referenceAt: (
       location: ModelDocumentPosition
@@ -1425,7 +1427,7 @@ export class Explore extends Entity {
   }
 
   public getSingleExploreModel(): Model {
-    return new Model(this.modelDef, [], [], []);
+    return new Model(this.modelDef, [], [], [], []);
   }
 
   private get fieldMap(): Map<string, Field> {
@@ -2115,7 +2117,7 @@ export class Runtime {
   //      be used in tests.
   public _loadModelFromModelDef(modelDef: ModelDef): ModelMaterializer {
     return new ModelMaterializer(this, async () => {
-      return new Model(modelDef, [], [], []);
+      return new Model(modelDef, [], [], [], []);
     });
   }
 


### PR DESCRIPTION
In order to do better cache invalidation, I need to know what files a model depends on, so when an upstream file changes, the current model recompiles (https://github.com/malloydata/malloy-vscode-extension/issues/258) and that info is not currently exposed. 