### PR TITLE
WN-0006 Scalar Lenses and support views with literal heads having no fields

### DIFF
--- a/packages/malloy/package.json
+++ b/packages/malloy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@malloydata/malloy",
-  "version": "0.0.99",
+  "version": "0.0.98",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/malloy/package.json
+++ b/packages/malloy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@malloydata/malloy",
-  "version": "0.0.98",
+  "version": "0.0.99",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/malloy/src/lang/ast/elements/pipeline-desc.ts
+++ b/packages/malloy/src/lang/ast/elements/pipeline-desc.ts
@@ -110,6 +110,7 @@ export abstract class PipelineDesc extends MalloyElement {
     turtleName: string,
     fromStruct: StructDef
   ): {
+    needsExpansionDueToScalar: boolean;
     pipeline: PipeSegment[];
     location: DocumentLocation | undefined;
     annotation: Annotation | undefined;
@@ -119,14 +120,33 @@ export abstract class PipelineDesc extends MalloyElement {
     if (!turtle) {
       this.log(`Query '${turtleName}' is not defined in source`);
     } else if (turtle.type !== 'turtle') {
-      this.log(`'${turtleName}' is not a query`);
+      if (this.inExperiment('scalar_lenses', true)) {
+        return {
+          needsExpansionDueToScalar: true,
+          pipeline: [{type: 'reduce', fields: [turtle.name]}],
+          location: turtle.location,
+          annotation,
+        };
+      } else {
+        this.log(`'${turtleName}' is not a query`);
+      }
     } else {
       if (turtle.annotation) {
         annotation = {inherits: turtle.annotation};
       }
-      return {pipeline: turtle.pipeline, location: turtle.location, annotation};
+      return {
+        pipeline: turtle.pipeline,
+        location: turtle.location,
+        annotation,
+        needsExpansionDueToScalar: false,
+      };
     }
-    return {pipeline: [], location: undefined, annotation};
+    return {
+      pipeline: [],
+      location: undefined,
+      annotation,
+      needsExpansionDueToScalar: false,
+    };
   }
 }
 

