### PR TITLE
Consistently use luxon 2.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17380,10 +17380,11 @@
       }
     },
     "node_modules/luxon": {
-      "version": "1.28.1",
-      "license": "MIT",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-2.5.2.tgz",
+      "integrity": "sha512-Yg7/RDp4nedqmLgyH0LwgGRvMEKVzKbUdkBYyCosbHgJ+kaOUx0qzSiSatVc3DFygnirTPYnMM2P5dg2uH1WvA==",
       "engines": {
-        "node": "*"
+        "node": ">=12"
       }
     },
     "node_modules/lz-string": {
@@ -24401,7 +24402,7 @@
         "assert": "^2.0.0",
         "jest-diff": "^29.6.2",
         "lodash": "^4.17.20",
-        "luxon": "^1.26.0",
+        "luxon": "^2.4.0",
         "uuid": "^8.3.2"
       },
       "devDependencies": {
@@ -24545,13 +24546,6 @@
       "version": "2.4.0",
       "license": "MIT"
     },
-    "packages/malloy-render/node_modules/luxon": {
-      "version": "2.5.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "packages/malloy-syntax-highlight": {
       "name": "@malloydata/syntax-highlight",
       "version": "0.0.99",
@@ -24650,7 +24644,7 @@
         "@malloydata/malloy": "^0.0.99",
         "@malloydata/render": "^0.0.99",
         "jsdom": "^22.1.0",
-        "luxon": "^1.26.4",
+        "luxon": "^2.4.0",
         "madge": "^6.0.0"
       },
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7281,9 +7281,9 @@
       "license": "MIT"
     },
     "node_modules/@types/luxon": {
-      "version": "1.27.1",
-      "dev": true,
-      "license": "MIT"
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-2.4.0.tgz",
+      "integrity": "sha512-oCavjEjRXuR6URJEtQm0eBdfsBiEcGBZbq21of8iGkeKxU1+1xgKuFPClaBZl2KB8ZZBSWlgk61tH6Mf+nvZVw=="
     },
     "node_modules/@types/mdx": {
       "version": "2.0.9",
@@ -24407,7 +24407,7 @@
       },
       "devDependencies": {
         "@types/lodash": "^4.14.165",
-        "@types/luxon": "^1.26.4",
+        "@types/luxon": "^2.4.0",
         "antlr4ts-cli": "^0.5.0-alpha.4"
       },
       "engines": {
@@ -24542,10 +24542,6 @@
         "node": ">=16"
       }
     },
-    "packages/malloy-render/node_modules/@types/luxon": {
-      "version": "2.4.0",
-      "license": "MIT"
-    },
     "packages/malloy-syntax-highlight": {
       "name": "@malloydata/syntax-highlight",
       "version": "0.0.99",
@@ -24649,7 +24645,7 @@
       },
       "devDependencies": {
         "@types/jsdom": "^21.1.1",
-        "@types/luxon": "^1.26.4"
+        "@types/luxon": "^2.4.0"
       }
     },
     "test/node_modules/@jest/environment": {

--- a/packages/malloy/package.json
+++ b/packages/malloy/package.json
@@ -25,7 +25,7 @@
     "assert": "^2.0.0",
     "jest-diff": "^29.6.2",
     "lodash": "^4.17.20",
-    "luxon": "^1.26.0",
+    "luxon": "^2.4.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/packages/malloy/package.json
+++ b/packages/malloy/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@types/lodash": "^4.14.165",
-    "@types/luxon": "^1.26.4",
+    "@types/luxon": "^2.4.0",
     "antlr4ts-cli": "^0.5.0-alpha.4"
   }
 }

--- a/test/package.json
+++ b/test/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "@types/jsdom": "^21.1.1",
-    "@types/luxon": "^1.26.4"
+    "@types/luxon": "^2.4.0"
   },
   "version": "0.0.99"
 }

--- a/test/package.json
+++ b/test/package.json
@@ -24,7 +24,7 @@
     "@malloydata/malloy": "^0.0.99",
     "@malloydata/render": "^0.0.99",
     "jsdom": "^22.1.0",
