### PR TITLE
defaultProject -> projectId and projectId -> billingProjectId. The pr…

### DIFF
--- a/packages/malloy-db-bigquery/src/bigquery_connection.ts
+++ b/packages/malloy-db-bigquery/src/bigquery_connection.ts
@@ -74,7 +74,7 @@ interface CredentialBody {
 }
 
 interface BigQueryConnectionConfiguration {
-  projectId?: string;
+  projectId?: string /** This ID is used for Bigquery Table Normalization */;
   serviceAccountKeyPath?: string;
   location?: string;
   maximumBytesBilled?: string;

--- a/test/src/databases/bigquery-postgres/multi_connection.spec.ts
+++ b/test/src/databases/bigquery-postgres/multi_connection.spec.ts
@@ -44,7 +44,7 @@ describe('Multi-connection', () => {
   const bqConnection = new BigQueryTestConnection(
     'bigquery',
     {},
-    {defaultProject: 'malloy-data'}
+    {projectId: 'malloy-data'}
   );
   const postgresConnection = new PostgresTestConnection('postgres');
   const files = new EmptyURLReader();

--- a/test/src/runtimes.ts
+++ b/test/src/runtimes.ts
@@ -124,7 +124,7 @@ export function runtimeFor(dbName: string): SingleConnectionRuntime {
       connection = new BigQueryTestConnection(
         dbName,
         {},
-        {defaultProject: 'malloy-data'}
+        {projectId: 'malloy-data'}
       );
       break;
     case 'postgres':


### PR DESCRIPTION
…ojectId is used for table name normalization and the billingProjectId is now passed to the BQ SDK as its projectId