--- a/packages/malloy/src/lang/ast/elements/pipeline-desc.ts
+++ b/packages/malloy/src/lang/ast/elements/pipeline-desc.ts
@@ -39,7 +39,7 @@ import {Refinement} from '../query-properties/refinements';
 
 interface AppendResult {
   opList: PipeSegment[];
-  structDef: StructDef;
+  structDef: () => StructDef;
 }
 
 /**
@@ -74,15 +74,15 @@ export abstract class PipelineDesc extends MalloyElement {
     const returnPipe: PipeSegment[] = [...modelPipe];
     const nestedIn =
       modelPipe.length === 0 ? this.nestedInQuerySpace : undefined;
-    let nextFS = pipelineOutput;
+    let nextFS = () => pipelineOutput;
     for (const qop of this.qops) {
-      const next = qop.getOp(nextFS, nestedIn);
+      const next = qop.getOp(nextFS(), nestedIn);
       returnPipe.push(next.segment);
-      nextFS = next.outputSpace();
+      nextFS = () => next.outputSpace();
     }
     return {
       opList: returnPipe,
-      structDef: nextFS.structDef(),
+      structDef: () => nextFS().structDef(),
     };
   }
 

--- a/packages/malloy/src/lang/ast/elements/source-query-nodes.ts
+++ b/packages/malloy/src/lang/ast/elements/source-query-nodes.ts
@@ -273,10 +273,12 @@ export class SQAppendView extends SourceQueryNode {
         theQuery.addSegments(head);
         views.shift();
       } else {
+        // TODO implement scalar_lenses in subsequent stages
         this.sqLog(`Cannot reference view '${head}' in output of query`);
         return;
       }
     } else {
+      // TODO implement combinations for subsequent stages
       this.sqLog('query definition by combining not yet supported');
       return;
     }

--- a/packages/malloy/src/lang/ast/query-builders/index-builder.ts
+++ b/packages/malloy/src/lang/ast/query-builders/index-builder.ts
@@ -25,6 +25,8 @@ import {
   FilterExpression,
   PipeSegment,
   Sampling,
+  isIndexSegment,
+  isPartialSegment,
 } from '../../../model/malloy_types';
 
 import {ErrorFactory} from '../error-factory';
@@ -76,7 +78,7 @@ export class IndexBuilder implements QueryBuilder {
   }
 
   finalize(from: PipeSegment | undefined): PipeSegment {
-    if (from && from.type !== 'index') {
+    if (from && !isIndexSegment(from) && !isPartialSegment(from)) {
       this.resultFS.log(`Can't refine index with ${from.type}`);
       return ErrorFactory.indexSegment;
     }
@@ -101,7 +103,7 @@ export class IndexBuilder implements QueryBuilder {
       indexSegment.weightMeasure = this.indexOn.refString;
     }
 
-    if (from?.sample) {
+    if (from && isIndexSegment(from) && from?.sample) {
       indexSegment.sample = from.sample;
     }
     if (this.sample) {

--- a/packages/malloy/src/lang/ast/query-builders/partial-builder.ts
+++ b/packages/malloy/src/lang/ast/query-builders/partial-builder.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files
+ * (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+import {PipeSegment} from '../../../model';
+import {ReduceBuilder} from './reduce-builder';
+
+export class PartialBuilder extends ReduceBuilder {
+  finalize(fromSeg: PipeSegment | undefined): PipeSegment {
+    const seg = super.finalize(fromSeg);
+    return {...seg, type: 'partial'};
+  }
+}

--- a/packages/malloy/src/lang/ast/query-builders/project-builder.ts
+++ b/packages/malloy/src/lang/ast/query-builders/project-builder.ts
@@ -22,8 +22,10 @@
  */
 
 import {
+  PartialSegment,
   PipeSegment,
   ProjectSegment,
+  isPartialSegment,
   isProjectSegment,
 } from '../../../model/malloy_types';
 