-    "luxon": "^1.26.4",
+    "luxon": "^2.4.0",
     "madge": "^6.0.0"
   },
   "devDependencies": {

--- a/test/src/databases/all/time.spec.ts
+++ b/test/src/databases/all/time.spec.ts
@@ -585,24 +585,32 @@ describe.each(runtimes.runtimeList)('%s date and time', (dbName, runtime) => {
 */
 
 const zone = 'America/Mexico_City'; // -06:00 no DST
-const zone_2020 = LuxonDateTime.fromObject({
-  year: 2020,
-  month: 2,
-  day: 20,
-  hour: 0,
-  minute: 0,
-  second: 0,
-  zone,
-});
-const utc_2020 = LuxonDateTime.fromObject({
-  year: 2020,
-  month: 2,
-  day: 20,
-  hour: 0,
-  minute: 0,
-  second: 0,
-  zone: 'UTC',
-});
+const zone_2020 = LuxonDateTime.fromObject(
+  {
+    year: 2020,
+    month: 2,
+    day: 20,
+    hour: 0,
+    minute: 0,
+    second: 0,
+  },
+  {
+    zone,
+  }
+);
+const utc_2020 = LuxonDateTime.fromObject(
+  {
+    year: 2020,
+    month: 2,
+    day: 20,
+    hour: 0,
+    minute: 0,
+    second: 0,
+  },
+  {
+    zone: 'UTC',
+  }
+);
 
 describe.each(runtimes.runtimeList)('%s: tz literals', (dbName, runtime) => {
   test(`${dbName} - default timezone is UTC`, async () => {

--- a/test/src/databases/bigquery/time.spec.ts
+++ b/test/src/databases/bigquery/time.spec.ts
@@ -36,15 +36,19 @@ afterAll(async () => {
 describe('time specific tests for standardsql', () => {
   const runtime = runtimes.runtimeMap.get('bigquery');
 
-  const utc_2020 = DateTime.fromObject({
-    year: 2020,
-    month: 2,
-    day: 20,
-    hour: 0,
-    minute: 0,
-    second: 0,
-    zone: 'UTC',
-  });
+  const utc_2020 = DateTime.fromObject(
+    {
+      year: 2020,
+      month: 2,
+      day: 20,
+      hour: 0,
+      minute: 0,
+      second: 0,
+    },
+    {
+      zone: 'UTC',
+    }
+  );
   test('can cast unsupported DATETIME to timestamp', async () => {
     await expect(
       `run: bigquery.sql("SELECT DATETIME '2020-02-20 00:00:00' as t_datetime") -> {

--- a/test/src/databases/duckdb/duckdb.spec.ts
+++ b/test/src/databases/duckdb/duckdb.spec.ts
@@ -100,15 +100,19 @@ describe.each(allDucks.runtimeList)('duckdb:%s', (dbName, runtime) => {
 
   describe('time', () => {
     const zone = 'America/Mexico_City'; // -06:00 no DST
-    const zone_2020 = DateTime.fromObject({
-      year: 2020,
-      month: 2,
-      day: 20,
-      hour: 0,
-      minute: 0,
-      second: 0,
-      zone,
-    });
+    const zone_2020 = DateTime.fromObject(
+      {
+        year: 2020,
+        month: 2,
+        day: 20,
+        hour: 0,
+        minute: 0,
+        second: 0,
+      },
+      {
+        zone,
+      }
+    );
     test('can cast TIMESTAMPTZ to timestamp', async () => {
       await expect(
         `run: duckdb.sql("""

--- a/test/src/databases/postgres/postgres.spec.ts
+++ b/test/src/databases/postgres/postgres.spec.ts
@@ -122,15 +122,19 @@ describe('Postgres tests', () => {
 
   describe('time', () => {
     const zone = 'America/Mexico_City'; // -06:00 no DST
-    const zone_2020 = DateTime.fromObject({
-      year: 2020,
-      month: 2,
-      day: 20,
-      hour: 0,
-      minute: 0,
-      second: 0,
-      zone,
-    });
+    const zone_2020 = DateTime.fromObject(
+      {
+        year: 2020,
+        month: 2,
+        day: 20,
+        hour: 0,
+        minute: 0,
+        second: 0,
+      },
+      {
+        zone,
+      }
+    );
     test('can cast TIMESTAMPTZ to timestamp', async () => {
       await expect(
         `run: postgres.sql("""


### PR DESCRIPTION
We were using luxon 2.4.0 in some places and luxon 1.26 in others, update to 2.4.0 and fix API usage.