### PR TITLE
Add flattened measure lists

### DIFF
--- a/packages/malloy-render/src/html/table.ts
+++ b/packages/malloy-render/src/html/table.ts
@@ -113,8 +113,6 @@ export class HTMLTableRenderer extends ContainerRenderer {
       return this.document.createElement('span');
     }
 
-    this.childRenderers;
-
     if (!table.isArray() && !table.isRecord()) {
       throw new Error('Invalid type for Table Renderer');
     }
@@ -249,9 +247,14 @@ export class HTMLTableRenderer extends ContainerRenderer {
         }
         pivotDepth = Math.max(pivotDepth, dimensions!.length);
       } else if (shouldFlatten) {
-        const exField = field as ExploreField;
-        const flattenedFields = exField.allFields.map(
-          f => new FlattenedColumnField(exField, f, `${exField.name} ${f.name}`)
+        const parentField = field as ExploreField;
+        const flattenedFields = parentField.allFields.map(
+          f =>
+            new FlattenedColumnField(
+              parentField,
+              f,
+              `${parentField.name} ${f.name}`
+            )
         );
         for (const flatField of flattenedFields) {
           cells[rowIndex][columnIndex] = this.createHeaderCell(

--- a/packages/malloy-render/src/html/table.ts
+++ b/packages/malloy-render/src/html/table.ts
@@ -82,14 +82,19 @@ class FlattenedColumnField {
     if (baseRenderer instanceof HTMLTableRenderer) {
       return baseRenderer.childRenderers[this.field.name];
     } else {
-      throw Error('cannot flatten non-tables');
+      throw Error(
+        'Could not render flattened table. `# flatten` only supports nests.'
+      );
     }
   }
 
   getValue(row: DataRecord) {
     const parentRecord = row.cell(this.flattenedField);
     if (parentRecord.isRecord()) return parentRecord.cell(this.field);
-    else throw Error('Cannot find nested record');
+    else
+      throw Error(
+        'Cannot find nested record within flattened field. `# flatten` only supports nests with no group_bys.'
+      );
   }
 }
 

--- a/packages/malloy-render/src/html/table.ts
+++ b/packages/malloy-render/src/html/table.ts
@@ -21,14 +21,20 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import {DataColumn, Field, SortableField} from '@malloydata/malloy';
+import {
+  DataColumn,
+  DataRecord,
+  ExploreField,
+  Field,
+  SortableField,
+} from '@malloydata/malloy';
 import {StyleDefaults} from '../data_styles';
 import {getDrillQuery} from '../drill';
 import {ContainerRenderer} from './container';
 import {HTMLNumberRenderer} from './number';
 import {createDrillIcon, formatTitle, yieldTask} from './utils';
 import {isFieldHidden} from '../tags_utils';
-import {Renderer} from '../renderer';
+import {ChildRenderers, Renderer} from '../renderer';
 
 class PivotedField {
   readonly key: string;
@@ -60,7 +66,35 @@ class PivotedColumnField {
   }
 }
 
-type TableField = Field | PivotedColumnField;
+class FlattenedColumnField {
+  constructor(
+    readonly flattenedField: Field,
+    readonly field: Field,
+    readonly name: string
+  ) {}
+
+  isFlattenedColumnField(): this is FlattenedColumnField {
+    return this instanceof FlattenedColumnField;
+  }
+
+  getChildRenderer(childRenderers: ChildRenderers) {
+    const baseRenderer = childRenderers[this.flattenedField.name];
+    if (baseRenderer instanceof HTMLTableRenderer) {
+      return baseRenderer.childRenderers[this.field.name];
+    } else {
+      throw Error('cannot flatten non-tables');
+    }
+  }
+
+  getValue(row: DataRecord) {
+    const parentRecord = row.cell(this.flattenedField);
+    if (parentRecord.isRecord()) return parentRecord.cell(this.field);
+    else throw Error('Cannot find nested record');
+  }
+}
+
+type TableField = Field | PivotedColumnField | FlattenedColumnField;
+type NonDimension = SortableField & {flattenedField?: FlattenedColumnField};
 
 type SpannableCell = HTMLTableCellElement | undefined;
 
@@ -73,6 +107,8 @@ export class HTMLTableRenderer extends ContainerRenderer {
     if (table.isNull()) {
       return this.document.createElement('span');
     }
+
+    this.childRenderers;
 
     if (!table.isArray() && !table.isRecord()) {
       throw new Error('Invalid type for Table Renderer');
@@ -97,9 +133,14 @@ export class HTMLTableRenderer extends ContainerRenderer {
       }
 
       const childRenderer = this.childRenderers[field.name];
+
       const shouldPivot =
         childRenderer instanceof HTMLTableRenderer &&
         childRenderer.tagged.has('pivot');
+
+      const shouldFlatten =
+        childRenderer instanceof HTMLTableRenderer &&
+        childRenderer.tagged.has('flatten');
 
       if (shouldPivot) {
         const userDefinedDimensions = childRenderer.tagged.textArray(
@@ -108,7 +149,7 @@ export class HTMLTableRenderer extends ContainerRenderer {
         );
 
         let dimensions: SortableField[] | undefined = undefined;
-        let nonDimensions: SortableField[] = [];
+        let nonDimensions: NonDimension[] = [];
         const pivotedFields: Map<string, PivotedField> = new Map();
         for (const row of table) {
           const dc = row.cell(field);
@@ -190,12 +231,35 @@ export class HTMLTableRenderer extends ContainerRenderer {
             );
             cells[rowIndex][columnIndex] = childRenderer.createHeaderCell(
               nonDimension.field,
-              shouldTranspose
+              shouldTranspose,
+              {
+                name: nonDimension.flattenedField?.name,
+                childRenderer: nonDimension.flattenedField?.getChildRenderer(
+                  childRenderer.childRenderers
+                ),
+              }
             );
             columnIndex++;
           }
         }
         pivotDepth = Math.max(pivotDepth, dimensions!.length);
+      } else if (shouldFlatten) {
+        const exField = field as ExploreField;
+        const flattenedFields = exField.allFields.map(
+          f => new FlattenedColumnField(exField, f, `${exField.name} ${f.name}`)
+        );
+        for (const flatField of flattenedFields) {
+          cells[rowIndex][columnIndex] = this.createHeaderCell(
+            flatField.field,
+            shouldTranspose,
+            {
+              name: flatField.name,
+              childRenderer: flatField.getChildRenderer(this.childRenderers),
+            }
+          );
+          columnFields.push(flatField);
+          columnIndex++;
+        }
       } else {
         cells[rowIndex][columnIndex] = this.createHeaderCell(
           field,
@@ -313,6 +377,13 @@ export class HTMLTableRenderer extends ContainerRenderer {
           }
           columnIndex++;
           // back
+        } else if (field instanceof FlattenedColumnField) {
+          cells[rowIndex][columnIndex] = await this.createCellAndRender(
+            field.getChildRenderer(this.childRenderers),
+            field.getValue(row),
+            shouldTranspose
+          );
+          columnIndex++;
         } else {
           if (isFieldHidden(field)) {
             continue;
@@ -391,7 +462,7 @@ export class HTMLTableRenderer extends ContainerRenderer {
     userSpecifiedDimensions?: Array<string>
   ): {
     dimensions: SortableField[];
-    nonDimensions: SortableField[];
+    nonDimensions: NonDimension[];
   } {
     if (!table.isArray() && !table.isRecord()) {
       throw new Error(`Could not pivot ${table.field.name}`);
@@ -417,9 +488,30 @@ export class HTMLTableRenderer extends ContainerRenderer {
       dimensions = table.field.dimensions;
     }
 
-    const nonDimensions = table.field.allFieldsWithOrder.filter(
-      f => dimensions!.indexOf(f) < 0
-    );
+    const nonDimensions: NonDimension[] = [];
+    for (const f of table.field.allFieldsWithOrder) {
+      if (dimensions!.indexOf(f) >= 0) continue;
+
+      if (f.field.isExploreField()) {
+        const {tag} = f.field.tagParse();
+        if (tag.has('flatten')) {
+          const nestedFields = f.field.allFieldsWithOrder.map(nf => ({
+            dir: nf.dir,
+            field: nf.field,
+            flattenedField: new FlattenedColumnField(
+              f.field,
+              nf.field,
+              `${f.field.name} ${nf.field.name}`
+            ),
+          }));
+
+          nonDimensions.push(...nestedFields);
+        }
+      } else {
+        nonDimensions.push(f);
+      }
+    }
+
     if (nonDimensions.length === 0) {
       throw new Error(
         `Can not pivot ${table.field.name} since all of its fields are dimensions.`
@@ -448,6 +540,7 @@ export class HTMLTableRenderer extends ContainerRenderer {
       table,
       userSpecifiedDimensions
     );
+
     for (const row of table) {
       const pf = new PivotedField(
         table.field as Field,
@@ -455,17 +548,23 @@ export class HTMLTableRenderer extends ContainerRenderer {
         nonDimensions.length
       );
       const renderedCells: Map<string, HTMLTableCellElement> = new Map();
-      for (const nonDimension of table.field.allFieldsWithOrder.filter(
-        f => dimensions.indexOf(f) < 0
-      )) {
-        const childRenderer = this.childRenderers[nonDimension.field.name];
+      for (const nonDimension of nonDimensions) {
+        let childRenderer;
+        let value;
+        if (nonDimension.flattenedField) {
+          childRenderer = nonDimension.flattenedField.getChildRenderer(
+            this.childRenderers
+          );
+
+          value = nonDimension.flattenedField.getValue(row);
+        } else {
+          childRenderer = this.childRenderers[nonDimension.field.name];
+          value = row.cell(nonDimension.field.name);
+        }
+
         renderedCells.set(
           nonDimension.field.name,
-          await this.createCellAndRender(
-            childRenderer,
-            row.cell(nonDimension.field.name),
-            shouldTranspose
-          )
+          await this.createCellAndRender(childRenderer, value, shouldTranspose)
         );
       }
 
@@ -513,17 +612,24 @@ export class HTMLTableRenderer extends ContainerRenderer {
 
   createHeaderCell(
     field: Field,
-    shouldTranspose: boolean
+    shouldTranspose: boolean,
+    override: {
+      name?: string;
+      childRenderer?: Renderer;
+    } = {}
   ): HTMLTableCellElement {
-    let name = formatTitle(
-      this.options,
-      field,
-      this.options.dataStyles[field.name],
-      field.parentExplore.queryTimezone
-    );
+    let name =
+      override.name ??
+      formatTitle(
+        this.options,
+        field,
+        this.options.dataStyles[field.name],
+        field.parentExplore.queryTimezone
+      );
 
-    const isNumeric =
-      this.childRenderers[field.name] instanceof HTMLNumberRenderer;
+    const childRenderer =
+      override.childRenderer ?? this.childRenderers[field.name];
+    const isNumeric = childRenderer instanceof HTMLNumberRenderer;
     const headerCell = this.document.createElement('th');
     headerCell.style.cssText = `
       padding: 8px;

--- a/packages/malloy-render/src/html/table.ts
+++ b/packages/malloy-render/src/html/table.ts
@@ -491,22 +491,19 @@ export class HTMLTableRenderer extends ContainerRenderer {
     const nonDimensions: NonDimension[] = [];
     for (const f of table.field.allFieldsWithOrder) {
       if (dimensions!.indexOf(f) >= 0) continue;
+      const {tag} = f.field.tagParse();
+      if (f.field.isExploreField() && tag.has('flatten')) {
+        const nestedFields = f.field.allFieldsWithOrder.map(nf => ({
+          dir: nf.dir,
+          field: nf.field,
+          flattenedField: new FlattenedColumnField(
+            f.field,
+            nf.field,
+            `${f.field.name} ${nf.field.name}`
+          ),
+        }));
 
-      if (f.field.isExploreField()) {
-        const {tag} = f.field.tagParse();
-        if (tag.has('flatten')) {
-          const nestedFields = f.field.allFieldsWithOrder.map(nf => ({
-            dir: nf.dir,
-            field: nf.field,
-            flattenedField: new FlattenedColumnField(
-              f.field,
-              nf.field,
-              `${f.field.name} ${nf.field.name}`
-            ),
-          }));
-
-          nonDimensions.push(...nestedFields);
-        }
+        nonDimensions.push(...nestedFields);
       } else {
         nonDimensions.push(f);
       }
@@ -555,7 +552,6 @@ export class HTMLTableRenderer extends ContainerRenderer {
           childRenderer = nonDimension.flattenedField.getChildRenderer(
             this.childRenderers
           );
-
           value = nonDimension.flattenedField.getValue(row);
         } else {
           childRenderer = this.childRenderers[nonDimension.field.name];

--- a/packages/malloy-render/src/stories/basic.stories.ts
+++ b/packages/malloy-render/src/stories/basic.stories.ts
@@ -22,3 +22,10 @@ export const ProductsBar = {
     view: 'category_bar',
   },
 };
+
+export const FlattenNestedMeasures = {
+  args: {
+    source: 'products',
+    view: 'flatten',
+  },
+};

--- a/packages/malloy-render/src/stories/static/basic.malloy
+++ b/packages/malloy-render/src/stories/static/basic.malloy
@@ -30,14 +30,14 @@ source: products is duckdb.table("data/products.parquet") extend {
         group_by: distribution_center_id
         aggregate: avg_retail is retail_price.avg()
         nest:
-          # flattenx
+          # flatten
           mens is {
             aggregate:
               avg_price is retail_price.avg()
               total_cost is cost.sum()
             where: department="Men"
           }
-          # flattenx
+          # flatten
           womens is {
             aggregate:
               avg_price is retail_price.avg()

--- a/packages/malloy-render/src/stories/static/basic.malloy
+++ b/packages/malloy-render/src/stories/static/basic.malloy
@@ -40,8 +40,8 @@ source: products is duckdb.table("data/products.parquet") extend {
           # flatten
           womens is {
             aggregate:
-              avg_price is retail_price.avg()
-              total_cost is cost.sum()
+              avg_price1 is retail_price.avg()
+              total_cost1 is cost.sum()
             where: department="Women"
           }
         where: distribution_center_id=1 or distribution_center_id=2

--- a/packages/malloy-render/src/stories/static/basic.malloy
+++ b/packages/malloy-render/src/stories/static/basic.malloy
@@ -5,4 +5,46 @@ source: products is duckdb.table("data/products.parquet") extend {
     group_by: category
     aggregate: avg_retail is retail_price.avg()
   }
+
+  view: flatten is {
+    group_by: category
+    aggregate: avg_retail is retail_price.avg()
+    nest:
+      # flatten
+      mens is {
+        aggregate:
+          avg_price is retail_price.avg()
+          total_cost is cost.sum()
+        where: department="Men"
+      }
+      # flatten
+      womens is {
+        aggregate:
+          avg_price is retail_price.avg()
+          total_cost is cost.sum()
+        where: department="Women"
+      }
+
+      # pivot
+      test is {
+        group_by: distribution_center_id
+        aggregate: avg_retail is retail_price.avg()
+        nest:
+          # flattenx
+          mens is {
+            aggregate:
+              avg_price is retail_price.avg()
+              total_cost is cost.sum()
+            where: department="Men"
+          }
+          # flattenx
+          womens is {
+            aggregate:
+              avg_price is retail_price.avg()
+              total_cost is cost.sum()
+            where: department="Women"
+          }
+        where: distribution_center_id=1 or distribution_center_id=2
+      }
+  }
 };

--- a/test/src/render/__snapshots__/render.spec.ts.snap
+++ b/test/src/render/__snapshots__/render.spec.ts.snap
@@ -10620,6 +10620,163 @@ exports[`rendering results html renderer complex query with tags transposed tabl
 </table>
 `;
 
+exports[`rendering results html renderer flattened nests render correctly 1`] = `
+<table
+  style="vertical-align: top; border-collapse: collapse; width: 100%;"
+>
+  <thead>
+    <tr>
+      <th
+        style="padding: 8px; text-align: left;"
+      >
+        nm
+      </th>
+      <th
+        style="padding: 8px; text-align: right;"
+      >
+        avg_​height
+      </th>
+      <th
+        style="padding: 8px; text-align: right;"
+      >
+        monday avg_​height
+      </th>
+      <th
+        style="padding: 8px; text-align: right;"
+      >
+        thursday avg_​height
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td
+        style="padding: 8px; vertical-align: top;"
+      >
+        <span>
+          Sebastian
+        </span>
+      </td>
+      <td
+        style="padding: 8px; vertical-align: top; text-align: right;"
+      >
+        <span>
+          33.25
+        </span>
+      </td>
+      <td
+        style="padding: 8px; vertical-align: top; text-align: right;"
+      >
+        <span>
+          41
+        </span>
+      </td>
+      <td
+        style="padding: 8px; vertical-align: top; text-align: right;"
+      >
+        <span>
+          25.5
+        </span>
+      </td>
+    </tr>
+    <tr>
+      <td
+        style="padding: 8px; vertical-align: top;"
+      >
+        <span>
+          Miguel
+        </span>
+      </td>
+      <td
+        style="padding: 8px; vertical-align: top; text-align: right;"
+      >
+        <span>
+          33.25
+        </span>
+      </td>
+      <td
+        style="padding: 8px; vertical-align: top; text-align: right;"
+      >
+        <span>
+          25.5
+        </span>
+      </td>
+      <td
+        style="padding: 8px; vertical-align: top; text-align: right;"
+      >
+        <span
+          class="value-null"
+        >
+          ∅
+        </span>
+      </td>
+    </tr>
+    <tr>
+      <td
+        style="padding: 8px; vertical-align: top;"
+      >
+        <span>
+          Alex
+        </span>
+      </td>
+      <td
+        style="padding: 8px; vertical-align: top; text-align: right;"
+      >
+        <span>
+          33.25
+        </span>
+      </td>
+      <td
+        style="padding: 8px; vertical-align: top; text-align: right;"
+      >
+        <span>
+          47
+        </span>
+      </td>
+      <td
+        style="padding: 8px; vertical-align: top; text-align: right;"
+      >
+        <span>
+          31.5
+        </span>
+      </td>
+    </tr>
+    <tr>
+      <td
+        style="padding: 8px; vertical-align: top;"
+      >
+        <span>
+          Pedro
+        </span>
+      </td>
+      <td
+        style="padding: 8px; vertical-align: top; text-align: right;"
+      >
+        <span>
+          32
+        </span>
+      </td>
+      <td
+        style="padding: 8px; vertical-align: top; text-align: right;"
+      >
+        <span>
+          20
+        </span>
+      </td>
+      <td
+        style="padding: 8px; vertical-align: top; text-align: right;"
+      >
+        <span
+          class="value-null"
+        >
+          ∅
+        </span>
+      </td>
+    </tr>
+  </tbody>
+</table>
+`;
+
 exports[`rendering results html renderer hidden tags rendered correctly dashboard 1`] = `
 <div>
   <div

--- a/test/src/render/render.spec.ts
+++ b/test/src/render/render.spec.ts
@@ -410,6 +410,57 @@ describe('rendering results', () => {
 
       expect(html).toMatchSnapshot();
     });
+
+    test('flattened nests render correctly', async () => {
+      const src = `
+          source: height
+          is duckdb.sql("""SELECT 'Pedro' as nm, 'Monday' as dayito, 1 as loc, 2 as lac, 1 as monthy, 20 as height, 3 as wt, 50 apptcost, 1 as vaccine, 'A' as btype
+          UNION ALL SELECT 'Pedro', 'Tuesday', 1, 2, 2, 25, 3.4, 100, 1, 'B'
+          UNION ALL SELECT 'Pedro', 'Tuesday', 1, 2, 3, 38, 3.6, 200, 0, 'A'
+          UNION ALL SELECT 'Pedro', 'Wednesday', 1, 2, 4, 45, 3.7, 300, 1, 'O'
+          UNION ALL SELECT 'Sebastian', 'Thursday', 1, 2, 1, 23, 2, 400, 1, 'C'
+          UNION ALL SELECT 'Sebastian', 'Thursday', 1, 2, 2, 28, 2.6, 500, 1, 'A'
+          UNION ALL SELECT 'Sebastian', 'Monday', 1, 2, 3, 35, 3.6, 650, 0, 'A'
+          UNION ALL SELECT 'Sebastian', 'Monday', 1, 2, 4, 47, 4.2, 70, 1, 'B'
+          UNION ALL SELECT 'Alex', 'Tuesday', 1, 2, 1, 23, 2.5, 85, 0, 'X'
+          UNION ALL SELECT 'Alex', 'Thursday', 1, 2, 2, 28, 3, 42, 1, 'P'
+          UNION ALL SELECT 'Alex', 'Thursday', 1, 2,  3, 35, 3.2, 63, 1, 'A'
+          UNION ALL SELECT 'Alex', 'Monday', 1, 2, 4, 47, 3.4, 81, 1, 'D'
+          UNION ALL SELECT 'Miguel', 'Monday', 1, 2, 1, 23, 4, 34, 0, 'E'
+          UNION ALL SELECT 'Miguel', 'Monday', 1, 2, 2, 28, 4.1, 64, 1, 'R'
+          UNION ALL SELECT 'Miguel', 'Wednesday', 1, 2, 3, 35, 4.2, 31, 1, 'E'
+          UNION ALL SELECT 'Miguel', 'Wednesday', 1, 2, 4, 47, 4.3, 76, 0, 'F' """) extend {
+
+
+            view: flatten is {
+              group_by: nm
+              aggregate: avg_height is height.avg()
+              nest:
+                # flatten
+                monday is {
+                  aggregate: avg_height is height.avg()
+                  where: dayito='Monday'
+                },
+                # flatten
+                thursday is {
+                  aggregate: avg_height is height.avg()
+                  where: dayito='Thursday'
+                }
+            }
+          }
+
+          query: flatten is height -> flatten
+      `;
+      const result = await (
+        await duckdb.loadModel(src).loadQueryByName('flatten')
+      ).run();
+      const document = new JSDOM().window.document;
+      const html = await new HTMLView(document).render(result, {
+        dataStyles: {},
+      });
+
+      expect(html).toMatchSnapshot();
+    });
   });
 
   describe('date renderer', () => {


### PR DESCRIPTION
## Feature

When rendering a nested query with no group_bys, you can get an ugly looking table with unnecessarily embedded headers:
```malloy
{
    group_by: category
    aggregate: avg_retail is retail_price.avg()
    nest:
      mens is {
        aggregate:
          avg_price is retail_price.avg()
          total_cost is cost.sum()
        where: department="Men"
      }
      womens is {
        aggregate:
          avg_price is retail_price.avg()
          total_cost is cost.sum()
        where: department="Women"
      }
 }
```
<img width="635" alt="CleanShot 2023-11-02 at 12 19 50@2x" src="https://github.com/malloydata/malloy/assets/5554373/3f6506a7-d546-4703-8915-3b779044fd04">

Using a `# flatten` tag, a nested query with no group_bys will automatically pull the column names of the nested measures up a level like so:
```malloy
{
  group_by: category
  aggregate: avg_retail is retail_price.avg()
  nest:
    # flatten
    mens is {
      aggregate:
        avg_price is retail_price.avg()
        total_cost is cost.sum()
      where: department="Men"
    }
    # flatten
    womens is {
      aggregate:
        avg_price is retail_price.avg()
        total_cost is cost.sum()
      where: department="Women"
    }
 }
```
<img width="765" alt="CleanShot 2023-11-02 at 12 20 58@2x" src="https://github.com/malloydata/malloy/assets/5554373/baa1d96b-2d45-479f-9e6c-b3e090b15285">

This has limited support within pivoting; it will work within a pivot as long as none of the flattened measure names are repeated:
```malloy
# pivot
test is {
  group_by: distribution_center_id
  aggregate: avg_retail is retail_price.avg()
  nest:
    # flatten
    mens is {
      aggregate:
        avg_price is retail_price.avg()
        total_cost is cost.sum()
      where: department="Men"
    }
    # flatten
    womens is {
      aggregate:
        avg_price1 is retail_price.avg()
        total_cost1 is cost.sum()
      where: department="Women"
    }
  where: distribution_center_id=1 or distribution_center_id=2
}
```
<img width="1265" alt="CleanShot 2023-11-02 at 12 22 20@2x" src="https://github.com/malloydata/malloy/assets/5554373/632f3883-b65e-4583-acbc-2d75e2c185ae">


However, there is a bug where if you try to flatten multiple queries with the same measure names within a pivot, it will not render properly. We will fix this bug later.

## Implementation notes
This isn't the cleanest implementation, but we are going to refactor this code soon so I did not spend much time here perfecting the architecture. We need this feature ASAP for demos.