### PR TITLE
SQL queries should run raw, not `select: *`

### DIFF
--- a/packages/malloy/src/lang/ast/query-builders/reduce-builder.ts
+++ b/packages/malloy/src/lang/ast/query-builders/reduce-builder.ts
@@ -101,7 +101,7 @@ export class ReduceBuilder implements QueryBuilder {
   }
 
   refineFrom(from: PipeSegment | undefined, to: QuerySegment): void {
-    if (from && from.type !== 'index') {
+    if (from && from.type !== 'index' && from.type !== 'raw') {
       if (!this.order) {
         if (from.orderBy) {
           to.orderBy = from.orderBy;

--- a/packages/malloy/src/lang/ast/query-elements/full-query.ts
+++ b/packages/malloy/src/lang/ast/query-elements/full-query.ts
@@ -50,18 +50,14 @@ export class FullQuery extends TurtleHeadedPipe {
       : this.explore.structDef();
     let pipeFS = new StaticSpace(structDef);
 
-    // TODO update the compiler to allow for a SQL-headed query with 0 stages,
-    // which just runs the SQL. This would also allow us in ExistingQuery
-    // to error on `my_sql_query refine { ... }` by checking if it is a 0
-    // stage query.
     if (
       structDef.structSource.type === 'sql' &&
       this.qops.length === 0 &&
       !this.turtleName
     ) {
       destQuery.pipeline.push({
-        type: 'project',
-        fields: ['*'],
+        type: 'raw',
+        fields: [],
       });
     }
 

--- a/packages/malloy/src/lang/ast/sources/query-source.ts
+++ b/packages/malloy/src/lang/ast/sources/query-source.ts
@@ -35,7 +35,7 @@ export class QuerySource extends Source {
     const comp = this.query.queryComp(false);
     const queryStruct = {
       ...comp.outputStruct,
-      structSource: ({type: 'query', query: comp.query} as StructSource)
+      structSource: {type: 'query', query: comp.query} as StructSource,
     };
     this.document()?.rememberToAddModelAnnotations(queryStruct);
     return queryStruct;

--- a/packages/malloy/src/lang/ast/sources/query-source.ts
+++ b/packages/malloy/src/lang/ast/sources/query-source.ts
@@ -21,7 +21,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import {StructDef} from '../../../model/malloy_types';
+import {StructDef, StructSource} from '../../../model/malloy_types';
 import {Source} from '../elements/source';
 import {QueryElement} from '../types/query-element';
 
@@ -33,8 +33,10 @@ export class QuerySource extends Source {
 
   structDef(): StructDef {
     const comp = this.query.queryComp(false);
-    const queryStruct = comp.outputStruct;
-    queryStruct.structSource = {type: 'query', query: comp.query};
+    const queryStruct = {
+      ...comp.outputStruct,
+      structSource: ({type: 'query', query: comp.query} as StructSource)
+    };
     this.document()?.rememberToAddModelAnnotations(queryStruct);
     return queryStruct;
   }

--- a/packages/malloy/src/model/malloy_query.ts
+++ b/packages/malloy/src/model/malloy_query.ts
@@ -66,7 +66,6 @@ import {
   isQuerySegment,
   isRawSegment,
   isSpreadFragment,
-  isSQLBlockStruct,
   isSQLExpressionFragment,
   isUngroupFragment,
   isValueParameter,
@@ -1283,7 +1282,10 @@ class FieldInstanceResult implements FieldInstance {
   }
 
   getQueryInfo(): QueryInfo {
-    if (!isIndexSegment(this.firstSegment) && !isRawSegment(this.firstSegment)) {
+    if (
+      !isIndexSegment(this.firstSegment) &&
+      !isRawSegment(this.firstSegment)
+    ) {
       const {queryTimezone} = this.firstSegment;
       if (queryTimezone) {
         return {queryTimezone};
@@ -3239,7 +3241,9 @@ class QueryQuery extends QueryField {
     // let fieldsSQL: string[] = [];
     const dialectFieldList: DialectFieldList = [];
     let orderBy = '';
-    const limit: number | undefined = isRawSegment(resultStruct.firstSegment) ? undefined : resultStruct.firstSegment.limit;
+    const limit: number | undefined = isRawSegment(resultStruct.firstSegment)
+      ? undefined
+      : resultStruct.firstSegment.limit;
 
     // calculate the ordering.
     const obSQL: string[] = [];
@@ -3634,10 +3638,12 @@ class QueryQueryRaw extends QueryQuery {
   generateSQL(stageWriter: StageWriter): string {
     const ssrc = this.parent.fieldDef.structSource;
     if (ssrc.type !== 'sql' || ssrc.method !== 'subquery') {
-      throw new Error("Invalid struct for QueryQueryRaw, currently only supports SQL");
+      throw new Error(
+        'Invalid struct for QueryQueryRaw, currently only supports SQL'
+      );
     }
     const s = ssrc.sqlBlock.selectStr;
-    return stageWriter.addStage(s)
+    return stageWriter.addStage(s);
   }
 
   prepare() {
@@ -3648,7 +3654,9 @@ class QueryQueryRaw extends QueryQuery {
     return this.parent.fieldDef;
   }
 
-  getResultMetadata(fi: FieldInstance): ResultStructMetadataDef | ResultMetadataDef | undefined {
+  getResultMetadata(
+    _fi: FieldInstance
+  ): ResultStructMetadataDef | ResultMetadataDef | undefined {
     return undefined;
   }
 }

--- a/packages/malloy/src/model/malloy_types.ts
+++ b/packages/malloy/src/model/malloy_types.ts
@@ -768,7 +768,7 @@ export interface Query extends Pipeline, Filtered, HasLocation {
 
 export type NamedQuery = Query & NamedObject;
 
-export type PipeSegment = QuerySegment | IndexSegment;
+export type PipeSegment = QuerySegment | IndexSegment | RawSegment;
 
 export interface ReduceSegment extends QuerySegment {
   type: 'reduce';
@@ -812,6 +812,14 @@ interface SamplingEnable {
 
 export function isSamplingEnable(s: Sampling): s is SamplingEnable {
   return (s as SamplingEnable).enable !== undefined;
+}
+
+export interface RawSegment extends Filtered {
+  type: 'raw';
+  fields: never[];
+}
+export function isRawSegment(pe: PipeSegment): pe is RawSegment {
+  return (pe as RawSegment).type === 'raw';
 }
 
 export interface IndexSegment extends Filtered {

--- a/test/src/databases/all/nomodel.spec.ts
+++ b/test/src/databases/all/nomodel.spec.ts
@@ -689,6 +689,36 @@ runtimes.runtimeMap.forEach((runtime, databaseName) => {
     }
   );
 
+  it(`simple sql is exactly as written - ${databaseName}`, async () => {
+    const result = await runtime
+      .loadQuery(`run: conn.sql("select 1 as one")`)
+      .run();
+    expect(result.sql).toBe("select 1 as one");
+    expect(result.resultExplore).not.toBeUndefined();
+  });
+
+  it(`source from query defined as sql query - ${databaseName}`, async () => {
+    const result = await runtime
+      .loadQuery(`
+        query: q is conn.sql("select 1 as one")
+        source: s is q
+        run: s -> { select: * }
+      `)
+      .run();
+    expect(result.data.path(0, "one").number.value).toBe(1);
+  });
+
+  it(`source from query defined as other query - ${databaseName}`, async () => {
+    const result = await runtime
+      .loadQuery(`
+        query: q is conn.table('malloytest.flights') -> { group_by: carrier }
+        source: s is q
+        run: s -> { select: * }
+      `)
+      .run();
+      expect(result.data.path(0, "carrier").string.value).toBe("AA");
+  });
+
   it(`all with parameters - basic  - ${databaseName}`, async () => {
     const result = await runtime
       .loadQuery(

--- a/test/src/databases/all/nomodel.spec.ts
+++ b/test/src/databases/all/nomodel.spec.ts
@@ -691,32 +691,36 @@ runtimes.runtimeMap.forEach((runtime, databaseName) => {
 
   it(`simple sql is exactly as written - ${databaseName}`, async () => {
     const result = await runtime
-      .loadQuery(`run: conn.sql("select 1 as one")`)
+      .loadQuery('run: conn.sql("select 1 as one")')
       .run();
-    expect(result.sql).toBe("select 1 as one");
+    expect(result.sql).toBe('select 1 as one');
     expect(result.resultExplore).not.toBeUndefined();
   });
 
   it(`source from query defined as sql query - ${databaseName}`, async () => {
     const result = await runtime
-      .loadQuery(`
+      .loadQuery(
+        `
         query: q is conn.sql("select 1 as one")
         source: s is q
         run: s -> { select: * }
-      `)
+      `
+      )
       .run();
-    expect(result.data.path(0, "one").number.value).toBe(1);
+    expect(result.data.path(0, 'one').number.value).toBe(1);
   });
 
   it(`source from query defined as other query - ${databaseName}`, async () => {
     const result = await runtime
-      .loadQuery(`
+      .loadQuery(
+        `
         query: q is conn.table('malloytest.flights') -> { group_by: carrier }
         source: s is q
         run: s -> { select: * }
-      `)
+      `
+      )
       .run();
-      expect(result.data.path(0, "carrier").string.value).toBe("AA");
+    expect(result.data.path(0, 'carrier').string.value).toBe('AA');
   });
 
   it(`all with parameters - basic  - ${databaseName}`, async () => {


### PR DESCRIPTION
Previously, running `run: conn.sql("SELECT 1 AS one")` would run `run: conn.sql("SELECT 1 AS one") -> { select: * }` with SQL like `SELECT one FROM (SELECT 1 AS one)` as a hack. This completely breaks nested fields, e.g. if you had `run: conn.sql("SELECT LIST(STRUCT_PACK(foo := 1))")`, you would get a SQL error because the `{ select: * }` would find no scalar fields.

This adds a new query stage type, `'raw'`, which currently is only allowed to be used in queries whose source is a SQL source, and just runs the source query directly.

In the future, this can be implemented with some syntax like `run: flights -> { raw }` or even just `run: flights` to run any source to get it's _intrinsic fields_ (that is, no defined dimensions, only columns from the table).