### PR TITLE
feat: theme overrides

### DIFF
--- a/packages/malloy-render/src/component/render.ts
+++ b/packages/malloy-render/src/component/render.ts
@@ -25,24 +25,14 @@ import {Result} from '@malloydata/malloy';
 import {LitElement, html, css} from 'lit';
 import {customElement, property} from 'lit/decorators.js';
 import './table';
+import {getThemeValue} from './theme';
 
 @customElement('malloy-render')
 export class MalloyRender extends LitElement {
   static override styles = css`
     :host {
-      --table-font-size: 12px;
-      --table-header-color: #5d626b;
-      --table-header-weight: bold;
-      --table-body-color: #727883;
-      --table-body-weight: 400;
-      --table-border: 1px solid #e5e7eb;
-      --table-background: white;
-      --table-gutter-size: 15px;
-      --table-pinned-background: #f5fafc;
-      --table-pinned-border: 1px solid #daedf3;
-
       font-family: Inter, system-ui, sans-serif;
-      font-size: var(--table-font-size);
+      font-size: var(--malloy-render--table-font-size);
     }
 
     @supports (font-variation-settings: normal) {
@@ -63,14 +53,76 @@ export class MalloyRender extends LitElement {
   result!: Result;
 
   override render() {
-    const isCompact = this.result.resultExplore.modelTag.has(
-      'renderer_next',
-      'compact'
+    const modelTag = this.result.resultExplore.modelTag;
+    const {tag: resultTag} = this.result.tagParse();
+
+    const modelTheme = modelTag.tag('theme');
+    const localTheme = resultTag.tag('theme');
+    const tableRowHeight = getThemeValue(
+      'tableRowHeight',
+      localTheme,
+      modelTheme
+    );
+    const tableBodyColor = getThemeValue(
+      'tableBodyColor',
+      localTheme,
+      modelTheme
+    );
+    const tableFontSize = getThemeValue(
+      'tableFontSize',
+      localTheme,
+      modelTheme
+    );
+    const tableHeaderColor = getThemeValue(
+      'tableHeaderColor',
+      localTheme,
+      modelTheme
+    );
+    const tableHeaderWeight = getThemeValue(
+      'tableHeaderWeight',
+      localTheme,
+      modelTheme
+    );
+    const tableBodyWeight = getThemeValue(
+      'tableBodyWeight',
+      localTheme,
+      modelTheme
+    );
+    const tableBorder = getThemeValue('tableBorder', localTheme, modelTheme);
+    const tableBackground = getThemeValue(
+      'tableBackground',
+      localTheme,
+      modelTheme
+    );
+    const tableGutterSize = getThemeValue(
+      'tableGutterSize',
+      localTheme,
+      modelTheme
+    );
+    const tablePinnedBackground = getThemeValue(
+      'tablePinnedBackground',
+      localTheme,
+      modelTheme
+    );
+    const tablePinnedBorder = getThemeValue(
+      'tablePinnedBorder',
+      localTheme,
+      modelTheme
     );
 
     const dynamicStyle = html`<style>
       :host {
-        --table-row-height: ${isCompact ? '28px' : '36px'};
+        --malloy-render--table-row-height: ${tableRowHeight};
+        --malloy-render--table-body-color: ${tableBodyColor};
+        --malloy-render--table-font-size: ${tableFontSize};
+        --malloy-render--table-header-color: ${tableHeaderColor};
+        --malloy-render--table-header-weight: ${tableHeaderWeight};
+        --malloy-render--table-body-weight: ${tableBodyWeight};
+        --malloy-render--table-border: ${tableBorder};
+        --malloy-render--table-background: ${tableBackground};
+        --malloy-render--table-gutter-size: ${tableGutterSize};
+        --malloy-render--table-pinned-background: ${tablePinnedBackground};
+        --malloy-render--table-pinned-border: ${tablePinnedBorder};
       }
     </style>`;
 

--- a/packages/malloy-render/src/component/render.ts
+++ b/packages/malloy-render/src/component/render.ts
@@ -31,6 +31,18 @@ import {getThemeValue} from './theme';
 export class MalloyRender extends LitElement {
   static override styles = css`
     :host {
+      --malloy-theme--table-row-height: 28px;
+      --malloy-theme--table-font-size: 12px;
+      --malloy-theme--table-header-color: #5d626b;
+      --malloy-theme--table-header-weight: bold;
+      --malloy-theme--table-body-color: #727883;
+      --malloy-theme--table-body-weight: 400;
+      --malloy-theme--table-border: 1px solid #e5e7eb;
+      --malloy-theme--table-background: white;
+      --malloy-theme--table-gutter-size: 15px;
+      --malloy-theme--table-pinned-background: #f5fafc;
+      --malloy-theme--table-pinned-border: 1px solid #daedf3;
+
       font-family: Inter, system-ui, sans-serif;
       font-size: var(--malloy-render--table-font-size);
     }

--- a/packages/malloy-render/src/component/table.ts
+++ b/packages/malloy-render/src/component/table.ts
@@ -160,7 +160,7 @@ export class Table extends LitElement {
 
     table {
       border-collapse: collapse;
-      background: var(--table-background);
+      background: var(--malloy-render--table-background);
     }
 
     th {
@@ -172,7 +172,7 @@ export class Table extends LitElement {
     }
 
     .column-cell {
-      height: var(--table-row-height);
+      height: var(--malloy-render--table-row-height);
       overflow: hidden;
       white-space: nowrap;
       text-align: left;
@@ -182,13 +182,13 @@ export class Table extends LitElement {
     }
 
     td.column-cell {
-      font-weight: var(--table-body-weight);
-      color: var(--table-body-color);
+      font-weight: var(--malloy-render--table-body-weight);
+      color: var(--malloy-render--table-body-color);
     }
 
     th.column-cell {
-      font-weight: var(--table-header-weight);
-      color: var(--table-header-color);
+      font-weight: var(--malloy-render--table-header-weight);
+      color: var(--malloy-render--table-header-color);
     }
 
     .column-cell.numeric {
@@ -197,25 +197,25 @@ export class Table extends LitElement {
     }
 
     .cell-wrapper {
-      height: var(--table-row-height);
+      height: var(--malloy-render--table-row-height);
       display: flex;
       align-items: center;
       overflow: hidden;
     }
 
     .cell-content {
-      border-top: var(--table-border);
-      height: var(--table-row-height);
-      line-height: var(--table-row-height);
+      border-top: var(--malloy-render--table-border);
+      height: var(--malloy-render--table-row-height);
+      line-height: var(--malloy-render--table-row-height);
       flex: 1;
       overflow: hidden;
       text-overflow: ellipsis;
     }
 
     .cell-gutter {
-      border-top: var(--table-border);
-      height: var(--table-row-height);
-      width: var(--table-gutter-size);
+      border-top: var(--malloy-render--table-border);
+      height: var(--malloy-render--table-row-height);
+      width: var(--malloy-render--table-gutter-size);
       transition: border-color 0.25s;
     }
 
@@ -228,11 +228,11 @@ export class Table extends LitElement {
     }
 
     .pinned-header th {
-      background: var(--table-background);
+      background: var(--malloy-render--table-background);
     }
 
     .pinned-header.scrolled th {
-      background: var(--table-pinned-background);
+      background: var(--malloy-render--table-pinned-background);
       box-shadow: 0 0 0.5em rgba(0, 0, 0, 0.5);
     }
 
@@ -240,7 +240,7 @@ export class Table extends LitElement {
       .cell-content,
       .cell-gutter,
       .cell-gutter.hide-gutter-border {
-        border-top: var(--table-pinned-border);
+        border-top: var(--malloy-render--table-pinned-border);
       }
     }
   `;

--- a/packages/malloy-render/src/component/theme.ts
+++ b/packages/malloy-render/src/component/theme.ts
@@ -1,24 +1,16 @@
 import {Tag} from '@malloydata/malloy';
-
-export const defaultTheme = {
-  'tableRowHeight': '28px',
-  'tableBodyColor': '#727883',
-  'tableFontSize': '12px',
-  'tableHeaderColor': '#5d626b',
-  'tableHeaderWeight': 'bold',
-  'tableBodyWeight': '400',
-  'tableBorder': '1px solid #e5e7eb',
-  'tableBackground': 'white',
-  'tableGutterSize': '15px',
-  'tablePinnedBackground': '#f5fafc',
-  'tablePinnedBorder': '1px solid #daedf3',
-};
-
+// Get the first valid theme value or fallback to CSS variable
 export function getThemeValue(prop: string, ...themes: Array<Tag | undefined>) {
   let value: string | undefined;
   for (const theme of themes) {
     value = theme?.text(prop);
     if (typeof value !== 'undefined') break;
   }
-  return value ?? defaultTheme[prop];
+  // If no theme overrides, convert prop name from camelCase to kebab and pull from --malloy-theme-- variable
+  return (
+    value ??
+    `var(--malloy-theme--${prop
+      .replace(/([a-z])([A-Z])/g, '$1-$2')
+      .toLowerCase()})`
+  );
 }

--- a/packages/malloy-render/src/component/theme.ts
+++ b/packages/malloy-render/src/component/theme.ts
@@ -1,0 +1,24 @@
+import {Tag} from '@malloydata/malloy';
+
+export const defaultTheme = {
+  'tableRowHeight': '28px',
+  'tableBodyColor': '#727883',
+  'tableFontSize': '12px',
+  'tableHeaderColor': '#5d626b',
+  'tableHeaderWeight': 'bold',
+  'tableBodyWeight': '400',
+  'tableBorder': '1px solid #e5e7eb',
+  'tableBackground': 'white',
+  'tableGutterSize': '15px',
+  'tablePinnedBackground': '#f5fafc',
+  'tablePinnedBorder': '1px solid #daedf3',
+};
+
+export function getThemeValue(prop: string, ...themes: Array<Tag | undefined>) {
+  let value: string | undefined;
+  for (const theme of themes) {
+    value = theme?.text(prop);
+    if (typeof value !== 'undefined') break;
+  }
+  return value ?? defaultTheme[prop];
+}

--- a/packages/malloy-render/src/stories/static/tables.malloy
+++ b/packages/malloy-render/src/stories/static/tables.malloy
@@ -1,5 +1,3 @@
-## renderer_next
-
 source: products is duckdb.table("data/products.parquet") extend {
 
   view: records is{
@@ -7,7 +5,7 @@ source: products is duckdb.table("data/products.parquet") extend {
     limit: 1000
   }
 
-  # bar_chart renderer_next
+  # bar_chart
   view: category_bar is {
     group_by: category
     aggregate: avg_retail is retail_price.avg()

--- a/packages/malloy-render/src/stories/static/themes.malloy
+++ b/packages/malloy-render/src/stories/static/themes.malloy
@@ -1,0 +1,14 @@
+## theme.tableBodyColor=blue
+source: products is duckdb.table("data/products.parquet") extend {
+
+  view: records is{
+    select: *
+    limit: 1000
+  }
+
+  # theme.tableBodyColor=red
+  view: records_override is{
+    select: *
+    limit: 1000
+  }
+}

--- a/packages/malloy-render/src/stories/themes.css
+++ b/packages/malloy-render/src/stories/themes.css
@@ -1,12 +1,7 @@
 .night {
-  --table-body-color: white;
-  --table-header-color: #b1cad6;
-  --table-body-weight: 400;
-  --table-background: #212122;
-  --table-border: 1px solid #4c505b;
-}
-
-.compact {
-  --table-row-height: 28px;
-  --table-font-size: 12px;
+  --malloy-render--table-body-color: white;
+  --malloy-render--table-header-color: #b1cad6;
+  --malloy-render--table-body-weight: 400;
+  --malloy-render--table-background: #212122;
+  --malloy-render--table-border: 1px solid #4c505b;
 }

--- a/packages/malloy-render/src/stories/themes.css
+++ b/packages/malloy-render/src/stories/themes.css
@@ -1,7 +1,7 @@
 .night {
-  --malloy-render--table-body-color: white;
-  --malloy-render--table-header-color: #b1cad6;
-  --malloy-render--table-body-weight: 400;
-  --malloy-render--table-background: #212122;
-  --malloy-render--table-border: 1px solid #4c505b;
+  --malloy-theme--table-body-color: white;
+  --malloy-theme--table-header-color: #b1cad6;
+  --malloy-theme--table-body-weight: 400;
+  --malloy-theme--table-background: #212122;
+  --malloy-theme--table-border: 1px solid #4c505b;
 }

--- a/packages/malloy-render/src/stories/themes.stories.ts
+++ b/packages/malloy-render/src/stories/themes.stories.ts
@@ -35,3 +35,11 @@ export const ViewThemeOverride = {
     view: `records_override`,
   },
 };
+
+export const ViewThemeOverrideCSS = {
+  args: {
+    source: 'products',
+    view: `records_override`,
+    classes: 'night',
+  },
+};

--- a/packages/malloy-render/src/stories/themes.stories.ts
+++ b/packages/malloy-render/src/stories/themes.stories.ts
@@ -1,11 +1,11 @@
 import {Meta} from '@storybook/html';
-import script from './static/tables.malloy?raw';
+import script from './static/themes.malloy?raw';
 import {createLoader} from './util';
 import './themes.css';
 import '../component/render';
 
 const meta: Meta = {
-  title: 'Malloy Next/Tables',
+  title: 'Malloy Next/Themes',
   render: ({classes}, context) => {
     const parent = document.createElement('div');
     parent.style.height = '1000px';
@@ -22,31 +22,16 @@ const meta: Meta = {
 
 export default meta;
 
-export const ProductsTable = {
+export const ModelThemeOverride = {
   args: {
     source: 'products',
     view: `records`,
   },
 };
 
-export const ProductsTableCustomTheme = {
+export const ViewThemeOverride = {
   args: {
     source: 'products',
-    view: 'records',
-    classes: 'night',
-  },
-};
-
-export const Products2Column = {
-  args: {
-    source: 'products',
-    view: 'category_bar',
-  },
-};
-
-export const Nested = {
-  args: {
-    source: 'products',
-    view: 'nested',
+    view: `records_override`,
   },
 };


### PR DESCRIPTION
Adds the ability to override renderer themes directly from a malloy file, either with model or view tags.

Examples:
```malloy
-- every table in model will have blue text
## renderer_next theme.tableBodyColor=blue

source: products is duckdb.table('products.parquet') extend {
  ...
  
  -- This table will have red text
  # theme.tableBodyColor=red
  view: local_override is { select: * }
}
```

The order of precedence for a theme setting is:
1. View theme override with `# theme.prop=x`
2. Model theme override with `## theme.prop=x`
3. CSS override with `malloy-render { --malloy-theme--prop: x; }`
4. The default style value for the given prop, defined internally by malloy