### PR TITLE
Export types we're using elsewhere

### DIFF
--- a/packages/malloy/src/index.ts
+++ b/packages/malloy/src/index.ts
@@ -21,7 +21,12 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-export {DuckDBDialect, StandardSQLDialect, PostgresDialect} from './dialect';
+export {
+  DuckDBDialect,
+  StandardSQLDialect,
+  PostgresDialect,
+  registerDialect,
+} from './dialect';
 // TODO tighten up exports
 export type {
   QueryDataRow,


### PR DESCRIPTION
There were more types, but they've been already handled by other PRs.