### PR TITLE
Revert "Allow '}' to end embedded SQL"

### DIFF
--- a/packages/malloy-malloy-sql/src/grammar/malloySQLSQL.pegjs
+++ b/packages/malloy-malloy-sql/src/grammar/malloySQLSQL.pegjs
@@ -30,7 +30,7 @@ parenthesized_embedded_malloy
   }
 }
 plain_embedded_malloy
-  = '%{' m:malloy '}' '%'|0..1| {
+  = '%{' m:malloy '}%' {
   return {
     type: "malloy",
     text:text(),
@@ -41,7 +41,7 @@ plain_embedded_malloy
   }
 }
 malloy
-  = (!'}' .)* {
+  = (!'}%' .)* {
   return {
     malloyRange: location(),
     text:text()

--- a/packages/malloy-malloy-sql/src/grammar/test/parse.spec.ts
+++ b/packages/malloy-malloy-sql/src/grammar/test/parse.spec.ts
@@ -179,7 +179,7 @@ SELECT 2
     });
   });
 
-  describe('Legacy Embedded Malloy (with }%)', () => {
+  describe('Embedded Malloy', () => {
     test('Parenthesized embedded malloy can handle space between ( and {%', () => {
       const parse = MalloySQLParser.parse(
         '>>>sql connection:bigquery\nSELECT (  %{ malloy }%  )'
@@ -195,32 +195,6 @@ SELECT 2
     test('Non-parenthesized embedded malloy', () => {
       const parse = MalloySQLParser.parse(
         '>>>sql connection:bigquery\nSELECT %{ malloy }%'
-      );
-      const stmt = parse.statements[0] as MalloySQLSQLStatement;
-      const embeddedMalloy = stmt.embeddedMalloyQueries[0];
-      expect(embeddedMalloy.query).toBe(' malloy ');
-      expect(embeddedMalloy.parenthesized).toBeFalsy();
-      expect(embeddedMalloy.range.start.character).toBe(7);
-      expect(embeddedMalloy.malloyRange.start.character).toBe(9);
-    });
-  });
-
-  describe('Embedded Malloy (with })', () => {
-    test('Parenthesized embedded malloy can handle space between ( and {%', () => {
-      const parse = MalloySQLParser.parse(
-        '>>>sql connection:bigquery\nSELECT (  %{ malloy }  )'
-      );
-      const stmt = parse.statements[0] as MalloySQLSQLStatement;
-      const embeddedMalloy = stmt.embeddedMalloyQueries[0];
-      expect(embeddedMalloy.query).toBe(' malloy ');
-      expect(embeddedMalloy.parenthesized).toBeTruthy();
-      expect(embeddedMalloy.range.start.character).toBe(7);
-      expect(embeddedMalloy.malloyRange.start.character).toBe(12);
-    });
-
-    test('Non-parenthesized embedded malloy', () => {
-      const parse = MalloySQLParser.parse(
-        '>>>sql connection:bigquery\nSELECT %{ malloy }'
       );
       const stmt = parse.statements[0] as MalloySQLSQLStatement;
       const embeddedMalloy = stmt.embeddedMalloyQueries[0];


### PR DESCRIPTION
Reverts malloydata/malloy#1473

Since `}` is a valid Malloy character this can terminate a Malloy block prematurely.