### PR TITLE
Update node engine and types packages to 18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@malloydata/render": "*",
         "@types/fs-extra": "^9.0.13",
         "@types/jest-expect-message": "^1.0.3",
-        "@types/node": "^16.6.2",
+        "@types/node": "^18.15.3",
         "@types/uuid": "^8.3.2",
         "@typescript-eslint/eslint-plugin": "^5.51.0",
         "@typescript-eslint/parser": "^5.51.0",
@@ -44,8 +44,8 @@
         "uuid": "^8.3.2"
       },
       "engines": {
-        "node": ">=16",
-        "npm": ">=8"
+        "node": ">=18",
+        "npm": ">=9"
       },
       "workspaces": {
         "packages": [
@@ -6723,11 +6723,6 @@
         "url": "https://opencollective.com/storybook"
       }
     },
-    "node_modules/@storybook/core-common/node_modules/@types/node": {
-      "version": "18.18.6",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@storybook/core-common/node_modules/brace-expansion": {
       "version": "2.0.1",
       "dev": true,
@@ -6939,11 +6934,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/storybook"
       }
-    },
-    "node_modules/@storybook/core-server/node_modules/@types/node": {
-      "version": "18.18.6",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@storybook/core-server/node_modules/fs-extra": {
       "version": "11.1.1",
@@ -7739,8 +7729,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "16.11.48",
-      "license": "MIT"
+      "version": "18.19.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.4.tgz",
+      "integrity": "sha512-xNzlUhzoHotIsnFoXmJB+yWmBvFZgKCI9TtPIEdYIMM1KWfwuY8zh7wvc1u1OAXlC7dlf6mZVx/s+Y5KfFz19A==",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/node-fetch": {
       "version": "2.6.7",
@@ -23718,6 +23712,11 @@
       "engines": {
         "node": ">=0.8.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "samples"
   ],
   "engines": {
-    "node": ">=16",
-    "npm": ">=8"
+    "node": ">=18",
+    "npm": ">=9"
   },
   "scripts": {
     "clean": "npm run -ws clean",
@@ -50,7 +50,7 @@
     "@malloydata/render": "*",
     "@types/fs-extra": "^9.0.13",
     "@types/jest-expect-message": "^1.0.3",
-    "@types/node": "^16.6.2",
+    "@types/node": "^18.15.3",
     "@types/uuid": "^8.3.2",
     "@typescript-eslint/eslint-plugin": "^5.51.0",
     "@typescript-eslint/parser": "^5.51.0",


### PR DESCRIPTION
You will now get a warning if you try to do `npm install` with a node < 18, or an npm < 9, which is what our `package-lock.json` file is built with. Also update the node typings to match. Node 16 is EOL and we've updated the other places it's referenced: `default.nix` and `.node-version`