### PR TITLE
fix: text not numeric img size props

### DIFF
--- a/packages/malloy-render/src/html/image.ts
+++ b/packages/malloy-render/src/html/image.ts
@@ -43,11 +43,11 @@ export class HTMLImageRenderer implements Renderer {
       ? createNullElement(this.document)
       : this.document.createElement('img');
     const {tag} = data.field.tagParse();
-    const width = tag.numeric('image', 'width');
-    const height = tag.numeric('image', 'height');
+    const width = tag.text('image', 'width');
+    const height = tag.text('image', 'height');
     // Both image and null placeholder get matching size
-    if (width) element.style.width = `${width}px`;
-    if (height) element.style.height = `${height}px`;
+    if (width) element.style.width = width;
+    if (height) element.style.height = height;
     // Image specific props
     if (!data.isNull()) {
       const alt = tag.text('image', 'alt');


### PR DESCRIPTION
Previous PR for adding width/height attributes to images claimed you could pass valid CSS text values for size, but that was incorrect. The code was actually pulling out numeric values and hardcoding to pixels.

This PR updates to the desired behavior: user's can define image sizes in pixels, ems, percentages, etc.