@@ -52,9 +54,9 @@ export class ProjectBuilder extends ReduceBuilder {
   }
 
   finalize(fromSeg: PipeSegment | undefined): PipeSegment {
-    let from: ProjectSegment | undefined;
+    let from: ProjectSegment | PartialSegment | undefined;
     if (fromSeg) {
-      if (isProjectSegment(fromSeg)) {
+      if (isProjectSegment(fromSeg) || isPartialSegment(fromSeg)) {
         from = fromSeg;
       } else {
         this.resultFS.log(`Can't refine select with ${fromSeg.type}`);

--- a/packages/malloy/src/lang/ast/query-builders/reduce-builder.ts
+++ b/packages/malloy/src/lang/ast/query-builders/reduce-builder.ts
@@ -23,9 +23,11 @@
 
 import {
   FilterExpression,
+  PartialSegment,
   PipeSegment,
   QuerySegment,
   ReduceSegment,
+  isPartialSegment,
   isReduceSegment,
 } from '../../../model/malloy_types';
 
@@ -137,9 +139,9 @@ export class ReduceBuilder implements QueryBuilder {
   }
 
   finalize(fromSeg: PipeSegment | undefined): PipeSegment {
-    let from: ReduceSegment | undefined;
+    let from: ReduceSegment | PartialSegment | undefined;
     if (fromSeg) {
-      if (isReduceSegment(fromSeg)) {
+      if (isReduceSegment(fromSeg) || isPartialSegment(fromSeg)) {
         from = fromSeg;
       } else {
         this.resultFS.log(`Can't refine reduce with ${fromSeg.type}`);

--- a/packages/malloy/src/lang/ast/query-elements/existing-query.ts
+++ b/packages/malloy/src/lang/ast/query-elements/existing-query.ts
@@ -87,7 +87,7 @@ export class ExistingQuery extends PipelineDesc {
       if (head.annotation) {
         query.annotation = head.annotation;
       }
-      return {outputStruct: appended.structDef, query};
+      return {outputStruct: appended.structDef(), query};
     }
     this.log(`Illegal reference to '${this.head}', query expected`);
     return oops();

--- a/packages/malloy/src/lang/ast/query-elements/full-query.ts
+++ b/packages/malloy/src/lang/ast/query-elements/full-query.ts
@@ -124,10 +124,16 @@ export class FullQuery extends TurtleHeadedPipe {
 
   query(): Query {
     const q = this.queryComp(true).query;
-    if (q.pipeline[0] && q.pipeline[0].fields.length === 0) {
+    if (q.pipeline[0] && q.pipeline[0].type === 'partial') {
       this.log(
         "Can't determine view type (`group_by` / `aggregate` / `nest`, `project`, `index`)"
       );
+      // We don't want to ever generate actual 'partial' stages, so convert this
+      // into a reduce so the compiler doesn't explode
+      return {
+        ...q,
+        pipeline: [{...q.pipeline[0], type: 'reduce'}, ...q.pipeline.slice(1)],
+      };
     }
     return q;
   }

--- a/packages/malloy/src/lang/ast/query-properties/calculate.ts
+++ b/packages/malloy/src/lang/ast/query-properties/calculate.ts
@@ -34,5 +34,6 @@ export class Calculate
 {
   elementType = 'calculate';
   forceQueryClass = undefined;
+  needsExplicitQueryClass = true;
   queryRefinementStage = LegalRefinementStage.Single;
 }

--- a/packages/malloy/src/lang/ast/query-properties/nest.ts
+++ b/packages/malloy/src/lang/ast/query-properties/nest.ts
@@ -136,10 +136,20 @@ abstract class TurtleDeclRoot
     if (this.note) {
       turtle.annotation = this.note;
     }
-    if (pipe.pipeline && pipe.pipeline[0].fields.length === 0) {
+    if (pipe.pipeline && pipe.pipeline[0].type === 'partial') {
+      // TODO duplicate code here
       this.log(
         "Can't determine view type (`group_by` / `aggregate` / `nest`, `project`, `index`)"
       );
+      // We don't want to ever generate actual 'partial' stages, so convert this
+      // into a reduce so the compiler doesn't explode
+      return {
+        ...turtle,
+        pipeline: [
+          {...pipe.pipeline[0], type: 'reduce'},
+          ...pipe.pipeline.slice(1),
+        ],
+      };
     }
     return turtle;
   }

--- a/packages/malloy/src/lang/ast/query-properties/qop-desc.ts
+++ b/packages/malloy/src/lang/ast/query-properties/qop-desc.ts
@@ -34,42 +34,42 @@ import {QueryProperty} from '../types/query-property';
 import {StaticSpace} from '../field-space/static-space';
 import {QueryClass} from '../types/query-property-interface';
 import {QueryInputSpace} from '../field-space/query-input-space';
+import {PartialBuilder} from '../query-builders/partial-builder';
 
 export class QOPDesc extends ListOf<QueryProperty> {
   elementType = 'queryOperation';
-  opClass = QueryClass.Grouping;
+  opClass: QueryClass | undefined;
   private refineThis?: PipeSegment;
 
-  protected computeType(): QueryClass {
-    let mustBe: QueryClass | undefined;
+  protected computeType(): QueryClass | undefined {
+    let guessType: QueryClass | undefined;
     let needsExplicitQueryClass = false;
     if (this.refineThis) {
       if (this.refineThis.type === 'reduce') {
-        mustBe = QueryClass.Grouping;
+        guessType = QueryClass.Grouping;
       } else if (this.refineThis.type === 'project') {
-        mustBe = QueryClass.Project;
-      } else {
-        mustBe = QueryClass.Index;
+        guessType = QueryClass.Project;
+      } else if (this.refineThis.type === 'index') {
+        guessType = QueryClass.Index;
       }
     }
     for (const el of this.list) {
       if (el.forceQueryClass) {
-        if (mustBe) {
-          if (mustBe !== el.forceQueryClass) {
-            el.log(`Not legal in ${mustBe} query`);
+        if (guessType) {
+          if (guessType !== el.forceQueryClass) {
+            el.log(`Not legal in ${guessType} query`);
           }
         } else {
-          mustBe = el.forceQueryClass;
+          guessType = el.forceQueryClass;
         }
       }
       needsExplicitQueryClass ||= el.needsExplicitQueryClass ?? false;
     }
-    if (mustBe === undefined && needsExplicitQueryClass) {
+    if (guessType === undefined && needsExplicitQueryClass) {
       this.log(
         "Can't determine view type (`group_by` / `aggregate` / `nest`, `project`, `index`)"
       );
     }
-    const guessType = mustBe ?? QueryClass.Grouping;
     this.opClass = guessType;
     return guessType;
   }
@@ -86,6 +86,8 @@ export class QOPDesc extends ListOf<QueryProperty> {
         return new ProjectBuilder(baseFS, this.refineThis);
       case QueryClass.Index:
         return new IndexBuilder(baseFS, this.refineThis);
+      case undefined:
+        return new PartialBuilder(baseFS, this.refineThis);
     }
   }
 

--- a/packages/malloy/src/lang/ast/query-properties/qop-desc.ts
+++ b/packages/malloy/src/lang/ast/query-properties/qop-desc.ts
@@ -42,6 +42,7 @@ export class QOPDesc extends ListOf<QueryProperty> {
 
   protected computeType(): QueryClass {
     let mustBe: QueryClass | undefined;
+    let needsExplicitQueryClass = false;
     if (this.refineThis) {
       if (this.refineThis.type === 'reduce') {
         mustBe = QueryClass.Grouping;
@@ -61,13 +62,14 @@ export class QOPDesc extends ListOf<QueryProperty> {
           mustBe = el.forceQueryClass;
         }
       }
+      needsExplicitQueryClass ||= el.needsExplicitQueryClass ?? false;
     }
-    if (mustBe === undefined) {
+    if (mustBe === undefined && needsExplicitQueryClass) {
       this.log(
-        "Can't determine query type (group_by/aggregate/nest,project,index)"
+        "Can't determine view type (`group_by` / `aggregate` / `nest`, `project`, `index`)"
       );
     }
-    const guessType = mustBe || QueryClass.Grouping;
+    const guessType = mustBe ?? QueryClass.Grouping;
     this.opClass = guessType;
     return guessType;
   }

--- a/packages/malloy/src/lang/ast/query-properties/qop-desc.ts
+++ b/packages/malloy/src/lang/ast/query-properties/qop-desc.ts
@@ -69,6 +69,7 @@ export class QOPDesc extends ListOf<QueryProperty> {
       this.log(
         "Can't determine view type (`group_by` / `aggregate` / `nest`, `project`, `index`)"
       );
+      guessType = QueryClass.Project;
     }
     this.opClass = guessType;
     return guessType;

--- a/packages/malloy/src/lang/ast/query-properties/refinements.ts
+++ b/packages/malloy/src/lang/ast/query-properties/refinements.ts
@@ -66,6 +66,11 @@ export class NamedRefinement extends Refinement {
         }
         return fieldDef.pipeline[0];
       }
+      if (fieldDef?.type !== 'struct') {
+        if (this.name.inExperiment('scalar_lenses', true)) {
+          return {type: 'reduce', fields: [this.name.refString]};
+        }
+      }
     }
     this.name.log(
       `named refinement \`${this.name.refString}\` must be a view, found a ${

--- a/packages/malloy/src/lang/ast/query-properties/refinements.ts
+++ b/packages/malloy/src/lang/ast/query-properties/refinements.ts
@@ -93,9 +93,13 @@ export class NamedRefinement extends Refinement {
     const to = {..._to};
     const from = this.getRefinementSegment(inputFS);
     if (from) {
-      if (from.type !== to.type) {
+      // TODO need to disallow partial + index for now to make the types happy
+      if (to.type === 'partial' && from.type !== 'index') {
+        to.type = from.type;
+      } else if (from.type !== to.type) {
         this.log(`cannot refine ${to.type} view with ${from.type} view`);
       }
+
       if (from.type !== 'index' && to.type !== 'index') {
         if (from.orderBy !== undefined || from.by !== undefined) {
           if (to.orderBy === undefined && to.by === undefined) {

--- a/packages/malloy/src/lang/ast/query-utils.ts
+++ b/packages/malloy/src/lang/ast/query-utils.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files
+ * (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import {PipeSegment, isPartialSegment} from '../../model';
+
+// We don't want to ever generate actual 'partial' stages, so convert this
+// into a reduce so the compiler doesn't explode
+export function detectAndRemovePartialStages(pipeline: PipeSegment[]): {
+  hasPartials: boolean;
+  pipeline: PipeSegment[];
+} {
+  const cleaned: PipeSegment[] = [];
+  let hasPartials = false;
+  for (const segment of pipeline) {
+    if (isPartialSegment(segment)) {
+      cleaned.push({...segment, type: 'reduce'});
+      hasPartials = true;
+    } else {
+      cleaned.push(segment);
+    }
+  }
+  return {hasPartials, pipeline: cleaned};
+}

--- a/packages/malloy/src/lang/ast/struct-utils.ts
+++ b/packages/malloy/src/lang/ast/struct-utils.ts
@@ -24,7 +24,12 @@
 import {inspect} from 'util';
 
 import {Segment} from '../../model/malloy_query';
-import {FieldDef, PipeSegment, StructDef} from '../../model/malloy_types';
+import {
+  FieldDef,
+  PipeSegment,
+  StructDef,
+  isPartialSegment,
+} from '../../model/malloy_types';
 
 import {ErrorFactory} from './error-factory';
 import {MalloyElement} from './types/malloy-element';
@@ -35,6 +40,10 @@ export function opOutputStruct(
   opDesc: PipeSegment
 ): StructDef {
   const badModel = ErrorFactory.isErrorStructDef(inputStruct);
+  // We don't want to expose partial segments to the compiler
+  if (isPartialSegment(opDesc)) {
+    opDesc = {...opDesc, type: 'reduce'};
+  }
   // Don't call into the model code with a broken model
   if (!badModel) {
     try {

--- a/packages/malloy/src/lang/ast/types/query-property-interface.ts
+++ b/packages/malloy/src/lang/ast/types/query-property-interface.ts
@@ -45,5 +45,8 @@ export enum LegalRefinementStage {
 export interface QueryPropertyInterface {
   queryRefinementStage: LegalRefinementStage | undefined;
   forceQueryClass: QueryClass | undefined;
+  // Edge case for `calculate:`, which needs a grouping or
+  // project to decide what kind of query it is
+  needsExplicitQueryClass?: boolean;
   queryExecute?: (executeFor: QueryBuilder) => void;
 }

--- a/packages/malloy/src/lang/test/lenses.spec.ts
+++ b/packages/malloy/src/lang/test/lenses.spec.ts
@@ -231,7 +231,7 @@ describe('partial views', () => {
       `
     ).toTranslate();
   });
-  test('partial with index', () => {
+  test.skip('partial with index', () => {
     expect(
       markSource`
         source: x is a extend {

--- a/packages/malloy/src/lang/test/lenses.spec.ts
+++ b/packages/malloy/src/lang/test/lenses.spec.ts
@@ -220,7 +220,7 @@ describe('lenses', () => {
   });
 });
 
-describe('assume reduce for views, check that they have fields later', () => {
+describe('partial views', () => {
   test('allow where-headed refinement chains', () => {
     expect(
       markSource`
@@ -231,7 +231,17 @@ describe('assume reduce for views, check that they have fields later', () => {
       `
     ).toTranslate();
   });
-  test('disallow chains that have no fields', () => {
+  test('partial with index', () => {
+    expect(
+      markSource`
+        source: x is a extend {
+          view: idx is { index: * }
+        }
+        run: x -> { where: true } + idx
+      `
+    ).toTranslate();
+  });
+  test('disallow chains that have no fields in view', () => {
     expect(
       markSource`
         source: x is a extend {
@@ -241,6 +251,26 @@ describe('assume reduce for views, check that they have fields later', () => {
       `
     ).translationToFailWith(
       "Can't determine view type (`group_by` / `aggregate` / `nest`, `project`, `index`)",
+      "Can't determine view type (`group_by` / `aggregate` / `nest`, `project`, `index`)"
+    );
+  });
+  test('disallow chains that have no fields in multi-stage', () => {
+    expect(
+      markSource`
+        source: x is a extend {
+          view: v is { group_by: ai }
+          view: v2 is v -> { where: true }
+          view: v3 is { where: true } -> { group_by: undef }
+        }
+        run: x -> v -> { where: true }
+        run: x -> { where: true } -> { group_by: undef }
+      `
+    ).translationToFailWith(
+      "Can't determine view type (`group_by` / `aggregate` / `nest`, `project`, `index`)",
+      "'undef' is not defined",
+      "Can't determine view type (`group_by` / `aggregate` / `nest`, `project`, `index`)",
+      "Can't determine view type (`group_by` / `aggregate` / `nest`, `project`, `index`)",
+      "'undef' is not defined",
       "Can't determine view type (`group_by` / `aggregate` / `nest`, `project`, `index`)"
     );
   });

--- a/packages/malloy/src/lang/test/lenses.spec.ts
+++ b/packages/malloy/src/lang/test/lenses.spec.ts
@@ -114,6 +114,17 @@ describe('lenses', () => {
       'cannot refine index view with project view'
     );
   });
+  test('cannot reference dimension at head of query ', () => {
+    expect(
+      markSource`
+        source: x is a extend {
+          dimension: n is 1
+          view: d is { group_by: n1 is 1 }
+        }
+        run: x -> n + d
+      `
+    ).translationToFailWith("'n' is not a query");
+  });
   test('cannot reference dimension', () => {
     expect(
       markSource`
@@ -126,6 +137,55 @@ describe('lenses', () => {
     ).translationToFailWith(
       'named refinement `n` must be a view, found a number'
     );
+  });
+  test('can reference dimension at head of query when experiment is enabled', () => {
+    expect(
+      markSource`
+        ##! experimental { scalar_lenses }
+        source: x is a extend {
+          dimension: n is 1
+        }
+        run: x -> n
+      `
+    ).toTranslate();
+  });
+  test('can reference dimension in refinement when experiment is enabled', () => {
+    expect(
+      markSource`
+        ##! experimental { scalar_lenses }
+        source: x is a extend {
+          dimension: n is 1
+          view: d is { group_by: n1 is 1 }
+        }
+        run: x -> d + n
+      `
+    ).toTranslate();
+  });
+  test('cannot nest dimension even when experiment is enabled', () => {
+    expect(
+      markSource`
+        ##! experimental { scalar_lenses }
+        source: x is a extend {
+          dimension: n is 1
+          view: d is { nest: n }
+        }
+        run: x -> d
+      `
+    ).translationToFailWith(
+      'Cannot use a scalar field in a nest operation, did you mean to use a group_by or select operation instead?'
+    );
+  });
+  test('can nest dimension with refinement when experiment is enabled', () => {
+    expect(
+      markSource`
+        ##! experimental { scalar_lenses }
+        source: x is a extend {
+          dimension: n is 1
+          view: d is { nest: n + { where: n > 0 } }
+        }
+        run: x -> d
+      `
+    ).toTranslate();
   });
   test('cannot reference join', () => {
     expect(
@@ -156,6 +216,32 @@ describe('lenses', () => {
     ).translationToFailWith(
       'Named refinements of multi-stage views are not supported',
       'named refinement `multi` must have exactly one stage'
+    );
+  });
+});
+
+describe('assume reduce for views, check that they have fields later', () => {
+  test('allow where-headed refinement chains', () => {
+    expect(
+      markSource`
+        source: x is a extend {
+          view: metrics is { aggregate: c is count() }
+          view: cool_metrics is { where: true } + metrics
+        }
+      `
+    ).toTranslate();
+  });
+  test('disallow chains that have no fields', () => {
+    expect(
+      markSource`
+        source: x is a extend {
+          view: bad1 is { where: true }
+          view: bad2 is { where: true } + { where: false }
+        }
+      `
+    ).translationToFailWith(
+      "Can't determine view type (`group_by` / `aggregate` / `nest`, `project`, `index`)",
+      "Can't determine view type (`group_by` / `aggregate` / `nest`, `project`, `index`)"
     );
   });
 });

--- a/packages/malloy/src/lang/test/parse.spec.ts
+++ b/packages/malloy/src/lang/test/parse.spec.ts
@@ -151,7 +151,7 @@ describe('error handling', () => {
   });
   test('query without fields', () => {
     expect('run: a -> { top: 5 }').translationToFailWith(
-      "Can't determine query type (group_by/aggregate/nest,project,index)"
+      "Can't determine view type (`group_by` / `aggregate` / `nest`, `project`, `index`)"
     );
   });
   test('refine cannot change query type', () => {

--- a/packages/malloy/src/lang/test/query.spec.ts
+++ b/packages/malloy/src/lang/test/query.spec.ts
@@ -655,7 +655,7 @@ describe('query:', () => {
       expect(`run: a -> {
         calculate: x is row_number()
       }`).translationToFailWith(
-        "Can't determine query type (group_by/aggregate/nest,project,index)"
+        "Can't determine view type (`group_by` / `aggregate` / `nest`, `project`, `index`)"
       );
     });
     // TODO someday make it so we can order by an analytic function

--- a/packages/malloy/src/model/malloy_query.ts
+++ b/packages/malloy/src/model/malloy_query.ts
@@ -1901,6 +1901,10 @@ class QueryQuery extends QueryField {
         return new QueryQueryProject(flatTurtleDef, parent, stageWriter);
       case 'index':
         return new QueryQueryIndex(flatTurtleDef, parent, stageWriter);
+      case 'partial':
+        // TODO this is a hack... we should never get here
+        return new QueryQueryReduce(flatTurtleDef, parent, stageWriter);
+      // throw new Error('Attempt to make query out of partial stage');
     }
   }
 

--- a/packages/malloy/src/model/malloy_query.ts
+++ b/packages/malloy/src/model/malloy_query.ts
@@ -1902,9 +1902,7 @@ class QueryQuery extends QueryField {
       case 'index':
         return new QueryQueryIndex(flatTurtleDef, parent, stageWriter);
       case 'partial':
-        // TODO this is a hack... we should never get here
-        return new QueryQueryReduce(flatTurtleDef, parent, stageWriter);
-      // throw new Error('Attempt to make query out of partial stage');
+        throw new Error('Attempt to make query out of partial stage');
     }
   }
 

--- a/packages/malloy/src/model/malloy_types.ts
+++ b/packages/malloy/src/model/malloy_types.ts
@@ -777,6 +777,13 @@ export function isReduceSegment(pe: PipeSegment): pe is ReduceSegment {
   return pe.type === 'reduce';
 }
 
+export interface PartialSegment extends QuerySegment {
+  type: 'partial';
+}
+export function isPartialSegment(pe: PipeSegment): pe is PartialSegment {
+  return pe.type === 'partial';
+}
+
 export interface ProjectSegment extends QuerySegment {
   type: 'project';
 }
@@ -826,7 +833,7 @@ export function isIndexSegment(pe: PipeSegment): pe is IndexSegment {
 }
 
 export interface QuerySegment extends Filtered {
-  type: 'reduce' | 'project';
+  type: 'reduce' | 'project' | 'partial';
   fields: QueryFieldDef[];
   extendSource?: FieldDef[];
   limit?: number;

--- a/test/src/databases/all/lenses.spec.ts
+++ b/test/src/databases/all/lenses.spec.ts
@@ -202,9 +202,9 @@ runtimes.runtimeMap.forEach((runtime, databaseName) => {
       run: x -> {
         nest: n + m
       }
-    `).malloyResultMatches(runtime, {d: [{n: 1, c: 1}]});
+    `).malloyResultMatches(runtime, {'n.n': 1, 'n.c': 1});
   });
-  it(`nest dimension only - ${databaseName}`, async () => {
+  it.skip(`nest dimension only - ${databaseName}`, async () => {
     await expect(`
       ##! experimental { scalar_lenses }
       source: x is ${databaseName}.sql("SELECT 1 AS n") extend {
@@ -213,7 +213,7 @@ runtimes.runtimeMap.forEach((runtime, databaseName) => {
       run: x -> {
         nest: n
       }
-    `).malloyResultMatches(runtime, {d: [{n: 1}]});
+    `).malloyResultMatches(runtime, {n: [{n: 1}]});
   });
   it(`view dimension only - ${databaseName}`, async () => {
     await expect(`

--- a/test/src/util/db-jest-matchers.ts
+++ b/test/src/util/db-jest-matchers.ts
@@ -118,7 +118,7 @@ expect.extend({
     try {
       result = await query.run();
     } catch (e) {
-      let failMsg = `query.run failed: ${e.message}`;
+      let failMsg = `query.run failed: ${e.message}\n`;
       if (e instanceof MalloyError) {
         failMsg = `Error in query compilation\n${errorLogToString(
           querySrc,
@@ -126,10 +126,11 @@ expect.extend({
         )}`;
       } else {
         try {
-          failMsg += `\nSQL: ${await query.getSQL()}`;
+          failMsg += `SQL: ${await query.getSQL()}\n`;
         } catch (e2) {
           // we could not show the SQL for unknown reasons
         }
+        failMsg += e.stack;
       }
       return {pass: false, message: () => failMsg};
     }

--- a/test/src/util/index.ts
+++ b/test/src/util/index.ts
@@ -181,7 +181,9 @@ export async function runQuery(runtime: Runtime, querySrc: string) {
     result = await query.run();
   } catch (e) {
     throw new Error(
-      `query.run failed: ${e.message}\n` + `SQL: ${await query.getSQL()}`
+      `query.run failed: ${e.message}\n` +
+        `SQL: ${await query.getSQL()}\n` +
+        e.stack
     );
   }
 


### PR DESCRIPTION
Implements the experimental parts (scalar lense) of [WN 0006](https://github.com/malloydata/whatsnext/blob/main/wns/WN-0006/WN-0006.md)
* Feature requires experimental tag: `##! experimental { scalar_lenses }`
* Anywhere where you can reference a view name in a query, you can reference a dimension or measure instead
* E.g. `run: flights -> flight_count` is equivalent to `run: flights -> { aggregate: flight_count }`
* Can be used in views and nests as well
* Doesn't work with dotted names (yet)
* Particularly useful for shorthand query "column building" style: `flights -> carrier + flight_count + { where: origin.state = 'CA' }`

Adds support for the first literal view of a refinement chain not specifying any fields.
* Previously, `run: flights -> { where: true } + metrics` would fail with an error indicating that it couldn't tell what kind of query you wanted (index, project, reduce). 
* Now that query runs fine
* But `run: flights -> { where: true }` has the same error as before