### PR TITLE
Fix refinement output space issue

### DIFF
--- a/packages/malloy/src/lang/ast/expressions/expr-id-reference.ts
+++ b/packages/malloy/src/lang/ast/expressions/expr-id-reference.ts
@@ -47,14 +47,15 @@ export class ExprIdReference extends ExpressionDef {
   getExpression(fs: FieldSpace): ExprValue {
     const def = this.fieldReference.getField(fs);
     if (def.found) {
-      if (def.found.typeDesc().evalSpace === 'output') {
+      const td = def.found.typeDesc();
+      if (def.isOutputField) {
         return {
-          ...def.found.typeDesc(),
+          ...td,
+          evalSpace: td.evalSpace === 'constant' ? 'constant' : 'output',
           value: [{type: 'outputField', name: this.refString}],
         };
       }
       const value = [{type: def.found.refType, path: this.refString}];
-      const td = def.found.typeDesc();
       // We think that aggregates are more 'output' like, but maybe we will reconsider that...
       const evalSpace = expressionIsAggregate(td.expressionType)
         ? 'output'

--- a/packages/malloy/src/lang/ast/field-space/column-space-field.ts
+++ b/packages/malloy/src/lang/ast/field-space/column-space-field.ts
@@ -36,7 +36,7 @@ export class ColumnSpaceField extends SpaceField {
     return this.haveFieldDef;
   }
 
-  describeType(): TypeDesc {
+  typeDesc(): TypeDesc {
     return this.fieldTypeFromFieldDef(this.haveFieldDef);
   }
 }

--- a/packages/malloy/src/lang/ast/field-space/join-space-field.ts
+++ b/packages/malloy/src/lang/ast/field-space/join-space-field.ts
@@ -21,15 +21,11 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import {FieldSpace} from '../types/field-space';
 import {Join} from '../query-properties/joins';
 import {StructSpaceField} from './static-space';
 
 export class JoinSpaceField extends StructSpaceField {
-  constructor(
-    readonly intoFS: FieldSpace,
-    readonly join: Join
-  ) {
+  constructor(readonly join: Join) {
     super(join.structDef());
   }
 }

--- a/packages/malloy/src/lang/ast/field-space/query-space-field.ts
+++ b/packages/malloy/src/lang/ast/field-space/query-space-field.ts
@@ -34,7 +34,7 @@ export abstract class QueryField extends SpaceField {
   abstract getQueryFieldDef(fs: FieldSpace): QueryFieldDef | undefined;
   abstract fieldDef(): FieldDef;
 
-  describeType(): TypeDesc {
+  typeDesc(): TypeDesc {
     return {dataType: 'turtle', expressionType: 'scalar', evalSpace: 'input'};
   }
 }

--- a/packages/malloy/src/lang/ast/field-space/query-spaces.ts
+++ b/packages/malloy/src/lang/ast/field-space/query-spaces.ts
@@ -65,19 +65,22 @@ export abstract class QuerySpace
       if (typeof field === 'string') {
         const ent = this.exprSpace.entry(field);
         if (ent) {
-          this.setEntry(field, ent);
+          this.setInputEntry(field, ent);
         }
       } else if (model.isFilteredAliasedName(field)) {
         const name = field.as ?? field.name;
         const ent = this.exprSpace.entry(name);
         if (ent) {
-          this.setEntry(name, ent);
+          this.setInputEntry(name, ent);
         }
       } else {
         // TODO can you reference fields in a turtle as fields in the output space,
         // e.g. order_by: my_turtle.foo, or lag(my_turtle.foo)
         if (field.type !== 'turtle') {
-          this.setEntry(field.as ?? field.name, new ColumnSpaceField(field));
+          this.setInputEntry(
+            field.as ?? field.name,
+            new ColumnSpaceField(field)
+          );
         }
       }
     }
@@ -97,6 +100,10 @@ export abstract class QuerySpace
         super.pushFields(f);
       }
     }
+  }
+
+  private setInputEntry(name: string, value: SpaceEntry): void {
+    super.setEntry(name, value);
   }
 
   setEntry(name: string, value: SpaceEntry): void {

--- a/packages/malloy/src/lang/ast/field-space/query-spaces.ts
+++ b/packages/malloy/src/lang/ast/field-space/query-spaces.ts
@@ -34,7 +34,6 @@ import {LookupResult} from '../types/lookup-result';
 import {ColumnSpaceField} from './column-space-field';
 import {StructSpaceField} from './static-space';
 import {QueryInputSpace} from './query-input-space';
-import {SpaceEntry} from '../types/space-entry';
 
 /**
  * The output space of a query operation, it is not named "QueryOutputSpace"
@@ -65,22 +64,19 @@ export abstract class QuerySpace
       if (typeof field === 'string') {
         const ent = this.exprSpace.entry(field);
         if (ent) {
-          this.setInputEntry(field, ent);
+          this.setEntry(field, ent);
         }
       } else if (model.isFilteredAliasedName(field)) {
         const name = field.as ?? field.name;
         const ent = this.exprSpace.entry(name);
         if (ent) {
-          this.setInputEntry(name, ent);
+          this.setEntry(name, ent);
         }
       } else {
         // TODO can you reference fields in a turtle as fields in the output space,
         // e.g. order_by: my_turtle.foo, or lag(my_turtle.foo)
         if (field.type !== 'turtle') {
-          this.setInputEntry(
-            field.as ?? field.name,
-            new ColumnSpaceField(field)
-          );
+          this.setEntry(field.as ?? field.name, new ColumnSpaceField(field));
         }
       }
     }
@@ -100,16 +96,6 @@ export abstract class QuerySpace
         super.pushFields(f);
       }
     }
-  }
-
-  private setInputEntry(name: string, value: SpaceEntry): void {
-    super.setEntry(name, value);
-  }
-
-  setEntry(name: string, value: SpaceEntry): void {
-    super.setEntry(name, value);
-    // Everything in this namespace is an output field
-    value.outputField = true;
   }
 
   protected addWild(wild: WildcardFieldReference): void {
@@ -223,9 +209,9 @@ export abstract class QuerySpace
         // (see creation of a QuerySpace) we add references to all the fields from
         // the refinement, but they don't have definitions. So in the case where we
         // don't have a field def, we "know" that that field is already in the query,
-        // and we don't need to worry about actually adding it. This is also true for
-        // project statements, where we add "*" as a field and also all the individuala
-        // fields, but the individual fields don't have field defs.
+        // and we don't need to worry about actually adding it. Previously, this was also true for
+        // project statements, where we added "*" as a field and also all the individual
+        // fields, but the individual fields didn't have field defs.
       }
     }
     this.isComplete();
@@ -288,7 +274,7 @@ export abstract class QuerySpace
   lookup(path: FieldName[]): LookupResult {
     const result = super.lookup(path);
     if (result.found) {
-      return result;
+      return {...result, isOutputField: true};
     }
     return this.exprSpace.lookup(path);
   }

--- a/packages/malloy/src/lang/ast/field-space/reference-field.ts
+++ b/packages/malloy/src/lang/ast/field-space/reference-field.ts
@@ -67,11 +67,11 @@ export class ReferenceField extends SpaceField {
     return this.queryFieldDef;
   }
 
-  describeType(): TypeDesc {
+  typeDesc(): TypeDesc {
     if (this.memoTypeDesc) return this.memoTypeDesc;
     const refTo = this.referenceTo;
     if (refTo) {
-      this.memoTypeDesc = refTo.describeType();
+      this.memoTypeDesc = refTo.typeDesc();
       return this.memoTypeDesc;
     }
     return {dataType: 'error', expressionType: 'scalar', evalSpace: 'input'};

--- a/packages/malloy/src/lang/ast/field-space/rename-space-field.ts
+++ b/packages/malloy/src/lang/ast/field-space/rename-space-field.ts
@@ -50,7 +50,7 @@ export class RenameSpaceField extends SpaceField {
     };
   }
 
-  describeType(): TypeDesc {
+  typeDesc(): TypeDesc {
     return this.otherField.typeDesc();
   }
 }

--- a/packages/malloy/src/lang/ast/field-space/static-space.ts
+++ b/packages/malloy/src/lang/ast/field-space/static-space.ts
@@ -182,7 +182,7 @@ export class StaticSpace implements FieldSpace {
         found: undefined,
       };
     }
-    return {found, error: undefined, relationship};
+    return {found, error: undefined, relationship, isOutputField: false};
   }
 
   isQueryFieldSpace(): this is QueryFieldSpace {

--- a/packages/malloy/src/lang/ast/field-space/struct-space-field-base.ts
+++ b/packages/malloy/src/lang/ast/field-space/struct-space-field-base.ts
@@ -45,7 +45,7 @@ export abstract class StructSpaceFieldBase extends SpaceField {
     return this.sourceDef;
   }
 
-  describeType(): TypeDesc {
+  typeDesc(): TypeDesc {
     return {dataType: 'struct', expressionType: 'scalar', evalSpace: 'input'};
   }
 }

--- a/packages/malloy/src/lang/ast/field-space/wild-space-field.ts
+++ b/packages/malloy/src/lang/ast/field-space/wild-space-field.ts
@@ -31,7 +31,7 @@ export class WildSpaceField extends SpaceField {
     super();
   }
 
-  describeType(): TypeDesc {
+  typeDesc(): TypeDesc {
     throw new Error('should never ask a wild field for its type');
   }
 

--- a/packages/malloy/src/lang/ast/query-items/field-declaration.ts
+++ b/packages/malloy/src/lang/ast/query-items/field-declaration.ts
@@ -306,7 +306,7 @@ export class FieldDefinitionValue extends SpaceField {
   // really know what type we have. However since we have the FieldSpace,
   // we can compile the expression to find out, this might result in
   // some expressions being compiled twice.
-  describeType(): TypeDesc {
+  typeDesc(): TypeDesc {
     const typeFrom = this.qfd || this.fieldDef();
     return this.fieldTypeFromFieldDef(typeFrom);
   }

--- a/packages/malloy/src/lang/ast/query-properties/joins.ts
+++ b/packages/malloy/src/lang/ast/query-properties/joins.ts
@@ -57,7 +57,7 @@ export abstract class Join
   note?: Annotation;
 
   makeEntry(fs: DynamicSpace) {
-    fs.newEntry(this.name.refString, this, new JoinSpaceField(fs, this));
+    fs.newEntry(this.name.refString, this, new JoinSpaceField(this));
   }
 
   protected getStructDefFromExpr() {

--- a/packages/malloy/src/lang/ast/query-properties/ordering.ts
+++ b/packages/malloy/src/lang/ast/query-properties/ordering.ts
@@ -58,7 +58,7 @@ export class OrderBy extends MalloyElement {
       if (entry.error) {
         this.field.log(entry.error);
       }
-      if (entry.found?.typeDesc().evalSpace === 'input') {
+      if (!entry.found || !entry.isOutputField) {
         this.log(`Unknown field ${this.field.refString} in output space`);
       }
       if (expressionIsAnalytic(entry.found?.typeDesc().expressionType)) {

--- a/packages/malloy/src/lang/ast/query-properties/qop-desc.ts
+++ b/packages/malloy/src/lang/ast/query-properties/qop-desc.ts
@@ -109,7 +109,7 @@ export class QOPDesc extends ListOf<QueryProperty> {
       segment,
       outputSpace: () =>
         // TODO someday we'd like to get rid of the call to opOutputStruct here.
-        // If the `qex.resultFS` is correct, then we should be able to just use that
+        // If the `build.resultFS` is correct, then we should be able to just use that
         // in a more direct way.
         new StaticSpace(opOutputStruct(this, inputFS.structDef(), segment)),
     };

--- a/packages/malloy/src/lang/ast/query-properties/refinements.ts
+++ b/packages/malloy/src/lang/ast/query-properties/refinements.ts
@@ -78,7 +78,7 @@ export class NamedRefinement extends Refinement {
     }
     this.name.log(
       `named refinement \`${this.name.refString}\` must be a view, found a ${
-        res.found.describeType().dataType
+        res.found.typeDesc().dataType
       }`
     );
   }

--- a/packages/malloy/src/lang/ast/query-properties/top.ts
+++ b/packages/malloy/src/lang/ast/query-properties/top.ts
@@ -62,7 +62,7 @@ export class Top extends MalloyElement implements QueryPropertyInterface {
           if (entry.error) {
             this.by.log(entry.error);
           }
-          if (entry.found?.typeDesc().evalSpace === 'input') {
+          if (!entry.found || !entry.isOutputField) {
             this.by.log(`Unknown field ${this.by.refString} in output space`);
           }
           if (expressionIsAnalytic(entry.found?.typeDesc().expressionType)) {

--- a/packages/malloy/src/lang/ast/types/lookup-result.ts
+++ b/packages/malloy/src/lang/ast/types/lookup-result.ts
@@ -28,6 +28,7 @@ export interface LookupFound {
   found: SpaceEntry;
   relationship: {name: string; structRelationship: StructRelationship}[];
   error: undefined;
+  isOutputField: boolean;
 }
 export interface LookupError {
   error: string;

--- a/packages/malloy/src/lang/ast/types/space-entry.ts
+++ b/packages/malloy/src/lang/ast/types/space-entry.ts
@@ -33,17 +33,9 @@ export abstract class SpaceEntry {
    */
   abstract describeType(): TypeDesc;
   abstract refType: 'field' | 'parameter';
-  outputField = false;
 
   typeDesc(): TypeDesc {
-    const type = this.describeType();
-    if (this.outputField) {
-      return {
-        ...type,
-        evalSpace: type.evalSpace === 'constant' ? 'constant' : 'output',
-      };
-    }
-    return type;
+    return this.describeType();
   }
 }
 

--- a/packages/malloy/src/lang/ast/types/space-entry.ts
+++ b/packages/malloy/src/lang/ast/types/space-entry.ts
@@ -26,17 +26,8 @@ import {DynamicSpace} from '../field-space/dynamic-space';
 import {MalloyElement} from './malloy-element';
 
 export abstract class SpaceEntry {
-  /**
-   * Once upon a time this was called `typeDesc()` but now that is implemented here
-   * as a wrapper which knows about output spaces. Individual entries should describe
-   * themselves with describeType() and the typeDesc() here will call that.
-   */
-  abstract describeType(): TypeDesc;
+  abstract typeDesc(): TypeDesc;
   abstract refType: 'field' | 'parameter';
-
-  typeDesc(): TypeDesc {
-    return this.describeType();
-  }
 }
 
 export interface MakeEntry {

--- a/packages/malloy/src/lang/ast/types/space-param.ts
+++ b/packages/malloy/src/lang/ast/types/space-param.ts
@@ -40,7 +40,7 @@ export class AbstractParameter extends SpaceParam {
     return this.astParam.parameter();
   }
 
-  describeType(): TypeDesc {
+  typeDesc(): TypeDesc {
     const type = this.astParam.type || 'error';
     // TODO Not sure whether params are considered "input space". It seems like they
     // could be input or constant, depending on usage.
@@ -57,7 +57,7 @@ export class DefinedParameter extends SpaceParam {
     return this.paramDef;
   }
 
-  describeType(): TypeDesc {
+  typeDesc(): TypeDesc {
     return {
       dataType: this.paramDef.type,
       expressionType: 'scalar',

--- a/packages/malloy/src/lang/test/lenses.spec.ts
+++ b/packages/malloy/src/lang/test/lenses.spec.ts
@@ -72,12 +72,21 @@ describe('lenses', () => {
     expect(
       markSource`
         source: x is a extend {
-          view: d1 is { group_by: n1 is 1; order_by: n1 }
-          view: d2 is { group_by: n2 is 2; order_by: n2 }
+          view: d1 is { group_by: n1 is ai; order_by: n1 }
+          view: d2 is { group_by: n2 is 1; order_by: n2 }
         }
         run: x -> d1 + d2
       `
     ).translationToFailWith('refinement cannot override existing ordering');
+  });
+  test('weird issue with order by constant group by', () => {
+    expect(
+      markSource`
+        source: x is a extend {
+          view: d1 is { group_by: n1 is 1; order_by: n1 }
+        }
+      `
+    ).toTranslate();
   });
   test('can add a limit late', () => {
     expect(
@@ -309,6 +318,16 @@ describe('lenses', () => {
     ).translationToFailWith(
       'named refinement `b` must be a view, found a struct'
     );
+  });
+  test('cannot reference field in LHS of refinement in group_by', () => {
+    expect(
+      markSource`
+        source: x is a extend {
+          view: v is { group_by: i is 1 }
+        }
+        run: x -> v + { group_by: j is ${'i'} }
+      `
+    ).translationToFailWith("'i' is not defined");
   });
   test('cannot named-refine multi-stage query', () => {
     expect(

--- a/packages/malloy/src/lang/test/source.spec.ts
+++ b/packages/malloy/src/lang/test/source.spec.ts
@@ -296,6 +296,50 @@ describe('source:', () => {
         }
       `).toTranslate();
     });
+    test('chained explore-query with refinement two steps', () => {
+      expect(`
+        source: c is a extend {
+          view: base is {
+            group_by: astr
+          } + {
+            group_by: ai
+          }
+          view: chain2 is base -> {
+            top: 10; order_by: astr
+            select: *
+          }
+        }
+      `).toTranslate();
+    });
+    test('pipelined explore-query with refinement', () => {
+      expect(`
+        source: c is a extend {
+          view: base is {
+            group_by: astr
+          }
+          view: chain is base + {
+            group_by: ai
+          } -> {
+            top: 10; order_by: astr
+            select: *
+          }
+        }
+      `).toTranslate();
+    });
+    test.skip('pipelined explore-query with view chain', () => {
+      expect(`
+        source: c is a extend {
+          view: chain is {
+            group_by: astr
+          } + {
+            group_by: ai
+          } -> {
+            top: 10; order_by: astr
+            select: *
+          }
+        }
+      `).toTranslate();
+    });
     test('multiple explore-query', () => {
       expect(`
         source: abNew is ab extend {


### PR DESCRIPTION
Before this fix, this query does the wrong thing:

```malloy
source: x is duckdb.sql("SELECT 1 AS n") extend {
  measure: c is count()
  view: v is { aggregate: c }
}
run: x -> v + {
  aggregate: e is c { where: false }
}
```

In particular, `e` should be `0` in the result, but it is `1` instead. This is because `c` (in the definition of `e`) is being treated as an output field, and the compiler gets confused when there is an output field with filters, because that shouldn't normally be possible.

This was due to an issue involving mutating the `SpaceEntry` that is copied from the refinement LHS `exprSpace` into the `QuerySpace` of the refinement RHS in order to specify that in the `QuerySpace` the field is in the output space. With a small refactor of the way that output space is recorded for `QuerySpace` fields, this should be fixed.


