### PR TITLE
duckdb 0.9.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4062,9 +4062,9 @@
       "link": true
     },
     "node_modules/@malloydata/duckdb-wasm": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/@malloydata/duckdb-wasm/-/duckdb-wasm-0.0.3.tgz",
-      "integrity": "sha512-kDL01iEmHTiclRJrcfdnQxDvITls0zmg+MRe4h721SwPvs2JaFzqDyzqNgffZj0Jj/m1LoPgwC4PPdhFd7f5YA==",
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@malloydata/duckdb-wasm/-/duckdb-wasm-0.0.4.tgz",
+      "integrity": "sha512-McsP0n1d9/zBPIluEQmAs1BF8F9y8ADSJ3QTNdPrnU8sSBIv3hWcFaHt7R2EqsBRt9sGs55SM3lhbsjYc4KfGw==",
       "dependencies": {
         "apache-arrow": "^13.0.0"
       }
@@ -11159,15 +11159,20 @@
       }
     },
     "node_modules/duckdb": {
-      "version": "0.9.1-dev95.0",
-      "resolved": "https://registry.npmjs.org/duckdb/-/duckdb-0.9.1-dev95.0.tgz",
-      "integrity": "sha512-MoG6lgpAAiCjDPpXGlanCvu+qJcCTUynyL5RnmjNi73lAXWJmMcaPm7SLmRHGaFwjZqGjTGfUP2z4WVt7XbBiA==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/duckdb/-/duckdb-0.9.1.tgz",
+      "integrity": "sha512-mYfQXKADGUoBVOfy6OordgEkPlY6EtEIgrwRbFgVDoen2iQRVymr4RcDGhA2QTrniwgK+GnhszCu0vqrZJ1sFQ==",
       "hasInstallScript": true,
       "dependencies": {
         "@mapbox/node-pre-gyp": "^1.0.0",
-        "node-addon-api": "*",
+        "node-addon-api": "^7.0.0",
         "node-gyp": "^9.3.0"
       }
+    },
+    "node_modules/duckdb/node_modules/node-addon-api": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.0.0.tgz",
+      "integrity": "sha512-vgbBJTS4m5/KkE16t5Ly0WW9hz46swAstv0hYYwMtbG7AznRhNyfLRe8HZAiWIpcHzoO7HxhLuBQj9rJ/Ho0ZA=="
     },
     "node_modules/duplexer": {
       "version": "0.1.2",
@@ -18572,6 +18577,7 @@
     },
     "node_modules/node-addon-api": {
       "version": "3.2.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/node-dir": {
@@ -25076,11 +25082,11 @@
       "version": "0.0.102",
       "license": "MIT",
       "dependencies": {
-        "@malloydata/duckdb-wasm": "0.0.3",
+        "@malloydata/duckdb-wasm": "0.0.4",
         "@malloydata/malloy": "^0.0.102",
         "@malloydata/malloy-interfaces": "^0.0.102",
         "apache-arrow": "^13.0.0",
-        "duckdb": "0.9.1-dev95.0",
+        "duckdb": "0.9.1",
         "web-worker": "^1.2.0"
       },
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4062,9 +4062,9 @@
       "link": true
     },
     "node_modules/@malloydata/duckdb-wasm": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@malloydata/duckdb-wasm/-/duckdb-wasm-0.0.4.tgz",
-      "integrity": "sha512-McsP0n1d9/zBPIluEQmAs1BF8F9y8ADSJ3QTNdPrnU8sSBIv3hWcFaHt7R2EqsBRt9sGs55SM3lhbsjYc4KfGw==",
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@malloydata/duckdb-wasm/-/duckdb-wasm-0.0.6.tgz",
+      "integrity": "sha512-jy+gIP8ITUnDsF8HhI+WMFQRzkGRx/vLxmWA/dA+DI7dbk9MlCnCR/U0XoOHOIyRlpCIVCHfb9L1EO0YGJHooA==",
       "dependencies": {
         "apache-arrow": "^13.0.0"
       }
@@ -11159,9 +11159,9 @@
       }
     },
     "node_modules/duckdb": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/duckdb/-/duckdb-0.9.1.tgz",
