### PR TITLE
max can be null

### DIFF
--- a/packages/malloy-render/src/component/table-layout.ts
+++ b/packages/malloy-render/src/component/table-layout.ts
@@ -83,8 +83,8 @@ function getColumnWidth(f: Field, metadata: RenderResultMetadata) {
       width =
         Math.max(getTextWidth(fieldMeta.maxString!, font), titleWidth) +
         COLUMN_BUFFER;
-    } else if (f.isAtomicField() && f.isNumber()) {
-      const formattedValue = renderNumericField(f, fieldMeta.max!);
+    } else if (f.isAtomicField() && f.isNumber() && fieldMeta.max !== null) {
+      const formattedValue = renderNumericField(f, fieldMeta.max);
       width =
         Math.max(getTextWidth(formattedValue, font), titleWidth) +
         COLUMN_BUFFER;


### PR DESCRIPTION
...when computing column width. Fixes
<img width="720" alt="Screenshot 2024-01-22 at 5 03 54 PM" src="https://github.com/malloydata/malloy/assets/2958002/e365d4ec-e2bc-4aaf-a7de-af3b9871b002">
