### PR TITLE
Fix code that skips tests that use `nest:` on databases that don't support nests

### DIFF
--- a/test/src/databases/all/lenses.spec.ts
+++ b/test/src/databases/all/lenses.spec.ts
@@ -105,7 +105,7 @@ runtimes.runtimeMap.forEach((runtime, databaseName) => {
       run: x -> {
         nest: d + m
       }
-    `).malloyResultMatches(runtime, {d: [{n: 1, c: 1}]});
+    `).malloyResultMatches(runtime, {'d.n': 1, 'd.c': 1});
   });
   it(`nested with name - ${databaseName}`, async () => {
     await expect(`
@@ -116,6 +116,6 @@ runtimes.runtimeMap.forEach((runtime, databaseName) => {
       run: x -> {
         nest: y is d + m
       }
-    `).malloyResultMatches(runtime, {y: [{n: 1, c: 1}]});
+    `).malloyResultMatches(runtime, {'y.n': 1, 'y.c': 1});
   });
 });

--- a/test/src/util/db-jest-matchers.ts
+++ b/test/src/util/db-jest-matchers.ts
@@ -29,6 +29,7 @@ import {
   Runtime,
   MalloyError,
   LogMessage,
+  SingleConnectionRuntime,
 } from '@malloydata/malloy';
 
 type ExpectedResultRow = Record<string, unknown>;
@@ -95,7 +96,10 @@ expect.extend({
   ) {
     // TODO -- THIS IS NOT OK BUT I AM NOT FIXING IT NOW
     if (querySrc.indexOf('nest:') >= 0) {
-      if (runtime instanceof Runtime) {
+      if (
+        runtime instanceof SingleConnectionRuntime &&
+        !runtime.supportsNesting
+      ) {
         return {
           pass: true,
           message: () =>


### PR DESCRIPTION
This code was clearly meant to be short-lived, but it also caused _all tests that use nests_ to be skipped, _regardless of whether the connection supports nesting_.