### PR TITLE
allows tabs in strings

### DIFF
--- a/packages/malloy/src/lang/grammar/MalloyLexer.g4
+++ b/packages/malloy/src/lang/grammar/MalloyLexer.g4
@@ -23,7 +23,7 @@
 
 lexer grammar MalloyLexer;
 
-fragment SPACE_CHAR: [ \u000B\t\r\n];
+fragment SPACE_CHAR: [ \u000B\t\r\n\u0080];
 
 // colon keywords ...
 ACCEPT: A C C E P T SPACE_CHAR* ':';

--- a/packages/malloy/src/lang/grammar/MalloyLexer.g4
+++ b/packages/malloy/src/lang/grammar/MalloyLexer.g4
@@ -130,10 +130,11 @@ HACKY_REGEX: ('/' | [rR]) '\'' (STRING_ESCAPE | ~('\\' | '\''))* '\'';
 fragment HEX: [0-9a-fA-F];
 fragment UNICODE: '\\u' HEX HEX HEX HEX;
 fragment SAFE_NON_QUOTE: ~ ['"`\\\u0000-\u001F];
-fragment ESCAPED: '\\' .;
-SQ_STRING: '\'' (UNICODE | ESCAPED | SAFE_NON_QUOTE | ["`])* '\'';
-DQ_STRING: '"' (UNICODE | ESCAPED | SAFE_NON_QUOTE | ['`])* '"';
-BQ_STRING: '`' (UNICODE | ESCAPED | SAFE_NON_QUOTE | ['"])* '`';
+fragment ESCAPED: '\\' ~ '\n';
+fragment STR_CHAR: UNICODE | ESCAPED | SAFE_NON_QUOTE | '\t';
+SQ_STRING: '\'' (STR_CHAR | ["`])* '\'';
+DQ_STRING: '"' (STR_CHAR | ['`])* '"';
+BQ_STRING: '`' (STR_CHAR | ['"])* '`';
 
 fragment F_TO_EOL: ~[\r\n]* (('\r'? '\n') | EOF);
 DOC_ANNOTATION: '##' F_TO_EOL;

--- a/packages/malloy/src/lang/grammar/MalloyLexer.g4
+++ b/packages/malloy/src/lang/grammar/MalloyLexer.g4
@@ -23,7 +23,7 @@
 
 lexer grammar MalloyLexer;
 
-fragment SPACE_CHAR: [ \u000B\t\r\n\u0080];
+fragment SPACE_CHAR: [ \u000B\t\r\n\u00A0];
 
 // colon keywords ...
 ACCEPT: A C C E P T SPACE_CHAR* ':';

--- a/packages/malloy/src/lang/test/literals.spec.ts
+++ b/packages/malloy/src/lang/test/literals.spec.ts
@@ -276,5 +276,6 @@ describe('literals', () => {
       const x = new BetaExpression('"""x"""');
       expect(x).toParse();
     });
+    test('a string containing a tab', () => expect(expr`'\t'`).toParse());
   });
 });

--- a/packages/malloy/src/lang/test/parse.spec.ts
+++ b/packages/malloy/src/lang/test/parse.spec.ts
@@ -1091,3 +1091,6 @@ describe('m3/m4 source query sentences', () => {
     `).toTranslate();
   });
 });
+
+test('non breaking space in source', () =>
+  expect('source:\u00a0z\u00a0is\u00a0a').toParse());


### PR DESCRIPTION
A tab was not included in the list of characters which it is legal to have inside of a string.
Grammar review as long I was here, also allow \U00A0 ( unicode non breaking space) as a space character in source code

Fixes #1402 