### PR TITLE
WN-0006 Scalar Lenses Part II

### DIFF
--- a/packages/malloy/src/lang/ast/elements/pipeline-desc.ts
+++ b/packages/malloy/src/lang/ast/elements/pipeline-desc.ts
@@ -28,7 +28,6 @@ import {
   Pipeline,
   StructDef,
   isAtomicField,
-  isAtomicFieldType,
   isTurtleDef,
 } from '../../../model/malloy_types';
 
@@ -148,7 +147,7 @@ export abstract class PipelineDesc extends MalloyElement {
             annotation,
           };
         } else {
-          this.log(`'${turtleName}' is not a query`);
+          this.log(`'${turtleName.refString}' is not a query`);
         }
       } else if (turtleName.list.length > 1) {
         this.log('Cannot use view from join');

--- a/packages/malloy/src/lang/ast/elements/source-query-nodes.ts
+++ b/packages/malloy/src/lang/ast/elements/source-query-nodes.ts
@@ -248,7 +248,7 @@ export class SQAppendView extends SourceQueryNode {
       const refinements = views.slice(1);
 
       if (head instanceof ViewFieldReference) {
-        theQuery.turtleName = head.list[0];
+        theQuery.turtleName = head;
       } else if (head instanceof QOPDesc) {
         theQuery.addSegments(head);
       }

--- a/packages/malloy/src/lang/ast/query-elements/full-query.ts
+++ b/packages/malloy/src/lang/ast/query-elements/full-query.ts
@@ -79,9 +79,8 @@ export class FullQuery extends TurtleHeadedPipe {
     if (this.turtleName) {
       const lookFor = this.turtleName.getField(pipeFS);
       if (lookFor.error) this.log(lookFor.error);
-      const name = this.turtleName.refString;
       const {pipeline, location, annotation, needsExpansionDueToScalar} =
-        this.expandTurtle(name, structDef);
+        this.expandTurtle(this.turtleName, structDef);
       destQuery.location = location;
       let walkPipe = pipeline;
       if (
@@ -101,7 +100,7 @@ export class FullQuery extends TurtleHeadedPipe {
         // fields as pipe heads.
         destQuery.pipeline = pipeline;
       } else {
-        destQuery.pipeHead = {name};
+        destQuery.pipeHead = {name: this.turtleName.refString};
       }
       if (annotation) {
         destQuery.annotation = annotation;

--- a/packages/malloy/src/lang/ast/query-properties/nest.ts
+++ b/packages/malloy/src/lang/ast/query-properties/nest.ts
@@ -80,6 +80,9 @@ abstract class TurtleDeclRoot
         this.log(headEnt.error);
         reportWrongType = false;
       } else if (headEnt.found instanceof QueryField) {
+        if (this.turtleName.list.length > 1) {
+          this.turtleName.log('Cannot use view from join');
+        }
         const headDef = headEnt.found.getQueryFieldDef(fs);
         if (isTurtle(headDef)) {
           const newPipe = this.refinePipeline(fs, headDef);

--- a/packages/malloy/src/lang/ast/query-properties/nest.ts
+++ b/packages/malloy/src/lang/ast/query-properties/nest.ts
@@ -331,7 +331,7 @@ export class NestReference
         this.log('Cannot nest view from join');
         return;
       }
-      super.makeEntry(fs);
+      return super.makeEntry(fs);
     }
     throw this.internalError('Unexpected namespace for nest');
   }

--- a/packages/malloy/src/lang/ast/query-properties/refinements.ts
+++ b/packages/malloy/src/lang/ast/query-properties/refinements.ts
@@ -64,6 +64,10 @@ export class NamedRefinement extends Refinement {
           );
           return;
         }
+        if (this.name.list.length > 1) {
+          this.log('Cannot use view from join as refinement');
+          return;
+        }
         return fieldDef.pipeline[0];
       }
       if (fieldDef?.type !== 'struct') {

--- a/packages/malloy/src/lang/grammar/MalloyParser.g4
+++ b/packages/malloy/src/lang/grammar/MalloyParser.g4
@@ -145,7 +145,7 @@ pipelineFromName
 
 firstSegment
   : ARROW? queryProperties queryRefinement*
-  | exploreQueryName queryRefinement*
+  | fieldPath queryRefinement*
   ;
 
 pipeElement
@@ -169,7 +169,6 @@ filterShortcut
   : OCURLY QMARK fieldExpr CCURLY
   ;
 
-exploreQueryName : id;
 queryName : id;
 
 sourcePropertyList
@@ -273,12 +272,12 @@ sqExpr
   ;
 
 leadSeg
-  : id queryRefinement*
+  : fieldPath queryRefinement*
   | queryProperties
   ;
 
 qSeg
-  : id
+  : fieldPath
   | queryProperties
   ;
 
@@ -387,7 +386,7 @@ nestedQueryList
   ;
 
 nestEntry
-  : tags queryName queryRefinement*   # nestExisting
+  : tags fieldPath queryRefinement*   # nestExisting
   | tags queryName isDefine pipelineFromName            # nestDef
   ;
 

--- a/packages/malloy/src/lang/grammar/MalloyParser.g4
+++ b/packages/malloy/src/lang/grammar/MalloyParser.g4
@@ -128,7 +128,7 @@ turtleName
 
 queryRefinement
   : (REFINE | refineOperator)? queryProperties
-  | refineOperator turtleName
+  | refineOperator fieldPath
   ;
 
 sourceExtension

--- a/packages/malloy/src/lang/malloy-to-ast.ts
+++ b/packages/malloy/src/lang/malloy-to-ast.ts
@@ -386,11 +386,11 @@ export class MalloyToAST
       }
       return properties;
     }
-    const turtleNameCx = pcx.turtleName();
-    if (turtleNameCx) {
+    const fieldPathCx = pcx.fieldPath();
+    if (fieldPathCx) {
       return this.astAt(
-        new ast.ViewFieldReference([this.getFieldName(turtleNameCx)]),
-        turtleNameCx
+        this.getFieldPath(fieldPathCx, ast.ViewFieldReference),
+        fieldPathCx
       );
     }
     throw this.internalError(

--- a/packages/malloy/src/lang/parse-tree-walkers/document-symbol-walker.ts
+++ b/packages/malloy/src/lang/parse-tree-walkers/document-symbol-walker.ts
@@ -154,7 +154,10 @@ class DocumentSymbolWalker implements MalloyParserListener {
   handleNestEntry(pcx: parser.NestExistingContext | parser.NestDefContext) {
     const symbol = {
       range: this.translator.rangeFromContext(pcx),
-      name: pcx.queryName().id().text,
+      name:
+        pcx instanceof parser.NestExistingContext
+          ? pcx.fieldPath().text
+          : pcx.queryName().id().text,
       type: 'query',
       children: [],
     };

--- a/packages/malloy/src/lang/test/lenses.spec.ts
+++ b/packages/malloy/src/lang/test/lenses.spec.ts
@@ -172,6 +172,28 @@ describe('lenses', () => {
       `
     ).toTranslate();
   });
+  test('can reference join field in refinement when experiment is enabled', () => {
+    expect(
+      markSource`
+        ##! experimental { scalar_lenses }
+        source: x is a extend {
+          join_cross: y is a extend { dimension: n is 1 } on true
+        }
+        run: x -> ai + y.n
+      `
+    ).toTranslate();
+  });
+  test('can reference join field in nest refinement when experiment is enabled', () => {
+    expect(
+      markSource`
+        ##! experimental { scalar_lenses }
+        source: x is a extend {
+          join_cross: y is a extend { dimension: n is 1 } on true
+        }
+        run: x -> { nest: ai + y.n }
+      `
+    ).toTranslate();
+  });
   test('can nest dimension when experiment is enabled', () => {
     expect(
       markSource`
@@ -197,7 +219,7 @@ describe('lenses', () => {
       'named refinement `y` must be a view, found a struct'
     );
   });
-  test('cannot use view from join', () => {
+  test('cannot use view from join as whole pipeline', () => {
     expect(
       markSource`
         ##! experimental { scalar_lenses }
@@ -210,7 +232,7 @@ describe('lenses', () => {
       `
     ).translationToFailWith('Cannot use view from join');
   });
-  test('cannot use view from join', () => {
+  test('cannot use view from join in nest', () => {
     expect(
       markSource`
         ##! experimental { scalar_lenses }
@@ -223,7 +245,7 @@ describe('lenses', () => {
       `
     ).translationToFailWith('Cannot nest view from join');
   });
-  test('cannot use view from join', () => {
+  test('cannot use view from join as nest view head', () => {
     expect(
       markSource`
         ##! experimental { scalar_lenses }
@@ -235,6 +257,32 @@ describe('lenses', () => {
         run: x -> { nest: y.z + { limit: 1 } }
       `
     ).translationToFailWith('Cannot use view from join');
+  });
+  test('cannot use view from join as lens in query', () => {
+    expect(
+      markSource`
+        ##! experimental { scalar_lenses }
+        source: x is a extend {
+          join_one: y is a extend {
+            view: z is { group_by: d is 1 }
+          } on true
+        }
+        run: x -> ai + y.z
+      `
+    ).translationToFailWith('Cannot use view from join as refinement');
+  });
+  test('cannot use view from join as lens in nest', () => {
+    expect(
+      markSource`
+        ##! experimental { scalar_lenses }
+        source: x is a extend {
+          join_one: y is a extend {
+            view: z is { group_by: d is 1 }
+          } on true
+        }
+        run: x -> { nest: ai + y.z }
+      `
+    ).translationToFailWith('Cannot use view from join as refinement');
   });
   test('can nest dimension with refinement when experiment is enabled', () => {
     expect(

--- a/packages/malloy/src/model/malloy_types.ts
+++ b/packages/malloy/src/model/malloy_types.ts
@@ -1175,6 +1175,10 @@ export function isTurtleDef(def: FieldDef): def is TurtleDef {
   return def.type === 'turtle';
 }
 
+export function isAtomicField(def: FieldDef): def is FieldAtomicDef {
+  return isAtomicFieldType(def.type);
+}
+
 export interface SearchResultRow {
   field_name: string; // eslint-disable-line camelcase
   field_value: string; // eslint-disable-line camelcase

--- a/test/src/databases/all/lenses.spec.ts
+++ b/test/src/databases/all/lenses.spec.ts
@@ -204,7 +204,7 @@ runtimes.runtimeMap.forEach((runtime, databaseName) => {
       }
     `).malloyResultMatches(runtime, {'n.n': 1, 'n.c': 1});
   });
-  it.skip(`nest dimension only - ${databaseName}`, async () => {
+  it(`nest dimension only - ${databaseName}`, async () => {
     await expect(`
       ##! experimental { scalar_lenses }
       source: x is ${databaseName}.sql("SELECT 1 AS n") extend {
@@ -213,7 +213,29 @@ runtimes.runtimeMap.forEach((runtime, databaseName) => {
       run: x -> {
         nest: n
       }
-    `).malloyResultMatches(runtime, {n: [{n: 1}]});
+    `).malloyResultMatches(runtime, {'n.n': 1});
+  });
+  it(`nest measure only in second stage - ${databaseName}`, async () => {
+    await expect(`
+      ##! experimental { scalar_lenses }
+      source: x is ${databaseName}.sql("SELECT 1 AS n") extend {
+        view: m is { aggregate: c is count() }
+      }
+      run: x -> m -> {
+        nest: c
+      }
+    `).malloyResultMatches(runtime, {m: [{c: 1}]});
+  });
+  it(`nest dimension only in refinement - ${databaseName}`, async () => {
+    await expect(`
+      ##! experimental { scalar_lenses }
+      source: x is ${databaseName}.sql("SELECT 1 AS n") extend {
+        view: m is { aggregate: c is count() }
+      }
+      run: x -> m + {
+        nest: n
+      }
+    `).malloyResultMatches(runtime, {m: [{n: 1}]});
   });
   it(`view dimension only - ${databaseName}`, async () => {
     await expect(`

--- a/test/src/databases/all/lenses.spec.ts
+++ b/test/src/databases/all/lenses.spec.ts
@@ -119,7 +119,7 @@ runtimes.runtimeMap.forEach((runtime, databaseName) => {
       run: x -> { group_by: n } + c
     `).malloyResultMatches(runtime, {n: 1, c: 1});
   });
-  it(`dimension plus literal view - ${databaseName}`, async () => {
+  it(`measure plus literal view - ${databaseName}`, async () => {
     await expect(`
       ##! experimental { scalar_lenses }
       source: x is ${databaseName}.sql("SELECT 1 AS n") extend {
@@ -215,7 +215,61 @@ runtimes.runtimeMap.forEach((runtime, databaseName) => {
       }
     `).malloyResultMatches(runtime, {'n.n': 1});
   });
-  it(`nest measure only in second stage - ${databaseName}`, async () => {
+  it(`joined dimension in middle of refinements - ${databaseName}`, async () => {
+    await expect(`
+      ##! experimental { scalar_lenses }
+      source: x is ${databaseName}.sql("SELECT 1 AS n") extend {
+        join_one: y is ${databaseName}.sql("SELECT 2 AS n") on true
+        view: m is { aggregate: c is count() }
+      }
+      run: x -> m + y.n + { limit: 1 }
+    `).malloyResultMatches(runtime, {'n': 2, 'c': 1});
+  });
+  it(`nest joined dimension refined - ${databaseName}`, async () => {
+    await expect(`
+      ##! experimental { scalar_lenses }
+      source: x is ${databaseName}.sql("SELECT 1 AS n") extend {
+        join_one: y is ${databaseName}.sql("SELECT 1 AS n") on true
+        view: m is { aggregate: c is count() }
+      }
+      run: x -> {
+        nest: y.n + { limit: 1 }
+      }
+    `).malloyResultMatches(runtime, {'n.n': 1});
+  });
+  it(`joined dimension refined - ${databaseName}`, async () => {
+    await expect(`
+      ##! experimental { scalar_lenses }
+      source: x is ${databaseName}.sql("SELECT 1 AS n") extend {
+        join_one: y is ${databaseName}.sql("SELECT 2 AS n") on true
+        view: m is { aggregate: c is count() }
+      }
+      run: x -> y.n + { limit: 1 }
+    `).malloyResultMatches(runtime, {'n': 2});
+  });
+  it(`nest joined dimension bare - ${databaseName}`, async () => {
+    await expect(`
+      ##! experimental { scalar_lenses }
+      source: x is ${databaseName}.sql("SELECT 1 AS n") extend {
+        join_one: y is ${databaseName}.sql("SELECT 2 AS n") on true
+        view: m is { aggregate: c is count() }
+      }
+      run: x -> {
+        nest: y.n
+      }
+    `).malloyResultMatches(runtime, {'n.n': 2});
+  });
+  it(`joined dimension bare - ${databaseName}`, async () => {
+    await expect(`
+      ##! experimental { scalar_lenses }
+      source: x is ${databaseName}.sql("SELECT 1 AS n") extend {
+        join_one: y is ${databaseName}.sql("SELECT 2 AS n") on true
+        view: m is { aggregate: c is count() }
+      }
+      run: x -> y.n
+    `).malloyResultMatches(runtime, {'n': 2});
+  });
+  it.skip(`nest measure only in second stage - ${databaseName}`, async () => {
     await expect(`
       ##! experimental { scalar_lenses }
       source: x is ${databaseName}.sql("SELECT 1 AS n") extend {
@@ -224,7 +278,7 @@ runtimes.runtimeMap.forEach((runtime, databaseName) => {
       run: x -> m -> {
         nest: c
       }
-    `).malloyResultMatches(runtime, {m: [{c: 1}]});
+    `).malloyResultMatches(runtime, {'m.c': 1});
   });
   it(`nest dimension only in refinement - ${databaseName}`, async () => {
     await expect(`
@@ -235,7 +289,7 @@ runtimes.runtimeMap.forEach((runtime, databaseName) => {
       run: x -> m + {
         nest: n
       }
-    `).malloyResultMatches(runtime, {m: [{n: 1}]});
+    `).malloyResultMatches(runtime, {'n.n': 1, 'c': 1});
   });
   it(`view dimension only - ${databaseName}`, async () => {
     await expect(`
@@ -245,6 +299,16 @@ runtimes.runtimeMap.forEach((runtime, databaseName) => {
       }
       run: x -> m
     `).malloyResultMatches(runtime, {n: 1});
+  });
+  it(`view join dimension only - ${databaseName}`, async () => {
+    await expect(`
+      ##! experimental { scalar_lenses }
+      source: x is ${databaseName}.sql("SELECT 1 AS n") extend {
+        join_one: y is ${databaseName}.sql("SELECT 2 AS n") on true
+        view: m is y.n
+      }
+      run: x -> m
+    `).malloyResultMatches(runtime, {n: 2});
   });
   it(`run dimension only - ${databaseName}`, async () => {
     await expect(`

--- a/test/src/databases/all/lenses.spec.ts
+++ b/test/src/databases/all/lenses.spec.ts
@@ -269,6 +269,16 @@ runtimes.runtimeMap.forEach((runtime, databaseName) => {
       run: x -> y.n
     `).malloyResultMatches(runtime, {'n': 2});
   });
+  it(`joined dimension nest refinement - ${databaseName}`, async () => {
+    await expect(`
+      ##! experimental { scalar_lenses }
+      source: x is ${databaseName}.sql("SELECT 1 AS n") extend {
+        join_one: y is ${databaseName}.sql("SELECT 2 AS n") on true
+        view: m is { aggregate: c is count() }
+      }
+      run: x -> { nest: m + y.n }
+    `).malloyResultMatches(runtime, {'m.c': 1, 'm.n': 2});
+  });
   it.skip(`nest measure only in second stage - ${databaseName}`, async () => {
     await expect(`
       ##! experimental { scalar_lenses }


### PR DESCRIPTION
Updates to the scalar lenses experiment feature —

* `nest: name_of_dimension` is equivalent to `nest: { group_by: name_of_dimension }`
* Using `join_name.field_name` is allowed in view refinement chains