### PR TITLE
Allow comma instead of plus for scalar_lenses experiment

### DIFF
--- a/packages/malloy/src/lang/grammar/MalloyParser.g4
+++ b/packages/malloy/src/lang/grammar/MalloyParser.g4
@@ -121,7 +121,7 @@ topLevelQueryDef
   : tags queryName isDefine sqExpr
   ;
 
-refineOperator: PLUS ;
+refineOperator: PLUS | COMMA;
 
 turtleName
   : id;

--- a/packages/malloy/src/lang/test/lenses.spec.ts
+++ b/packages/malloy/src/lang/test/lenses.spec.ts
@@ -274,4 +274,25 @@ describe('partial views', () => {
       "Can't determine view type (`group_by` / `aggregate` / `nest`, `project`, `index`)"
     );
   });
+  test('comma allowed in experiment', () => {
+    expect(
+      markSource`
+        ##! experimental.scalar_lenses
+        run: a -> ai, astr
+      `
+    ).toTranslate();
+  });
+  test('comma not allowed not in experiment', () => {
+    expect(
+      markSource`
+        source: x is a extend {
+          view: i is { group_by: i is 1 }
+          view: j is { group_by: j is 1 }
+        }
+        run: x -> i${','} j
+      `
+    ).translationToFailWith(
+      "Experimental flag 'scalar_lenses' required to enable this feature"
+    );
+  });
 });


### PR DESCRIPTION
Allows `flights -> carrier, flight_count` instead of `flights -> carrier + flight_count` when the `scalar_lenses` experiment is enabled.