-      "integrity": "sha512-mYfQXKADGUoBVOfy6OordgEkPlY6EtEIgrwRbFgVDoen2iQRVymr4RcDGhA2QTrniwgK+GnhszCu0vqrZJ1sFQ==",
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/duckdb/-/duckdb-0.9.2.tgz",
+      "integrity": "sha512-POZ37Vf5cHVmk4W8z0PsdGi67VeQsr9HRrBbmivDt9AQ8C1XLESVE79facydbroNiqm7+n7fx6jqjyxyrBFYlQ==",
       "hasInstallScript": true,
       "dependencies": {
         "@mapbox/node-pre-gyp": "^1.0.0",
@@ -25082,11 +25082,11 @@
       "version": "0.0.102",
       "license": "MIT",
       "dependencies": {
-        "@malloydata/duckdb-wasm": "0.0.4",
+        "@malloydata/duckdb-wasm": "0.0.6",
         "@malloydata/malloy": "^0.0.102",
         "@malloydata/malloy-interfaces": "^0.0.102",
         "apache-arrow": "^13.0.0",
-        "duckdb": "0.9.1",
+        "duckdb": "0.9.2",
         "web-worker": "^1.2.0"
       },
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11159,9 +11159,9 @@
       }
     },
     "node_modules/duckdb": {
-      "version": "0.9.1-dev19.0",
-      "resolved": "https://registry.npmjs.org/duckdb/-/duckdb-0.9.1-dev19.0.tgz",
-      "integrity": "sha512-vCoWc3lmWzjJ3dlWlGpczBCI0xfK1lweIKnNX4uR3LJYqYx2YoRFmsxbpCxycZsGqAcX9qya8nrAdYfrWm+1iQ==",
+      "version": "0.9.1-dev95.0",
+      "resolved": "https://registry.npmjs.org/duckdb/-/duckdb-0.9.1-dev95.0.tgz",
+      "integrity": "sha512-MoG6lgpAAiCjDPpXGlanCvu+qJcCTUynyL5RnmjNi73lAXWJmMcaPm7SLmRHGaFwjZqGjTGfUP2z4WVt7XbBiA==",
       "hasInstallScript": true,
       "dependencies": {
         "@mapbox/node-pre-gyp": "^1.0.0",
@@ -25080,7 +25080,7 @@
         "@malloydata/malloy": "^0.0.102",
         "@malloydata/malloy-interfaces": "^0.0.102",
         "apache-arrow": "^13.0.0",
-        "duckdb": "0.9.1-dev19.0",
+        "duckdb": "0.9.1-dev95.0",
         "web-worker": "^1.2.0"
       },
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,6 +62,26 @@
         ]
       }
     },
