### PR TITLE
feat: dynamic rendering props

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -59,6 +59,26 @@
         ]
       }
     },
+    "node_modules/@75lb/deep-merge": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@75lb/deep-merge/-/deep-merge-1.1.1.tgz",
+      "integrity": "sha512-xvgv6pkMGBA6GwdyJbNAnDmfAIR/DfWhrj9jgWh3TY7gRm3KO46x/GPjRg6wJ0nOepwqrNxFfojebh0Df4h4Tw==",
+      "dependencies": {
+        "lodash.assignwith": "^4.2.0",
+        "typical": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
+    "node_modules/@75lb/deep-merge/node_modules/typical": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-7.1.1.tgz",
+      "integrity": "sha512-T+tKVNs6Wu7IWiAce5BgMd7OZfNYUndHwc5MknN+UHOudi7sGZzuHdCadllRuqJ3fPtgFtIH9+lt9qRv6lmpfA==",
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
     "node_modules/@aashutoshrathi/word-wrap": {
       "version": "1.2.6",
       "license": "MIT",
@@ -3614,10 +3634,104 @@
       "link": true
     },
     "node_modules/@malloydata/duckdb-wasm": {
-      "version": "0.0.2",
-      "license": "MIT",
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@malloydata/duckdb-wasm/-/duckdb-wasm-0.0.5.tgz",
+      "integrity": "sha512-kGlvsxS71cOUzVXy33PKJhi4rLW9Uopc490y1M2dUamFnDPWv6438nxQDHVCbYvenEruhpvmoGjdUYTCDtAZMA==",
       "dependencies": {
-        "apache-arrow": "^11.0.0"
+        "apache-arrow": "^13.0.0"
+      }
+    },
+    "node_modules/@malloydata/duckdb-wasm/node_modules/@types/node": {
+      "version": "20.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.3.0.tgz",
+      "integrity": "sha512-cumHmIAf6On83X7yP+LrsEyUOf/YlociZelmpRYaGFydoaPdxdt80MAbu6vWerQT2COCp2nPvHdsbD7tHn/YlQ=="
+    },
+    "node_modules/@malloydata/duckdb-wasm/node_modules/apache-arrow": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/apache-arrow/-/apache-arrow-13.0.0.tgz",
+      "integrity": "sha512-3gvCX0GDawWz6KFNC28p65U+zGh/LZ6ZNKWNu74N6CQlKzxeoWHpi4CgEQsgRSEMuyrIIXi1Ea2syja7dwcHvw==",
+      "dependencies": {
+        "@types/command-line-args": "5.2.0",
+        "@types/command-line-usage": "5.0.2",
+        "@types/node": "20.3.0",
+        "@types/pad-left": "2.1.1",
+        "command-line-args": "5.2.1",
+        "command-line-usage": "7.0.1",
+        "flatbuffers": "23.5.26",
+        "json-bignum": "^0.0.3",
+        "pad-left": "^2.1.0",
+        "tslib": "^2.5.3"
+      },
+      "bin": {
+        "arrow2csv": "bin/arrow2csv.js"
+      }
+    },
+    "node_modules/@malloydata/duckdb-wasm/node_modules/array-back": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.2.tgz",
+      "integrity": "sha512-gUAZ7HPyb4SJczXAMUXMGAvI976JoK3qEx9v1FTmeYuJj0IBiaKttG1ydtGKdkfqWkIkouke7nG8ufGy77+Cvw==",
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
+    "node_modules/@malloydata/duckdb-wasm/node_modules/command-line-usage": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-7.0.1.tgz",
+      "integrity": "sha512-NCyznE//MuTjwi3y84QVUGEOT+P5oto1e1Pk/jFPVdPPfsG03qpTIl3yw6etR+v73d0lXsoojRpvbru2sqePxQ==",
+      "dependencies": {
+        "array-back": "^6.2.2",
+        "chalk-template": "^0.4.0",
+        "table-layout": "^3.0.0",
+        "typical": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/@malloydata/duckdb-wasm/node_modules/flatbuffers": {
+      "version": "23.5.26",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-23.5.26.tgz",
+      "integrity": "sha512-vE+SI9vrJDwi1oETtTIFldC/o9GsVKRM+s6EL0nQgxXlYV1Vc4Tk30hj4xGICftInKQKj1F3up2n8UbIVobISQ=="
+    },
+    "node_modules/@malloydata/duckdb-wasm/node_modules/table-layout": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-3.0.2.tgz",
+      "integrity": "sha512-rpyNZYRw+/C+dYkcQ3Pr+rLxW4CfHpXjPDnG7lYhdRoUcZTUt+KEsX+94RGp/aVp/MQU35JCITv2T/beY4m+hw==",
+      "dependencies": {
+        "@75lb/deep-merge": "^1.1.1",
+        "array-back": "^6.2.2",
+        "command-line-args": "^5.2.1",
+        "command-line-usage": "^7.0.0",
+        "stream-read-all": "^3.0.1",
+        "typical": "^7.1.1",
+        "wordwrapjs": "^5.1.0"
+      },
+      "bin": {
+        "table-layout": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
+    "node_modules/@malloydata/duckdb-wasm/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
+    "node_modules/@malloydata/duckdb-wasm/node_modules/typical": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-7.1.1.tgz",
+      "integrity": "sha512-T+tKVNs6Wu7IWiAce5BgMd7OZfNYUndHwc5MknN+UHOudi7sGZzuHdCadllRuqJ3fPtgFtIH9+lt9qRv6lmpfA==",
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
+    "node_modules/@malloydata/duckdb-wasm/node_modules/wordwrapjs": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-5.1.0.tgz",
+      "integrity": "sha512-JNjcULU2e4KJwUNv6CHgI46UvDGitb6dGryHajXTDiLgg1/RiGoPSDw4kZfYnwGtEXf2ZMeIewDQgFGzkCB2Sg==",
+      "engines": {
+        "node": ">=12.17"
       }
     },
     "node_modules/@malloydata/eslint-plugin-lint": {
@@ -8635,6 +8749,20 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk-template": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/chalk-template/-/chalk-template-0.4.0.tgz",
+      "integrity": "sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==",
+      "dependencies": {
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk-template?sponsor=1"
       }
     },
     "node_modules/char-regex": {
@@ -16867,6 +16995,11 @@
       "version": "4.17.21",
       "license": "MIT"
     },
