### PR TITLE
Attempt to support cancel when possible

### DIFF
--- a/packages/malloy-db-duckdb/src/duckdb_connection.ts
+++ b/packages/malloy-db-duckdb/src/duckdb_connection.ts
@@ -132,7 +132,7 @@ export class DuckDBConnection extends DuckDBCommon {
 
   public async *runSQLStream(
     sql: string,
-    _options: RunSQLOptions = {}
+    {rowLimit, abortSignal}: RunSQLOptions = {}
   ): AsyncIterableIterator<QueryDataRow> {
     await this.setup();
     if (!this.connection) {
@@ -146,7 +146,15 @@ export class DuckDBConnection extends DuckDBCommon {
       statements.shift();
     }
 
+    let index = 0;
     for await (const row of this.connection.stream(statements[0])) {
+      if (
+        (rowLimit !== undefined && index >= rowLimit) ||
+        abortSignal?.aborted
+      ) {
+        break;
+      }
+      index++;
       yield row;
     }
   }

--- a/packages/malloy/src/run_sql_options.ts
+++ b/packages/malloy/src/run_sql_options.ts
@@ -23,4 +23,5 @@
 
 export interface RunSQLOptions {
   rowLimit?: number;
+  abortSignal?: AbortSignal;
 }


### PR DESCRIPTION
This was less successful than I'd hoped - node-pg and our duckdb node library both do not support cancellation, only bigquery and duckdb-wasm have support.