### PR TITLE
feat: renderer next setup

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -28,8 +28,18 @@ module.exports = {
   setupFilesAfterEnv: ['jest-expect-message'],
   testMatch: ['**/?(*.)spec.(ts|js)?(x)'],
   testPathIgnorePatterns: ['/node_modules/', '/dist/', '/out/'],
+  transformIgnorePatterns: [
+    'node_modules/(?!(lit-html|lit-element|lit|@lit|@lit-labs)/)',
+  ],
   transform: {
     '^.+\\.(ts|tsx)$': ['ts-jest', {tsconfig: '<rootDir>/tsconfig.json'}],
+    '^.+\\.(js|jsx)$': [
+      'babel-jest',
+      {
+        'presets': ['@babel/preset-env'],
+        'plugins': [['@babel/transform-runtime']],
+      },
+    ],
   },
   testTimeout: 100000,
   verbose: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -3959,6 +3959,19 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.1.2.tgz",
+      "integrity": "sha512-jnOD+/+dSrfTWYfSXBXlo5l5f0q1UuJo3tkbMDCYA2lKUYq79jaxqtGEvnRoh049nt1vdo1+45RinipU6FGY2g=="
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.0.1.tgz",
+      "integrity": "sha512-eu50SQXHRthFwWJMp0oAFg95Rvm6MTPjxSXWuvAu7It90WVFLFpNBoIno7XOXSDvVgTrtKnUV4OLJqys2Svn4g==",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.1.2"
+      }
+    },
     "node_modules/@malloydata/db-bigquery": {
       "resolved": "packages/malloy-db-bigquery",
       "link": true
@@ -7732,6 +7745,11 @@
       "version": "4.0.2",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.5.tgz",
+      "integrity": "sha512-I3pkr8j/6tmQtKV/ZzHtuaqYSQvyjGRKH4go60Rr0IDLlFxuRT5V32uvB1mecM5G1EVAUyF/4r4QZ1GHgz+mxA=="
     },
     "node_modules/@types/unist": {
       "version": "2.0.6",
@@ -17603,6 +17621,34 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.0.2.tgz",
+      "integrity": "sha512-ZoVUPGgXOQocP4OvxehEOBmC4rWB4cRYDPaz7aFmH8DFytsCi/NeACbr4C6vNPGDEC07BrhUos7uVNayDKLQ2Q==",
+      "dependencies": {
+        "@lit/reactive-element": "^2.0.0",
+        "lit-element": "^4.0.0",
+        "lit-html": "^3.0.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.0.1.tgz",
+      "integrity": "sha512-OxRMJem4HKZt0320HplLkBPoi4KHiEHoPHKd8Lzf07ZQVAOKIjZ32yPLRKRDEolFU1RgrQBfSHQMoxKZ72V3Kw==",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.1.2",
+        "@lit/reactive-element": "^2.0.0",
+        "lit-html": "^3.0.0"
+      }
+    },
+    "node_modules/lit-html": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.0.2.tgz",
+      "integrity": "sha512-Q1A5lHza3bnmxoWJn6yS6vQZQdExl4fghk8W1G+jnAEdoFNYo5oeBBb/Ol7zSEdKd3TR7+r0zsJQyuWEVguiyQ==",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
+    },
     "node_modules/load-json-file": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-6.2.0.tgz",
