### PR TITLE
feat: image properties for width, height, alt text

### DIFF
--- a/packages/malloy-render/src/html/image.ts
+++ b/packages/malloy-render/src/html/image.ts
@@ -39,16 +39,20 @@ export class HTMLImageRenderer implements Renderer {
       );
     }
 
-    if (data.isNull()) {
-      return createNullElement(this.document);
-    }
+
+    let element: HTMLElement = data.isNull() ? createNullElement(this.document) : this.document.createElement("img");
     const { tag } = data.field.tagParse();
     const height = tag.numeric("image", "height");
     const width = tag.numeric("image", "width");
-    const element = this.document.createElement('img');
     if(height) element.style.height = `${height}px`;
     if(width) element.style.width = `${width}px`;
-    element.src = data.value;
+    // Img specific props
+    if(!data.isNull()) {
+      const alt = tag.text("image", "alt");
+      const img = element as HTMLImageElement;
+      img.src = data.value;
+      if(alt) img.alt = alt;
+    }
     return element;
   }
 }

--- a/packages/malloy-render/src/html/image.ts
+++ b/packages/malloy-render/src/html/image.ts
@@ -42,8 +42,12 @@ export class HTMLImageRenderer implements Renderer {
     if (data.isNull()) {
       return createNullElement(this.document);
     }
-
+    const { tag } = data.field.tagParse();
+    const height = tag.numeric("image", "height");
+    const width = tag.numeric("image", "width");
     const element = this.document.createElement('img');
+    if(height) element.style.height = `${height}px`;
+    if(width) element.style.width = `${width}px`;
     element.src = data.value;
     return element;
   }

--- a/packages/malloy-render/src/html/image.ts
+++ b/packages/malloy-render/src/html/image.ts
@@ -39,19 +39,21 @@ export class HTMLImageRenderer implements Renderer {
       );
     }
 
-
-    let element: HTMLElement = data.isNull() ? createNullElement(this.document) : this.document.createElement("img");
-    const { tag } = data.field.tagParse();
-    const width = tag.numeric("image", "width");
-    if(width) element.style.width = `${width}px`;
-    // Img specific props
-    if(!data.isNull()) {
-      const alt = tag.text("image", "alt");
-      const height = tag.numeric("image", "height");
+    const element: HTMLElement = data.isNull()
+      ? createNullElement(this.document)
+      : this.document.createElement('img');
+    const {tag} = data.field.tagParse();
+    const width = tag.numeric('image', 'width');
+    const height = tag.numeric('image', 'height');
+    // Both image and null placeholder get matching size
+    if (width) element.style.width = `${width}px`;
+    if (height) element.style.height = `${height}px`;
+    // Image specific props
+    if (!data.isNull()) {
+      const alt = tag.text('image', 'alt');
       const img = element as HTMLImageElement;
       img.src = data.value;
-      if(alt) img.alt = alt;
-      if(height) element.style.height = `${height}px`;
+      if (alt) img.alt = alt;
     }
     return element;
   }

--- a/packages/malloy-render/src/html/image.ts
+++ b/packages/malloy-render/src/html/image.ts
@@ -42,16 +42,16 @@ export class HTMLImageRenderer implements Renderer {
 
     let element: HTMLElement = data.isNull() ? createNullElement(this.document) : this.document.createElement("img");
     const { tag } = data.field.tagParse();
-    const height = tag.numeric("image", "height");
     const width = tag.numeric("image", "width");
-    if(height) element.style.height = `${height}px`;
     if(width) element.style.width = `${width}px`;
     // Img specific props
     if(!data.isNull()) {
       const alt = tag.text("image", "alt");
+      const height = tag.numeric("image", "height");
       const img = element as HTMLImageElement;
       img.src = data.value;
       if(alt) img.alt = alt;
+      if(height) element.style.height = `${height}px`;
     }
     return element;
   }


### PR DESCRIPTION
Adds support for the following properties for an image tag:
- width: set a width value to be applied to the image. Will also be applied to the null value placeholder to maintain consistent size
- height: set a height value to be applied to the image. Will also be applied to the null value placeholder to maintain consistent size
- alt: set alt text for the image

## Examples
Set width to 200px. All images will be 200px wide. The corresponding height will be according to the aspect ratio of the image. The null value placeholder will also be sized to 200px wide to maintain horizontal alignment in dashboards.
```
# image { width=200px }
```

Set height to 200px. All images will be 200px tall. Width will be according to the aspect ratio of the image. Null value placeholders will get the 200px height as well.
```
# image { height=200px }
```

Set width and height to 200px. All images will be given width and height of 200px. Note that this can warp images with the wrong aspect ratio.
```
# image { height=200px width=200px }
```

Set alt text to 'hello'. All images will be given the alt text of 'hello'.
```
# image { alt=hello }
```