### PR TITLE
Fix property set on existing tag with no properties

### DIFF
--- a/packages/malloy/src/tags.ts
+++ b/packages/malloy/src/tags.ts
@@ -398,7 +398,7 @@ function getBuildOn(ctx: ParserRuleContext): Tag {
  * so that the caller can delete the tag with delete parent.tagName
  * or assign to it with parent[tagName] = new_value
  */
-function pathToAccess(buildOn: Tag, path: string[]): [string, TagDict] {
+function buildAccessPath(buildOn: Tag, path: string[]): [string, TagDict] {
   let parentPropertyObject = buildOn.getProperties();
   for (const p of path.slice(0, path.length - 1)) {
     let next: Tag;
@@ -406,6 +406,10 @@ function pathToAccess(buildOn: Tag, path: string[]): [string, TagDict] {
       next = new Tag({});
       parentPropertyObject[p] = next;
     } else {
+      // The access that we are performing requires that `.properties` be the
+      // same JS object (not equal, but identical), and `Tag.tagFrom` only copies
+      // the exact object in if it is actually present.
+      parentPropertyObject[p].properties ??= {};
       next = Tag.tagFrom(parentPropertyObject[p]);
     }
     parentPropertyObject = next.getProperties();
@@ -553,7 +557,7 @@ class TaglineParser
   visitTagEq(ctx: TagEqContext): Tag {
     const buildOn = getBuildOn(ctx);
     const name = this.getPropName(ctx.propName());
-    const [writeKey, writeInto] = pathToAccess(buildOn, name);
+    const [writeKey, writeInto] = buildAccessPath(buildOn, name);
     const eq = this.visit(ctx.eqValue());
     const propCx = ctx.properties();
     if (propCx) {
@@ -575,7 +579,7 @@ class TaglineParser
   visitTagReplaceProperties(ctx: TagReplacePropertiesContext): Tag {
     const buildOn = getBuildOn(ctx);
     const name = this.getPropName(ctx.propName());
-    const [writeKey, writeInto] = pathToAccess(buildOn, name);
+    const [writeKey, writeInto] = buildAccessPath(buildOn, name);
     const propCx = ctx.properties();
     const props = this.visitProperties(propCx);
     if (ctx.DOTTY() === undefined) {
@@ -591,7 +595,7 @@ class TaglineParser
   visitTagUpdateProperties(ctx: TagUpdatePropertiesContext): Tag {
     const buildOn = getBuildOn(ctx);
     const name = this.getPropName(ctx.propName());
-    const [writeKey, writeInto] = pathToAccess(buildOn, name);
+    const [writeKey, writeInto] = buildAccessPath(buildOn, name);
     const propCx = ctx.properties();
     propCx['buildOn'] = Tag.tagFrom(writeInto[writeKey]);
     const props = this.visitProperties(propCx);
@@ -604,7 +608,7 @@ class TaglineParser
   visitTagDef(ctx: TagDefContext): Tag {
     const buildOn = getBuildOn(ctx);
     const path = this.getPropName(ctx.propName());
-    const [writeKey, writeInto] = pathToAccess(buildOn, path);
+    const [writeKey, writeInto] = buildAccessPath(buildOn, path);
     if (ctx.MINUS()) {
       delete writeInto[writeKey];
     } else {

--- a/test/src/tags.spec.ts
+++ b/test/src/tags.spec.ts
@@ -107,6 +107,12 @@ describe('tagParse to Tag', () => {
       {name: {properties: {prop: {properties: {prop2: {}}}}}},
     ],
     ['no yes -no', {yes: {}}],
+
+    // TODO interesting behavior that removing a non-existant element, or the last element,
+    // does not remove the `properties`.
+    ['x -x.y', {x: {properties: {}}}],
+    ['x={y} -x.y', {x: {properties: {}}}],
+
     ['x={y z} -x.y', {x: {properties: {z: {}}}}],
     ['x={y z} x {-y}', {x: {properties: {z: {}}}}],
     ['x=1 x {xx=11}', {x: {eq: '1', properties: {xx: {eq: '11'}}}}],
@@ -486,5 +492,16 @@ describe('tags in results', () => {
     const result = await query.run();
     const modelTags = result.modelTag;
     expect(modelTags.text('from')).toEqual('cell2');
+  });
+  test('property access on existing tag (which does not yet have properties)', () => {
+    const parsePlot = Tag.fromTagline('# plot', undefined);
+    const parsed = Tag.fromTagline('# plot.x=2', parsePlot.tag);
+    const allTags = parsed.tag;
+    const plotTag = allTags.tag('plot');
+    const xTag = plotTag!.tag('x');
+    const x = xTag!.numeric();
+    expect(parsed.tag.numeric('plot', 'x')).toEqual(2);
+    expect(plotTag!.numeric('x')).toEqual(2);
+    expect(x).toEqual(2);
   });
 });


### PR DESCRIPTION
Fixes a bug where setting a property on a tag which does not yet have properties doesn't work, e.g.

```
# plot
# plot.x=2
```

This occurred because the code which extracted the object on which to set the new property did not create an empty `.properties` object that was actually linked to the parent object (`plot`). In that case, the `properties` object is created when the `.x` is set, but it is not linked back to the `plot`.

Fixed this by changing that function to create the `.properties` before the child `Tag` object is created, so that `pathToSet === parent.properties`. 