### PR TITLE
feat: nested tables

### DIFF
--- a/packages/malloy-render/.storybook/preview.ts
+++ b/packages/malloy-render/.storybook/preview.ts
@@ -3,7 +3,9 @@ import {Preview} from '@storybook/html';
 import registeredData from './registered_data.json';
 
 async function createConnection() {
-  const connection = new DuckDBWASMConnection('duckdb');
+  const connection = new DuckDBWASMConnection('duckdb', null, undefined, {
+    rowLimit: 1000,
+  });
   await connection.connecting;
   for (let tableName of registeredData) {
     const fullTableName = `data/${tableName}`;

--- a/packages/malloy-render/src/component/render.ts
+++ b/packages/malloy-render/src/component/render.ts
@@ -15,6 +15,7 @@ export class MalloyRender extends LitElement {
       --table-body-weight: 400;
       --table-border: 1px solid #e5e7eb;
       --table-background: white;
+      --table-gutter-size: 15px;
 
       font-family: Inter, system-ui, sans-serif;
       font-size: var(--table-font-size);

--- a/packages/malloy-render/src/component/table.ts
+++ b/packages/malloy-render/src/component/table.ts
@@ -1,40 +1,71 @@
-import {DataArray, DataRecord, Explore, Field} from '@malloydata/malloy';
+import {DataArray, DataRecord, Field} from '@malloydata/malloy';
 import {LitElement, css, html} from 'lit';
 import {customElement, property} from 'lit/decorators.js';
 import {classMap} from 'lit/directives/class-map.js';
-import {styleMap} from 'lit/directives/style-map.js';
+import {isFirstChild, isLastChild} from './util';
 
-function getPath(f: Field | Explore) {
-  const path = [f.name];
-  while (f.parentExplore) {
-    path.unshift(f.parentExplore.name);
-    f = f.parentExplore;
-  }
-  return path;
-}
-
-function getLocationInParent(f: Field | Explore) {
-  const parent = f.parentExplore;
-  return parent?.allFields.findIndex(pf => pf.name === f.name) ?? -1;
-}
-
-function getNextParentSibling(f: Field) {
-  const parent = f.parentExplore;
-  const loc = getLocationInParent(parent);
-  if (loc) return parent.parentExplore?.allFields[loc + 1];
-  return undefined;
-}
-
-function getPreviousParentSibling(f: Field) {
-  const parent = f.parentExplore;
-  const loc = getLocationInParent(parent);
-  if (loc) return parent.parentExplore?.allFields[loc - 1];
-  return undefined;
-}
-
+// TODO: replace with an estimator per column
 function getColumnWidth() {
   return 130;
 }
+
+const getContentStyle = (f: Field) => {
+  if (f.isAtomicField()) {
+    const width = getColumnWidth();
+    return `width: ${width}px; min-width: ${width}px; max-width: ${width}px;`;
+  }
+  return '';
+};
+
+const renderCell = (f: Field, value: unknown) => {
+  return html`<div class="cell-wrapper">
+    <div class="cell-gutter-start"></div>
+    <div class="cell-content" style="${getContentStyle(f)}">${value}</div>
+    <div class="cell-gutter-end"></div>
+  </div>`;
+};
+
+const renderFieldContent = (row: DataRecord, f: Field) => {
+  if (f.isExploreField()) {
+    return html`<malloy-table
+      .data=${row.cell(f) as DataArray}
+    ></malloy-table>`;
+  }
+  return renderCell(f, row.cell(f).value);
+};
+
+const renderField = (row: DataRecord, f: Field) => {
+  return html`<td
+    class=${classMap({
+      'column-cell': true,
+      'hide-end-gutter': isLastChild(f),
+      'hide-start-gutter': isFirstChild(f),
+    })}
+  >
+    ${renderFieldContent(row, f)}
+  </td>`;
+};
+
+const renderHeader = (f: Field) => {
+  const isFirst = isFirstChild(f);
+  const isParentFirst = isFirstChild(f.parentExplore);
+  const isParentNotAField = !f.parentExplore.isExploreField();
+  const hideStartGutter = isFirst && (isParentFirst || isParentNotAField);
+
+  const isLast = isLastChild(f);
+  const isParentLast = isLastChild(f.parentExplore);
+  const hideEndGutter = isLast && (isParentLast || isParentNotAField);
+
+  return html`<th
+    class=${classMap({
+      'column-cell': true,
+      'hide-end-gutter': hideEndGutter,
+      'hide-start-gutter': hideStartGutter,
+    })}
+  >
+    ${renderCell(f, f.name)}
+  </th>`;
+};
 
 @customElement('malloy-table')
 export class Table extends LitElement {
@@ -59,70 +90,6 @@ export class Table extends LitElement {
       position: relative;
     }
 
-    /* TODO: remove */
-
-    .column-cell::after {
-      position: absolute;
-      height: 12px;
-      width: 12px;
-      background: red;
-      content: ' ';
-      right: 0px;
-      top: 12px;
-      display: none;
-    }
-
-    /* TODO: remove */
-    .column-cell:hover::after {
-      display: block;
-    }
-
-    /* TODO: remove */
-    .column-cell::before {
-      position: absolute;
-      height: 12px;
-      width: 12px;
-      background: green;
-      content: ' ';
-      left: 0px;
-      top: 12px;
-      display: none;
-    }
-
-    /* TODO: remove */
-    .column-cell:hover::before {
-      display: block;
-    }
-
-    .cell-wrapper {
-      height: var(--table-row-height);
-      display: flex;
-      align-items: center;
-      overflow: hidden;
-    }
-
-    .inner-cell-wrapper {
-      border-top: var(--table-border);
-      height: var(--table-row-height);
-      line-height: var(--table-row-height);
-    }
-
-    .cell-gutter {
-      border-top: var(--table-border);
-    }
-
-    .cell-gutter-start {
-      border-top: var(--table-border);
-    }
-
-    .hide-end-gutter .cell-gutter {
-      border-top: none;
-    }
-
-    .hide-start-gutter .cell-gutter-start {
-      border-top: none;
-    }
-
     td.column-cell {
       font-weight: var(--table-body-weight);
       color: var(--table-body-color);
@@ -132,6 +99,42 @@ export class Table extends LitElement {
       font-weight: var(--table-header-weight);
       color: var(--table-header-color);
     }
+
+    .cell-wrapper {
+      height: var(--table-row-height);
+      display: flex;
+      align-items: center;
+      overflow: hidden;
+    }
+
+    .cell-content {
+      border-top: var(--table-border);
+      height: var(--table-row-height);
+      line-height: var(--table-row-height);
+      flex: 1;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .cell-gutter-start {
+      border-top: var(--table-border);
+      height: var(--table-row-height);
+      width: var(--table-gutter-size);
+    }
+
+    .cell-gutter-end {
+      border-top: var(--table-border);
+      height: var(--table-row-height);
+      width: var(--table-gutter-size);
+    }
+
+    .hide-end-gutter .cell-gutter-end {
+      border-top: none;
+    }
+
+    .hide-start-gutter .cell-gutter-start {
+      border-top: none;
+    }
   `;
 
   @property({attribute: false})
@@ -139,113 +142,22 @@ export class Table extends LitElement {
 
   render() {
     const fields = this.data.field.allFields;
-    const renderField = (row: DataRecord, f: Field) => {
-      if (f.isExploreField()) {
-        return html`<malloy-table
-          class="embedded"
-          .data=${row.cell(f) as DataArray}
-        ></malloy-table>`;
-      }
-      // style="flex: 1; overflow: hidden; text-overflow: ellipsis;"
-      return html`<div class="cell-wrapper">
-        <div class="cell-gutter-start" style="width: 15px; height: 36px;"></div>
 
-        <div
-          class="inner-cell-wrapper"
-          style="flex: 1; overflow: hidden; text-overflow: ellipsis;"
-        >
-          ${row.cell(f).value}
-        </div>
-
-        <div class="cell-gutter" style="width: 15px; height: 36px;"></div>
-      </div> `;
-    };
-
-    const atomicStyle = (f: Field) =>
-      f.isAtomicField()
-        ? 'width: 130px; min-width: 130px; max-width: 130px;'
-        : '';
-
-    const getTestStyle = (f: Field, i: number) => {
-      return 'padding-left: 0px';
-    };
-
-    const getTestHeaderStyle = (f: Field, i: number) => {
-      return 'padding-left: 0px;';
-    };
-
-    const headers = fields.map(
-      (f, i) =>
-        html`<th
-          class="column-cell ${classMap({
-            'last-col':
-              getLocationInParent(f) === f.parentExplore.allFields.length - 1,
-            'start-col': getLocationInParent(f) === 0,
-
-            'hide-end-gutter':
-              getLocationInParent(f) === f.parentExplore.allFields.length - 1 &&
-              (f.parentExplore.parentExplore?.allFields
-                ? getLocationInParent(f.parentExplore) ===
-                  f.parentExplore.parentExplore?.allFields.length - 1
-                : false),
-
-            'hide-start-gutter':
-              getLocationInParent(f) === 0 &&
-              // f.parentExplore.parentExplore?.structSource.type === "query_result"
-              (f.parentExplore.parentExplore?.allFields
-                ? getLocationInParent(f.parentExplore) === 0 ||
-                  !f.parentExplore.isExploreField()
-                : true),
-          })}"
-          style="${getTestHeaderStyle(f, i)}"
-        >
-          <div class="cell-wrapper" style="${atomicStyle(f)}">
-            <div
-              class="cell-gutter-start"
-              style="width: 15px; height: 36px;"
-            ></div>
-
-            <div
-              class="inner-cell-wrapper"
-              style="flex: 1; overflow: hidden; text-overflow: ellipsis;"
-            >
-              ${f.name}
-            </div>
-
-            <div class="cell-gutter" style="width: 15px; height: 36px;"></div>
-          </div>
-        </th>`
-    );
+    const headers = fields.map(f => renderHeader(f));
 
     const rows = Array.from(
       this.data,
       row =>
         html`<tr>
-          ${fields.map(
-            (f, i) =>
-              html`<td
-                class="column-cell ${classMap({
-                  'column-cell-table': f.isExploreField(),
-                  'last-col':
-                    getLocationInParent(f) ===
-                    f.parentExplore.allFields.length - 1,
-                  'start-col': getLocationInParent(f) === 0,
-                  'hide-end-gutter':
-                    getLocationInParent(f) ===
-                    f.parentExplore.allFields.length - 1,
-                  'hide-start-gutter': getLocationInParent(f) === 0,
-                })}"
-                style="${atomicStyle(f)} ${getTestStyle(f, i)}"
-              >
-                ${renderField(row, f)}
-              </td>`
-          )}
+          ${fields.map(f => renderField(row, f))}
         </tr>`
     );
 
     return html`<table>
       <thead>
-        ${headers}
+        <tr>
+          ${headers}
+        </tr>
       </thead>
       <tbody>
         ${rows}

--- a/packages/malloy-render/src/component/table.ts
+++ b/packages/malloy-render/src/component/table.ts
@@ -13,12 +13,18 @@ function getPath(f: Field | Explore) {
   return path;
 }
 
+function getLocationInParent(f: Field) {
+  const parent = f.parentExplore;
+  return parent.allFields.findIndex(pf => pf.name === f.name);
+}
+
 @customElement('malloy-table')
 export class Table extends LitElement {
   static styles = css`
     table {
       border-collapse: collapse;
-      background: var(--table-background);
+      // background: var(--table-background);
+      // background: #fdb7b8;
     }
 
     table * {
@@ -28,7 +34,7 @@ export class Table extends LitElement {
     .column-cell {
       height: var(--table-row-height);
       border-top: var(--table-border);
-      border-inline: 1px solid red;
+      // border-inline: 1px solid red;
       overflow: hidden;
       white-space: nowrap;
       text-align: left;
@@ -38,18 +44,60 @@ export class Table extends LitElement {
       // width: 200px;
       // max-width: 200px;
       // min-width: 200px;
+      // border-inline: 1px solid red;
+      // box-shadow: red 1px 0px 0px 0px inset;
+      position: relative;
     }
+
+    // .column-cell::after {
+    //   position: absolute;
+    //   height: 12px;
+    //   width: 12px;
+    //   background: red;
+    //   content: ' ';
+    //   right: 0px;
+    //   top: 12px;
+    //   display: none;
+    // }
+
+    // .column-cell:hover::after {
+    //   display: block;
+    // }
 
     .column-cell-table {
       padding: 0px;
-      padding-left: 15px;
+      // padding-left: 15px;
+      // padding-right: 0px;
+      height: 100%;
     }
+
+    .column-cell.last-col {
+      // border: 1px solid red;
+      // border-bottom: none;
+      // border-top: none;
+    }
+
+    // .column-cell.last-col .cell-wrapper {
+    //   border-top: 1px solid black;
+    //   display: inline-block;
+    // }
+
+    // .column-cell.last-col::after {
+    //   width: 15px;
+    //   height: 15px;
+    //   background: red;
+    //   content: 'x';
+    //   display: inline-block;
+    // }
 
     .cell-wrapper {
       height: var(--table-row-height);
       display: flex;
       align-items: center;
-      border-inline: 1px solid red;
+      overflow: hidden;
+      // background: #eee;
+      // height: 100%;
+      // border-inline: 1px solid red;
     }
 
     th.column-cell {
@@ -66,14 +114,14 @@ export class Table extends LitElement {
       color: var(--table-body-color);
     }
 
-    // th.column-cell:first-child,
-    // td.column-cell:first-child {
-    //   padding-left: 0px;
-    // }
-    // th.column-cell:last-child,
-    // td.column-cell:last-child {
-    //   padding-right: 0px;
-    // }
+    th.column-cell:first-child,
+    td.column-cell:first-child {
+      padding-left: 0px;
+    }
+    th.column-cell:last-child,
+    td.column-cell:last-child {
+      padding-right: 0px;
+    }
   `;
 
   @property({attribute: false})
@@ -99,17 +147,41 @@ export class Table extends LitElement {
 
     const atomicStyle = (f: Field) =>
       f.isAtomicField()
-        ? 'width: 200px; min-width: 200px; max-width: 200px;'
+        ? 'width: 100px; min-width: 100px; max-width: 100px;'
         : '';
 
     const getTestStyle = (f: Field, i: number) => {
+      // return '';
       // const field = f;
       // const prevField = fields[(i - 1)];
       // console.log({field, prevField});
+      const locationInParent = getLocationInParent(f);
+      if (f.isExploreField() && locationInParent === 0)
+        return 'padding-left: 0px';
       if (fields[i - 1]?.isExploreField()) {
         return 'padding-left: 30px;';
       }
+
+      if (locationInParent === 0) return '';
+      // return
+      // return '';
       return 'padding-left: 15px;';
+    };
+
+    const getTestHeaderStyle = (f: Field, i: number) => {
+      const prevField = fields[i - 1];
+      if (f.isExploreField() && getPath(f).length < 40) {
+        const locationInParent = getLocationInParent(f);
+        if (locationInParent === 0) return 'padding-left: 0px';
+        console.log({
+          f,
+          path: getPath(f),
+          locationInParent: getLocationInParent(f),
+        });
+        if (prevField && prevField.isExploreField())
+          return 'padding-left: 30px';
+        return 'padding-left: 15px';
+      } else return '';
     };
 
     /**
@@ -117,9 +189,9 @@ export class Table extends LitElement {
      */
 
     const headers = fields.map(
-      f =>
-        html`<th class="column-cell">
-          <div class="cell-wrapper" style=${atomicStyle(f)}>${f.name}</div>
+      (f, i) =>
+        html`<th class="column-cell" style="${getTestHeaderStyle(f, i)}">
+          <div class="cell-wrapper" style="${atomicStyle(f)}">${f.name}</div>
         </th>`
     );
 
@@ -132,6 +204,9 @@ export class Table extends LitElement {
               html`<td
                 class="column-cell ${classMap({
                   'column-cell-table': f.isExploreField(),
+                  'last-col':
+                    getLocationInParent(f) ===
+                    f.parentExplore.allFields.length - 1,
                 })}"
                 style="${atomicStyle(f)} ${getTestStyle(f, i)}"
               >

--- a/packages/malloy-render/src/component/table.ts
+++ b/packages/malloy-render/src/component/table.ts
@@ -1,6 +1,17 @@
-import {DataArray} from '@malloydata/malloy';
+import {DataArray, DataRecord, Explore, Field} from '@malloydata/malloy';
 import {LitElement, css, html} from 'lit';
 import {customElement, property} from 'lit/decorators.js';
+import {classMap} from 'lit/directives/class-map.js';
+import {styleMap} from 'lit/directives/style-map.js';
+
+function getPath(f: Field | Explore) {
+  const path = [f.name];
+  while (f.parentExplore) {
+    path.unshift(f.parentExplore.name);
+    f = f.parentExplore;
+  }
+  return path;
+}
 
 @customElement('malloy-table')
 export class Table extends LitElement {
@@ -10,14 +21,35 @@ export class Table extends LitElement {
       background: var(--table-background);
     }
 
+    table * {
+      box-sizing: border-box;
+    }
+
     .column-cell {
       height: var(--table-row-height);
-      border-block: var(--table-border);
+      border-top: var(--table-border);
+      border-inline: 1px solid red;
       overflow: hidden;
       white-space: nowrap;
       text-align: left;
       padding: 0px 15px;
       font-variant-numeric: tabular-nums;
+      vertical-align: top;
+      // width: 200px;
+      // max-width: 200px;
+      // min-width: 200px;
+    }
+
+    .column-cell-table {
+      padding: 0px;
+      padding-left: 15px;
+    }
+
+    .cell-wrapper {
+      height: var(--table-row-height);
+      display: flex;
+      align-items: center;
+      border-inline: 1px solid red;
     }
 
     th.column-cell {
@@ -25,19 +57,23 @@ export class Table extends LitElement {
       color: var(--table-header-color);
     }
 
+    :host(.embedded) th.column-cell {
+      border-top: 0px;
+    }
+
     td.column-cell {
       font-weight: var(--table-body-weight);
       color: var(--table-body-color);
     }
 
-    th.column-cell:first-child,
-    td.column-cell:first-child {
-      padding-left: 0px;
-    }
-    th.column-cell:last-child,
-    td.column-cell:last-child {
-      padding-right: 0px;
-    }
+    // th.column-cell:first-child,
+    // td.column-cell:first-child {
+    //   padding-left: 0px;
+    // }
+    // th.column-cell:last-child,
+    // td.column-cell:last-child {
+    //   padding-right: 0px;
+    // }
   `;
 
   @property({attribute: false})
@@ -45,9 +81,46 @@ export class Table extends LitElement {
 
   render() {
     const fields = this.data.field.allFields;
+    const fieldClass = (f: Field) =>
+      f.isExploreField() ? 'column-cell-table' : '';
+    const renderField = (row: DataRecord, f: Field) => {
+      if (f.isExploreField()) {
+        return html`<malloy-table
+          class="embedded"
+          .data=${row.cell(f) as DataArray}
+        ></malloy-table>`;
+      }
+      return html`<div class="cell-wrapper">${row.cell(f).value}</div>`;
+    };
+
+    if (this.data.field.name === 'n') {
+      console.log(this.data.field);
+    }
+
+    const atomicStyle = (f: Field) =>
+      f.isAtomicField()
+        ? 'width: 200px; min-width: 200px; max-width: 200px;'
+        : '';
+
+    const getTestStyle = (f: Field, i: number) => {
+      // const field = f;
+      // const prevField = fields[(i - 1)];
+      // console.log({field, prevField});
+      if (fields[i - 1]?.isExploreField()) {
+        return 'padding-left: 30px;';
+      }
+      return 'padding-left: 15px;';
+    };
+
+    /**
+     * if table, strike out right padding so its rows end with parent above
+     */
 
     const headers = fields.map(
-      f => html`<th class="column-cell">${f.name}</th>`
+      f =>
+        html`<th class="column-cell">
+          <div class="cell-wrapper" style=${atomicStyle(f)}>${f.name}</div>
+        </th>`
     );
 
     const rows = Array.from(
@@ -55,7 +128,15 @@ export class Table extends LitElement {
       row =>
         html`<tr>
           ${fields.map(
-            f => html`<td class="column-cell">${row.cell(f).value}</td>`
+            (f, i) =>
+              html`<td
+                class="column-cell ${classMap({
+                  'column-cell-table': f.isExploreField(),
+                })}"
+                style="${atomicStyle(f)} ${getTestStyle(f, i)}"
+              >
+                ${renderField(row, f)}
+              </td>`
           )}
         </tr>`
     );

--- a/packages/malloy-render/src/component/util.ts
+++ b/packages/malloy-render/src/component/util.ts
@@ -1,0 +1,16 @@
+import {Explore, Field} from '@malloydata/malloy';
+
+function getLocationInParent(f: Field | Explore) {
+  const parent = f.parentExplore;
+  return parent?.allFields.findIndex(pf => pf.name === f.name) ?? -1;
+}
+
+export function isLastChild(f: Field | Explore) {
+  if (f.parentExplore)
+    return getLocationInParent(f) === f.parentExplore.allFields.length - 1;
+  return true;
+}
+
+export function isFirstChild(f: Field | Explore) {
+  return getLocationInParent(f) === 0;
+}

--- a/packages/malloy-render/src/stories/basic.stories.ts
+++ b/packages/malloy-render/src/stories/basic.stories.ts
@@ -12,7 +12,7 @@ export default {
 export const ProductsTable = {
   args: {
     source: 'products',
-    view: '{ select: * }',
+    view: 'records',
   },
 };
 

--- a/packages/malloy-render/src/stories/static/basic.malloy
+++ b/packages/malloy-render/src/stories/static/basic.malloy
@@ -1,5 +1,10 @@
 source: products is duckdb.table("data/products.parquet") extend {
 
+  view: records is{
+    select: *
+    limit: 1000
+  }
+
   # bar_chart
   view: category_bar is {
     group_by: category

--- a/packages/malloy-render/src/stories/static/tables.malloy
+++ b/packages/malloy-render/src/stories/static/tables.malloy
@@ -12,4 +12,42 @@ source: products is duckdb.table("data/products.parquet") extend {
     group_by: category
     aggregate: avg_retail is retail_price.avg()
   }
+
+  view: nested is {
+    group_by: category
+    aggregate: avg_retail is retail_price.avg()
+    nest:
+      nested_column_1 is {
+        group_by: brand
+        aggregate: avg_retail is retail_price.avg()
+        limit: 10
+      }
+      another_nested is {
+        group_by: department
+        aggregate: avg_retail is retail_price.avg()
+        nest: deeply_nested is {
+          group_by: `sku`
+          aggregate: total_cost is cost.sum()
+          limit: 3
+        }
+        limit: 5
+      }
+      record is {
+        nest: nested_record is {
+          group_by: id
+          aggregate: total_cost is cost.sum()
+          limit: 5
+        }
+      }
+      another_nested2 is {
+        group_by: department
+        aggregate: avg_retail is retail_price.avg()
+        nest: deeply_nested is {
+          group_by: `sku`
+          aggregate: total_cost is cost.sum()
+          limit: 3
+        }
+        limit: 5
+      }
+  }
 };

--- a/packages/malloy-render/src/stories/static/tables.malloy
+++ b/packages/malloy-render/src/stories/static/tables.malloy
@@ -31,21 +31,6 @@ source: products is duckdb.table("data/products.parquet") extend {
             aggregate: total_cost is cost.sum()
             limit: 3
           }
-          -- deeply_nested_next is {
-          --   group_by: `brand`
-          --   aggregate: total_cost is cost.sum()
-          --   nest: in_the_mines is {
-          --     group_by: id
-          --     limit: 3
-          --   }
-          --   limit: 3
-          -- }
-          -- deeply_nested_dup is {
-          --   group_by: `sku`
-          --   aggregate: total_cost is cost.sum()
-          --   limit: 3
-          -- }
-        -- aggregate: total_cost is cost.sum()
         limit: 5
       }
       record is {

--- a/packages/malloy-render/src/stories/static/tables.malloy
+++ b/packages/malloy-render/src/stories/static/tables.malloy
@@ -25,11 +25,27 @@ source: products is duckdb.table("data/products.parquet") extend {
       another_nested is {
         group_by: department
         aggregate: avg_retail is retail_price.avg()
-        nest: deeply_nested is {
-          group_by: `sku`
-          aggregate: total_cost is cost.sum()
-          limit: 3
-        }
+        nest:
+          deeply_nested is {
+            group_by: `sku`
+            aggregate: total_cost is cost.sum()
+            limit: 3
+          }
+          -- deeply_nested_next is {
+          --   group_by: `brand`
+          --   aggregate: total_cost is cost.sum()
+          --   nest: in_the_mines is {
+          --     group_by: id
+          --     limit: 3
+          --   }
+          --   limit: 3
+          -- }
+          -- deeply_nested_dup is {
+          --   group_by: `sku`
+          --   aggregate: total_cost is cost.sum()
+          --   limit: 3
+          -- }
+        -- aggregate: total_cost is cost.sum()
         limit: 5
       }
       record is {

--- a/packages/malloy-render/src/stories/tables.stories.ts
+++ b/packages/malloy-render/src/stories/tables.stories.ts
@@ -39,3 +39,10 @@ export const Products2Column = {
     view: 'category_bar',
   },
 };
+
+export const Nested = {
+  args: {
+    source: 'products',
+    view: 'nested',
+  },
+};

--- a/packages/malloy/src/malloy.ts
+++ b/packages/malloy/src/malloy.ts
@@ -1434,6 +1434,10 @@ export class Explore extends Entity {
     return FieldIsIntrinsic(this._structDef);
   }
 
+  public isExploreField(): this is ExploreField {
+    return false;
+  }
+
   private parsedModelTag?: Tag;
   public get modelTag(): Tag {
     this.parsedModelTag ||= Tag.annotationToTag(


### PR DESCRIPTION
Implements nested tables in the next-gen renderer according to our design spec
<img width="2279" alt="CleanShot 2023-11-16 at 14 00 40@2x" src="https://github.com/malloydata/malloy/assets/5554373/9836463f-5fba-4b2f-9506-967abd49d953">

## Features
- Table cells have left and right gutters, defaulting to 15px side
- Gutter divs used instead of padding, because in the future we need to render content in those gutters while hiding text overflow within the cell content
- Gutter divs also required because in some scenarios, we want to remove the border from the gutter. This is mainly the case for nested tables. We don't want nested tables that are side by side to look like they are connected, so we don't draw borders in the gutters on the bookends of tables (nested or otherwise)
- Nested tables gutters should not cascade, so gutters aren't applied in the cells embedding a nested table
- Column widths must be hardcoded for nested columns to line up across parent rows. For now, we are hardcoding the width until we implement a sampling approach to dynamically determine a width per column