### PR TITLE
Use configured project as default project

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,4 +1,5 @@
 {
+  "root": true,
   "extends": "./node_modules/gts/",
   "parserOptions": {
     "warnOnUnsupportedTypeScriptVersion": false,

--- a/packages/malloy-db-bigquery/src/bigquery_connection.ts
+++ b/packages/malloy-db-bigquery/src/bigquery_connection.ts
@@ -142,9 +142,9 @@ export class BigQueryConnection
   };
 
   private bigQuery: BigQuerySDK;
-  private projectId;
+  private projectId: string;
   private temporaryTables = new Map<string, string>();
-  private defaultProject;
+  private defaultProject: string;
 
   private schemaCache = new Map<
     string,
@@ -176,7 +176,7 @@ export class BigQueryConnection
       userAgent: `Malloy/${Malloy.version}`,
       keyFilename: config.serviceAccountKeyPath,
       credentials: config.credentials,
-      projectId: config.projectId,
+      projectId: config.projectId || config.defaultProject,
     });
 
     // record project ID because for unclear reasons we have to modify the project ID on the SDK when


### PR DESCRIPTION
Right now if somebody configures a project id, it's used to normalize table paths, but not as a project id for the connection, which is what I think people expect. This uses the default project as the connection projectId, which I think is what is expected, unless somebody knows something I don't...