### PR TITLE
correctly  compute dependencies

### DIFF
--- a/packages/malloy/src/lang/parse-malloy.ts
+++ b/packages/malloy/src/lang/parse-malloy.ts
@@ -625,6 +625,7 @@ class TranslateStep implements TranslationStep {
           queryList: that.queryList,
           sqlBlocks: that.sqlBlocks,
         },
+        fromSources: that.getDependencies(),
         ...that.problemResponse(),
         final: true,
       };
@@ -685,6 +686,14 @@ export abstract class MalloyTranslation {
     if (!this.childTranslators.get(url)) {
       this.childTranslators.set(url, new MalloyChildTranslator(url, this.root));
     }
+  }
+
+  getDependencies(): string[] {
+    const dependencies = [this.sourceURL];
+    for (const [_childURL, child] of this.childTranslators) {
+      dependencies.push(...child.getDependencies());
+    }
+    return dependencies;
   }
 
   addReference(reference: DocumentReference): void {
@@ -827,7 +836,6 @@ export abstract class MalloyTranslation {
     const attempt = this.translateStep.step(this, extendingModel);
     if (attempt.final) {
       this.finalAnswer = attempt;
-      this.buildImports();
     }
     return attempt;
   }
@@ -946,6 +954,7 @@ export class MalloyChildTranslator extends MalloyTranslation {
 export class MalloyTranslator extends MalloyTranslation {
   schemaZone = new Zone<StructDef>();
   importZone = new Zone<string>();
+  imporList: string[] = [];
   sqlQueryZone = new Zone<SQLBlockStructDef>();
   logger = new MessageLog();
   readonly root: MalloyTranslator;

--- a/packages/malloy/src/lang/parse-malloy.ts
+++ b/packages/malloy/src/lang/parse-malloy.ts
@@ -954,7 +954,6 @@ export class MalloyChildTranslator extends MalloyTranslation {
 export class MalloyTranslator extends MalloyTranslation {
   schemaZone = new Zone<StructDef>();
   importZone = new Zone<string>();
-  imporList: string[] = [];
   sqlQueryZone = new Zone<SQLBlockStructDef>();
   logger = new MessageLog();
   readonly root: MalloyTranslator;

--- a/packages/malloy/src/lang/parse-malloy.ts
+++ b/packages/malloy/src/lang/parse-malloy.ts
@@ -298,6 +298,10 @@ class ImportsAndTablesStep implements TranslationStep {
             ).toString()
           );
           that.addChild(ref);
+          that.imports.push({
+            importURL: ref,
+            location: {url: that.sourceURL, range: firstRef},
+          });
           that.root.importZone.reference(ref, {
             url: that.sourceURL,
             range: firstRef,
@@ -850,16 +854,6 @@ export abstract class MalloyTranslation {
       }
     }
     return undefined;
-  }
-
-  private buildImports(): void {
-    for (const [key, value] of Object.entries(this.root.importZone.location)) {
-      // Ignore any import in another file
-      if (value.url !== this.sourceURL) {
-        continue;
-      }
-      this.imports.push({importURL: key, location: value});
-    }
   }
 
   metadata(): MetadataResponse {

--- a/packages/malloy/src/lang/test/imports.spec.ts
+++ b/packages/malloy/src/lang/test/imports.spec.ts
@@ -121,6 +121,16 @@ source: botProjQSrc is botProjQ
     const xr = docParse.unresolved();
     expect(docParse).toParse();
     expect(xr).toEqual({urls: ['internal://test/langtests/grandChild']});
+    docParse.update({
+      urls: {'internal://test/langtests/grandChild': '// empty file'},
+    });
+    expect(docParse).toTranslate();
+    const sources = docParse.translate().fromSources;
+    expect(sources).toEqual([
+      'internal://test/langtests/root.malloy',
+      'internal://test/langtests/child',
+      'internal://test/langtests/grandChild',
+    ]);
   });
   test('relative imports', () => {
     const docParse = new TestTranslator('import "../parent.malloy"');

--- a/packages/malloy/src/lang/translate-response.ts
+++ b/packages/malloy/src/lang/translate-response.ts
@@ -96,6 +96,7 @@ interface TranslatedResponseData
     queryList: Query[];
     sqlBlocks: SQLBlockStructDef[];
   };
+  fromSources: string[];
 }
 
 export type TranslateResponse = Partial<TranslatedResponseData>;


### PR DESCRIPTION
For @whscullin 

A `TranslateResponse` (i.e. a return from `.translate()` will now always have a `fromSources` array of URLs fetched so far.

Since you will get a translate reponse for every import, asking for the actual source for each url, you probably don't want to look at `fromSources` until you have come back from the `.final = true` response before you pay attention to the lsit.