+    "node_modules/@75lb/deep-merge": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@75lb/deep-merge/-/deep-merge-1.1.1.tgz",
+      "integrity": "sha512-xvgv6pkMGBA6GwdyJbNAnDmfAIR/DfWhrj9jgWh3TY7gRm3KO46x/GPjRg6wJ0nOepwqrNxFfojebh0Df4h4Tw==",
+      "dependencies": {
+        "lodash.assignwith": "^4.2.0",
+        "typical": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
+    "node_modules/@75lb/deep-merge/node_modules/typical": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-7.1.1.tgz",
+      "integrity": "sha512-T+tKVNs6Wu7IWiAce5BgMd7OZfNYUndHwc5MknN+UHOudi7sGZzuHdCadllRuqJ3fPtgFtIH9+lt9qRv6lmpfA==",
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
     "node_modules/@aashutoshrathi/word-wrap": {
       "version": "1.2.6",
       "license": "MIT",
@@ -4041,6 +4061,14 @@
       "resolved": "packages/malloy-db-postgres",
       "link": true
     },
+    "node_modules/@malloydata/duckdb-wasm": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@malloydata/duckdb-wasm/-/duckdb-wasm-0.0.3.tgz",
+      "integrity": "sha512-kDL01iEmHTiclRJrcfdnQxDvITls0zmg+MRe4h721SwPvs2JaFzqDyzqNgffZj0Jj/m1LoPgwC4PPdhFd7f5YA==",
+      "dependencies": {
+        "apache-arrow": "^13.0.0"
+      }
+    },
     "node_modules/@malloydata/eslint-plugin-lint": {
       "resolved": "packages/malloy-lint",
       "link": true
@@ -7594,10 +7622,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/flatbuffers": {
-      "version": "1.10.0",
-      "license": "MIT"
-    },
     "node_modules/@types/fs-extra": {
       "version": "9.0.13",
       "dev": true,
@@ -8542,32 +8566,34 @@
       }
     },
     "node_modules/apache-arrow": {
-      "version": "11.0.0",
-      "license": "Apache-2.0",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/apache-arrow/-/apache-arrow-13.0.0.tgz",
+      "integrity": "sha512-3gvCX0GDawWz6KFNC28p65U+zGh/LZ6ZNKWNu74N6CQlKzxeoWHpi4CgEQsgRSEMuyrIIXi1Ea2syja7dwcHvw==",
       "dependencies": {
         "@types/command-line-args": "5.2.0",
         "@types/command-line-usage": "5.0.2",
-        "@types/flatbuffers": "*",
-        "@types/node": "18.7.23",
+        "@types/node": "20.3.0",
         "@types/pad-left": "2.1.1",
         "command-line-args": "5.2.1",
-        "command-line-usage": "6.1.3",
-        "flatbuffers": "2.0.4",
+        "command-line-usage": "7.0.1",
+        "flatbuffers": "23.5.26",
         "json-bignum": "^0.0.3",
         "pad-left": "^2.1.0",
-        "tslib": "^2.4.0"
+        "tslib": "^2.5.3"
       },
       "bin": {
         "arrow2csv": "bin/arrow2csv.js"
       }
     },
     "node_modules/apache-arrow/node_modules/@types/node": {
-      "version": "18.7.23",
-      "license": "MIT"
+      "version": "20.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.3.0.tgz",
+      "integrity": "sha512-cumHmIAf6On83X7yP+LrsEyUOf/YlociZelmpRYaGFydoaPdxdt80MAbu6vWerQT2COCp2nPvHdsbD7tHn/YlQ=="
     },
     "node_modules/apache-arrow/node_modules/tslib": {
-      "version": "2.5.0",
-      "license": "0BSD"
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/app-module-path": {
       "version": "2.2.0",
@@ -9365,6 +9391,20 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/chalk-template": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/chalk-template/-/chalk-template-0.4.0.tgz",
+      "integrity": "sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==",
+      "dependencies": {
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk-template?sponsor=1"
+      }
+    },
     "node_modules/char-regex": {
       "version": "1.0.2",
       "dev": true,
@@ -9602,87 +9642,33 @@
       }
     },
     "node_modules/command-line-usage": {
-      "version": "6.1.3",
-      "license": "MIT",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-7.0.1.tgz",
+      "integrity": "sha512-NCyznE//MuTjwi3y84QVUGEOT+P5oto1e1Pk/jFPVdPPfsG03qpTIl3yw6etR+v73d0lXsoojRpvbru2sqePxQ==",
       "dependencies": {
-        "array-back": "^4.0.2",
-        "chalk": "^2.4.2",
-        "table-layout": "^1.0.2",
-        "typical": "^5.2.0"
+        "array-back": "^6.2.2",
+        "chalk-template": "^0.4.0",
+        "table-layout": "^3.0.0",
+        "typical": "^7.1.1"
       },
       "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/command-line-usage/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
+        "node": ">=12.20.0"
       }
     },
     "node_modules/command-line-usage/node_modules/array-back": {
-      "version": "4.0.2",
-      "license": "MIT",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.2.tgz",
+      "integrity": "sha512-gUAZ7HPyb4SJczXAMUXMGAvI976JoK3qEx9v1FTmeYuJj0IBiaKttG1ydtGKdkfqWkIkouke7nG8ufGy77+Cvw==",
       "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/command-line-usage/node_modules/chalk": {
-      "version": "2.4.2",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/command-line-usage/node_modules/color-convert": {
-      "version": "1.9.3",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/command-line-usage/node_modules/color-name": {
-      "version": "1.1.3",
-      "license": "MIT"
-    },
-    "node_modules/command-line-usage/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/command-line-usage/node_modules/has-flag": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/command-line-usage/node_modules/supports-color": {
-      "version": "5.5.0",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
+        "node": ">=12.17"
       }
     },
     "node_modules/command-line-usage/node_modules/typical": {
-      "version": "5.2.0",
-      "license": "MIT",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-7.1.1.tgz",
+      "integrity": "sha512-T+tKVNs6Wu7IWiAce5BgMd7OZfNYUndHwc5MknN+UHOudi7sGZzuHdCadllRuqJ3fPtgFtIH9+lt9qRv6lmpfA==",
       "engines": {
-        "node": ">=8"
+        "node": ">=12.17"
       }
     },
     "node_modules/commander": {
@@ -11173,9 +11159,10 @@
       }
     },
     "node_modules/duckdb": {
-      "version": "0.8.1",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/duckdb/-/duckdb-0.9.0.tgz",
+      "integrity": "sha512-+zJ39mFaUqNAOG5Ef6JsZcfrgIjrqNyUm23i3+O3ZTTHBxVm3JQLEEfDSafevfbkAGbalhm5K7wFzXALl0+TIA==",
       "hasInstallScript": true,
-      "license": "MIT",
       "dependencies": {
         "@mapbox/node-pre-gyp": "^1.0.0",
         "node-addon-api": "*",
@@ -12661,8 +12648,9 @@
       }
     },
     "node_modules/flatbuffers": {
-      "version": "2.0.4",
-      "license": "SEE LICENSE IN LICENSE.txt"
+      "version": "23.5.26",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-23.5.26.tgz",
+      "integrity": "sha512-vE+SI9vrJDwi1oETtTIFldC/o9GsVKRM+s6EL0nQgxXlYV1Vc4Tk30hj4xGICftInKQKj1F3up2n8UbIVobISQ=="
     },
     "node_modules/flatted": {
       "version": "3.2.7",
@@ -17931,6 +17919,11 @@
       "version": "4.17.21",
       "license": "MIT"
     },
