### PR TITLE
retain refs for tag inspector

### DIFF
--- a/packages/malloy/src/tags.ts
+++ b/packages/malloy/src/tags.ts
@@ -133,14 +133,14 @@ export class Tag implements TagInterface {
         str += `\n${spaces}  =: ${this.eq}`;
       } else {
         str += `\n${spaces}  =: [\n${spaces}    ${this.eq
-          .map(el => new Tag(el).peek(indent + 4))
+          .map(el => Tag.tagFrom(el).peek(indent + 4))
           .join(`\n${spaces}    `)}\n${spaces}  ]`;
       }
     }
 
     if (this.properties) {
       for (const k in this.properties) {
-        const val = new Tag(this.properties[k]);
+        const val = Tag.tagFrom(this.properties[k]);
         str += `\n${spaces}  ${k}: ${val.peek(indent + 2)}`;
       }
     }

--- a/test/src/tags.spec.ts
+++ b/test/src/tags.spec.ts
@@ -487,4 +487,10 @@ describe('tags in results', () => {
     const modelTags = result.modelTag;
     expect(modelTags.text('from')).toEqual('cell2');
   });
+  test('test for speos and mtoy', () => {
+    const parse1 = Tag.fromTagline('# plot', undefined);
+    console.log('parse1 peek: ', parse1.tag.peek());
+    const parse2 = Tag.fromTagline('# plot.x=2', parse1.tag);
+    console.log('parse2 peek: ', parse2.tag.peek());
+  });
 });

--- a/test/src/tags.spec.ts
+++ b/test/src/tags.spec.ts
@@ -487,10 +487,4 @@ describe('tags in results', () => {
     const modelTags = result.modelTag;
     expect(modelTags.text('from')).toEqual('cell2');
   });
-  test('test for speos and mtoy', () => {
-    const parse1 = Tag.fromTagline('# plot', undefined);
-    console.log('parse1 peek: ', parse1.tag.peek());
-    const parse2 = Tag.fromTagline('# plot.x=2', parse1.tag);
-    console.log('parse2 peek: ', parse2.tag.peek());
-  });
 });


### PR DESCRIPTION
Make tag inspector show a slightly truer version of the tag tree, it was previously duping entities.