### PR TITLE
Make the runtime API automatically pass query and model annotations into the connection when running a query

### DIFF
--- a/packages/malloy/src/lang/parse-malloy.ts
+++ b/packages/malloy/src/lang/parse-malloy.ts
@@ -574,7 +574,10 @@ class ModelAnnotationStep implements TranslationStep {
   response?: ModelAnnotationResponse;
   constructor(readonly parseStep: ParseStep) {}
 
-  step(that: MalloyTranslation): ModelAnnotationResponse {
+  step(
+    that: MalloyTranslation,
+    extendingModel?: ModelDef
+  ): ModelAnnotationResponse {
     if (!this.response) {
       const tryParse = this.parseStep.step(that);
       if (!tryParse.parse || tryParse.final) {
@@ -585,7 +588,12 @@ class ModelAnnotationStep implements TranslationStep {
           tryParse.parse.tokenStream,
           tryParse.parse
         );
-        this.response = {modelAnnotation};
+        this.response = {
+          modelAnnotation: {
+            ...modelAnnotation,
+            inherits: extendingModel?.annotation,
+          },
+        };
       }
     }
     return this.response;
@@ -889,8 +897,8 @@ export abstract class MalloyTranslation {
     return this.metadataStep.step(this);
   }
 
-  modelAnnotation(): ModelAnnotationResponse {
-    return this.modelAnnotationStep.step(this);
+  modelAnnotation(extendingModel?: ModelDef): ModelAnnotationResponse {
+    return this.modelAnnotationStep.step(this, extendingModel);
   }
 
   completions(position: {

--- a/packages/malloy/src/lang/parse-tree-walkers/model-annotation-walker.ts
+++ b/packages/malloy/src/lang/parse-tree-walkers/model-annotation-walker.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files
+ * (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import {CommonTokenStream, ParserRuleContext} from 'antlr4ts';
+import {ParseTreeWalker} from 'antlr4ts/tree/ParseTreeWalker';
+import {MalloyParserListener} from '../lib/Malloy/MalloyParserListener';
+import * as parser from '../lib/Malloy/MalloyParser';
+import {MalloyTranslation} from '../parse-malloy';
+import {Annotation, DocumentLocation, Note} from '../../model/malloy_types';
+import {MalloyParseInfo} from '../malloy-parse-info';
+
+class ModelAnnotationWalker implements MalloyParserListener {
+  private readonly notes: Note[] = [];
+  constructor(
+    readonly translator: MalloyTranslation,
+    readonly tokens: CommonTokenStream,
+    private readonly parseInfo: MalloyParseInfo
+  ) {}
+
+  protected getLocation(cx: ParserRuleContext): DocumentLocation {
+    return {
+      url: this.parseInfo.sourceURL,
+      range: this.parseInfo.rangeFromContext(cx),
+    };
+  }
+
+  enterDocAnnotations(pcx: parser.DocAnnotationsContext): void {
+    const allNotes = pcx.DOC_ANNOTATION().map(note => {
+      return {
+        text: note.text,
+        at: this.getLocation(pcx),
+      };
+    });
+    this.notes.push(...allNotes);
+  }
+
+  get annotation(): Annotation {
+    return {notes: this.notes};
+  }
+}
+
+export function walkForModelAnnotation(
+  forParse: MalloyTranslation,
+  tokens: CommonTokenStream,
+  parseInfo: MalloyParseInfo
+): Annotation {
+  const finder = new ModelAnnotationWalker(forParse, tokens, parseInfo);
+  const listener: MalloyParserListener = finder;
+  ParseTreeWalker.DEFAULT.walk(listener, parseInfo.root);
+  return finder.annotation;
+}

--- a/packages/malloy/src/lang/test/model-annotation-walker.spec.ts
+++ b/packages/malloy/src/lang/test/model-annotation-walker.spec.ts
@@ -21,13 +21,25 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import {Annotation} from './model/malloy_types';
+import {TestTranslator, markSource} from './test-translator';
 
-export interface RunSQLOptions {
-  rowLimit?: number;
-  abortSignal?: AbortSignal;
-  /* This is an experimental feature */
-  modelAnnotation?: Annotation;
-  /* This is an experimental feature */
-  queryAnnotation?: Annotation;
-}
+test('model annotations can be retrieved', () => {
+  const src = markSource`${'## foo'}`;
+  const doc = new TestTranslator(src.code);
+  const {modelAnnotation} = doc.modelAnnotation();
+  expect(modelAnnotation?.notes?.length).toBe(1);
+  const notes = modelAnnotation?.notes ?? [];
+  expect(notes[0].text).toBe('## foo');
+  expect(notes[0].at).toMatchObject(src.locations[0]);
+});
+
+test('does not explode if bad parse', () => {
+  const src = markSource`
+    ${'## foo'}
+    asd afsjei ; duavby {{}}}
+  `;
+  const doc = new TestTranslator(src.code);
+  const response = doc.modelAnnotation();
+  expect(response.modelAnnotation).toBe(undefined);
+  expect(response.final).toBe(true);
+});

--- a/packages/malloy/src/lang/translate-response.ts
+++ b/packages/malloy/src/lang/translate-response.ts
@@ -22,6 +22,7 @@
  */
 
 import {
+  Annotation,
   ModelDef,
   Query,
   SQLBlockSource,
@@ -79,6 +80,13 @@ interface Metadata extends NeededData, ProblemResponse, FinalResponse {
   highlights: DocumentHighlight[];
 }
 export type MetadataResponse = Partial<Metadata>;
+interface ModelAnnotationData
+  extends NeededData,
+    ProblemResponse,
+    FinalResponse {
+  modelAnnotation: Annotation;
+}
+export type ModelAnnotationResponse = Partial<ModelAnnotationData>;
 interface Completions extends NeededData, ProblemResponse, FinalResponse {
   completions: DocumentCompletion[];
 }

--- a/packages/malloy/src/malloy.ts
+++ b/packages/malloy/src/malloy.ts
@@ -290,6 +290,7 @@ export class Malloy {
             }
           }
         }
+        const {modelAnnotation} = translator.modelAnnotation();
         if (result.tables) {
           // collect tables by connection name since there may be multiple connections
           const tablesByConnection: Map<
@@ -318,6 +319,7 @@ export class Malloy {
               const {schemas: tables, errors} =
                 await connection.fetchSchemaForTables(tablePathByKey, {
                   refreshTimestamp,
+                  modelAnnotation,
                 });
               translator.update({tables, errors: {tables: errors}});
             } catch (error) {
@@ -344,6 +346,7 @@ export class Malloy {
             );
             const resolved = await conn.fetchSchemaForSQLBlock(expanded, {
               refreshTimestamp,
+              modelAnnotation,
             });
             if (resolved.error) {
               translator.update({

--- a/packages/malloy/src/malloy.ts
+++ b/packages/malloy/src/malloy.ts
@@ -290,7 +290,7 @@ export class Malloy {
             }
           }
         }
-        const {modelAnnotation} = translator.modelAnnotation();
+        const {modelAnnotation} = translator.modelAnnotation(model?._modelDef);
         if (result.tables) {
           // collect tables by connection name since there may be multiple connections
           const tablesByConnection: Map<

--- a/packages/malloy/src/run_sql_options.ts
+++ b/packages/malloy/src/run_sql_options.ts
@@ -21,7 +21,11 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+import {Annotation} from './model';
+
 export interface RunSQLOptions {
   rowLimit?: number;
   abortSignal?: AbortSignal;
+  modelAnnotation?: Annotation;
+  queryAnnotation?: Annotation;
 }

--- a/packages/malloy/src/run_sql_options.ts
+++ b/packages/malloy/src/run_sql_options.ts
@@ -21,7 +21,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import {Annotation} from './model';
+import {Annotation} from './model/malloy_types';
 
 export interface RunSQLOptions {
   rowLimit?: number;

--- a/packages/malloy/src/runtime_types.ts
+++ b/packages/malloy/src/runtime_types.ts
@@ -23,6 +23,7 @@
 
 import {RunSQLOptions} from './run_sql_options';
 import {
+  Annotation,
   MalloyQueryData,
   QueryDataRow,
   QueryRunStats,
@@ -70,6 +71,8 @@ export interface URLReader {
 export interface FetchSchemaOptions {
   // Fetch a fresh copy of the schema instead of using cache
   refreshTimestamp?: number;
+  /* This is an experimental feature */
+  modelAnnotation?: Annotation;
 }
 
 /**


### PR DESCRIPTION
> I have not written any tests for this since it's somewhat experimental at the moment, and none of our built-in connections have any use for it yet.

Adds `modelAnnotation` and `queryAnnotation` options to the `RunSQLOptions` passed into the `Connection.runSQL` and `.runSQLStream` methods.

These can be manually provided if you want:

```ts
myConnection.runSQL('SELECT 1', { modelAnnotation: someAnnotationObject });
```

You can also pass it in manually in the `.run()` methods in the `RuntimeAPI`.

The easy way, though, is that the `Runtime` API automatically adds these in:

```ts
const result = runtime.loadQuery('duckdb.sql("select 1") -> { select: * }').run(
  // runtime automatically adds in `modelAnnotation` and `queryAnnotation`
);
```

Then in a connection, you can implement custom logic for reading these in the `runSQL` and `runSQLStream` methods:

```ts
runSQL(sql: string, options: RunSQLOptions) {
  const queryTags = Tag.annotationToTag(options.queryAnnotation, { prefix: "#(my_connection)" )).tag;
  const mySpecialOption = queryTags.text('my_special_option');
}
```