+    "node_modules/lodash.assignwith": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.assignwith/-/lodash.assignwith-4.2.0.tgz",
+      "integrity": "sha512-ZznplvbvtjK2gMvnQ1BR/zqPFZmS6jbK4p+6Up4xcRYA7yMIwxHCfbTcrYxXKzzqLsQ05eJPVznEW3tuwV7k1g=="
+    },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
       "license": "MIT"
@@ -21406,13 +21399,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/reduce-flatten": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/regenerate": {
       "version": "1.4.2",
       "dev": true,
@@ -22512,6 +22498,14 @@
         "stubs": "^3.0.0"
       }
     },
+    "node_modules/stream-read-all": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/stream-read-all/-/stream-read-all-3.0.1.tgz",
+      "integrity": "sha512-EWZT9XOceBPlVJRrYcykW8jyRSZYbkb/0ZK36uLEmoWVO5gxBOnntNTseNzfREsqxqdfEGQrD8SXQ3QWbBmq8A==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/stream-shift": {
       "version": "1.0.1",
       "license": "MIT"
@@ -22792,30 +22786,39 @@
       "license": "0BSD"
     },
     "node_modules/table-layout": {
-      "version": "1.0.2",
-      "license": "MIT",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-3.0.2.tgz",
+      "integrity": "sha512-rpyNZYRw+/C+dYkcQ3Pr+rLxW4CfHpXjPDnG7lYhdRoUcZTUt+KEsX+94RGp/aVp/MQU35JCITv2T/beY4m+hw==",
       "dependencies": {
-        "array-back": "^4.0.1",
-        "deep-extend": "~0.6.0",
-        "typical": "^5.2.0",
-        "wordwrapjs": "^4.0.0"
+        "@75lb/deep-merge": "^1.1.1",
+        "array-back": "^6.2.2",
+        "command-line-args": "^5.2.1",
+        "command-line-usage": "^7.0.0",
+        "stream-read-all": "^3.0.1",
+        "typical": "^7.1.1",
+        "wordwrapjs": "^5.1.0"
+      },
+      "bin": {
+        "table-layout": "bin/cli.js"
       },
       "engines": {
-        "node": ">=8.0.0"
+        "node": ">=12.17"
       }
     },
     "node_modules/table-layout/node_modules/array-back": {
-      "version": "4.0.2",
-      "license": "MIT",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.2.tgz",
+      "integrity": "sha512-gUAZ7HPyb4SJczXAMUXMGAvI976JoK3qEx9v1FTmeYuJj0IBiaKttG1ydtGKdkfqWkIkouke7nG8ufGy77+Cvw==",
       "engines": {
-        "node": ">=8"
+        "node": ">=12.17"
       }
     },
     "node_modules/table-layout/node_modules/typical": {
-      "version": "5.2.0",
-      "license": "MIT",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-7.1.1.tgz",
+      "integrity": "sha512-T+tKVNs6Wu7IWiAce5BgMd7OZfNYUndHwc5MknN+UHOudi7sGZzuHdCadllRuqJ3fPtgFtIH9+lt9qRv6lmpfA==",
       "engines": {
-        "node": ">=8"
+        "node": ">=12.17"
       }
     },
     "node_modules/tapable": {
@@ -24796,21 +24799,11 @@
       "license": "MIT"
     },
     "node_modules/wordwrapjs": {
-      "version": "4.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "reduce-flatten": "^2.0.0",
-        "typical": "^5.2.0"
-      },
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-5.1.0.tgz",
+      "integrity": "sha512-JNjcULU2e4KJwUNv6CHgI46UvDGitb6dGryHajXTDiLgg1/RiGoPSDw4kZfYnwGtEXf2ZMeIewDQgFGzkCB2Sg==",
       "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/wordwrapjs/node_modules/typical": {
-      "version": "5.2.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
+        "node": ">=12.17"
       }
     },
     "node_modules/wrap-ansi": {
@@ -25083,23 +25076,15 @@
       "version": "0.0.102",
       "license": "MIT",
       "dependencies": {
-        "@malloydata/duckdb-wasm": "0.0.2-rev3",
+        "@malloydata/duckdb-wasm": "0.0.3",
         "@malloydata/malloy": "^0.0.102",
         "@malloydata/malloy-interfaces": "^0.0.102",
-        "apache-arrow": "^11.0.0",
-        "duckdb": "0.8.1",
+        "apache-arrow": "^13.0.0",
+        "duckdb": "0.9.0",
         "web-worker": "^1.2.0"
       },
       "engines": {
         "node": ">=16"
-      }
-    },
-    "packages/malloy-db-duckdb/node_modules/@malloydata/duckdb-wasm": {
-      "version": "0.0.2-rev3",
-      "resolved": "https://registry.npmjs.org/@malloydata/duckdb-wasm/-/duckdb-wasm-0.0.2-rev3.tgz",
-      "integrity": "sha512-xTMfD0o5ZSotY3Bs/WPQ4V2uTmYsTOur/Ifux7yA8ld9mfjdx/Pj260LbD1tUqeCJy1NTaf1Ui5+ILjaqoBIew==",
-      "dependencies": {
-        "apache-arrow": "^11.0.0"
       }
     },
     "packages/malloy-db-postgres": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11159,9 +11159,9 @@
       }
     },
     "node_modules/duckdb": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/duckdb/-/duckdb-0.9.0.tgz",
