### PR TITLE
Add lens support for imports

### DIFF
--- a/packages/malloy/src/malloy.ts
+++ b/packages/malloy/src/malloy.ts
@@ -66,6 +66,7 @@ import {
   QueryRunStats,
   ImportLocation,
   Annotation,
+  NamedModelObject,
 } from './model';
 import {
   Connection,
@@ -812,14 +813,24 @@ export class Model implements Taggable {
    * @return An array of `Explore`s contained in the model.
    */
   public get explores(): Explore[] {
-    const explores: Explore[] = [];
-    for (const me in this.modelDef.contents) {
-      const ent = this.modelDef.contents[me];
-      if (ent.type === 'struct') {
-        explores.push(new Explore(ent));
-      }
-    }
-    return explores;
+    const isStructDef = (object: NamedModelObject): object is StructDef =>
+      object.type === 'struct';
+
+    return Object.values(this.modelDef.contents)
+      .filter(isStructDef)
+      .map(structDef => new Explore(structDef));
+  }
+
+  /**
+   * Get an array of `NamedQuery`s contained in the model.
+   *
+   * @return An array of `NamedQuery`s contained in the model.
+   */
+  public get namedQueries(): NamedQuery[] {
+    const isNamedQuery = (object: NamedModelObject): object is NamedQuery =>
+      object.type === 'query';
+
+    return Object.values(this.modelDef.contents).filter(isNamedQuery);
   }
 
   public get exportedExplores(): Explore[] {


### PR DESCRIPTION
We want to enable lenses to preview sources to `import` statements, so add that information to the list of symbols returned from the document symbol walker.

Also enable removing a hack in the extension to retrieve `NamedQuery` objects for a model for schema views.