### PR TITLE
feat: renderer can produce result

### DIFF
--- a/packages/malloy/src/index.ts
+++ b/packages/malloy/src/index.ts
@@ -80,6 +80,7 @@ export type {
   SearchIndexResult,
   ModelDef,
   Query,
+  QueryResult,
   QueryRunStats,
   NamedQuery,
   NamedModelObject,


### PR DESCRIPTION
Enable the renderer to optionally receive `queryResult` and `modelDef` and reconstruct the Result object internally, as an override to providing an already constructed Result object. This makes it easier to use the web component in apps like notebooks that are receiving the serialized queryResult and modelDef but don't have malloy code for constructing the Result.