### PR TITLE
Handle unsupported values that are numbers

### DIFF
--- a/packages/malloy-render/src/html/unsupported.ts
+++ b/packages/malloy-render/src/html/unsupported.ts
@@ -37,7 +37,7 @@ export class HTMLUnsupportedRenderer implements Renderer {
       return value;
     } else if (value === null) {
       return null;
-    } else {
+    } else if (typeof data.value === 'object') {
       const record = data.value as Record<string, unknown>;
       if ('value' in record && typeof record['value'] === 'string') {
         return record['value'];

--- a/packages/malloy/src/malloy.ts
+++ b/packages/malloy/src/malloy.ts
@@ -1919,6 +1919,9 @@ export class UnsupportedField extends AtomicField {
     super(fieldUnsupportedDef, parent, source);
     this.fieldUnsupportedDef = fieldUnsupportedDef;
   }
+  get rawType(): string | undefined {
+    return this.fieldUnsupportedDef.rawType;
+  }
 }
 
 export class StringField extends AtomicField {


### PR DESCRIPTION
For instance, latitude and longitude in our postgres "airports" table are the unsupported type "double precision". Because both 'number' and 'object' types were falling into this conditional, it was generating:
`TypeError: cannot use 'in' operator to search for 'value' in 171.73`

