### PR TITLE
WIP: SQL expression functions

### DIFF
--- a/packages/malloy-render/src/component/table-layout.ts
+++ b/packages/malloy-render/src/component/table-layout.ts
@@ -77,7 +77,7 @@ function getColumnWidth(f: Field, metadata: RenderResultMetadata) {
   let width = 0;
   if (f.isAtomicField()) {
     // TODO: get font styles from theme
-    const font = `12px Inter, sans-serif`;
+    const font = '12px Inter, sans-serif';
     const titleWidth = getTextWidth(f.name, font);
     if (f.isAtomicField() && f.isString()) {
       width =

--- a/packages/malloy-render/src/stories/tables.stories.ts
+++ b/packages/malloy-render/src/stories/tables.stories.ts
@@ -25,7 +25,7 @@ export default meta;
 export const ProductsTable = {
   args: {
     source: 'products',
-    view: `records`,
+    view: 'records',
   },
 };
 

--- a/packages/malloy-render/src/stories/themes.stories.ts
+++ b/packages/malloy-render/src/stories/themes.stories.ts
@@ -25,21 +25,21 @@ export default meta;
 export const ModelThemeOverride = {
   args: {
     source: 'products',
-    view: `records`,
+    view: 'records',
   },
 };
 
 export const ViewThemeOverride = {
   args: {
     source: 'products',
-    view: `records_override`,
+    view: 'records_override',
   },
 };
 
 export const ViewThemeOverrideCSS = {
   args: {
     source: 'products',
-    view: `records_override`,
+    view: 'records_override',
     classes: 'night',
   },
 };

--- a/packages/malloy/src/dialect/functions/all_functions.ts
+++ b/packages/malloy/src/dialect/functions/all_functions.ts
@@ -79,6 +79,13 @@ import {
 import {fnAvgRolling} from './avg_moving';
 import {FunctionMap} from './function_map';
 import {fnCoalesce} from './coalesce';
+import {
+  fnSqlBoolean,
+  fnSqlDate,
+  fnSqlNumber,
+  fnSqlString,
+  fnSqlTimestamp,
+} from './sql';
 
 /**
  * This is a function map containing default implementations of all Malloy
@@ -154,5 +161,11 @@ FUNCTIONS.add('min_window', fnMinWindow);
 FUNCTIONS.add('max_window', fnMaxWindow);
 FUNCTIONS.add('sum_window', fnSumWindow);
 FUNCTIONS.add('avg_moving', fnAvgRolling);
+
+FUNCTIONS.add('sql_number', fnSqlNumber);
+FUNCTIONS.add('sql_string', fnSqlString);
+FUNCTIONS.add('sql_date', fnSqlDate);
+FUNCTIONS.add('sql_timestamp', fnSqlTimestamp);
+FUNCTIONS.add('sql_boolean', fnSqlBoolean);
 
 FUNCTIONS.seal();

--- a/packages/malloy/src/dialect/functions/sql.ts
+++ b/packages/malloy/src/dialect/functions/sql.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files
+ * (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import {
+  overload,
+  minScalar,
+  DialectFunctionOverloadDef,
+  makeParam,
+  maxScalar,
+  literal,
+} from './util';
+
+export function fnSqlNumber(): DialectFunctionOverloadDef[] {
+  const value = makeParam('value', literal(maxScalar('string')));
+  return [
+    overload(
+      minScalar('number'),
+      [value.param],
+      [{type: 'sql-string', e: [value.arg]}]
+    ),
+  ];
+}
+
+export function fnSqlString(): DialectFunctionOverloadDef[] {
+  const value = makeParam('value', literal(maxScalar('string')));
+  return [
+    overload(
+      minScalar('string'),
+      [value.param],
+      [{type: 'sql-string', e: [value.arg]}]
+    ),
+  ];
+}
+
+export function fnSqlDate(): DialectFunctionOverloadDef[] {
+  const value = makeParam('value', literal(maxScalar('string')));
+  return [
+    overload(
+      minScalar('date'),
+      [value.param],
+      [{type: 'sql-string', e: [value.arg]}]
+    ),
+  ];
+}
+
+export function fnSqlTimestamp(): DialectFunctionOverloadDef[] {
+  const value = makeParam('value', literal(maxScalar('string')));
+  return [
+    overload(
+      minScalar('timestamp'),
+      [value.param],
+      [{type: 'sql-string', e: [value.arg]}]
+    ),
+  ];
+}
+
+export function fnSqlBoolean(): DialectFunctionOverloadDef[] {
+  const value = makeParam('value', literal(maxScalar('string')));
+  return [
+    overload(
+      minScalar('boolean'),
+      [value.param],
+      [{type: 'sql-string', e: [value.arg]}]
+    ),
+  ];
+}

--- a/packages/malloy/src/lang/ast/expressions/expr-aggregate-function.ts
+++ b/packages/malloy/src/lang/ast/expressions/expr-aggregate-function.ts
@@ -261,6 +261,7 @@ function getJoinUsage(
   };
   exprWalk(expr, frag => {
     if (typeof frag !== 'string') {
+      // TODO make this work for field references inside sql_* functions
       if (frag.type === 'field') {
         const def = lookup(fs, frag.path);
         if (def.def.type !== 'struct' && def.def.type !== 'turtle') {

--- a/packages/malloy/src/model/malloy_types.ts
+++ b/packages/malloy/src/model/malloy_types.ts
@@ -261,6 +261,34 @@ export function isFieldFragment(f: Fragment): f is FieldFragment {
   return (f as FieldFragment)?.type === 'field';
 }
 
+export interface FieldReferenceFragment {
+  type: 'field-reference';
+  path: string;
+}
+export function isFieldReferenceFragment(
+  f: Fragment
+): f is FieldReferenceFragment {
+  return (f as FieldReferenceFragment)?.type === 'field-reference';
+}
+
+export interface SqlStringFragment {
+  type: 'sql-string';
+  e: Expr;
+}
+export function isSqlStringFragment(f: Fragment): f is SqlStringFragment {
+  return (f as SqlStringFragment)?.type === 'sql-string';
+}
+
+export interface SourceReferenceFragment {
+  type: 'source-reference';
+  path?: string;
+}
+export function isSourceReferenceFragment(
+  f: Fragment
+): f is SourceReferenceFragment {
+  return (f as SourceReferenceFragment)?.type === 'source-reference';
+}
+
 export interface ParameterFragment {
   type: 'parameter';
   path: string;
@@ -382,6 +410,9 @@ export type Fragment =
   | ApplyFragment
   | ApplyValueFragment
   | FieldFragment
+  | FieldReferenceFragment
+  | SourceReferenceFragment
+  | SqlStringFragment
   | ParameterFragment
   | FilterFragment
   | OutputFieldFragment

--- a/packages/malloy/src/model/utils.ts
+++ b/packages/malloy/src/model/utils.ts
@@ -134,6 +134,11 @@ export function exprMap(expr: Expr, func: (fragment: Fragment) => Expr): Expr {
         case 'parameter':
         case 'outputField':
           return fragment;
+        case 'sql-string':
+          return {
+            ...fragment,
+            e: exprMap(fragment.e, func),
+          };
         case 'function_call':
           return {
             ...fragment,
@@ -239,6 +244,11 @@ export function exprWalk(expr: Expr, func: (fragment: Fragment) => void): void {
         return {
           ...fragment,
           args: fragment.args.map(arg => exprWalk(arg, func)),
+        };
+      case 'sql-string':
+        return {
+          ...fragment,
+          e: exprWalk(fragment.e, func),
         };
       case 'filterExpression':
         return {

--- a/test/src/databases/all/expr.spec.ts
+++ b/test/src/databases/all/expr.spec.ts
@@ -25,6 +25,7 @@
 import {RuntimeList, allDatabases} from '../../runtimes';
 import '../../util/db-jest-matchers';
 import {databasesFromEnvironmentOr, mkSqlEqWith, testIf} from '../../util';
+import {fail} from 'assert';
 
 const runtimes = new RuntimeList(databasesFromEnvironmentOr(allDatabases));
 
@@ -337,6 +338,179 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
     `).malloyResultMatches(runtime, {
       avg_a_year_built1: 1969,
       avg_a_year_built2: 1969,
+    });
+  });
+
+  describe('sql expr functions', () => {
+    it('sql_string', async () => {
+      await expect(`
+      ##! experimental { sql_functions }
+      source: a is ${databaseName}.table('malloytest.aircraft_models') extend { where: aircraft_model_code ? '0270202' }
+
+      run: a -> {
+          group_by: string_1 is sql_string("UPPER(\${manufacturer})")
+        }
+      `).malloyResultMatches(expressionModel, {
+        string_1: 'AHRENS AIRCRAFT CORP.',
+      });
+    });
+
+    it('sql_number', async () => {
+      await expect(`
+      ##! experimental { sql_functions }
+      source: a is ${databaseName}.table('malloytest.aircraft_models') extend { where: aircraft_model_code ? '0270202' }
+
+      run: a -> {
+          group_by: seats
+          group_by: number_1 is sql_number("\${seats} * 2")
+        }
+  `).malloyResultMatches(expressionModel, {
+        seats: 29,
+        number_1: 58,
+      });
+    });
+
+    it('sql_boolean', async () => {
+      await expect(`
+      ##! experimental { sql_functions }
+      source: a is ${databaseName}.table('malloytest.aircraft_models') extend { where: aircraft_model_code ? '0270202' }
+
+      run: a -> {
+          group_by: boolean_1 is sql_boolean("\${seats} > 20")
+          group_by: boolean_2 is sql_boolean("\${engines} = 2")
+        }
+  `).malloyResultMatches(expressionModel, {
+        boolean_1: true,
+        boolean_2: false,
+      });
+    });
+
+    it('sql_date', async () => {
+      await expect(`
+      ##! experimental { sql_functions }
+      source: a is ${databaseName}.table('malloytest.aircraft') extend { where: tail_num ? 'N110WL' }
+
+      run: a -> {
+          group_by: date_1 is sql_date("\${last_action_date}")
+        }
+  `).malloyResultMatches(expressionModel, {
+        date_1: new Date('2000-01-04T00:00:00.000Z'),
+      });
+    });
+
+    it('sql_timestamp', async () => {
+      await expect(`
+      ##! experimental { sql_functions }
+      source: a is ${databaseName}.table('malloytest.aircraft') extend { where: tail_num ? 'N110WL' }
+
+      run: a -> {
+        group_by: timestamp_1 is sql_timestamp("\${last_action_date}")
+        }
+  `).malloyResultMatches(expressionModel, {
+        timestamp_1: new Date('2000-01-04T00:00:00.000Z'),
+      });
+    });
+
+    it('with ${TABLE}.field', async () => {
+      await expect(`
+      ##! experimental { sql_functions }
+      source: a is ${databaseName}.table('malloytest.aircraft_models') extend { where: aircraft_model_code ? '0270202' }
+
+      run: a -> {
+          group_by: string_1 is sql_string("UPPER(\${TABLE}.manufacturer)")
+        }
+      `).malloyResultMatches(expressionModel, {
+        string_1: 'AHRENS AIRCRAFT CORP.',
+      });
+    });
+
+    it('with ${field}', async () => {
+      await expect(`
+      ##! experimental { sql_functions }
+      source: a is ${databaseName}.table('malloytest.aircraft_models') extend { where: aircraft_model_code ? '0270202' }
+
+      run: a -> {
+          group_by: string_1 is sql_string("UPPER(\${manufacturer})")
+        }
+      `).malloyResultMatches(expressionModel, {
+        string_1: 'AHRENS AIRCRAFT CORP.',
+      });
+    });
+
+    it('sql_functions - experimental feature is ignored', async () => {
+      const query = await expressionModel.loadQuery(
+        `
+        source: a is ${databaseName}.table('malloytest.aircraft_models') extend { where: aircraft_model_code ? '0270202' }
+
+        run: a -> {
+            group_by: manufacturer
+            group_by: string_1 is sql_string("UPPER(\${manufacturer})")
+          }
+        `
+      );
+
+      const runResult = await query.run();
+      const dataResult = runResult.data.toObject();
+      expect(dataResult.length).toEqual(1);
+      const firstRow = dataResult.at(0);
+      if (firstRow !== undefined) {
+        expect(firstRow['manufacturer']).toEqual('AHRENS AIRCRAFT CORP.');
+        expect('string_1' in firstRow).toBeFalsy();
+      } else {
+        fail('exepected a single row, but found none');
+      }
+    });
+
+    describe('[not yet supported]', () => {
+      // See ${...} documentation for lookml here for guidance on remaining work:
+      // https://cloud.google.com/looker/docs/reference/param-field-sql#sql_for_dimensions
+      it('${view_name.dimension_name} - one path', async () => {
+        const query = await expressionModel.loadQuery(
+          `
+          ##! experimental { sql_functions }
+          source: a is ${databaseName}.table('malloytest.aircraft_models') extend { where: aircraft_model_code ? '0270202' }
+
+          run: a -> {
+              group_by: string_1 is sql_string("UPPER(\${a.manufacturer})")
+            }
+          `
+        );
+        await expect(query.run()).rejects.toThrow(
+          "'.' paths are not yet supported in sql interpolations, found ${a.manufacturer}"
+        );
+      });
+
+      it('${view_name.dimension_name} - multiple paths', async () => {
+        const query = await expressionModel.loadQuery(
+          `
+          ##! experimental { sql_functions }
+          source: a is ${databaseName}.table('malloytest.aircraft_models') extend { where: aircraft_model_code ? '0270202' }
+
+          run: a -> {
+              group_by: number_1 is sql_number("\${a.seats} * \${a.seats} + \${a.total_seats}")
+            }
+          `
+        );
+        await expect(query.run()).rejects.toThrow(
+          "'.' paths are not yet supported in sql interpolations, found [${a.seats}, ${a.seats}, ${a.total_seats}]"
+        );
+      });
+
+      it('${view_name.SQL_TABLE_NAME}', async () => {
+        const query = await expressionModel.loadQuery(
+          `
+          ##! experimental { sql_functions }
+          source: a is ${databaseName}.table('malloytest.aircraft_models') extend { where: aircraft_model_code ? '0270202' }
+
+          run: a -> {
+              group_by: number_1 is sql_number("\${a.SQL_TABLE_NAME}.seats")
+            }
+          `
+        );
+        await expect(query.run()).rejects.toThrow(
+          "'.' paths are not yet supported in sql interpolations, found ${a.SQL_TABLE_NAME}"
+        );
+      });
     });
   });
 


### PR DESCRIPTION
TODO:
- [x] Add experiment `sql_functions` for this feature
- [x] Log an error if the user tries to interpolate a field from a join (for now)
- [x] Log an error if the user tries to interpolate a join itself (for now)

(The join stuff is going to be disabled for now because it doesn't fully work with the compiler's join finder yet. We were thinking first step would be to disable it with an error, second step would be to fix it and re-enable.) 

Need to think about, for the future:
- Whether we want a real syntax for this rather than functions, e.g. `sql'MY SQL EXPRESSION'!number`
- Whether a user can specify an aggregate or analytic expression
