### PR TITLE
better tag inspection

### DIFF
--- a/packages/malloy/src/tags.ts
+++ b/packages/malloy/src/tags.ts
@@ -117,21 +117,34 @@ export class Tag implements TagInterface {
     }
     return thisTagId;
   }
-  peek(): string {
+  peek(indent = 0): string {
+    const spaces = ' '.repeat(indent);
     let str = `#${Tag.id(this)}`;
+    if (
+      this.properties === undefined &&
+      this.eq &&
+      typeof this.eq === 'string'
+    ) {
+      return str + `=${this.eq}`;
+    }
+    str += ' {';
     if (this.eq) {
       if (typeof this.eq === 'string') {
-        str += `=${this.eq}`;
+        str += `\n${spaces}  =: ${this.eq}`;
       } else {
-        str += '=[]';
+        str += `\n${spaces}  =: [\n${spaces}    ${this.eq
+          .map(el => new Tag(el).peek(indent + 4))
+          .join(`\n${spaces}    `)}\n${spaces}  ]`;
       }
     }
+
     if (this.properties) {
-      const propStr = Object.keys(this.properties)
-        .map(k => `${k}:`)
-        .join(', ');
-      str += `{${propStr}}`;
+      for (const k in this.properties) {
+        const val = new Tag(this.properties[k]);
+        str += `\n${spaces}  ${k}: ${val.peek(indent + 2)}`;
+      }
     }
+    str += `\n${spaces}}`;
     return str;
   }
 


### PR DESCRIPTION
There was a debugging method `Tag.peek()` which was vaguely use for me to inspect tag trees for parsing errors. Made it more generally useful, it now does a more full dump of a tag tree and all the values.