### PR TITLE
Stop using "project" and "turtle" in error messages

### DIFF
--- a/packages/malloy/src/lang/ast/query-builders/project-builder.ts
+++ b/packages/malloy/src/lang/ast/query-builders/project-builder.ts
@@ -45,7 +45,7 @@ export class ProjectBuilder extends ReduceBuilder {
 
   execute(qp: QueryProperty): void {
     if (qp.elementType === 'having' || qp instanceof GroupBy) {
-      qp.log('Illegal statement in a project query operation');
+      qp.log('Illegal statement in a select query operation');
     } else {
       super.execute(qp);
     }
@@ -57,7 +57,7 @@ export class ProjectBuilder extends ReduceBuilder {
       if (isProjectSegment(fromSeg)) {
         from = fromSeg;
       } else {
-        this.resultFS.log(`Can't refine project with ${fromSeg.type}`);
+        this.resultFS.log(`Can't refine select with ${fromSeg.type}`);
         return ErrorFactory.projectSegment;
       }
     }

--- a/packages/malloy/src/lang/ast/query-items/typecheck_utils.ts
+++ b/packages/malloy/src/lang/ast/query-items/typecheck_utils.ts
@@ -48,7 +48,7 @@ export function typecheckProject(type: TypeDesc, logTo: MalloyElement) {
       );
     }
     logTo.log(
-      `Cannot use ${kind} field in a project operation, did you mean to use ${useInstead} operation instead?`
+      `Cannot use ${kind} field in a select operation, did you mean to use ${useInstead} operation instead?`
     );
   }
 }

--- a/packages/malloy/src/lang/ast/query-items/typecheck_utils.ts
+++ b/packages/malloy/src/lang/ast/query-items/typecheck_utils.ts
@@ -125,7 +125,7 @@ export function typecheckCalculate(type: TypeDesc, logTo: MalloyElement) {
       useInstead = 'an aggregate';
       kind = 'an aggregate';
     } else if (expressionIsScalar(type.expressionType)) {
-      useInstead = 'a group_by or project';
+      useInstead = 'a group_by or select';
       kind = 'a scalar';
     } else {
       throw new Error(
@@ -152,7 +152,7 @@ export function typecheckAggregate(type: TypeDesc, logTo: MalloyElement) {
       useInstead = 'a calculate';
       kind = 'an analytic';
     } else if (expressionIsScalar(type.expressionType)) {
-      useInstead = 'a group_by or project';
+      useInstead = 'a group_by or select';
       kind = 'a scalar';
     } else {
       throw new Error(`Unexpected expression type ${type} not handled here`);

--- a/packages/malloy/src/lang/ast/query-properties/nest.ts
+++ b/packages/malloy/src/lang/ast/query-properties/nest.ts
@@ -87,7 +87,7 @@ abstract class TurtleDeclRoot
       }
     } else if (this.withRefinement) {
       throw this.internalError(
-        "Can't refine the head of a turtle in its definition"
+        "Can't refine the head of a view  in its definition"
       );
     }
 

--- a/packages/malloy/src/lang/ast/query-properties/nest.ts
+++ b/packages/malloy/src/lang/ast/query-properties/nest.ts
@@ -240,7 +240,7 @@ export class NestReference
         useInstead = 'a calculate';
         kind = 'an analytic';
       } else if (expressionIsScalar(type.expressionType)) {
-        useInstead = 'a group_by or project';
+        useInstead = 'a group_by or select';
         kind = 'a scalar';
       } else if (expressionIsAggregate(type.expressionType)) {
         useInstead = 'an aggregate';

--- a/packages/malloy/src/lang/malloy-to-ast.ts
+++ b/packages/malloy/src/lang/malloy-to-ast.ts
@@ -919,7 +919,7 @@ export class MalloyToAST
     );
   }
 