+    "node_modules/lodash.assignwith": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.assignwith/-/lodash.assignwith-4.2.0.tgz",
+      "integrity": "sha512-ZznplvbvtjK2gMvnQ1BR/zqPFZmS6jbK4p+6Up4xcRYA7yMIwxHCfbTcrYxXKzzqLsQ05eJPVznEW3tuwV7k1g=="
+    },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
       "license": "MIT"
@@ -21222,6 +21355,14 @@
         "stubs": "^3.0.0"
       }
     },
+    "node_modules/stream-read-all": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/stream-read-all/-/stream-read-all-3.0.1.tgz",
+      "integrity": "sha512-EWZT9XOceBPlVJRrYcykW8jyRSZYbkb/0ZK36uLEmoWVO5gxBOnntNTseNzfREsqxqdfEGQrD8SXQ3QWbBmq8A==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/stream-shift": {
       "version": "1.0.1",
       "license": "MIT"
@@ -23687,7 +23828,7 @@
       "version": "0.0.95",
       "license": "MIT",
       "dependencies": {
-        "@malloydata/duckdb-wasm": "0.0.2",
+        "@malloydata/duckdb-wasm": "0.0.5",
         "@malloydata/malloy": "^0.0.95",
         "apache-arrow": "^11.0.0",
         "duckdb": "0.8.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,26 +59,6 @@
         ]
       }
     },
