### PR TITLE
fix: capture VARCHARs with max length as strings

### DIFF
--- a/packages/malloy/src/dialect/duckdb/duckdb.ts
+++ b/packages/malloy/src/dialect/duckdb/duckdb.ts
@@ -463,12 +463,9 @@ export class DuckDBDialect extends Dialect {
   }
 
   sqlTypeToMalloyType(sqlType: string): FieldAtomicTypeDef | undefined {
-    // Clean types with args
-    const baseSqlType = sqlType
-      .toUpperCase()
-      .replace(/\(.*\)/, '')
-      .trim();
-    return duckDBToMalloyTypes[baseSqlType];
+    // Remove trailing params
+    const baseSqlType = sqlType.match(/^(\w+)/)?.at(0) ?? sqlType;
+    return duckDBToMalloyTypes[baseSqlType.toUpperCase()];
   }
 
   castToString(expression: string): string {

--- a/packages/malloy/src/dialect/duckdb/duckdb.ts
+++ b/packages/malloy/src/dialect/duckdb/duckdb.ts
@@ -463,8 +463,11 @@ export class DuckDBDialect extends Dialect {
   }
 
   sqlTypeToMalloyType(sqlType: string): FieldAtomicTypeDef | undefined {
-    // Clean VARCHAR(n)
-    const baseSqlType = sqlType.toUpperCase().replace(/\(\d+)/, '');
+    // Clean types with args
+    const baseSqlType = sqlType
+      .toUpperCase()
+      .replace(/\(\.*)/, '')
+      .trim();
     return duckDBToMalloyTypes[baseSqlType];
   }
 

--- a/packages/malloy/src/dialect/duckdb/duckdb.ts
+++ b/packages/malloy/src/dialect/duckdb/duckdb.ts
@@ -70,16 +70,6 @@ const duckDBToMalloyTypes: {[key: string]: FieldAtomicTypeDef} = {
   'BOOLEAN': {type: 'boolean'},
 };
 
-const duckDBToMalloyTypesMatchers: Array<{
-  match: RegExp;
-  malloyType: FieldAtomicTypeDef;
-}> = [
-  {
-    match: /^VARCHAR\(\d*\)$/,
-    malloyType: {type: 'string'},
-  },
-];
-
 export class DuckDBDialect extends Dialect {
   name = 'duckdb';
   defaultNumberType = 'DOUBLE';
@@ -473,10 +463,9 @@ export class DuckDBDialect extends Dialect {
   }
 
   sqlTypeToMalloyType(sqlType: string): FieldAtomicTypeDef | undefined {
-    const regExMatch = duckDBToMalloyTypesMatchers.find(m =>
-      sqlType.toUpperCase().match(m.match)
-    )?.malloyType;
-    return regExMatch ?? duckDBToMalloyTypes[sqlType.toUpperCase()];
+    // Clean VARCHAR(n)
+    const baseSqlType = sqlType.toUpperCase().replace(/\(\d+)/, '');
+    return duckDBToMalloyTypes[baseSqlType];
   }
 
   castToString(expression: string): string {

--- a/packages/malloy/src/dialect/duckdb/duckdb.ts
+++ b/packages/malloy/src/dialect/duckdb/duckdb.ts
@@ -466,7 +466,7 @@ export class DuckDBDialect extends Dialect {
     // Clean types with args
     const baseSqlType = sqlType
       .toUpperCase()
-      .replace(/\(\.*)/, '')
+      .replace(/\(.*\)/, '')
       .trim();
     return duckDBToMalloyTypes[baseSqlType];
   }

--- a/packages/malloy/src/dialect/duckdb/duckdb.ts
+++ b/packages/malloy/src/dialect/duckdb/duckdb.ts
@@ -70,6 +70,16 @@ const duckDBToMalloyTypes: {[key: string]: FieldAtomicTypeDef} = {
   'BOOLEAN': {type: 'boolean'},
 };
 
+const duckDBToMalloyTypesMatchers: Array<{
+  match: RegExp;
+  malloyType: FieldAtomicTypeDef;
+}> = [
+  {
+    match: /^VARCHAR\(\d*\)$/,
+    malloyType: {type: 'string'},
+  },
+];
+
 export class DuckDBDialect extends Dialect {
   name = 'duckdb';
   defaultNumberType = 'DOUBLE';
@@ -463,7 +473,10 @@ export class DuckDBDialect extends Dialect {
   }
 
   sqlTypeToMalloyType(sqlType: string): FieldAtomicTypeDef | undefined {
-    return duckDBToMalloyTypes[sqlType.toUpperCase()];
+    const regExMatch = duckDBToMalloyTypesMatchers.find(m =>
+      sqlType.toUpperCase().match(m.match)
+    )?.malloyType;
+    return regExMatch ?? duckDBToMalloyTypes[sqlType.toUpperCase()];
   }
 
   castToString(expression: string): string {

--- a/packages/malloy/src/dialect/postgres/postgres.ts
+++ b/packages/malloy/src/dialect/postgres/postgres.ts
@@ -490,12 +490,9 @@ export class PostgresDialect extends Dialect {
   }
 
   sqlTypeToMalloyType(sqlType: string): FieldAtomicTypeDef | undefined {
-    // Clean types with args
-    const baseSqlType = sqlType
-      .toLowerCase()
-      .replace(/\(.*\)/, '')
-      .trim();
-    return postgresToMalloyTypes[baseSqlType];
+    // Remove trailing params
+    const baseSqlType = sqlType.match(/^(\w+)/)?.at(0) ?? sqlType;
+    return postgresToMalloyTypes[baseSqlType.toLowerCase()];
   }
 
   castToString(expression: string): string {

--- a/packages/malloy/src/dialect/postgres/postgres.ts
+++ b/packages/malloy/src/dialect/postgres/postgres.ts
@@ -88,6 +88,7 @@ const postgresToMalloyTypes: {[key: string]: FieldAtomicTypeDef} = {
   'numeric': {type: 'number', numberType: 'float'},
   'bytea': {type: 'string'},
   'pg_ndistinct': {type: 'number', numberType: 'integer'},
+  'varchar': {type: 'string'},
 };
 
 export class PostgresDialect extends Dialect {
@@ -489,7 +490,12 @@ export class PostgresDialect extends Dialect {
   }
 
   sqlTypeToMalloyType(sqlType: string): FieldAtomicTypeDef | undefined {
-    return postgresToMalloyTypes[sqlType.toLowerCase()];
+    // Clean types with args
+    const baseSqlType = sqlType
+      .toLowerCase()
+      .replace(/\(\.*)/, '')
+      .trim();
+    return postgresToMalloyTypes[baseSqlType];
   }
 
   castToString(expression: string): string {

--- a/packages/malloy/src/dialect/postgres/postgres.ts
+++ b/packages/malloy/src/dialect/postgres/postgres.ts
@@ -493,7 +493,7 @@ export class PostgresDialect extends Dialect {
     // Clean types with args
     const baseSqlType = sqlType
       .toLowerCase()
-      .replace(/\(\.*)/, '')
+      .replace(/\(.*\)/, '')
       .trim();
     return postgresToMalloyTypes[baseSqlType];
   }

--- a/packages/malloy/src/dialect/standardsql/standardsql.ts
+++ b/packages/malloy/src/dialect/standardsql/standardsql.ts
@@ -538,7 +538,7 @@ ${indent(sql)}
     // Clean types with args
     const baseSqlType = sqlType
       .toUpperCase()
-      .replace(/\(\.*)/, '')
+      .replace(/\(.*\)/, '')
       .trim();
     return bqToMalloyTypes[baseSqlType];
   }

--- a/packages/malloy/src/dialect/standardsql/standardsql.ts
+++ b/packages/malloy/src/dialect/standardsql/standardsql.ts
@@ -535,12 +535,9 @@ ${indent(sql)}
   }
 
   sqlTypeToMalloyType(sqlType: string): FieldAtomicTypeDef | undefined {
-    // Clean types with args
-    const baseSqlType = sqlType
-      .toUpperCase()
-      .replace(/\(.*\)/, '')
-      .trim();
-    return bqToMalloyTypes[baseSqlType];
+    // Remove trailing params
+    const baseSqlType = sqlType.match(/^(\w+)/)?.at(0) ?? sqlType;
+    return bqToMalloyTypes[baseSqlType.toUpperCase()];
   }
 
   castToString(expression: string): string {

--- a/packages/malloy/src/dialect/standardsql/standardsql.ts
+++ b/packages/malloy/src/dialect/standardsql/standardsql.ts
@@ -535,7 +535,12 @@ ${indent(sql)}
   }
 
   sqlTypeToMalloyType(sqlType: string): FieldAtomicTypeDef | undefined {
-    return bqToMalloyTypes[sqlType.toUpperCase()];
+    // Clean types with args
+    const baseSqlType = sqlType
+      .toUpperCase()
+      .replace(/\(\.*)/, '')
+      .trim();
+    return bqToMalloyTypes[baseSqlType];
   }
 
   castToString(expression: string): string {

--- a/test/src/databases/duckdb/duckdb.spec.ts
+++ b/test/src/databases/duckdb/duckdb.spec.ts
@@ -100,6 +100,13 @@ describe.each(allDucks.runtimeList)('duckdb:%s', (dbName, runtime) => {
     expect(result.rows[0]).toEqual({"current_setting('TimeZone')": 'CET'});
   });
 
+  it('supports varchars with parameters', async () => {
+    await expect(runtime).queryMatches(
+      "run: duckdb.sql(\"SELECT 'a'::VARCHAR as abc, 'a3'::VARCHAR(3) as abc3\")",
+      {abc: 'a', abc3: 'a3'}
+    );
+  });
+
   describe('time', () => {
     const zone = 'America/Mexico_City'; // -06:00 no DST
     const zone_2020 = DateTime.fromObject({

--- a/test/src/databases/postgres/postgres.spec.ts
+++ b/test/src/databases/postgres/postgres.spec.ts
@@ -140,6 +140,14 @@ describe('Postgres tests', () => {
       .run();
     expect(result.data.value[0]['ranger']).toBeDefined();
   });
+
+  it('supports varchars with parameters', async () => {
+    await expect(runtime).queryMatches(
+      "run: postgres.sql(\"SELECT 'a'::VARCHAR as abc, 'a3'::VARCHAR(3) as abc3\")",
+      {abc: 'a', abc3: 'a3'}
+    );
+  });
+
   describe('time', () => {
     const zone = 'America/Mexico_City'; // -06:00 no DST
     const zone_2020 = DateTime.fromObject({


### PR DESCRIPTION
Fixes https://github.com/malloydata/malloy/issues/1364

The issue is that when we convert SQL types to Malloy types, we only check literal values like BOOLEAN, VARCHAR, etc. If a user casts to a VARCHAR with max length like `VARCHAR(3)`, this is not caught by our type conversion and results in an Unsupported Type, which then won't get rendered as a string.

The solution I've added here is to add an additional set of checks that use regex pattern matching so we can capture more complex SQL types than just literals. If this solution is acceptable, then I will implement it in the other connectors besides DuckDB.