-      "integrity": "sha512-+zJ39mFaUqNAOG5Ef6JsZcfrgIjrqNyUm23i3+O3ZTTHBxVm3JQLEEfDSafevfbkAGbalhm5K7wFzXALl0+TIA==",
+      "version": "0.9.1-dev19.0",
+      "resolved": "https://registry.npmjs.org/duckdb/-/duckdb-0.9.1-dev19.0.tgz",
+      "integrity": "sha512-vCoWc3lmWzjJ3dlWlGpczBCI0xfK1lweIKnNX4uR3LJYqYx2YoRFmsxbpCxycZsGqAcX9qya8nrAdYfrWm+1iQ==",
       "hasInstallScript": true,
       "dependencies": {
         "@mapbox/node-pre-gyp": "^1.0.0",
@@ -25080,7 +25080,7 @@
         "@malloydata/malloy": "^0.0.102",
         "@malloydata/malloy-interfaces": "^0.0.102",
         "apache-arrow": "^13.0.0",
-        "duckdb": "0.9.0",
+        "duckdb": "0.9.1-dev19.0",
         "web-worker": "^1.2.0"
       },
       "engines": {

--- a/packages/malloy-db-duckdb/package.json
+++ b/packages/malloy-db-duckdb/package.json
@@ -40,11 +40,11 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@malloydata/duckdb-wasm": "0.0.3",
+    "@malloydata/duckdb-wasm": "0.0.4",
     "@malloydata/malloy": "^0.0.102",
     "@malloydata/malloy-interfaces": "^0.0.102",
     "apache-arrow": "^13.0.0",
-    "duckdb": "0.9.1-dev95.0",
+    "duckdb": "0.9.1",
     "web-worker": "^1.2.0"
   }
 }

