### PR TITLE
feat: styling prep for VS Code ext

### DIFF
--- a/packages/malloy-render/src/component/render.ts
+++ b/packages/malloy-render/src/component/render.ts
@@ -31,7 +31,6 @@ export class MalloyRender extends LitElement {
   static override styles = css`
     :host {
       --table-font-size: 12px;
-      --table-row-height: 36px;
       --table-header-color: #5d626b;
       --table-header-weight: bold;
       --table-body-color: #727883;
@@ -70,7 +69,21 @@ export class MalloyRender extends LitElement {
   result!: Result;
 
   override render() {
-    return html`<malloy-table .data=${this.result.data}></malloy-table>`;
+    const isCompact = this.result.resultExplore.modelTag.has(
+      'renderer_next',
+      'compact'
+    );
+
+    const dynamicStyle = html`<style>
+      :host {
+        --table-row-height: ${isCompact ? '28px' : '36px'};
+      }
+    </style>`;
+
+    return html`${dynamicStyle}<malloy-table
+        exportparts="table-container: container"
+        .data=${this.result.data}
+      ></malloy-table>`;
   }
 }
 

--- a/packages/malloy-render/src/component/render.ts
+++ b/packages/malloy-render/src/component/render.ts
@@ -52,13 +52,7 @@ export class MalloyRender extends LitElement {
           Inter,
           system-ui sans-serif;
 
-        font-variant-numeric: tabular-nums;
         font-feature-settings:
-          'cv01' 1,
-          'cv02' 1,
-          'cv03' 1,
-          'cv04' 1,
-          'cv09' 1,
           'liga' 1,
           'calt' 1;
       }

--- a/packages/malloy-render/src/component/table.ts
+++ b/packages/malloy-render/src/component/table.ts
@@ -325,7 +325,11 @@ export class Table extends LitElement {
       return nothing;
     };
 
-    return html`<div @scroll=${this._handleScroll} class="table-wrapper">
+    return html`<div
+      @scroll=${this._handleScroll}
+      class="table-wrapper"
+      part=${this.ctx.root ? 'table-container' : nothing}
+    >
       ${renderStickyHeader()}
       <table>
         <thead>

--- a/packages/malloy-render/src/component/table.ts
+++ b/packages/malloy-render/src/component/table.ts
@@ -193,6 +193,7 @@ export class Table extends LitElement {
 
     .column-cell.numeric {
       text-align: right;
+      font-variant-numeric: tabular-nums;
     }
 
     .cell-wrapper {


### PR DESCRIPTION
Adds a few style changes to support VS Code extension integration and testing

- Adds and exposes `container` part so that table wrapper can be styled with CSS; needed to control max height of table in a notebook
- Adds a compact mode setting so that we can easily test some variations on the table design with real data
- Cleans up some of the number typography