@@ -24857,6 +24903,7 @@
       "dependencies": {
         "@malloydata/malloy": "^0.0.100",
         "@types/luxon": "^2.4.0",
+        "lit": "^3.0.2",
         "lodash": "^4.17.20",
         "luxon": "^2.4.0",
         "ssf": "^0.11.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "@babel/plugin-transform-runtime": "^7.23.3",
+        "@babel/preset-env": "^7.23.2",
         "@jest/globals": "^26.6.2",
         "@malloydata/db-bigquery": "*",
         "@malloydata/malloy": "*",
@@ -21,6 +22,7 @@
         "@typescript-eslint/eslint-plugin": "^5.51.0",
         "@typescript-eslint/parser": "^5.51.0",
         "axios": "^1.4.0",
+        "babel-jest": "^29.3.1",
         "cross-os": "^1.5.0",
         "csv-stringify": "^5.6.5",
         "dotenv-cli": "^6.0.0",
@@ -1757,8 +1759,9 @@
     },
     "node_modules/@babel/preset-env": {
       "version": "7.23.2",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.23.2.tgz",
+      "integrity": "sha512-BW3gsuDD+rvHL2VO2SjAUNTBe5YrjsTiDyqamPDWY723na3/yPQ65X5oQkFVJZ0o50/2d+svm1rkPoJeR1KxVQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.23.2",
         "@babel/helper-compilation-targets": "^7.22.15",
@@ -8711,8 +8714,9 @@
     },
     "node_modules/babel-jest": {
       "version": "29.3.1",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.3.1.tgz",
+      "integrity": "sha512-aard+xnMoxgjwV70t0L6wkW/3HQQtV+O0PEimxKgzNqCJnbYmroPojdP2tqKSOAt8QAKV/uSZU8851M7B5+fcA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@jest/transform": "^29.3.1",
         "@types/babel__core": "^7.1.14",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,8 @@
       "name": "malloy",
       "version": "0.0.1",
       "license": "MIT",
-      "dependencies": {
-        "@babel/plugin-transform-runtime": "^7.23.3"
-      },
       "devDependencies": {
+        "@babel/plugin-transform-runtime": "^7.23.3",
         "@jest/globals": "^26.6.2",
         "@malloydata/db-bigquery": "*",
         "@malloydata/malloy": "*",
@@ -336,6 +334,7 @@
     },
     "node_modules/@babel/helper-define-polyfill-provider": {
       "version": "0.4.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-compilation-targets": "^7.22.6",
@@ -1584,6 +1583,7 @@
       "version": "7.23.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.23.3.tgz",
       "integrity": "sha512-XcQ3X58CKBdBnnZpPaQjgVMePsXtSZzHoku70q9tUAQp02ggPQNM04BF3RvlW1GSM/McbSOQAzEK4MXbS7/JFg==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-module-imports": "^7.22.15",
         "@babel/helper-plugin-utils": "^7.22.5",
@@ -1603,6 +1603,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -8758,6 +8759,7 @@
     },
     "node_modules/babel-plugin-polyfill-corejs2": {
       "version": "0.4.6",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.22.6",
@@ -8770,6 +8772,7 @@
     },
     "node_modules/babel-plugin-polyfill-corejs2/node_modules/semver": {
       "version": "6.3.1",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -8777,6 +8780,7 @@
     },
     "node_modules/babel-plugin-polyfill-corejs3": {
       "version": "0.8.5",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-define-polyfill-provider": "^0.4.3",
@@ -8788,6 +8792,7 @@
     },
     "node_modules/babel-plugin-polyfill-regenerator": {
       "version": "0.5.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-define-polyfill-provider": "^0.4.3"
@@ -10126,6 +10131,7 @@
     },
     "node_modules/core-js-compat": {
       "version": "3.33.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "browserslist": "^4.22.1"
@@ -17717,6 +17723,7 @@
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.ismatch": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "malloy",
       "version": "0.0.1",
       "license": "MIT",
+      "dependencies": {
+        "@babel/plugin-transform-runtime": "^7.23.3"
+      },
       "devDependencies": {
         "@jest/globals": "^26.6.2",
         "@malloydata/db-bigquery": "*",
@@ -333,7 +336,6 @@
     },
     "node_modules/@babel/helper-define-polyfill-provider": {
       "version": "0.4.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-compilation-targets": "^7.22.6",
@@ -1576,6 +1578,33 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-runtime": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.23.3.tgz",
+      "integrity": "sha512-XcQ3X58CKBdBnnZpPaQjgVMePsXtSZzHoku70q9tUAQp02ggPQNM04BF3RvlW1GSM/McbSOQAzEK4MXbS7/JFg==",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.22.15",
+        "@babel/helper-plugin-utils": "^7.22.5",
+        "babel-plugin-polyfill-corejs2": "^0.4.6",
+        "babel-plugin-polyfill-corejs3": "^0.8.5",
+        "babel-plugin-polyfill-regenerator": "^0.5.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-runtime/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/@babel/plugin-transform-shorthand-properties": {
@@ -8729,7 +8758,6 @@
     },
     "node_modules/babel-plugin-polyfill-corejs2": {
       "version": "0.4.6",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.22.6",
@@ -8742,7 +8770,6 @@
     },
     "node_modules/babel-plugin-polyfill-corejs2/node_modules/semver": {
       "version": "6.3.1",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -8750,7 +8777,6 @@
     },
     "node_modules/babel-plugin-polyfill-corejs3": {
       "version": "0.8.5",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-define-polyfill-provider": "^0.4.3",
@@ -8762,7 +8788,6 @@
     },
     "node_modules/babel-plugin-polyfill-regenerator": {
       "version": "0.5.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-define-polyfill-provider": "^0.4.3"
@@ -10101,7 +10126,6 @@
     },
     "node_modules/core-js-compat": {
       "version": "3.33.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "browserslist": "^4.22.1"
@@ -17693,7 +17717,6 @@
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.ismatch": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24919,10 +24919,71 @@
         "@storybook/html": "^7.5.0",
         "@storybook/html-vite": "^7.5.0",
         "@storybook/testing-library": "^0.2.2",
+        "@storybook/types": "^7.5.3",
         "storybook": "^7.5.0"
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "packages/malloy-render/node_modules/@storybook/channels": {
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-7.5.3.tgz",
+      "integrity": "sha512-dhWuV2o2lmxH0RKuzND8jxYzvSQTSmpE13P0IT/k8+I1up/rSNYOBQJT6SalakcNWXFAMXguo/8E7ApmnKKcEw==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/client-logger": "7.5.3",
+        "@storybook/core-events": "7.5.3",
+        "@storybook/global": "^5.0.0",
+        "qs": "^6.10.0",
+        "telejson": "^7.2.0",
+        "tiny-invariant": "^1.3.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "packages/malloy-render/node_modules/@storybook/client-logger": {
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-7.5.3.tgz",
+      "integrity": "sha512-vUFYALypjix5FoJ5M/XUP6KmyTnQJNW1poHdW7WXUVSg+lBM6E5eAtjTm0hdxNNDH8KSrdy24nCLra5h0X0BWg==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/global": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "packages/malloy-render/node_modules/@storybook/core-events": {
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-7.5.3.tgz",
+      "integrity": "sha512-DFOpyQ22JD5C1oeOFzL8wlqSWZzrqgDfDbUGP8xdO4wJu+FVTxnnWN6ZYLdTPB1u27DOhd7TzjQMfLDHLu7kbQ==",
+      "dev": true,
+      "dependencies": {
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "packages/malloy-render/node_modules/@storybook/types": {
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/@storybook/types/-/types-7.5.3.tgz",
+      "integrity": "sha512-iu5W0Kdd6nysN5CPkY4GRl+0BpxRTdSfBIJak7mb6xCIHSB5t1tw4BOuqMQ5EgpikRY3MWJ4gY647QkWBX3MNQ==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/channels": "7.5.3",
+        "@types/babel__core": "^7.0.0",
+        "@types/express": "^4.7.0",
+        "file-system-cache": "2.3.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
       }
     },
     "packages/malloy-syntax-highlight": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "build-duckdb-db": "ts-node scripts/build_duckdb_test_database"
   },
   "devDependencies": {
+    "@babel/plugin-transform-runtime": "^7.23.3",
     "@jest/globals": "^26.6.2",
     "@malloydata/db-bigquery": "*",
     "@malloydata/malloy": "*",
@@ -78,8 +79,5 @@
     "nanoid": "3.1.31",
     "node-forge": "1.3.0",
     "ansi-regex": "5.0.1"
-  },
-  "dependencies": {
-    "@babel/plugin-transform-runtime": "^7.23.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   },
   "devDependencies": {
     "@babel/plugin-transform-runtime": "^7.23.3",
+    "@babel/preset-env": "^7.23.2",
     "@jest/globals": "^26.6.2",
     "@malloydata/db-bigquery": "*",
     "@malloydata/malloy": "*",
@@ -54,6 +55,7 @@
     "@typescript-eslint/eslint-plugin": "^5.51.0",
     "@typescript-eslint/parser": "^5.51.0",
     "axios": "^1.4.0",
+    "babel-jest": "^29.3.1",
     "cross-os": "^1.5.0",
     "csv-stringify": "^5.6.5",
     "dotenv-cli": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -78,5 +78,8 @@
     "nanoid": "3.1.31",
     "node-forge": "1.3.0",
     "ansi-regex": "5.0.1"
+  },
+  "dependencies": {
+    "@babel/plugin-transform-runtime": "^7.23.3"
   }
 }

--- a/packages/malloy-render/.gitignore
+++ b/packages/malloy-render/.gitignore
@@ -1,0 +1,1 @@
+storybook-static

--- a/packages/malloy-render/.npmignore
+++ b/packages/malloy-render/.npmignore
@@ -2,3 +2,4 @@ src/
 *.map
 tsconfig*
 *.spec
+storybook-static

--- a/packages/malloy-render/.storybook/main.ts
+++ b/packages/malloy-render/.storybook/main.ts
@@ -43,6 +43,10 @@ const config: StorybookConfig = {
           ),
         },
       },
+      server: {
+        // Disable HMR for now, as we can't seem to get malloy core nor Lit to fully support it
+        hmr: false,
+      },
       define: {
         'process.env': {},
       },

--- a/packages/malloy-render/package.json
+++ b/packages/malloy-render/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "@malloydata/malloy": "^0.0.100",
     "@types/luxon": "^2.4.0",
+    "lit": "^3.0.2",
     "lodash": "^4.17.20",
     "luxon": "^2.4.0",
     "ssf": "^0.11.2",

--- a/packages/malloy-render/package.json
+++ b/packages/malloy-render/package.json
@@ -41,6 +41,7 @@
     "@storybook/html": "^7.5.0",
     "@storybook/html-vite": "^7.5.0",
     "@storybook/testing-library": "^0.2.2",
+    "@storybook/types": "^7.5.3",
     "storybook": "^7.5.0"
   }
 }

--- a/packages/malloy-render/src/component/render.ts
+++ b/packages/malloy-render/src/component/render.ts
@@ -1,0 +1,36 @@
+import {Result} from '@malloydata/malloy';
+import {LitElement, html, css} from 'lit';
+import {customElement, property} from 'lit/decorators.js';
+import './table';
+
+@customElement('malloy-render')
+export class MalloyRender extends LitElement {
+  static styles = css`
+    :host {
+      --table-font-size: 12px;
+      --table-row-height: 36px;
+      --table-header-color: #5d626b;
+      --table-header-weight: bold;
+      --table-body-color: #727883;
+      --table-body-weight: 400;
+      --table-border: 1px solid #e5e7eb;
+      --table-background: white;
+
+      font-family: Inter, system-ui, sans-serif;
+      font-size: var(--table-font-size);
+    }
+  `;
+
+  @property({attribute: false})
+  result!: Result;
+
+  override render() {
+    return html`<malloy-table .data=${this.result.data}></malloy-table>`;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'malloy-render': MalloyRender;
+  }
+}

--- a/packages/malloy-render/src/component/table.ts
+++ b/packages/malloy-render/src/component/table.ts
@@ -1,0 +1,97 @@
+import {DataArray} from '@malloydata/malloy';
+import {LitElement, css, html} from 'lit';
+import {customElement, property} from 'lit/decorators.js';
+
+@customElement('malloy-table')
+export class Table extends LitElement {
+  // Define scoped styles right with your component, in plain CSS
+  static styles = css`
+    :host {
+      --table-font-size: 12px;
+      --table-row-height: 36px;
+      --table-column-width-unit: 94px;
+      --table-header-color: #5d626b;
+      --table-header-weight: bold;
+      --table-body-color: #727883;
+      --table-body-weight: 400;
+      --table-border: 1px solid #e5e7eb;
+      --table-background: white;
+
+      font-family: Inter, system-ui, sans-serif;
+      font-size: var(--table-font-size);
+    }
+
+    table {
+      border-collapse: collapse;
+      background: var(--table-background);
+    }
+
+    th {
+      font-weight: var(--table-header-weight);
+      color: var(--table-header-color);
+      height: var(--table-row-height);
+      width: var(--table-column-width-unit);
+      border-block: var(--table-border);
+      overflow: hidden;
+      white-space: nowrap;
+      text-align: left;
+      padding: 0px 15px;
+    }
+
+    td {
+      font-weight: var(--table-body-weight);
+      color: var(--table-body-color);
+      height: var(--table-row-height);
+      width: var(--table-column-width-unit);
+      border-block: var(--table-border);
+      overflow: hidden;
+      overflow: hidden;
+      white-space: nowrap;
+      text-align: left;
+      padding: 0px 15px;
+    }
+    th:first-child,
+    td:first-child {
+      padding-left: 0px;
+    }
+    th:last-child,
+    td:last-child {
+      padding-right: 0px;
+    }
+  `;
+
+  constructor() {
+    super();
+  }
+
+  // Declare reactive properties
+  @property({attribute: false})
+  table!: DataArray;
+
+  // Render the UI as a function of component state
+  render() {
+    const fields = this.table.field.allFields;
+
+    const rows = Array.from(
+      this.table,
+      row =>
+        html`<tr>
+          ${fields.map(f => html`<td>${row.cell(f).value}</td>`)}
+        </tr>`
+    );
+    return html`<table>
+      <thead>
+        ${fields.map(f => html`<th>${f.name}</th>`)}
+      </thead>
+      <tbody>
+        ${rows}
+      </tbody>
+    </table>`;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'malloy-table': Table;
+  }
+}

--- a/packages/malloy-render/src/component/table.ts
+++ b/packages/malloy-render/src/component/table.ts
@@ -4,84 +4,65 @@ import {customElement, property} from 'lit/decorators.js';
 
 @customElement('malloy-table')
 export class Table extends LitElement {
-  // Define scoped styles right with your component, in plain CSS
   static styles = css`
-    :host {
-      --table-font-size: 12px;
-      --table-row-height: 36px;
-      --table-column-width-unit: 94px;
-      --table-header-color: #5d626b;
-      --table-header-weight: bold;
-      --table-body-color: #727883;
-      --table-body-weight: 400;
-      --table-border: 1px solid #e5e7eb;
-      --table-background: white;
-
-      font-family: Inter, system-ui, sans-serif;
-      font-size: var(--table-font-size);
-    }
-
     table {
       border-collapse: collapse;
       background: var(--table-background);
     }
 
-    th {
-      font-weight: var(--table-header-weight);
-      color: var(--table-header-color);
+    .column-cell {
       height: var(--table-row-height);
-      width: var(--table-column-width-unit);
       border-block: var(--table-border);
       overflow: hidden;
       white-space: nowrap;
       text-align: left;
       padding: 0px 15px;
+      font-variant-numeric: tabular-nums;
     }
 
-    td {
+    th.column-cell {
+      font-weight: var(--table-header-weight);
+      color: var(--table-header-color);
+    }
+
+    td.column-cell {
       font-weight: var(--table-body-weight);
       color: var(--table-body-color);
-      height: var(--table-row-height);
-      width: var(--table-column-width-unit);
-      border-block: var(--table-border);
-      overflow: hidden;
-      overflow: hidden;
-      white-space: nowrap;
-      text-align: left;
-      padding: 0px 15px;
     }
-    th:first-child,
-    td:first-child {
+
+    th.column-cell:first-child,
+    td.column-cell:first-child {
       padding-left: 0px;
     }
-    th:last-child,
-    td:last-child {
+    th.column-cell:last-child,
+    td.column-cell:last-child {
       padding-right: 0px;
     }
   `;
 
-  constructor() {
-    super();
-  }
-
-  // Declare reactive properties
   @property({attribute: false})
-  table!: DataArray;
+  data!: DataArray;
 
-  // Render the UI as a function of component state
   render() {
-    const fields = this.table.field.allFields;
+    const fields = this.data.field.allFields;
+
+    const headers = fields.map(
+      f => html`<th class="column-cell">${f.name}</th>`
+    );
 
     const rows = Array.from(
-      this.table,
+      this.data,
       row =>
         html`<tr>
-          ${fields.map(f => html`<td>${row.cell(f).value}</td>`)}
+          ${fields.map(
+            f => html`<td class="column-cell">${row.cell(f).value}</td>`
+          )}
         </tr>`
     );
+
     return html`<table>
       <thead>
-        ${fields.map(f => html`<th>${f.name}</th>`)}
+        ${headers}
       </thead>
       <tbody>
         ${rows}

--- a/packages/malloy-render/src/html/html_view.ts
+++ b/packages/malloy-render/src/html/html_view.ts
@@ -33,7 +33,7 @@ import {ContainerRenderer} from './container';
 import {createErrorElement} from './utils';
 import {MainRendererFactory} from '../main_renderer_factory';
 import {HTMLListRenderer} from './list';
-import '../component/table';
+import '../component/render';
 
 export class HTMLView {
   constructor(private document: Document) {}
@@ -41,16 +41,9 @@ export class HTMLView {
   async render(result: Result, options: RendererOptions): Promise<HTMLElement> {
     const isNextRenderer = result.resultExplore.modelTag.has('renderer_next');
     if (isNextRenderer) {
-      const el = document.createElement('malloy-table');
-      el.table = result.data;
-      if (options.target) {
-        options.target.replaceChildren(el);
-        return Promise.resolve(el);
-      }
-      return createErrorElement(
-        this.document,
-        'The renderer requires a target element to render into. Please set via options.target.'
-      );
+      const el = document.createElement('malloy-render');
+      el.result = result;
+      return el;
     }
 
     const table = result.data;

--- a/packages/malloy-render/src/html/html_view.ts
+++ b/packages/malloy-render/src/html/html_view.ts
@@ -41,7 +41,7 @@ export class HTMLView {
   async render(result: Result, options: RendererOptions): Promise<HTMLElement> {
     const isNextRenderer = result.resultExplore.modelTag.has('renderer_next');
     if (isNextRenderer) {
-      const el = document.createElement('malloy-render');
+      const el = this.document.createElement('malloy-render');
       el.result = result;
       return el;
     }

--- a/packages/malloy-render/src/html/html_view.ts
+++ b/packages/malloy-render/src/html/html_view.ts
@@ -33,11 +33,26 @@ import {ContainerRenderer} from './container';
 import {createErrorElement} from './utils';
 import {MainRendererFactory} from '../main_renderer_factory';
 import {HTMLListRenderer} from './list';
+import '../component/table';
 
 export class HTMLView {
   constructor(private document: Document) {}
 
   async render(result: Result, options: RendererOptions): Promise<HTMLElement> {
+    const isNextRenderer = result.resultExplore.modelTag.has('renderer_next');
+    if (isNextRenderer) {
+      const el = document.createElement('malloy-table');
+      el.table = result.data;
+      if (options.target) {
+        options.target.replaceChildren(el);
+        return Promise.resolve(el);
+      }
+      return createErrorElement(
+        this.document,
+        'The renderer requires a target element to render into. Please set via options.target.'
+      );
+    }
+
     const table = result.data;
     const renderer = makeRenderer(
       table.field,

--- a/packages/malloy-render/src/renderer_types.ts
+++ b/packages/malloy-render/src/renderer_types.ts
@@ -29,6 +29,7 @@ export interface RendererOptions {
   onDrill?: DrillFunction;
   titleCase?: boolean;
   queryTimezone?: string;
+  target?: HTMLElement;
 }
 
 export type DrillFunction = (

--- a/packages/malloy-render/src/renderer_types.ts
+++ b/packages/malloy-render/src/renderer_types.ts
@@ -29,7 +29,6 @@ export interface RendererOptions {
   onDrill?: DrillFunction;
   titleCase?: boolean;
   queryTimezone?: string;
-  target?: HTMLElement;
 }
 
 export type DrillFunction = (

--- a/packages/malloy-render/src/stories/basic.stories.ts
+++ b/packages/malloy-render/src/stories/basic.stories.ts
@@ -2,7 +2,7 @@ import script from './static/basic.malloy?raw';
 import {renderMalloy} from './render-malloy';
 
 export default {
-  title: 'Malloy/Basic',
+  title: 'Malloy Legacy/Basic',
   render: ({source, view}, {globals: {connection}}) => {
     return renderMalloy({script, source, view, connection});
   },

--- a/packages/malloy-render/src/stories/basic.stories.ts
+++ b/packages/malloy-render/src/stories/basic.stories.ts
@@ -1,5 +1,5 @@
 import script from './static/basic.malloy?raw';
-import {renderMalloy} from './render-malloy';
+import {renderMalloy} from './render-malloy-legacy';
 
 export default {
   title: 'Malloy Legacy/Basic',

--- a/packages/malloy-render/src/stories/image.stories.ts
+++ b/packages/malloy-render/src/stories/image.stories.ts
@@ -1,5 +1,5 @@
 import script from './static/image.malloy?raw';
-import {renderMalloy} from './render-malloy';
+import {renderMalloy} from './render-malloy-legacy';
 
 export default {
   title: 'Malloy Legacy/Image',

--- a/packages/malloy-render/src/stories/image.stories.ts
+++ b/packages/malloy-render/src/stories/image.stories.ts
@@ -2,7 +2,7 @@ import script from './static/image.malloy?raw';
 import {renderMalloy} from './render-malloy';
 
 export default {
-  title: 'Malloy/Image',
+  title: 'Malloy Legacy/Image',
   render: ({source, view}, {globals: {connection}}) => {
     return renderMalloy({script, source, view, connection});
   },

--- a/packages/malloy-render/src/stories/render-malloy-legacy.ts
+++ b/packages/malloy-render/src/stories/render-malloy-legacy.ts
@@ -19,7 +19,6 @@ export function renderMalloy(options: RenderOptions) {
   const div = document.createElement('div');
   runAndRender(options, {
     dataStyles: {},
-    target: div,
   }).then(el => {
     if (options.classes) el.classList.add(options.classes);
     div.replaceChildren(el);

--- a/packages/malloy-render/src/stories/render-malloy-legacy.ts
+++ b/packages/malloy-render/src/stories/render-malloy-legacy.ts
@@ -1,13 +1,8 @@
-import {SingleConnectionRuntime} from '@malloydata/malloy';
-import {DuckDBWASMConnection} from '@malloydata/db-duckdb/wasm';
 import {HTMLView} from '../html';
 import {RendererOptions} from '../renderer_types';
+import {QueryOptions, runQuery} from './util';
 
-type RenderOptions = {
-  script: string;
-  source: string;
-  view: string;
-  connection: Promise<DuckDBWASMConnection>;
+type RenderOptions = QueryOptions & {
   classes?: '';
 };
 
@@ -15,12 +10,8 @@ async function runAndRender(
   {script, source, view, connection}: RenderOptions,
   options: RendererOptions = {dataStyles: {}}
 ) {
-  const conn = await connection;
-  const runtime = new SingleConnectionRuntime(conn);
-  const model = runtime.loadModel(script);
-  const runner = model.loadQuery(`run: ${source} -> ${view}`);
   const viewer = new HTMLView(document);
-  const result = await runner.run();
+  const result = await runQuery({script, source, view, connection});
   return await viewer.render(result, options);
 }
 
@@ -31,7 +22,6 @@ export function renderMalloy(options: RenderOptions) {
     target: div,
   }).then(el => {
     if (options.classes) el.classList.add(options.classes);
-    // Needed to support legacy renderer
     div.replaceChildren(el);
   });
   return div;

--- a/packages/malloy-render/src/stories/render-malloy.ts
+++ b/packages/malloy-render/src/stories/render-malloy.ts
@@ -1,26 +1,38 @@
 import {SingleConnectionRuntime} from '@malloydata/malloy';
 import {DuckDBWASMConnection} from '@malloydata/db-duckdb/wasm';
 import {HTMLView} from '../html';
+import {RendererOptions} from '../renderer_types';
 
 type RenderOptions = {
   script: string;
   source: string;
   view: string;
   connection: Promise<DuckDBWASMConnection>;
+  classes?: '';
 };
 
-async function runAndRender({script, source, view, connection}: RenderOptions) {
+async function runAndRender(
+  {script, source, view, connection}: RenderOptions,
+  options: RendererOptions = {dataStyles: {}}
+) {
   const conn = await connection;
   const runtime = new SingleConnectionRuntime(conn);
   const model = runtime.loadModel(script);
   const runner = model.loadQuery(`run: ${source} -> ${view}`);
   const viewer = new HTMLView(document);
   const result = await runner.run();
-  return await viewer.render(result, {dataStyles: {}});
+  return await viewer.render(result, options);
 }
 
 export function renderMalloy(options: RenderOptions) {
   const div = document.createElement('div');
-  runAndRender(options).then(el => div.replaceChildren(el));
+  runAndRender(options, {
+    dataStyles: {},
+    target: div,
+  }).then(el => {
+    if (options.classes) el.classList.add(options.classes);
+    // Needed to support legacy renderer
+    div.replaceChildren(el);
+  });
   return div;
 }

--- a/packages/malloy-render/src/stories/static/tables.malloy
+++ b/packages/malloy-render/src/stories/static/tables.malloy
@@ -1,0 +1,15 @@
+## renderer_next
+
+source: products is duckdb.table("data/products.parquet") extend {
+
+  view: records is{
+    select: *
+    limit: 1000
+  }
+
+  # bar_chart renderer_next
+  view: category_bar is {
+    group_by: category
+    aggregate: avg_retail is retail_price.avg()
+  }
+};

--- a/packages/malloy-render/src/stories/tables.stories.ts
+++ b/packages/malloy-render/src/stories/tables.stories.ts
@@ -1,0 +1,33 @@
+import script from './static/tables.malloy?raw';
+import {renderMalloy} from './render-malloy';
+import './themes.css';
+
+export default {
+  title: 'Malloy Next/Tables',
+  render: ({source, view, classes}, {globals: {connection}}) => {
+    return renderMalloy({script, source, view, connection, classes});
+  },
+  argTypes: {},
+};
+
+export const ProductsTable = {
+  args: {
+    source: 'products',
+    view: `records`,
+  },
+};
+
+export const ProductsTableCustomTheme = {
+  args: {
+    source: 'products',
+    view: 'records',
+    classes: 'night',
+  },
+};
+
+export const Products2Column = {
+  args: {
+    source: 'products',
+    view: 'category_bar',
+  },
+};

--- a/packages/malloy-render/src/stories/tables.stories.ts
+++ b/packages/malloy-render/src/stories/tables.stories.ts
@@ -1,14 +1,21 @@
+import {Meta} from '@storybook/html';
 import script from './static/tables.malloy?raw';
-import {renderMalloy} from './render-malloy';
+import {createLoader} from './util';
 import './themes.css';
 
-export default {
+const meta: Meta = {
   title: 'Malloy Next/Tables',
-  render: ({source, view, classes}, {globals: {connection}}) => {
-    return renderMalloy({script, source, view, connection, classes});
+  render: ({classes}, context) => {
+    const el = document.createElement('malloy-render');
+    if (classes) el.classList.add(classes);
+    el.result = context.loaded['result'];
+    return el;
   },
+  loaders: [createLoader(script)],
   argTypes: {},
 };
+
+export default meta;
 
 export const ProductsTable = {
   args: {

--- a/packages/malloy-render/src/stories/tables.stories.ts
+++ b/packages/malloy-render/src/stories/tables.stories.ts
@@ -2,6 +2,7 @@ import {Meta} from '@storybook/html';
 import script from './static/tables.malloy?raw';
 import {createLoader} from './util';
 import './themes.css';
+import '../component/render';
 
 const meta: Meta = {
   title: 'Malloy Next/Tables',

--- a/packages/malloy-render/src/stories/themes.css
+++ b/packages/malloy-render/src/stories/themes.css
@@ -1,0 +1,7 @@
+.night {
+  --table-body-color: white;
+  --table-header-color: #b1cad6;
+  --table-body-weight: 400;
+  --table-background: #212122;
+  --table-border: 1px solid #4c505b;
+}

--- a/packages/malloy-render/src/stories/util.ts
+++ b/packages/malloy-render/src/stories/util.ts
@@ -1,0 +1,38 @@
+import {LoaderFunction, Args} from '@storybook/types';
+import {HtmlRenderer} from '@storybook/html';
+import {SingleConnectionRuntime} from '@malloydata/malloy';
+import {DuckDBWASMConnection} from '@malloydata/db-duckdb/wasm';
+
+export type QueryOptions = {
+  script: string;
+  source: string;
+  view: string;
+  connection: Promise<DuckDBWASMConnection>;
+};
+
+export function createLoader(
+  script: string
+): LoaderFunction<HtmlRenderer, Args> {
+  return async context => ({
+    result: await runQuery({
+      script,
+      source: context.args['source'],
+      view: context.args['view'],
+      connection: context.globals['connection'],
+    }),
+  });
+}
+
+export async function runQuery({
+  script,
+  source,
+  view,
+  connection,
+}: QueryOptions) {
+  const conn = await connection;
+  const runtime = new SingleConnectionRuntime(conn);
+  const model = runtime.loadModel(script);
+  const runner = model.loadQuery(`run: ${source} -> ${view}`);
+  const result = await runner.run();
+  return result;
+}


### PR DESCRIPTION
This PR sets up the foundation for the next generation Malloy renderer.

## Changes
- Lit installed for web components, storybook/types added for missing types
- New renderer deployed inside the legacy HTMLView behind a `## renderer_next` document tag
- New renderer wrapper implemented as a Lit web component
- Initial implementation of a basic table matching design specs from @tschomer 
- basic theme control with CSS variables
- Stories showing new renderer as well as ability to custom theme it

In the future, we will probably want to export the web component directly so that developers have flexibility to use it in different ways like so:
```typescript
import "@malloy/render";

// In vanilla js
const el = document.createElement("malloy-render");

// In Lit
html`<malloy-render></malloy-render>`

// In frameworks like React/Solid/Vue/etc, however they support web components
<MyReactApp>
  <malloy-render></malloy-render>
</MyReactApp>
```