### PR TITLE
Use node resolution to allow hoisting in submodules

### DIFF
--- a/packages/malloy-syntax-highlight/tsconfig.json
+++ b/packages/malloy-syntax-highlight/tsconfig.json
@@ -3,16 +3,10 @@
     "outDir": "dist",
     "skipLibCheck": true,
     "downlevelIteration": true,
+    "moduleResolution": "node",
     "noPropertyAccessFromIndexSignature": false,
     "lib": ["ES2021.String", "dom"],
     "target": "es6",
-    "paths": {
-      "monaco-editor": [
-        "../../node_modules/monaco-editor/esm/vs/editor/editor.api"
-      ],
-      "vscode-textmate": ["../../node_modules/vscode-textmate/release/main"],
-      "vscode-oniguruma": ["../../node_modules/vscode-oniguruma/main"]
-    },
     "types": ["node", "jasmine"]
   },
   "include": [


### PR DESCRIPTION
When installed as a submodule, these packages are hoisted so they are not predictably in malloy's node_modules directory.