### PR TITLE
feat: basic nested bar chart

### DIFF
--- a/packages/malloy-render/src/component/bar-chart.ts
+++ b/packages/malloy-render/src/component/bar-chart.ts
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files
+ * (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+import {LitElement, html} from 'lit';
+import {customElement, property} from 'lit/decorators.js';
+import './vega-chart';
+import {DataArray, ExploreField} from '@malloydata/malloy';
+import {consume} from '@lit/context';
+import {resultContext} from './result-context';
+import {RenderResultMetadata} from './render-result-metadata';
+import {getChartSettings} from './chart-settings';
+import {baseSpec} from './vega-lite-base-spec';
+import {valueIsNumber, valueIsString} from './util';
+
+@customElement('malloy-bar-chart')
+export class BarChart extends LitElement {
+  @property({attribute: false})
+  data!: DataArray;
+
+  @consume({context: resultContext})
+  @property({attribute: false})
+  metadata!: RenderResultMetadata;
+
+  override render() {
+    const field = this.data.field as ExploreField;
+    const keys = field.allFields;
+    const {tag} = field.tagParse();
+    const isSpark = tag.text('size') === 'spark';
+    const chartSettings = getChartSettings(field, this.metadata);
+
+    const records: Partial<{barDim: string; sizeMeasure: number}>[] = [];
+    for (const rec of this.data) {
+      const record: Partial<{barDim: string; sizeMeasure: number}> = {};
+      const xValue = rec.cell(chartSettings.xField.name).value;
+      const yValue = rec.cell(chartSettings.yField.name).value;
+      if (valueIsString(chartSettings.xField, xValue)) {
+        record.barDim = xValue;
+      }
+      if (valueIsNumber(chartSettings.yField, yValue)) {
+        record.sizeMeasure = yValue;
+      }
+      records.push(record);
+    }
+
+    const spec = baseSpec();
+    spec.data = {
+      values: records,
+    };
+
+    spec.layer = [
+      {
+        mark: {
+          type: 'bar',
+          width: {'band': 0.8},
+          cornerRadiusEnd: 0,
+        },
+        encoding: {
+          x: {
+            field: 'barDim',
+            type: 'nominal',
+            sort: null, // Uses the sort order of underlying data
+            axis: {
+              labelAngle: chartSettings.xAxis.labelAngle,
+              maxExtent: chartSettings.xAxis.height,
+              labelLimit: chartSettings.xAxis.labelSize,
+              title: keys[0].name,
+            },
+            scale: {},
+          },
+          y: {
+            field: 'sizeMeasure',
+            type: 'quantitative',
+            scale: {
+              domain: chartSettings.yScale.domain,
+            },
+            axis: {
+              maxExtent: chartSettings.yAxis.width,
+              labelLimit: chartSettings.yAxis.width + 10,
+              tickCount: chartSettings.yAxis.tickCount,
+              title: keys[1].name,
+            },
+          },
+          // TODO: fill color from theme
+          fill: {value: '#53B2C8'},
+        },
+      },
+    ];
+
+    if (isSpark) {
+      spec.padding = 0;
+      spec.layer[0].encoding.y.axis = null;
+    } else {
+      spec.padding = chartSettings.padding;
+    }
+
+    return html`<div style="">
+      <malloy-vega-chart
+        .spec="${spec}"
+        type="vega-lite"
+        width="${chartSettings.plotWidth}"
+        height="${chartSettings.plotHeight}"
+      ></malloy-vega-chart>
+    </div>`;
+  }
+}

--- a/packages/malloy-render/src/component/chart-settings.ts
+++ b/packages/malloy-render/src/component/chart-settings.ts
@@ -99,7 +99,7 @@ export function getChartSettings(
   const hasXAxis = presetSize !== 'spark';
   const hasYAxis = presetSize !== 'spark';
   const exploreMetadata = metadata.fields[getFieldKey(field)];
-  let topPadding = ROW_HEIGHT;
+  let topPadding = presetSize !== 'spark' ? ROW_HEIGHT - 1 : 0; // Subtract 1 to account for top border
   let yTickCount: number | undefined;
   const yKey = getFieldKey(yField);
   const maxVal = metadata.fields[yKey]!.max!;

--- a/packages/malloy-render/src/component/chart-settings.ts
+++ b/packages/malloy-render/src/component/chart-settings.ts
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files
+ * (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import {ExploreField, Field} from '@malloydata/malloy';
+import {scale, locale} from 'vega';
+import {getFieldKey, getTextWidth} from './util';
+import {RenderResultMetadata} from './render-result-metadata';
+
+export type ChartSettings = {
+  plotWidth: number;
+  plotHeight: number;
+  xAxis: {
+    labelAngle: number;
+    labelSize: number;
+    height: number;
+    titleSize: number;
+  };
+  yAxis: {
+    width: number;
+    tickCount?: number;
+  };
+  yScale: {
+    domain: number[];
+  };
+  xField: Field;
+  yField: Field;
+  padding: {
+    top: number;
+    left: number;
+    right: number;
+    bottom: number;
+  };
+  totalWidth: number;
+  totalHeight: number;
+};
+
+// Later should depend on chart type?
+const CHART_SIZES = {
+  'spark': [180, 1], // row height
+  'xs': [170, 2], // 2x row height
+  'sm': [216, 3], // 3x row height
+  'md': [256, 4], // 4x row height
+  'lg': [472, 7], // 7x row height
+  'xl': [508, 10], // 10x row height
+  '2xl': [730, 14], // 14x row height
+};
+
+// TODO: read from theme CSS
+const ROW_HEIGHT = 28;
+
+export function getChartSettings(
+  field: ExploreField,
+  metadata: RenderResultMetadata
+): ChartSettings {
+  // TODO: improve logic for field extraction
+  const xField = field.allFields.at(0)!;
+  const yField = field.allFields.at(1)!;
+  const {tag} = field.tagParse();
+
+  let chartWidth = 0,
+    chartHeight = 0;
+  const customWidth = tag.numeric('size', 'width');
+  const customHeight = tag.numeric('size', 'height');
+  let presetSize = tag.text('size');
+  if (customWidth && customHeight) {
+    chartWidth = customWidth;
+    chartHeight = customHeight;
+  } else {
+    presetSize = presetSize || 'md';
+    [chartWidth, chartHeight] = CHART_SIZES[presetSize];
+    chartHeight = chartHeight * ROW_HEIGHT;
+  }
+
+  let xAxisHeight = 0;
+  let yAxisWidth = 0;
+  let labelAngle = -90;
+  let labelSize = 0;
+  let xTitleSize = 0;
+  const hasXAxis = presetSize !== 'spark';
+  const hasYAxis = presetSize !== 'spark';
+  const exploreMetadata = metadata.fields[getFieldKey(field)];
+  let topPadding = ROW_HEIGHT;
+  let yTickCount: number | undefined;
+  const yKey = getFieldKey(yField);
+  const maxVal = metadata.fields[yKey]!.max!;
+  const yScale = scale('linear')()
+    .domain([0, maxVal])
+    .nice()
+    .range([chartHeight, 0]);
+  const yDomain = yScale.domain();
+
+  if (hasYAxis) {
+    const maxAxisVal = yScale.domain().at(1);
+    const l = locale();
+    const formatted = l.format(',')(maxAxisVal);
+    const yTitleSize = 31; // Estimate for now, can be dynamic later
+    const yLabelOffset = 5;
+    yAxisWidth =
+      getTextWidth(formatted, 'Inter, sans-serif 12px') +
+      yLabelOffset +
+      yTitleSize;
+
+    // Check whether we need to adjust axis values manually
+    const noOfTicks = Math.ceil(chartHeight / 40);
+    const ticks = yScale.ticks(noOfTicks);
+    if (ticks.at(-1) < maxAxisVal) {
+      const offRatio = (maxAxisVal - ticks.at(-1)) / maxAxisVal;
+      // adjust chart height
+      const newChartHeight = chartHeight / (1 - offRatio);
+      // adjust chart padding
+      topPadding = topPadding - (newChartHeight - chartHeight);
+      chartHeight = newChartHeight;
+
+      // Hardcode # of ticks, or the resize could make room for more ticks and then screw things up
+      yTickCount = noOfTicks;
+    }
+  }
+
+  if (hasXAxis) {
+    // TODO: add type checking here for axis. for now assume number, string
+    const xKey = getFieldKey(xField);
+    const maxString = metadata.fields[xKey]!.maxString!;
+    const maxStringSize = getTextWidth(maxString, 'Inter, sans-serif 12px');
+    const X_AXIS_THRESHOLD = 0.3;
+    const minBottomPadding = 15;
+    xTitleSize = 22 + minBottomPadding;
+    xAxisHeight = Math.min(maxStringSize, X_AXIS_THRESHOLD * chartHeight);
+    labelSize = xAxisHeight;
+
+    const xSpacePerLabel =
+      (chartWidth - yAxisWidth) / exploreMetadata.maxRecordCt!;
+    if (xSpacePerLabel > xAxisHeight) {
+      labelAngle = 0;
+      labelSize = xSpacePerLabel;
+    }
+  }
+
+  // Additional xTitle padding to snap to row height grid
+  const totalSize = chartHeight + xAxisHeight + xTitleSize;
+  const roundedUpRowHeight = Math.ceil(totalSize / ROW_HEIGHT) * ROW_HEIGHT;
+  xTitleSize += roundedUpRowHeight - totalSize;
+
+  return {
+    plotWidth: chartWidth,
+    plotHeight: chartHeight,
+    xAxis: {
+      labelAngle,
+      labelSize,
+      height: xAxisHeight,
+      titleSize: xTitleSize,
+    },
+    yAxis: {
+      width: yAxisWidth,
+      tickCount: yTickCount,
+    },
+    yScale: {
+      domain: yDomain,
+    },
+    padding: {
+      top: topPadding,
+      left: yAxisWidth,
+      bottom: xAxisHeight + xTitleSize,
+      right: 0,
+    },
+    xField,
+    yField,
+    get totalWidth() {
+      return this.plotWidth + this.padding.left + this.padding.right;
+    },
+    get totalHeight() {
+      return this.plotHeight + this.padding.top + this.padding.bottom;
+    },
+  };
+}

--- a/packages/malloy-render/src/component/render.ts
+++ b/packages/malloy-render/src/component/render.ts
@@ -25,6 +25,7 @@ import {Result, Tag} from '@malloydata/malloy';
 import {LitElement, html, css, PropertyValues} from 'lit';
 import {customElement, property} from 'lit/decorators.js';
 import './table';
+import './bar-chart';
 import {provide} from '@lit/context';
 import {resultContext} from './result-context';
 import {

--- a/packages/malloy-render/src/component/table-layout.ts
+++ b/packages/malloy-render/src/component/table-layout.ts
@@ -33,10 +33,13 @@ import {ChartSettings, getChartSettings} from './chart-settings';
 const MIN_COLUMN_WIDTH = 32;
 const MAX_COLUMN_WIDTH = 384;
 const COLUMN_BUFFER = 12;
+// TODO: get from theme
+const ROW_HEIGHT = 28;
 
 type LayoutEntry = {
   metadata: FieldRenderMetadata;
   width: number;
+  height: number | null;
   chartSettings: ChartSettings | null;
 };
 
@@ -50,6 +53,7 @@ export function getTableLayout(metadata: RenderResultMetadata): TableLayout {
     const layoutEntry: LayoutEntry = {
       metadata: fieldMeta,
       width: getColumnWidth(field, metadata),
+      height: null,
       chartSettings: null,
     };
 
@@ -57,6 +61,9 @@ export function getTableLayout(metadata: RenderResultMetadata): TableLayout {
     if (tag.has('bar') && field.isExploreField()) {
       layoutEntry.chartSettings = getChartSettings(field, metadata);
       layoutEntry.width = layoutEntry.chartSettings.totalWidth;
+      layoutEntry.height = layoutEntry.chartSettings.totalHeight;
+    } else if (field.isAtomicField()) {
+      layoutEntry.height = ROW_HEIGHT;
     }
 
     layout[key] = layoutEntry;

--- a/packages/malloy-render/src/component/table-layout.ts
+++ b/packages/malloy-render/src/component/table-layout.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files
+ * (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import {Field} from '@malloydata/malloy';
+import {
+  FieldRenderMetadata,
+  RenderResultMetadata,
+} from './render-result-metadata';
+import {clamp, getFieldKey, getTextWidth} from './util';
+import {renderNumericField} from './render-numeric-field';
+import {ChartSettings, getChartSettings} from './chart-settings';
+
+const MIN_COLUMN_WIDTH = 32;
+const MAX_COLUMN_WIDTH = 384;
+const COLUMN_BUFFER = 12;
+
+type LayoutEntry = {
+  metadata: FieldRenderMetadata;
+  width: number;
+  chartSettings: ChartSettings | null;
+};
+
+export type TableLayout = Record<string, LayoutEntry>;
+
+export function getTableLayout(metadata: RenderResultMetadata): TableLayout {
+  const layout = {};
+
+  for (const [key, fieldMeta] of Object.entries(metadata.fields)) {
+    const field = fieldMeta.field;
+    const layoutEntry: LayoutEntry = {
+      metadata: fieldMeta,
+      width: getColumnWidth(field, metadata),
+      chartSettings: null,
+    };
+
+    const {tag} = field.tagParse();
+    if (tag.has('bar') && field.isExploreField()) {
+      layoutEntry.chartSettings = getChartSettings(field, metadata);
+      layoutEntry.width = layoutEntry.chartSettings.totalWidth;
+    }
+
+    layout[key] = layoutEntry;
+  }
+  return layout;
+}
+
+function getColumnWidth(f: Field, metadata: RenderResultMetadata) {
+  const fieldKey = getFieldKey(f);
+  const fieldMeta = metadata.fields[fieldKey];
+  let width = 0;
+  if (f.isAtomicField()) {
+    // TODO: get font styles from theme
+    const font = `12px Inter, sans-serif`;
+    const titleWidth = getTextWidth(f.name, font);
+    if (f.isAtomicField() && f.isString()) {
+      width =
+        Math.max(getTextWidth(fieldMeta.maxString!, font), titleWidth) +
+        COLUMN_BUFFER;
+    } else if (f.isAtomicField() && f.isNumber()) {
+      const formattedValue = renderNumericField(f, fieldMeta.max!);
+      width =
+        Math.max(getTextWidth(formattedValue, font), titleWidth) +
+        COLUMN_BUFFER;
+    } else width = 130;
+    width = clamp(MIN_COLUMN_WIDTH, MAX_COLUMN_WIDTH, width);
+  }
+
+  return width;
+}

--- a/packages/malloy-render/src/component/table.ts
+++ b/packages/malloy-render/src/component/table.ts
@@ -125,15 +125,10 @@ export class Table extends LitElement {
       overflow: hidden;
     }
 
-    .cell-wrapper.atomic {
-      height: var(--malloy-render--table-row-height);
-    }
-
     .cell-content {
       border-top: var(--malloy-render--table-border);
       height: 100%;
-      /* Subtract 1px to make up for top border */
-      line-height: calc(var(--malloy-render--table-row-height) - 1px);
+      line-height: var(--malloy-render--table-row-height);
       flex: 1;
       overflow: hidden;
       text-overflow: ellipsis;
@@ -262,10 +257,19 @@ export class Table extends LitElement {
 
   private getContentStyle(f: Field, isHeader = false) {
     const width = this.getColumnWidth(f);
-    if (isHeader) return '';
-    return typeof width === 'undefined'
-      ? ''
-      : `width: ${width}px; min-width: ${width}px; max-width: ${width}px;`;
+    let style = '';
+    if (isHeader) return style;
+
+    if (typeof width !== 'undefined') {
+      style += `width: ${width}px; min-width: ${width}px; max-width: ${width}px;`;
+    }
+
+    const height = this.ctx.layout[getFieldKey(f)].height;
+    if (typeof height === 'number') {
+      style += `height: ${height}px;`;
+    }
+
+    return style;
   }
 
   private renderCell(

--- a/packages/malloy-render/src/component/util.ts
+++ b/packages/malloy-render/src/component/util.ts
@@ -60,3 +60,14 @@ export function getTextWidth(
 export function clamp(s: number, e: number, v: number) {
   return Math.max(s, Math.min(e, v));
 }
+
+export function shouldRenderAs(f: Field) {
+  if (f.isAtomicField()) return 'cell';
+  const {tag} = f.tagParse();
+  if (tag.has('bar')) return 'bar-chart';
+  else return 'table';
+}
+
+export function getFieldKey(f: Field) {
+  return JSON.stringify(f.fieldPath);
+}

--- a/packages/malloy-render/src/component/vega-chart.ts
+++ b/packages/malloy-render/src/component/vega-chart.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files
+ * (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import {LitElement, html, TemplateResult, css, PropertyValues} from 'lit';
+import {customElement, property} from 'lit/decorators.js';
+import {View, parse} from 'vega';
+import {compile} from 'vega-lite';
+import {VegaJSON, asVegaLiteSpec, asVegaSpec} from './vega-types';
+
+@customElement('malloy-vega-chart')
+export class VegaChart extends LitElement {
+  static override styles = css`
+    #vis > svg {
+      display: block;
+    }
+  `;
+  @property({attribute: false})
+  spec!: VegaJSON;
+
+  @property({type: String})
+  type: 'vega' | 'vega-lite' = 'vega';
+
+  @property({type: Number})
+  width?: number;
+
+  @property({type: Number})
+  height?: number;
+
+  private el: HTMLElement | null = null;
+  private view: View | null = null;
+
+  setupView() {
+    if (this.view) this.view.finalize();
+    const vegaspec =
+      this.type === 'vega-lite'
+        ? compile(asVegaLiteSpec(this.spec)).spec
+        : asVegaSpec(this.spec);
+
+    this.view = new View(parse(vegaspec))
+      .initialize(this.el!)
+      .renderer('svg')
+      .hover();
+    if (this.width) this.view.width(this.width);
+    if (this.height) this.view.height(this.height);
+
+    this.view.run();
+  }
+
+  firstUpdated() {
+    this.el = this.shadowRoot!.getElementById('vis')!;
+    this.setupView();
+  }
+
+  protected willUpdate(changedProperties: PropertyValues<this>) {
+    if (changedProperties.has('spec') || changedProperties.has('type')) {
+      if (this.el) this.setupView();
+    } else {
+      if (
+        (changedProperties.has('width') || changedProperties.has('height')) &&
+        this.view
+      ) {
+        if (this.width) this.view.width(this.width);
+        if (this.height) this.view.height(this.height);
+        this.view.run();
+      }
+    }
+  }
+
+  render(): TemplateResult {
+    return html` <div id="vis"></div> `;
+  }
+}

--- a/packages/malloy-render/src/component/vega-lite-base-spec.ts
+++ b/packages/malloy-render/src/component/vega-lite-base-spec.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files
+ * (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+import {VegaJSON} from './vega-types';
+
+const grayMedium = '#727883';
+const gridGray = '#E5E7EB';
+
+export const baseSpec = (): VegaJSON => ({
+  $schema: 'https://vega.github.io/schema/vega-lite/v5.json',
+  config: {
+    axisY: {
+      gridColor: gridGray,
+      tickColor: gridGray,
+      domain: false,
+      labelFont: 'Inter, sans-serif',
+      labelFontSize: 10,
+      labelFontWeight: 'normal',
+      labelColor: grayMedium,
+      labelPadding: 5,
+      titleColor: grayMedium,
+      titleFont: 'Inter, sans-serif',
+      titleFontSize: 12,
+      titleFontWeight: 'bold',
+      titlePadding: 10,
+      labelOverlap: false,
+    },
+    axisX: {
+      gridColor: gridGray,
+      tickColor: gridGray,
+      tickSize: 0,
+      domain: false,
+      labelFont: 'Inter, sans-serif',
+      labelFontSize: 10,
+      labelFontWeight: 'normal',
+      labelPadding: 5,
+      labelColor: grayMedium,
+      titleColor: grayMedium,
+      titleFont: 'Inter, sans-serif',
+      titleFontSize: 12,
+      titleFontWeight: 'bold',
+      titlePadding: 10,
+    },
+    view: {
+      strokeWidth: 0,
+    },
+  },
+  params: [],
+  padding: 0,
+  autosize: {
+    type: 'none',
+    resize: true,
+    contains: 'content',
+  },
+  // for vega-lite, if width/height is not specificed in spec it will try to autosize. Set values to prevent
+  width: 1,
+  height: 1,
+  data: {
+    values: [],
+  },
+  layer: [],
+});

--- a/packages/malloy-render/src/component/vega-types.ts
+++ b/packages/malloy-render/src/component/vega-types.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files
+ * (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import {Spec} from 'vega';
+import {TopLevelSpec} from 'vega-lite';
+
+/**
+ * TODO: create vega-lite-types package that exports types from vega-lite
+ * Because vega-lite typings are not available today, we are forced to use any
+ * */
+// tslint:disable-next-line:no-any
+export type VegaJSON = any;
+
+export function asVegaSpec(v: VegaJSON) {
+  return v as unknown as Spec;
+}
+
+export function asVegaLiteSpec(v: VegaJSON) {
+  return v as unknown as TopLevelSpec;
+}

--- a/packages/malloy-render/src/stories/bars.stories.ts
+++ b/packages/malloy-render/src/stories/bars.stories.ts
@@ -1,0 +1,44 @@
+import {Meta} from '@storybook/html';
+import script from './static/bars.malloy?raw';
+import {createLoader} from './util';
+import './themes.css';
+import '../component/render';
+
+const meta: Meta = {
+  title: 'Malloy Next/Bars',
+  render: ({classes}, context) => {
+    const parent = document.createElement('div');
+    parent.style.height = '1000px';
+    parent.style.position = 'relative';
+    const el = document.createElement('malloy-render');
+    if (classes) el.classList.add(classes);
+    el.result = context.loaded['result'];
+    parent.appendChild(el);
+    return parent;
+  },
+  loaders: [createLoader(script)],
+  argTypes: {},
+};
+
+export default meta;
+
+export const Products2Column = {
+  args: {
+    source: 'products',
+    view: 'category_bar',
+  },
+};
+
+export const Nested = {
+  args: {
+    source: 'products',
+    view: 'nested',
+  },
+};
+
+export const Sparks = {
+  args: {
+    source: 'products',
+    view: 'sparks',
+  },
+};

--- a/packages/malloy-render/src/stories/static/bars.malloy
+++ b/packages/malloy-render/src/stories/static/bars.malloy
@@ -1,0 +1,99 @@
+source: products is duckdb.table("data/products.parquet") extend {
+  measure: total_sales is retail_price.sum()
+  measure: avg_margin is avg(retail_price - cost)
+  dimension: product is name
+
+  # bar
+  view: topSellingBrands is {
+    group_by: brand
+    aggregate: `Sales $` is retail_price.avg()*500
+    limit: 10
+  }
+
+  view: sparks is {
+    group_by: category
+    # currency
+    aggregate: `Avg Retail` is retail_price.avg()
+    nest:
+    # size="spark"
+    `Top Brands` is topSellingBrands
+  }
+
+  view: category_bar is {
+    limit: 2
+    group_by: category
+    # currency
+    aggregate: `Avg Retail` is retail_price.avg()
+
+    nest:
+    `Top Departments` is {
+      group_by: department
+      # currency
+      aggregate: `Avg Retail` is retail_price.avg()
+      limit: 5
+    }
+    # size=lg
+    `Top Selling Brands` is topSellingBrands
+    `Top Products` is {
+      group_by: name
+      # currency
+      aggregate: `Sales` is retail_price.avg()
+      limit: 10
+    }
+    # size=spark
+    spark is topSellingBrands
+    # size=sm
+    sm is topSellingBrands
+    # size=md
+    md is topSellingBrands
+    # size=lg
+    lg is topSellingBrands
+    # size=xl
+    xl is topSellingBrands
+    # size=2xl
+    `2xl` is topSellingBrands
+  }
+
+
+  view: nested is {
+    group_by: category
+    aggregate: avg_retail is retail_price.avg()
+    nest:
+      # bar size=lg
+      # size.height=220 size.width=300
+      nested_column_1 is {
+        group_by: brand
+        aggregate: avg_retail is retail_price.avg()
+        limit: 10
+      }
+      another_nested is {
+        group_by: department
+        aggregate: avg_retail is retail_price.avg()
+        # bar
+        nest:
+          deeply_nested is {
+            group_by: `sku`
+            aggregate: total_cost is cost.sum()
+            limit: 3
+          }
+        limit: 5
+      }
+      record is {
+        nest: nested_record is {
+          group_by: id
+          aggregate: total_cost is cost.sum()
+          limit: 5
+        }
+      }
+      another_nested2 is {
+        group_by: department
+        aggregate: avg_retail is retail_price.avg()
+        nest: deeply_nested is {
+          group_by: `sku`
+          aggregate: total_cost is cost.sum()
+          limit: 3
+        }
+        limit: 5
+      }
+  }
+}

--- a/packages/malloy-render/src/vega.d.ts
+++ b/packages/malloy-render/src/vega.d.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files
+ * (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+declare module 'vega' {
+  // vega-typings does not export the typing for locale
+  const locale: () => {format: (f: string) => (v: number) => string};
+}


### PR DESCRIPTION
This PR adds a very basic nested bar chart to the new renderer.

## Limitations of this PR
In order to keep this PR from being massive, many necessary features and implementation details have been left out as future TODOs. Those include the following:
- this PR only implements bar chart as nested within a table cell; root level bar chart renderings do not work yet
- the bar chart implementation has its own bespoke Vega spec. We will rearchitect this to use a more generalized XY Plot components like the old renderer does. Starting just with bar here to keep things simple
- the extraction of which fields are X and Y in the bar chart is rudimentary
- many of the styles needed to calculate size and render the bar charts are hardcoded, instead of referencing the theme
- only supports strings in X axis and numbers in Y axis
- Vega-Lite specs are typed as `any`. [Vega-Lite does not currently export the sub-types of their spec](https://github.com/vega/vega-lite/issues/9222). We are working towards a resolution on this but in the meantime need to rely on `any`

## PR Summary
- Adds the ability to render nested bar charts within a table using `# bar` annotations
- Bar charts attempt to read the first column as a string for X and the second column as a number for Y
- Bar charts can be sized using preset dimensions via tags with `# size=spark|sm|md|lg|xl|2xl`. Alternatively, a user can provide a custom size in pixels using `# size.width=200 size.height=200`. The size is not implemented as a sub-property of the `bar` tag because we assume that all charts, cells, etc will use this common size property. But we can change that if needed.
- Bar charts share numeric y axis domains, but not x axis domains.
- Bar charts are expected to closely align with the surrounding rows of a table. See the Specs section below. When calculating chart layout settings, we do some math to make sure that top and bottom axis lines will always align with adjacent table row lines and that overall chart sizes snap to the row grid of a table
- X axis text can either be rotated 0 degrees or 90 degrees. Whether to rotate or not is determined by the max size of text and the available space. When rotated, we limit how big the axis can grow in relation to the total height of the chart and use truncation otherwise.

## Spec
![image](https://github.com/malloydata/malloy/assets/5554373/c056be0c-a539-49fb-9eba-ca86d90f0924)

## Demo
[The render book is updated here with some examples.](http://go/malloy-render-book)

## Snapshots
![CleanShot 2024-01-04 at 11 22 12@2x](https://github.com/malloydata/malloy/assets/5554373/9cccfccf-49b6-4f88-8cd5-cc80b34f3ba7)
![CleanShot 2024-01-04 at 11 22 29@2x](https://github.com/malloydata/malloy/assets/5554373/581bfa95-65fb-47c3-92c2-bc7f96b788af)