--- a/packages/malloy-db-duckdb/package.json
+++ b/packages/malloy-db-duckdb/package.json
@@ -40,11 +40,11 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@malloydata/duckdb-wasm": "0.0.2-rev3",
+    "@malloydata/duckdb-wasm": "0.0.3",
     "@malloydata/malloy": "^0.0.102",
     "@malloydata/malloy-interfaces": "^0.0.102",
-    "apache-arrow": "^11.0.0",
-    "duckdb": "0.8.1",
+    "apache-arrow": "^13.0.0",
+    "duckdb": "0.9.0",
     "web-worker": "^1.2.0"
   }
 }

--- a/packages/malloy-db-duckdb/package.json
+++ b/packages/malloy-db-duckdb/package.json
@@ -44,7 +44,7 @@
     "@malloydata/malloy": "^0.0.102",
     "@malloydata/malloy-interfaces": "^0.0.102",
     "apache-arrow": "^13.0.0",
-    "duckdb": "0.9.1-dev19.0",
+    "duckdb": "0.9.1-dev95.0",
     "web-worker": "^1.2.0"
   }
 }

--- a/packages/malloy-db-duckdb/package.json
+++ b/packages/malloy-db-duckdb/package.json
@@ -40,11 +40,11 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@malloydata/duckdb-wasm": "0.0.4",
+    "@malloydata/duckdb-wasm": "0.0.6",
     "@malloydata/malloy": "^0.0.102",
     "@malloydata/malloy-interfaces": "^0.0.102",
     "apache-arrow": "^13.0.0",
-    "duckdb": "0.9.1",
+    "duckdb": "0.9.2",
     "web-worker": "^1.2.0"
   }
 }

--- a/packages/malloy-db-duckdb/package.json
+++ b/packages/malloy-db-duckdb/package.json
@@ -44,7 +44,7 @@
     "@malloydata/malloy": "^0.0.102",
     "@malloydata/malloy-interfaces": "^0.0.102",
     "apache-arrow": "^13.0.0",
-    "duckdb": "0.9.0",
+    "duckdb": "0.9.1-dev19.0",
     "web-worker": "^1.2.0"
   }
 }

