### PR TITLE
feat: pinned headers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4041,6 +4041,14 @@
       "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.1.2.tgz",
       "integrity": "sha512-jnOD+/+dSrfTWYfSXBXlo5l5f0q1UuJo3tkbMDCYA2lKUYq79jaxqtGEvnRoh049nt1vdo1+45RinipU6FGY2g=="
     },
+    "node_modules/@lit/context": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@lit/context/-/context-1.1.0.tgz",
+      "integrity": "sha512-fCyv4dsH05wCNm3AKbB+PdYbXGJd/XT8OOwo4hVmD4COq5wOWJlQreGAMDvmHZ7osqxuu06Y4nmP6ooXpN7ErA==",
+      "dependencies": {
+        "@lit/reactive-element": "^1.6.2 || ^2.0.0"
+      }
+    },
     "node_modules/@lit/reactive-element": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.0.1.tgz",
@@ -25147,6 +25155,7 @@
       "version": "0.0.104",
       "license": "MIT",
       "dependencies": {
+        "@lit/context": "^1.1.0",
         "@malloydata/malloy": "^0.0.104",
         "@types/luxon": "^2.4.0",
         "lit": "^3.0.2",

--- a/packages/malloy-render/.storybook/preview-head.html
+++ b/packages/malloy-render/.storybook/preview-head.html
@@ -1,0 +1,2 @@
+<link rel="preconnect" href="https://rsms.me/" />
+<link rel="stylesheet" href="https://rsms.me/inter/inter.css" />

--- a/packages/malloy-render/package.json
+++ b/packages/malloy-render/package.json
@@ -23,6 +23,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
+    "@lit/context": "^1.1.0",
     "@malloydata/malloy": "^0.0.104",
     "@types/luxon": "^2.4.0",
     "lit": "^3.0.2",

--- a/packages/malloy-render/src/component/render.ts
+++ b/packages/malloy-render/src/component/render.ts
@@ -45,6 +45,25 @@ export class MalloyRender extends LitElement {
       font-family: Inter, system-ui, sans-serif;
       font-size: var(--table-font-size);
     }
+
+    @supports (font-variation-settings: normal) {
+      :host {
+        font-family:
+          InterVariable,
+          Inter,
+          system-ui sans-serif;
+
+        font-variant-numeric: tabular-nums;
+        font-feature-settings:
+          'cv01' 1,
+          'cv02' 1,
+          'cv03' 1,
+          'cv04' 1,
+          'cv09' 1,
+          'liga' 1,
+          'calt' 1;
+      }
+    }
   `;
 
   @property({attribute: false})

--- a/packages/malloy-render/src/component/render.ts
+++ b/packages/malloy-render/src/component/render.ts
@@ -39,6 +39,8 @@ export class MalloyRender extends LitElement {
       --table-border: 1px solid #e5e7eb;
       --table-background: white;
       --table-gutter-size: 15px;
+      --table-pinned-background: #f5fafc;
+      --table-pinned-border: 1px solid #daedf3;
 
       font-family: Inter, system-ui, sans-serif;
       font-size: var(--table-font-size);

--- a/packages/malloy-render/src/component/table.ts
+++ b/packages/malloy-render/src/component/table.ts
@@ -151,7 +151,6 @@ export class Table extends LitElement {
     table {
       border-collapse: collapse;
       background: var(--table-background);
-      font-variant-numeric: tabular-nums;
     }
 
     th {

--- a/packages/malloy-render/src/component/table.ts
+++ b/packages/malloy-render/src/component/table.ts
@@ -201,10 +201,11 @@ export class Table extends LitElement {
       border-top: var(--table-border);
       height: var(--table-row-height);
       width: var(--table-gutter-size);
+      transition: border-color 0.25s;
     }
 
     .cell-gutter.hide-gutter-border {
-      border-top: none;
+      border-color: transparent;
     }
 
     .pinned-header table {

--- a/packages/malloy-render/src/stories/tables.stories.ts
+++ b/packages/malloy-render/src/stories/tables.stories.ts
@@ -7,10 +7,14 @@ import '../component/render';
 const meta: Meta = {
   title: 'Malloy Next/Tables',
   render: ({classes}, context) => {
+    const parent = document.createElement('div');
+    parent.style.height = '1000px';
+    parent.style.position = 'relative';
     const el = document.createElement('malloy-render');
     if (classes) el.classList.add(classes);
     el.result = context.loaded['result'];
-    return el;
+    parent.appendChild(el);
+    return parent;
   },
   loaders: [createLoader(script)],
   argTypes: {},
@@ -44,5 +48,13 @@ export const Nested = {
   args: {
     source: 'products',
     view: 'nested',
+  },
+};
+
+export const NestedCompact = {
+  args: {
+    source: 'products',
+    view: 'nested',
+    classes: 'compact',
   },
 };

--- a/packages/malloy-render/src/stories/themes.css
+++ b/packages/malloy-render/src/stories/themes.css
@@ -5,3 +5,8 @@
   --table-background: #212122;
   --table-border: 1px solid #4c505b;
 }
+
+.compact {
+  --table-row-height: 28px;
+  --table-font-size: 12px;
+}

--- a/packages/malloy/src/malloy.ts
+++ b/packages/malloy/src/malloy.ts
@@ -3529,6 +3529,7 @@ class DataNull extends Data<null> {
 export class DataArray extends Data<QueryData> implements Iterable<DataRecord> {
   private queryData: QueryData;
   protected _field: Explore;
+  private rowCache: Map<number, DataRecord> = new Map();
 
   constructor(
     queryData: QueryData,
@@ -3560,6 +3561,18 @@ export class DataArray extends Data<QueryData> implements Iterable<DataRecord> {
   }
 
   row(index: number): DataRecord {
+    let record = this.rowCache.get(index);
+    if (!record) {
+      record = new DataRecord(
+        this.queryData[index],
+        index,
+        this.field,
+        this,
+        this.parentRecord
+      );
+      this.rowCache.set(index, record);
+    }
+    return record;
     return new DataRecord(
       this.queryData[index],
       index,
@@ -3614,6 +3627,7 @@ export class DataRecord extends Data<{[fieldName: string]: DataColumn}> {
   private queryDataRow: QueryDataRow;
   protected _field: Explore;
   public readonly index: number | undefined;
+  private cellCache: Map<string, DataColumn> = new Map();
 
   constructor(
     queryDataRow: QueryDataRow,
@@ -3640,39 +3654,45 @@ export class DataRecord extends Data<{[fieldName: string]: DataColumn}> {
     const fieldName =
       typeof fieldOrName === 'string' ? fieldOrName : fieldOrName.name;
     const field = this._field.getFieldByName(fieldName);
-    const value = this.queryDataRow[fieldName];
-    if (value === null) {
-      return new DataNull(field, this, this);
-    }
-    if (field.isAtomicField()) {
-      if (field.isBoolean()) {
-        return new DataBoolean(value as boolean, field, this, this);
-      } else if (field.isDate()) {
-        return new DataDate(value as Date, field, this, this);
-      } else if (field.isJSON()) {
-        return new DataJSON(value as string, field, this, this);
-      } else if (field.isTimestamp()) {
-        return new DataTimestamp(value as Date, field, this, this);
-      } else if (field.isNumber()) {
-        return new DataNumber(value as number, field, this, this);
-      } else if (field.isString()) {
-        return new DataString(value as string, field, this, this);
-      } else if (field.isUnsupported()) {
-        return new DataUnsupported(value as unknown, field, this, this);
+    let column = this.cellCache.get(fieldName);
+    if (!column) {
+      const value = this.queryDataRow[fieldName];
+      if (value === null) {
+        column = new DataNull(field, this, this);
+      } else if (field.isAtomicField()) {
+        if (field.isBoolean()) {
+          column = new DataBoolean(value as boolean, field, this, this);
+        } else if (field.isDate()) {
+          column = new DataDate(value as Date, field, this, this);
+        } else if (field.isJSON()) {
+          column = new DataJSON(value as string, field, this, this);
+        } else if (field.isTimestamp()) {
+          column = new DataTimestamp(value as Date, field, this, this);
+        } else if (field.isNumber()) {
+          column = new DataNumber(value as number, field, this, this);
+        } else if (field.isString()) {
+          column = new DataString(value as string, field, this, this);
+        } else if (field.isUnsupported()) {
+          column = new DataUnsupported(value as unknown, field, this, this);
+        }
+      } else if (field.isExploreField()) {
+        if (Array.isArray(value)) {
+          column = new DataArray(value, field, this, this);
+        } else {
+          column = new DataRecord(
+            value as QueryDataRow,
+            undefined,
+            field,
+            this,
+            this
+          );
+        }
       }
-    } else if (field.isExploreField()) {
-      if (Array.isArray(value)) {
-        return new DataArray(value, field, this, this);
-      } else {
-        return new DataRecord(
-          value as QueryDataRow,
-          undefined,
-          field,
-          this,
-          this
-        );
-      }
+      if (column) this.cellCache.set(fieldName, column);
     }
+
+    if (column) return column;
+
     throw new Error(
       `Internal Error: could not construct data column for field '${fieldName}'.`
     );


### PR DESCRIPTION

https://github.com/malloydata/malloy/assets/5554373/044345c6-6e42-4502-b48f-c5ce1d907282

## Changes
- Table now has a scroll wrapper around it. It will fit width/height to whatever it is embedded within
- Table uses a self-consuming context to determine if its at root or not.
- If at root, a set of sticky headers is drawn. The sticky headers are just another instance of the malloy-table embedded, but with only 1 row drawn at each level and all non-headers hidden
- On scroll, a class is added so that the sticky headers will change color. In order for this to work, sticky header versions of malloy-table are rendered within the parent root instead of its own ShadowDOM root
- For sticky headers, all pointer events are removed from base wrapper and then explicitly added to th cells. Otherwise, user can't interact with the content visible underneath the sticky header
- Malloy DataArray / DataRecord now caches calls to row() and cell(), rather than returning a new instance on every invocation. This was necessary for rendering tools downstream to have stable references to data points in order to not re-render unnecessarily
- Some typography tweaks with Inter
- Added an example story showing a more compact table, per Lloyd's feedback. This may become the default