-    "node_modules/@75lb/deep-merge": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@75lb/deep-merge/-/deep-merge-1.1.1.tgz",
-      "integrity": "sha512-xvgv6pkMGBA6GwdyJbNAnDmfAIR/DfWhrj9jgWh3TY7gRm3KO46x/GPjRg6wJ0nOepwqrNxFfojebh0Df4h4Tw==",
-      "dependencies": {
-        "lodash.assignwith": "^4.2.0",
-        "typical": "^7.1.1"
-      },
-      "engines": {
-        "node": ">=12.17"
-      }
-    },
-    "node_modules/@75lb/deep-merge/node_modules/typical": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/typical/-/typical-7.1.1.tgz",
-      "integrity": "sha512-T+tKVNs6Wu7IWiAce5BgMd7OZfNYUndHwc5MknN+UHOudi7sGZzuHdCadllRuqJ3fPtgFtIH9+lt9qRv6lmpfA==",
-      "engines": {
-        "node": ">=12.17"
-      }
-    },
     "node_modules/@aashutoshrathi/word-wrap": {
       "version": "1.2.6",
       "license": "MIT",
@@ -3632,107 +3612,6 @@
     "node_modules/@malloydata/db-postgres": {
       "resolved": "packages/malloy-db-postgres",
       "link": true
-    },
-    "node_modules/@malloydata/duckdb-wasm": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/@malloydata/duckdb-wasm/-/duckdb-wasm-0.0.5.tgz",
-      "integrity": "sha512-kGlvsxS71cOUzVXy33PKJhi4rLW9Uopc490y1M2dUamFnDPWv6438nxQDHVCbYvenEruhpvmoGjdUYTCDtAZMA==",
-      "dependencies": {
-        "apache-arrow": "^13.0.0"
-      }
-    },
-    "node_modules/@malloydata/duckdb-wasm/node_modules/@types/node": {
-      "version": "20.3.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.3.0.tgz",
-      "integrity": "sha512-cumHmIAf6On83X7yP+LrsEyUOf/YlociZelmpRYaGFydoaPdxdt80MAbu6vWerQT2COCp2nPvHdsbD7tHn/YlQ=="
-    },
-    "node_modules/@malloydata/duckdb-wasm/node_modules/apache-arrow": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/apache-arrow/-/apache-arrow-13.0.0.tgz",
-      "integrity": "sha512-3gvCX0GDawWz6KFNC28p65U+zGh/LZ6ZNKWNu74N6CQlKzxeoWHpi4CgEQsgRSEMuyrIIXi1Ea2syja7dwcHvw==",
-      "dependencies": {
-        "@types/command-line-args": "5.2.0",
-        "@types/command-line-usage": "5.0.2",
-        "@types/node": "20.3.0",
-        "@types/pad-left": "2.1.1",
-        "command-line-args": "5.2.1",
-        "command-line-usage": "7.0.1",
-        "flatbuffers": "23.5.26",
-        "json-bignum": "^0.0.3",
-        "pad-left": "^2.1.0",
-        "tslib": "^2.5.3"
-      },
-      "bin": {
-        "arrow2csv": "bin/arrow2csv.js"
-      }
-    },
-    "node_modules/@malloydata/duckdb-wasm/node_modules/array-back": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.2.tgz",
-      "integrity": "sha512-gUAZ7HPyb4SJczXAMUXMGAvI976JoK3qEx9v1FTmeYuJj0IBiaKttG1ydtGKdkfqWkIkouke7nG8ufGy77+Cvw==",
-      "engines": {
-        "node": ">=12.17"
-      }
-    },
-    "node_modules/@malloydata/duckdb-wasm/node_modules/command-line-usage": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-7.0.1.tgz",
-      "integrity": "sha512-NCyznE//MuTjwi3y84QVUGEOT+P5oto1e1Pk/jFPVdPPfsG03qpTIl3yw6etR+v73d0lXsoojRpvbru2sqePxQ==",
-      "dependencies": {
-        "array-back": "^6.2.2",
-        "chalk-template": "^0.4.0",
-        "table-layout": "^3.0.0",
-        "typical": "^7.1.1"
-      },
-      "engines": {
-        "node": ">=12.20.0"
-      }
-    },
-    "node_modules/@malloydata/duckdb-wasm/node_modules/flatbuffers": {
-      "version": "23.5.26",
-      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-23.5.26.tgz",
-      "integrity": "sha512-vE+SI9vrJDwi1oETtTIFldC/o9GsVKRM+s6EL0nQgxXlYV1Vc4Tk30hj4xGICftInKQKj1F3up2n8UbIVobISQ=="
-    },
-    "node_modules/@malloydata/duckdb-wasm/node_modules/table-layout": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-3.0.2.tgz",
-      "integrity": "sha512-rpyNZYRw+/C+dYkcQ3Pr+rLxW4CfHpXjPDnG7lYhdRoUcZTUt+KEsX+94RGp/aVp/MQU35JCITv2T/beY4m+hw==",
-      "dependencies": {
-        "@75lb/deep-merge": "^1.1.1",
-        "array-back": "^6.2.2",
-        "command-line-args": "^5.2.1",
-        "command-line-usage": "^7.0.0",
-        "stream-read-all": "^3.0.1",
-        "typical": "^7.1.1",
-        "wordwrapjs": "^5.1.0"
-      },
-      "bin": {
-        "table-layout": "bin/cli.js"
-      },
-      "engines": {
-        "node": ">=12.17"
-      }
-    },
-    "node_modules/@malloydata/duckdb-wasm/node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-    },
-    "node_modules/@malloydata/duckdb-wasm/node_modules/typical": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/typical/-/typical-7.1.1.tgz",
-      "integrity": "sha512-T+tKVNs6Wu7IWiAce5BgMd7OZfNYUndHwc5MknN+UHOudi7sGZzuHdCadllRuqJ3fPtgFtIH9+lt9qRv6lmpfA==",
-      "engines": {
-        "node": ">=12.17"
-      }
-    },
-    "node_modules/@malloydata/duckdb-wasm/node_modules/wordwrapjs": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-5.1.0.tgz",
-      "integrity": "sha512-JNjcULU2e4KJwUNv6CHgI46UvDGitb6dGryHajXTDiLgg1/RiGoPSDw4kZfYnwGtEXf2ZMeIewDQgFGzkCB2Sg==",
-      "engines": {
-        "node": ">=12.17"
-      }
     },
     "node_modules/@malloydata/eslint-plugin-lint": {
       "resolved": "packages/malloy-lint",
@@ -8749,20 +8628,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/chalk-template": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/chalk-template/-/chalk-template-0.4.0.tgz",
-      "integrity": "sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==",
-      "dependencies": {
-        "chalk": "^4.1.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk-template?sponsor=1"
       }
     },
     "node_modules/char-regex": {
@@ -16995,11 +16860,6 @@
       "version": "4.17.21",
       "license": "MIT"
     },
