### PR TITLE
fix "x x.y" taglines

### DIFF
--- a/test/src/tags.spec.ts
+++ b/test/src/tags.spec.ts
@@ -129,12 +129,32 @@ describe('tagParse to Tag', () => {
     ['x=.7e2', {x: {eq: '.7e2'}}],
     ['x=7E2', {x: {eq: '7E2'}}],
     ['`spacey name`=Zaphod', {'spacey name': {eq: 'Zaphod'}}],
+    [
+      'image { alt=hello { field=department } }',
+      {
+        image: {
+          properties: {
+            alt: {eq: 'hello', properties: {field: {eq: 'department'}}},
+          },
+        },
+      },
+    ],
+    [
+      'image { alt=hello { field=department } }',
+      {
+        image: {
+          properties: {
+            alt: {eq: 'hello', properties: {field: {eq: 'department'}}},
+          },
+        },
+      },
+    ],
   ];
   test.each(tagTests)('tag %s', (expression: string, expected: TagDict) => {
     expect(expression).tagsAre(expected);
   });
-  test('uncomment to debug just one of the expressions', () => {
-    const x: TagTestTuple = ['a=a b=$(a)', {a: {eq: 'a'}, b: {eq: 'a'}}];
+  test.skip('unskip to debug just one of the expressions', () => {
+    const x: TagTestTuple = ['x x.y', {x: {properties: {y: {}}}}];
     expect(x[0]).tagsAre(x[1]);
   });
 });

--- a/test/src/tags.spec.ts
+++ b/test/src/tags.spec.ts
@@ -140,7 +140,7 @@ describe('tagParse to Tag', () => {
       },
     ],
     [
-      'image { alt=hello { field=department } }',
+      'image image.alt=hello image.alt.field=department',
       {
         image: {
           properties: {


### PR DESCRIPTION
Reported by @skokenes who found that

```
      # image
      # image.alt=hello
      # image.alt.field=department
 ```
 
 Was producing the same thing as `# image`.
 
 The culprit was a bug which would cause `any any.thing` to result in `any`.
   