--- a/packages/malloy-db-duckdb/src/duckdb_connection.ts
+++ b/packages/malloy-db-duckdb/src/duckdb_connection.ts
@@ -115,6 +115,14 @@ export class DuckDBConnection extends DuckDBCommon {
           if (err) {
             reject(err);
           } else {
+            rows = JSON.parse(
+              JSON.stringify(rows, (_key, value) => {
+                if (typeof value === 'bigint') {
+                  return Number(value);
+                }
+                return value;
+              })
+            );
             resolve({
               rows,
               totalRows: rows.length,

--- a/packages/malloy-db-duckdb/src/duckdb_connection.ts
+++ b/packages/malloy-db-duckdb/src/duckdb_connection.ts
@@ -81,15 +81,10 @@ export class DuckDBConnection extends DuckDBCommon {
           `SET FILE_SEARCH_PATH='${this.workingDirectory}'`
         );
       }
-      const setupCmds = [
-        "INSTALL 'json'",
-        "LOAD 'json'",
-        "INSTALL 'httpfs'",
-        "LOAD 'httpfs'",
-        "INSTALL 'icu'",
-        "LOAD 'icu'",
-        "SET TimeZone='UTC'",
-      ];
+      for (const ext of ['json', 'httpfs', 'icu']) {
+        await this.loadExtension(ext);
+      }
+      const setupCmds = ["SET TimeZone='UTC'"];
       for (const cmd of setupCmds) {
         try {
           await this.runDuckDBQuery(cmd);

--- a/packages/malloy-db-duckdb/src/duckdb_wasm_connection.ts
+++ b/packages/malloy-db-duckdb/src/duckdb_wasm_connection.ts
@@ -184,6 +184,15 @@ export abstract class DuckDBWASMConnection extends DuckDBCommon {
       // for (const ext of ['json', 'httpfs', 'icu']) {
       //   await this.loadExtension(ext);
       // }
+      const setupCmds = ["SET TimeZone='UTC'"];
+      for (const cmd of setupCmds) {
+        try {
+          await this.runDuckDBQuery(cmd);
+        } catch (error) {
+          // eslint-disable-next-line no-console
+          console.error(`duckdb setup ${cmd} => ${error}`);
+        }
+      }
     };
     await this.connecting;
     if (!this.isSetup) {

--- a/packages/malloy/src/dialect/duckdb/duckdb.ts
+++ b/packages/malloy/src/dialect/duckdb/duckdb.ts
@@ -129,7 +129,7 @@ export class DuckDBDialect extends Dialect {
     const fields = fieldList
       .map(f => `${f.sqlExpression} as ${f.sqlOutputName}`)
       .join(', ');
-    return `ANY_VALUE(CASE WHEN group_set=${groupSet} THEN ROW(${fields}))`;
+    return `ANY_VALUE(CASE WHEN group_set=${groupSet} THEN STRUCT_PACK(${fields}))`;
   }
 
   sqlAnyValueLastTurtle(
@@ -243,13 +243,13 @@ export class DuckDBDialect extends Dialect {
     lastStageName: string,
     structDef: StructDef
   ): string {
-    return `SELECT LIST(ROW(${structDef.fields
+    return `SELECT LIST(STRUCT_PACK(${structDef.fields
       .map(fieldDef => this.sqlMaybeQuoteIdentifier(getIdentifier(fieldDef)))
       .join(',')})) FROM ${lastStageName}\n`;
   }
 
   sqlSelectAliasAsStruct(alias: string, physicalFieldNames: string[]): string {
-    return `ROW(${physicalFieldNames
+    return `STRUCT_PACK(${physicalFieldNames
       .map(name => `${alias}.${name}`)
       .join(', ')})`;
   }

--- a/packages/malloy/src/model/malloy_query.ts
+++ b/packages/malloy/src/model/malloy_query.ts
@@ -2354,6 +2354,7 @@ class QueryQuery extends QueryField {
   prepare(_stageWriter: StageWriter | undefined) {
     if (!this.prepared) {
       this.expandFields(this.rootResult);
+      this.rootResult.addStructToJoin(this.parent, this, false, []);
       this.rootResult.findJoins(this);
       this.rootResult.calculateSymmetricAggregates();
       this.prepared = true;

--- a/test/src/databases/all/nomodel.spec.ts
+++ b/test/src/databases/all/nomodel.spec.ts
@@ -504,6 +504,13 @@ runtimes.runtimeMap.forEach((runtime, databaseName) => {
     }
   );
 
+  it(`run simple sql - ${databaseName}`, async () => {
+    const result = await runtime
+      .loadQuery(`run: conn.sql("select 1 as one")`)
+      .run();
+    expect(result.data.value[0]['one']).toBe(1);
+  });
+
   it(`all with parameters - basic  - ${databaseName}`, async () => {
     await expect(`
       run: ${databaseName}.table('malloytest.state_facts') extend  {


### PR DESCRIPTION
Experiment with updating to duckdb 0.9.0. There was an issue with prebuilt binaries for 0.9.0 so this uses a recent dev build.

@lloydtabb / @christopherswenson - A bunch of UDF tests are failing, like "Multi value to udf". The results from DuckDB are lacking the "t1" property name. Not clear to me if this is a bug or a change in behavior we need to adapt to.

BigQuery:
```json
[
      {
        "fun": [
          {
            "t1": 52
          }
        ]
      }
    ]
```

DuckDB/DuckDB WASM:
```json
 [
      {
        "fun": [
          {
            "": 52
          }
        ]
      }
    ]
```

