### PR TITLE
feat: number formatting

### DIFF
--- a/packages/malloy-render/src/component/render-numeric-field.ts
+++ b/packages/malloy-render/src/component/render-numeric-field.ts
@@ -1,0 +1,83 @@
+import {AtomicField} from '@malloydata/malloy';
+import {Currency, DurationUnit} from '../data_styles';
+import {format} from 'ssf';
+
+// Map of unit to how many units of the make up the following time unit.
+const multiplierMap = new Map<DurationUnit, number>([
+  [DurationUnit.Nanoseconds, 1000],
+  [DurationUnit.Microseconds, 1000],
+  [DurationUnit.Milliseconds, 1000],
+  [DurationUnit.Seconds, 60],
+  [DurationUnit.Minutes, 60],
+  [DurationUnit.Hours, 24],
+  [DurationUnit.Days, Number.MAX_VALUE],
+]);
+
+function formatTimeUnit(value: number, unit: DurationUnit) {
+  let unitString = unit.toString();
+  if (value === 1) {
+    unitString = unitString.substring(0, unitString.length - 1);
+  }
+  return `${value} ${unitString}`;
+}
+
+export function renderNumericField(f: AtomicField, value: number) {
+  let displayValue: string | number = value;
+  const {tag} = f.tagParse();
+  if (tag.has('currency')) {
+    let unitText = '$';
+
+    switch (tag.text('currency')) {
+      case Currency.Euros:
+        unitText = '€';
+        break;
+      case Currency.Pounds:
+        unitText = '£';
+        break;
+      case Currency.Dollars:
+        // Do nothing.
+        break;
+    }
+    displayValue = format(`${unitText}#,##0.00`, value);
+  } else if (tag.has('percent')) displayValue = format('#,##0.00%', value);
+  else if (tag.has('duration')) {
+    const duration_unit = tag.text('duration');
+    const targetUnit = duration_unit ?? DurationUnit.Seconds;
+
+    let currentDuration = value;
+    let currentUnitValue = 0;
+    let durationParts: string[] = [];
+    let foundUnit = false;
+
+    for (const [unit, multiplier] of multiplierMap) {
+      if (unit === targetUnit) {
+        foundUnit = true;
+      }
+
+      if (!foundUnit) {
+        continue;
+      }
+
+      currentUnitValue = currentDuration % multiplier;
+      currentDuration = Math.floor((currentDuration /= multiplier));
+
+      if (currentUnitValue > 0) {
+        durationParts = [
+          formatTimeUnit(currentUnitValue, unit),
+          ...durationParts,
+        ];
+      }
+
+      if (currentDuration === 0) {
+        break;
+      }
+    }
+
+    if (durationParts.length > 0) {
+      displayValue = durationParts.slice(0, 2).join(' ');
+    } else displayValue = formatTimeUnit(0, targetUnit as DurationUnit);
+  } else if (tag.has('number'))
+    displayValue = format(tag.text('number')!, value);
+  else displayValue = (value as number).toLocaleString();
+  return displayValue;
+}

--- a/packages/malloy-render/src/component/table.ts
+++ b/packages/malloy-render/src/component/table.ts
@@ -27,6 +27,7 @@ import {customElement, eventOptions, property, state} from 'lit/decorators.js';
 import {classMap} from 'lit/directives/class-map.js';
 import {createContext, provide, consume} from '@lit/context';
 import {isFirstChild, isLastChild} from './util';
+import {renderNumericField} from './render-numeric-field';
 
 type TableContext = {
   root: boolean;
@@ -88,10 +89,11 @@ const renderFieldContent = (
       .rowLimit=${options.pinnedHeader ? 1 : Infinity}
     ></malloy-table>`;
   }
-  let value = row.cell(f).value;
+  let value: number | string = row.cell(f).value as number;
   if (options.pinnedHeader) value = '';
-  else if (f.isAtomicField() && f.isNumber())
-    value = (value as number).toLocaleString();
+  else if (f.isAtomicField() && f.isNumber()) {
+    value = renderNumericField(f, value);
+  }
 
   return renderCell(f, value, {
     hideStartGutter: isFirstChild(f),

--- a/packages/malloy-render/src/stories/static/tables.malloy
+++ b/packages/malloy-render/src/stories/static/tables.malloy
@@ -49,4 +49,17 @@ source: products is duckdb.table("data/products.parquet") extend {
         limit: 5
       }
   }
+
+  view: number_formats is {
+    group_by: category
+    aggregate:
+      # currency
+      avg_retail_currency is retail_price.avg()
+      # percent
+      avg_retail_percent is retail_price.avg()
+      # number="#,##0.00"
+      avg_retail_number is retail_price.avg()
+      # duration
+      avg_retail_duration is round(retail_price.avg())
+  }
 };

--- a/packages/malloy-render/src/stories/tables.stories.ts
+++ b/packages/malloy-render/src/stories/tables.stories.ts
@@ -50,3 +50,10 @@ export const Nested = {
     view: 'nested',
   },
 };
+
+export const NumberFormatting = {
+  args: {
+    source: 'products',
+    view: 'number_formats',
+  },
+};


### PR DESCRIPTION
Adds number formatting from old renderer to new renderer: `number`, `currency`, `percent`, and `duration`
![image](https://github.com/malloydata/malloy/assets/5554373/db9f8fc4-3624-4d59-9320-b8cebe53fe41)

For the number formatting logic in render-numeric-field.ts, the logic is just copied out of the legacy renderer code. I opted not to create separate renderer components for number formats for now; it seems wasteful to create a web component for every numeric cell in a table if it doesn't have any need for state, lifecycle events, etc.

So for now, our formatting just takes a numeric value and field def and returns a string of what it should look like. If our requirements grow such that these numbers need more complex features, we can refactor into a component.