-  // "FieldCollection" can only mean a project statement today
+  // "FieldCollection" can only mean a select statement today
   visitFieldCollection(
     pcx: parse.FieldCollectionContext
   ): ast.ProjectStatement {

--- a/packages/malloy/src/lang/test/query.spec.ts
+++ b/packages/malloy/src/lang/test/query.spec.ts
@@ -263,7 +263,7 @@ describe('query:', () => {
       });
       test('cannot use scalar in aggregate', () => {
         expect('run: a -> { aggregate: s is 1}').translationToFailWith(
-          'Cannot use a scalar field in an aggregate operation, did you mean to use a group_by or project operation instead?'
+          'Cannot use a scalar field in an aggregate operation, did you mean to use a group_by or select operation instead?'
         );
       });
       test('cannot use analytic in aggregate', () => {
@@ -277,7 +277,7 @@ describe('query:', () => {
         expect(
           'run: a -> { group_by: a is 1; calculate: s is 1 }'
         ).translationToFailWith(
-          'Cannot use a scalar field in a calculate operation, did you mean to use a group_by or project operation instead?'
+          'Cannot use a scalar field in a calculate operation, did you mean to use a group_by or select operation instead?'
         );
       });
       test('cannot use aggregate in calculate', () => {
@@ -289,12 +289,12 @@ describe('query:', () => {
       });
       test('cannot use aggregate in project', () => {
         expect('run: a -> { select: s is count() }').translationToFailWith(
-          'Cannot use an aggregate field in a project operation, did you mean to use an aggregate operation instead?'
+          'Cannot use an aggregate field in a select operation, did you mean to use an aggregate operation instead?'
         );
       });
       test('cannot use analytic in project', () => {
         expect('run: a -> { select: s is row_number() }').translationToFailWith(
-          'Cannot use an analytic field in a project operation, did you mean to use a calculate operation instead?'
+          'Cannot use an analytic field in a select operation, did you mean to use a calculate operation instead?'
         );
       });
       test('cannot use analytic in declare', () => {
@@ -338,14 +338,14 @@ describe('query:', () => {
         expect(
           'run: a -> { extend: {dimension: aconst is 1} aggregate: aconst }'
         ).translationToFailWith(
-          'Cannot use a scalar field in an aggregate operation, did you mean to use a group_by or project operation instead?'
+          'Cannot use a scalar field in an aggregate operation, did you mean to use a group_by or select operation instead?'
         );
       });
       test('cannot use scalar in calculate', () => {
         expect(
           'run: a -> { extend: {dimension: aconst is 1} group_by: x is 1; calculate: aconst }'
         ).translationToFailWith(
-          'Cannot use a scalar field in a calculate operation, did you mean to use a group_by or project operation instead?'
+          'Cannot use a scalar field in a calculate operation, did you mean to use a group_by or select operation instead?'
         );
       });
       test('cannot use aggregate in calculate', () => {
@@ -359,7 +359,7 @@ describe('query:', () => {
         expect(
           'run: a extend { view: q is { group_by: x is 1 } } -> { select: q }'
         ).translationToFailWith(
-          'Cannot use a view field in a project operation, did you mean to use a nest operation instead?'
+          'Cannot use a view field in a select operation, did you mean to use a nest operation instead?'
         );
       });
       test('cannot use query in index', () => {
@@ -400,7 +400,7 @@ describe('query:', () => {
         run: a1 + {
           calculate: b is c
         }`).translationToFailWith(
-          'Cannot use a scalar field in a calculate operation, did you mean to use a group_by or project operation instead?'
+          'Cannot use a scalar field in a calculate operation, did you mean to use a group_by or select operation instead?'
         );
       });
       test('cannot use analytic in group_by, preserved over refinement', () => {

--- a/packages/malloy/src/model/malloy_query.ts
+++ b/packages/malloy/src/model/malloy_query.ts
@@ -2250,7 +2250,7 @@ class QueryQuery extends QueryField {
       if (field instanceof QueryTurtle || field instanceof QueryQuery) {
         if (this.firstSegment.type === 'project') {
           throw new Error(
-            `Turtled Queries cannot be used in PROJECT - '${field.fieldDef.name}'`
+            `Nested views cannot be used in select - '${field.fieldDef.name}'`
           );
         }
         const fir = new FieldInstanceResult(
@@ -2269,7 +2269,7 @@ class QueryQuery extends QueryField {
         if (isAggregateField(field)) {
           if (this.firstSegment.type === 'project') {
             throw new Error(
-              `Aggregate Fields cannot be used in PROJECT - '${field.fieldDef.name}'`
+              `Aggregate Fields cannot be used in select - '${field.fieldDef.name}'`
             );
           }
         }


### PR DESCRIPTION
There were still a few places left using the old words