### PR TITLE
Common Connection constructor signature

### DIFF
--- a/packages/malloy-db-duckdb/src/duckdb_common.ts
+++ b/packages/malloy-db-duckdb/src/duckdb_common.ts
@@ -22,12 +22,14 @@
  */
 
 import {
+  FetchSchemaOptions,
   FieldTypeDef,
   MalloyQueryData,
   NamedStructDefs,
   PersistSQLResults,
   PooledConnection,
   QueryDataRow,
+  QueryOptionsReader,
   QueryRunStats,
   RunSQLOptions,
   SQLBlock,
@@ -35,16 +37,11 @@ import {
   StructDef,
   TestableConnection,
   DuckDBDialect,
-  FetchSchemaOptions,
 } from '@malloydata/malloy';
 
 export interface DuckDBQueryOptions {
   rowLimit: number;
 }
-
-export type QueryOptionsReader =
-  | Partial<DuckDBQueryOptions>
-  | (() => Partial<DuckDBQueryOptions>);
 
 const unquoteName = (name: string) => {
   const match = /^"(.*)"$/.exec(name);
@@ -79,7 +76,7 @@ export abstract class DuckDBCommon
     return 'duckdb';
   }
 
-  private readQueryOptions(): DuckDBQueryOptions {
+  protected readQueryOptions(): DuckDBQueryOptions {
     const options = DuckDBCommon.DEFAULT_QUERY_OPTIONS;
     if (this.queryOptions) {
       if (this.queryOptions instanceof Function) {
@@ -92,7 +89,7 @@ export abstract class DuckDBCommon
     }
   }
 
-  constructor(private queryOptions?: QueryOptionsReader) {}
+  constructor(protected queryOptions?: QueryOptionsReader) {}
 
   public isPool(): this is PooledConnection {
     return false;
@@ -139,7 +136,7 @@ export abstract class DuckDBCommon
 
   public abstract runSQLStream(
     sql: string,
-    _options: RunSQLOptions
+    options: RunSQLOptions
   ): AsyncIterableIterator<QueryDataRow>;
 
   private async getSQLBlockSchema(sqlRef: SQLBlock): Promise<StructDef> {

--- a/packages/malloy/src/index.ts
+++ b/packages/malloy/src/index.ts
@@ -166,7 +166,7 @@ export type {
   WriteStream,
   SerializedExplore,
 } from './malloy';
-export type {RunSQLOptions} from './run_sql_options';
+export type {QueryOptionsReader, RunSQLOptions} from './run_sql_options';
 export type {
   Connection,
   ConnectionConfig,
@@ -174,11 +174,11 @@ export type {
   ConnectionParameter,
   ConnectionParameterValue,
   ConnectionConfigSchema,
+  FetchSchemaOptions,
   InfoConnection,
   LookupConnection,
   ModelString,
   ModelURL,
-  FetchSchemaOptions,
   PersistSQLResults,
   PooledConnection,
   QueryString,

--- a/packages/malloy/src/run_sql_options.ts
+++ b/packages/malloy/src/run_sql_options.ts
@@ -31,3 +31,5 @@ export interface RunSQLOptions {
   /* This is an experimental feature */
   queryAnnotation?: Annotation;
 }
+
+export type QueryOptionsReader = RunSQLOptions | (() => RunSQLOptions);

--- a/packages/malloy/src/runtime_types.ts
+++ b/packages/malloy/src/runtime_types.ts
@@ -130,7 +130,10 @@ export interface ConnectionParameter {
 
 export type ConnectionConfigSchema = ConnectionParameter[];
 
-export type ConnectionConfig = Record<string, ConnectionParameterValue>;
+export interface ConnectionConfig {
+  name: string;
+  [key: string]: ConnectionParameterValue | undefined;
+}
 
 export interface ConnectionFactory {
   connectionName: string;


### PR DESCRIPTION
Provide a common constructor signature for Connection classes to simplify factories. The signature is now essentially
```
constructor<T extends ConnectionConfig>(config: T, optionsReader?: QueryOptionReader)
```