-    "node_modules/lodash.assignwith": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.assignwith/-/lodash.assignwith-4.2.0.tgz",
-      "integrity": "sha512-ZznplvbvtjK2gMvnQ1BR/zqPFZmS6jbK4p+6Up4xcRYA7yMIwxHCfbTcrYxXKzzqLsQ05eJPVznEW3tuwV7k1g=="
-    },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
       "license": "MIT"
@@ -21355,14 +21215,6 @@
         "stubs": "^3.0.0"
       }
     },
-    "node_modules/stream-read-all": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/stream-read-all/-/stream-read-all-3.0.1.tgz",
-      "integrity": "sha512-EWZT9XOceBPlVJRrYcykW8jyRSZYbkb/0ZK36uLEmoWVO5gxBOnntNTseNzfREsqxqdfEGQrD8SXQ3QWbBmq8A==",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/stream-shift": {
       "version": "1.0.1",
       "license": "MIT"
@@ -23828,7 +23680,7 @@
       "version": "0.0.95",
       "license": "MIT",
       "dependencies": {
-        "@malloydata/duckdb-wasm": "0.0.5",
+        "@malloydata/duckdb-wasm": "0.0.2-rev3",
         "@malloydata/malloy": "^0.0.95",
         "apache-arrow": "^11.0.0",
         "duckdb": "0.8.1",
@@ -23836,6 +23688,14 @@
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "packages/malloy-db-duckdb/node_modules/@malloydata/duckdb-wasm": {
+      "version": "0.0.2-rev3",
+      "resolved": "https://registry.npmjs.org/@malloydata/duckdb-wasm/-/duckdb-wasm-0.0.2-rev3.tgz",
+      "integrity": "sha512-xTMfD0o5ZSotY3Bs/WPQ4V2uTmYsTOur/Ifux7yA8ld9mfjdx/Pj260LbD1tUqeCJy1NTaf1Ui5+ILjaqoBIew==",
+      "dependencies": {
+        "apache-arrow": "^11.0.0"
       }
     },
     "packages/malloy-db-postgres": {

--- a/packages/malloy-db-duckdb/package.json
+++ b/packages/malloy-db-duckdb/package.json
@@ -40,7 +40,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@malloydata/duckdb-wasm": "0.0.5",
+    "@malloydata/duckdb-wasm": "0.0.2-rev3",
     "@malloydata/malloy": "^0.0.95",
     "apache-arrow": "^11.0.0",
     "duckdb": "0.8.1",

--- a/packages/malloy-db-duckdb/package.json
+++ b/packages/malloy-db-duckdb/package.json
@@ -40,7 +40,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@malloydata/duckdb-wasm": "0.0.2",
+    "@malloydata/duckdb-wasm": "0.0.5",
     "@malloydata/malloy": "^0.0.95",
     "apache-arrow": "^11.0.0",
     "duckdb": "0.8.1",

--- a/packages/malloy-render/.storybook/main.ts
+++ b/packages/malloy-render/.storybook/main.ts
@@ -1,5 +1,5 @@
 import {join, dirname} from 'path';
-import {mergeConfig} from 'vite';
+import {mergeConfig, InlineConfig} from 'vite';
 import {StorybookConfig} from '@storybook/html-vite';
 
 /**
@@ -32,14 +32,22 @@ const config: StorybookConfig = {
     if (configType === 'PRODUCTION') {
       // Your production configuration goes here.
     }
-    const finalConfig = mergeConfig(config, {
+    const configOverride: InlineConfig = {
       resolve: {
         preserveSymlinks: true,
+        alias: {
+          '@malloydata/malloy': join(__dirname, '../../malloy/src'),
+          '@malloydata/db-duckdb/wasm': join(
+            __dirname,
+            '../../malloy-db-duckdb/src/duckdb_wasm_connection_browser'
+          ),
+        },
       },
       define: {
         'process.env': {},
       },
-    });
+    };
+    const finalConfig = mergeConfig(config, configOverride);
     return finalConfig;
   },
 };

--- a/packages/malloy-render/.storybook/registered_data.json
+++ b/packages/malloy-render/.storybook/registered_data.json
@@ -1,1 +1,1 @@
-["products.parquet"]
+["products.parquet", "logos.csv"]

--- a/packages/malloy-render/README.md
+++ b/packages/malloy-render/README.md
@@ -17,3 +17,7 @@ Stories are written in the `src/stories` directory. To add more data and Malloy 
 - register data files be loaded into the DuckDB WASM connection by adding the file name to `.storybook/registered_data.json`
 
 [Take a look at the Basic story as an example.](./src/stories/basic.stories.ts)
+
+### On Reloading Changes
+
+When running `npm run storybook`, only changes in the malloy-render package will hot reload properly. Changes to dependencies like the core `malloy` package may require a browser reload to work properly.

--- a/packages/malloy-render/src/html/image.ts
+++ b/packages/malloy-render/src/html/image.ts
@@ -21,12 +21,36 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import {DataColumn, Explore, Field} from '@malloydata/malloy';
+import {DataColumn, Explore, Field, Tag} from '@malloydata/malloy';
 import {Renderer} from '../renderer';
 import {createErrorElement, createNullElement} from './utils';
 import {RendererFactory} from '../renderer_factory';
 import {ImageRenderOptions, StyleDefaults} from '../data_styles';
 import {RendererOptions} from '../renderer_types';
+
+function getParentRecord(data: DataColumn, n = 0) {
+  let record = data;
+  while (n > 0 && record.parentRecord) {
+    n -= 1;
+    record = record.parentRecord;
+  }
+  return record;
+}
+
+function getDynamicValue({tag, data}: {tag: Tag; data: DataColumn}) {
+  const match = tag
+    .tag('field')
+    ?.text()
+    ?.match(/^(\^*)(.*)/);
+  if (!match) return;
+
+  const [, parentScoping, fieldName] = match;
+
+  const ancestorCt = parentScoping.length;
+  const scope = getParentRecord(data, ancestorCt);
+  // @ts-ignore
+  return scope?.cell?.(fieldName)?.value;
+}
 
 export class HTMLImageRenderer implements Renderer {
   constructor(private readonly document: Document) {}
@@ -39,21 +63,37 @@ export class HTMLImageRenderer implements Renderer {
       );
     }
 
+    const {tag} = data.field.tagParse();
+    const imgTag = tag.tag('image');
+
+    if (!imgTag) {
+      return createErrorElement(
+        this.document,
+        'Missing tag for Image renderer'
+      );
+    }
+
     const element: HTMLElement = data.isNull()
       ? createNullElement(this.document)
       : this.document.createElement('img');
-    const {tag} = data.field.tagParse();
-    const width = tag.numeric('image', 'width');
-    const height = tag.numeric('image', 'height');
+
+    const width = imgTag.numeric('width');
+    const height = imgTag.numeric('height');
     // Both image and null placeholder get matching size
     if (width) element.style.width = `${width}px`;
     if (height) element.style.height = `${height}px`;
+
+    const img = element as HTMLImageElement;
+
+    const altTag = imgTag.tag('alt');
+    if (altTag) {
+      const alt = getDynamicValue({tag: altTag, data}) ?? altTag?.text();
+      img.alt = alt;
+    }
+
     // Image specific props
     if (!data.isNull()) {
-      const alt = tag.text('image', 'alt');
-      const img = element as HTMLImageElement;
       img.src = data.value;
-      if (alt) img.alt = alt;
     }
     return element;
   }

--- a/packages/malloy-render/src/html/image.ts
+++ b/packages/malloy-render/src/html/image.ts
@@ -21,36 +21,12 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import {DataColumn, Explore, Field, Tag} from '@malloydata/malloy';
+import {DataColumn, Explore, Field} from '@malloydata/malloy';
 import {Renderer} from '../renderer';
-import {createErrorElement, createNullElement} from './utils';
+import {createErrorElement, createNullElement, getDynamicValue} from './utils';
 import {RendererFactory} from '../renderer_factory';
 import {ImageRenderOptions, StyleDefaults} from '../data_styles';
 import {RendererOptions} from '../renderer_types';
-
-function getParentRecord(data: DataColumn, n = 0) {
-  let record = data;
-  while (n > 0 && record.parentRecord) {
-    n -= 1;
-    record = record.parentRecord;
-  }
-  return record;
-}
-
-function getDynamicValue({tag, data}: {tag: Tag; data: DataColumn}) {
-  const match = tag
-    .tag('field')
-    ?.text()
-    ?.match(/^(\^*)(.*)/);
-  if (!match) return;
-
-  const [, parentScoping, fieldName] = match;
-
-  const ancestorCt = parentScoping.length;
-  const scope = getParentRecord(data, ancestorCt);
-  // @ts-ignore
-  return scope?.cell?.(fieldName)?.value;
-}
 
 export class HTMLImageRenderer implements Renderer {
   constructor(private readonly document: Document) {}
@@ -87,8 +63,8 @@ export class HTMLImageRenderer implements Renderer {
 
     const altTag = imgTag.tag('alt');
     if (altTag) {
-      const alt = getDynamicValue({tag: altTag, data}) ?? altTag?.text();
-      img.alt = alt;
+      const alt = getDynamicValue<string>({tag: altTag, data}) ?? altTag.text();
+      if (alt) img.alt = alt;
     }
 
     // Image specific props

--- a/packages/malloy-render/src/html/utils.ts
+++ b/packages/malloy-render/src/html/utils.ts
@@ -21,7 +21,13 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import {DateTimeframe, Field, TimestampTimeframe} from '@malloydata/malloy';
+import {
+  DataColumn,
+  DateTimeframe,
+  Field,
+  Tag,
+  TimestampTimeframe,
+} from '@malloydata/malloy';
 import startCase from 'lodash/startCase';
 import {RenderDef} from '../data_styles';
 import {RendererOptions} from '../renderer_types';
@@ -256,4 +262,34 @@ export function formatTitle(
   }
 
   return title;
+}
+
+export function getParentRecord(data: DataColumn, n = 0) {
+  let record = data;
+  while (n > 0 && record.parentRecord) {
+    n -= 1;
+    record = record.parentRecord;
+  }
+  return record;
+}
+
+export function getDynamicValue<T = unknown>({
+  tag,
+  data,
+}: {
+  tag: Tag;
+  data: DataColumn;
+}): T | undefined {
+  const match = tag
+    .tag('field')
+    ?.text()
+    ?.match(/^(\^*)(.*)/);
+  if (!match) return undefined;
+
+  const [, parentScoping, fieldName] = match;
+
+  const ancestorCt = parentScoping.length;
+  const scope = getParentRecord(data, ancestorCt);
+  if ('cell' in scope) return scope.cell(fieldName)?.value as T;
+  return undefined;
 }

--- a/packages/malloy-render/src/stories/basic.stories.ts
+++ b/packages/malloy-render/src/stories/basic.stories.ts
@@ -22,31 +22,3 @@ export const ProductsBar = {
     view: 'category_bar',
   },
 };
-
-export const Image = {
-  args: {
-    source: 'products',
-    view: 'img_test',
-  },
-};
-
-export const ImageFromRecord = {
-  args: {
-    source: 'logos',
-    view: 'img_from_record',
-  },
-};
-
-export const ImageFromParent = {
-  args: {
-    source: 'logos',
-    view: 'img_from_parent',
-  },
-};
-
-export const ImageFromGrandparent = {
-  args: {
-    source: 'logos',
-    view: 'img_from_grandparent',
-  },
-};

--- a/packages/malloy-render/src/stories/basic.stories.ts
+++ b/packages/malloy-render/src/stories/basic.stories.ts
@@ -22,3 +22,31 @@ export const ProductsBar = {
     view: 'category_bar',
   },
 };
+
+export const Image = {
+  args: {
+    source: 'products',
+    view: 'img_test',
+  },
+};
+
+export const ImageFromRecord = {
+  args: {
+    source: 'logos',
+    view: 'img_from_record',
+  },
+};
+
+export const ImageFromParent = {
+  args: {
+    source: 'logos',
+    view: 'img_from_parent',
+  },
+};
+
+export const ImageFromGrandparent = {
+  args: {
+    source: 'logos',
+    view: 'img_from_grandparent',
+  },
+};

--- a/packages/malloy-render/src/stories/image.stories.ts
+++ b/packages/malloy-render/src/stories/image.stories.ts
@@ -1,0 +1,31 @@
+import script from './static/image.malloy?raw';
+import {renderMalloy} from './render-malloy';
+
+export default {
+  title: 'Malloy/Image',
+  render: ({source, view}, {globals: {connection}}) => {
+    return renderMalloy({script, source, view, connection});
+  },
+  argTypes: {},
+};
+
+export const ImageAltFromRecord = {
+  args: {
+    source: 'logos',
+    view: 'img_from_record',
+  },
+};
+
+export const ImageAltFromParent = {
+  args: {
+    source: 'logos',
+    view: 'img_from_parent',
+  },
+};
+
+export const ImageAltFromGrandparent = {
+  args: {
+    source: 'logos',
+    view: 'img_from_grandparent',
+  },
+};

--- a/packages/malloy-render/src/stories/static/basic.malloy
+++ b/packages/malloy-render/src/stories/static/basic.malloy
@@ -2,53 +2,7 @@ source: products is duckdb.table("data/products.parquet") extend {
 
   # bar_chart
   view: category_bar is {
-      group_by: category
-      aggregate: avg_retail is retail_price.avg()
-    }
-
-
-  view: img_test is {
-    group_by:
-      # image { alt=fallback { field='department' } }
-      category
-      -- # hidden
-      department
-
-      # image
-      # image.alt.field='^department'
-      category2 is category
-    nest: n is {
-      group_by:
-        brand
-        # image image.alt=nested image.alt.field='^^department'
-        foo is 'url'
-      limit: 3
-    }
-  }
-};
-
-source: logos is duckdb.table("data/logos.csv") extend {
-  view: img_from_record is {
-    group_by:
-      brand
-      # image image.height=40px image.alt=fallback image.alt.field=brand
-      logo
-  }
-
-  view: img_from_parent is {
-    group_by:
-      brand
-      # image image.height=40px image.alt=fallback image.alt.field='^brand'
-      logo
-  }
-
-  view: img_from_grandparent is {
-    group_by:
-      brand
-      logo
-      nest: n is {
-        group_by:
-          foo
-      }
+    group_by: category
+    aggregate: avg_retail is retail_price.avg()
   }
 };

--- a/packages/malloy-render/src/stories/static/basic.malloy
+++ b/packages/malloy-render/src/stories/static/basic.malloy
@@ -5,4 +5,50 @@ source: products is duckdb.table("data/products.parquet") extend {
       group_by: category
       aggregate: avg_retail is retail_price.avg()
     }
+
+
+  view: img_test is {
+    group_by:
+      # image { alt=fallback { field='department' } }
+      category
+      -- # hidden
+      department
+
+      # image
+      # image.alt.field='^department'
+      category2 is category
+    nest: n is {
+      group_by:
+        brand
+        # image image.alt=nested image.alt.field='^^department'
+        foo is 'url'
+      limit: 3
+    }
+  }
+};
+
+source: logos is duckdb.table("data/logos.csv") extend {
+  view: img_from_record is {
+    group_by:
+      brand
+      # image image.height=40px image.alt=fallback image.alt.field=brand
+      logo
+  }
+
+  view: img_from_parent is {
+    group_by:
+      brand
+      # image image.height=40px image.alt=fallback image.alt.field='^brand'
+      logo
+  }
+
+  view: img_from_grandparent is {
+    group_by:
+      brand
+      logo
+      nest: n is {
+        group_by:
+          foo
+      }
+  }
 };

--- a/packages/malloy-render/src/stories/static/data/logos.csv
+++ b/packages/malloy-render/src/stories/static/data/logos.csv
@@ -1,11 +1,11 @@
-id,brand,logo,foo
-1,Google,https://upload.wikimedia.org/wikipedia/commons/thumb/2/2f/Google_2015_logo.svg/2560px-Google_2015_logo.svg.png,a
-2,Google,https://upload.wikimedia.org/wikipedia/commons/thumb/2/2f/Google_2015_logo.svg/2560px-Google_2015_logo.svg.png,b
-3,Google,https://upload.wikimedia.org/wikipedia/commons/thumb/2/2f/Google_2015_logo.svg/2560px-Google_2015_logo.svg.png,c
-4,Looker,https://upload.wikimedia.org/wikipedia/commons/thumb/4/4c/Looker.svg/2560px-Looker.svg.png,a
-5,Looker,https://upload.wikimedia.org/wikipedia/commons/thumb/4/4c/Looker.svg/2560px-Looker.svg.png,b
-6,Looker,https://upload.wikimedia.org/wikipedia/commons/thumb/4/4c/Looker.svg/2560px-Looker.svg.png,c
-7,Malloy,https://malloydata.github.io/img/logo.png,a
-8,Malloy,https://malloydata.github.io/img/logo.png,b
-9,Malloy,https://malloydata.github.io/img/logo.png,c
-10,BrokenBrand,bad_url,a
+id,brand,logo,product
+1,Google,https://upload.wikimedia.org/wikipedia/commons/thumb/2/2f/Google_2015_logo.svg/2560px-Google_2015_logo.svg.png,gViz
+2,Google,https://upload.wikimedia.org/wikipedia/commons/thumb/2/2f/Google_2015_logo.svg/2560px-Google_2015_logo.svg.png,Plex
+3,Google,https://upload.wikimedia.org/wikipedia/commons/thumb/2/2f/Google_2015_logo.svg/2560px-Google_2015_logo.svg.png,Google Charts
+4,Looker,https://upload.wikimedia.org/wikipedia/commons/thumb/4/4c/Looker.svg/2560px-Looker.svg.png,Looker
+5,Looker,https://upload.wikimedia.org/wikipedia/commons/thumb/4/4c/Looker.svg/2560px-Looker.svg.png,Looker Studio
+6,Looker,https://upload.wikimedia.org/wikipedia/commons/thumb/4/4c/Looker.svg/2560px-Looker.svg.png,Looker Studio Pro
+7,Malloy,https://malloydata.github.io/img/logo.png,Malloy
+8,Malloy,https://malloydata.github.io/img/logo.png,Malloy Composer
+9,Malloy,https://malloydata.github.io/img/logo.png,Malloy Py
+10,BrokenBrand,bad_url,Viz

--- a/packages/malloy-render/src/stories/static/data/logos.csv
+++ b/packages/malloy-render/src/stories/static/data/logos.csv
@@ -1,0 +1,11 @@
+id,brand,logo,foo
+1,Google,https://upload.wikimedia.org/wikipedia/commons/thumb/2/2f/Google_2015_logo.svg/2560px-Google_2015_logo.svg.png,a
+2,Google,https://upload.wikimedia.org/wikipedia/commons/thumb/2/2f/Google_2015_logo.svg/2560px-Google_2015_logo.svg.png,b
+3,Google,https://upload.wikimedia.org/wikipedia/commons/thumb/2/2f/Google_2015_logo.svg/2560px-Google_2015_logo.svg.png,c
+4,Looker,https://upload.wikimedia.org/wikipedia/commons/thumb/4/4c/Looker.svg/2560px-Looker.svg.png,a
+5,Looker,https://upload.wikimedia.org/wikipedia/commons/thumb/4/4c/Looker.svg/2560px-Looker.svg.png,b
+6,Looker,https://upload.wikimedia.org/wikipedia/commons/thumb/4/4c/Looker.svg/2560px-Looker.svg.png,c
+7,Malloy,https://malloydata.github.io/img/logo.png,a
+8,Malloy,https://malloydata.github.io/img/logo.png,b
+9,Malloy,https://malloydata.github.io/img/logo.png,c
+10,BrokenBrand,bad_url,a

--- a/packages/malloy-render/src/stories/static/image.malloy
+++ b/packages/malloy-render/src/stories/static/image.malloy
@@ -1,0 +1,26 @@
+source: logos is duckdb.table("data/logos.csv") extend {
+  view: img_from_record is {
+    group_by:
+      brand
+      # image image.height=40px image.alt=fallback image.alt.field=brand
+      logo
+  }
+
+  view: img_from_parent is {
+    group_by:
+      brand
+      # image image.height=40px image.alt=fallback image.alt.field='^brand'
+      logo
+  }
+
+  view: img_from_grandparent is {
+    group_by:
+      brand
+      nest: details is {
+        group_by:
+          product
+          # image image.height=40px image.alt=fallback image.alt.field='^^brand'
+          logo
+      }
+  }
+};


### PR DESCRIPTION
Introduces the ability to have dynamic data lookup in the Malloy renderer, with the first implementation being with the `# image.alt` property:
![image](https://github.com/malloydata/malloy/assets/5554373/b9746e99-e682-4d36-ab7f-53c6f6008d54)

The renderer can optionally read tags of `field` as being references to data within the current record or any record above. To indicate reading from a record above, `^` are used to indicate how many record levels in the results tree to go up before looking for a field value. For example, `field=brand` would look at a brand field in the current cell's record (assuming we land https://github.com/malloydata/whatsnext/blob/main/wns/WN-0005/wn-0005.md). `field='^brand'` would look up brand in the parent record of the current cell. `field='^^brand'` would look at the parent's parent record, so on and so forth. When navigating up the tree, array parents are ignored. This PR does not support trying to read from a parent array.

In the case of the `alt` tag, a static value set to `alt` is used as a fallback value for when a dynamic lookup is not provided or does not work. Other props may or may not want to use the static value in the same way.

## Functional changes this PR covers:
- To support looking up parent data, the `DataColumn` types are updated with references to their direct `parent`, which would include `DataArray`s, and their `parentRecord` which skips `DataArray` and provides the next ancestor `DataRecord` of a cell.
- Utility functions are provided in the renderer for resolving a dynamic value lookup
- The Image renderer supports looking up dynamic values for the `alt` tag

## Dev changes this PR covers:
- Modifies the storybook setup so that it will hot reload changes to the Malloy dependencies within the monorepo
- Updates the malloy-db-duckdb package to use a newer version of our duckdb-wasm package that resolves some bugs (thanks @whscullin)