### PR TITLE
Bug fixes/improvements for string_agg

### DIFF
--- a/packages/malloy/src/dialect/dialect_map.ts
+++ b/packages/malloy/src/dialect/dialect_map.ts
@@ -113,6 +113,7 @@ export function getDialectFunction(name: string): FunctionDef | undefined {
           existingOverload.dialect[dialect.name] = {
             e: overload.e,
             supportsOrderBy: overload.supportsOrderBy,
+            defaultOrderByArgIndex: overload.defaultOrderByArgIndex,
             supportsLimit: overload.supportsLimit,
           };
           handled = true;
@@ -125,6 +126,7 @@ export function getDialectFunction(name: string): FunctionDef | undefined {
               [dialect.name]: {
                 e: overload.e,
                 supportsOrderBy: overload.supportsOrderBy,
+                defaultOrderByArgIndex: overload.defaultOrderByArgIndex,
                 supportsLimit: overload.supportsLimit,
               },
             },

--- a/packages/malloy/src/dialect/functions/string_agg.ts
+++ b/packages/malloy/src/dialect/functions/string_agg.ts
@@ -41,13 +41,13 @@ export function fnStringAgg(): DialectFunctionOverloadDef[] {
       minAggregate('string'),
       [value.param],
       sql`STRING_AGG(${value.arg}${orderBy})`,
-      {supportsOrderBy: true}
+      {supportsOrderBy: true, defaultOrderByArgIndex: 0}
     ),
     overload(
       minAggregate('string'),
       [value.param, separator.param],
       sql`STRING_AGG(${value.arg}, ${separator.arg}${orderBy})`,
-      {supportsOrderBy: true}
+      {supportsOrderBy: true, defaultOrderByArgIndex: 0}
     ),
   ];
 }
@@ -61,13 +61,21 @@ export function fnStringAggDistinct(): DialectFunctionOverloadDef[] {
       minAggregate('string'),
       [value.param],
       sql`STRING_AGG(DISTINCT ${value.arg}${orderBy})`,
-      {isSymmetric: true, supportsOrderBy: true}
+      {
+        isSymmetric: true,
+        supportsOrderBy: 'only_default',
+        defaultOrderByArgIndex: 0,
+      }
     ),
     overload(
       minAggregate('string'),
       [value.param, separator.param],
       sql`STRING_AGG(DISTINCT ${value.arg}, ${separator.arg}${orderBy})`,
-      {isSymmetric: true, supportsOrderBy: true}
+      {
+        isSymmetric: true,
+        supportsOrderBy: 'only_default',
+        defaultOrderByArgIndex: 0,
+      }
     ),
   ];
 }

--- a/packages/malloy/src/dialect/functions/util.ts
+++ b/packages/malloy/src/dialect/functions/util.ts
@@ -37,7 +37,8 @@ export interface DialectFunctionOverloadDef {
   e: Expr;
   needsWindowOrderBy?: boolean;
   isSymmetric?: boolean;
-  supportsOrderBy?: boolean;
+  supportsOrderBy?: boolean | 'only_default';
+  defaultOrderByArgIndex?: number;
   supportsLimit?: boolean;
   between: {preceding: number | string; following: number | string} | undefined;
 }
@@ -217,7 +218,8 @@ export function overload(
     between?: {preceding: number | string; following: number | string};
     isSymmetric?: boolean;
     supportsLimit?: boolean;
-    supportsOrderBy?: boolean;
+    defaultOrderByArgIndex?: number;
+    supportsOrderBy?: boolean | 'only_default';
   }
 ): DialectFunctionOverloadDef {
   return {
@@ -228,6 +230,7 @@ export function overload(
     between: options?.between,
     isSymmetric: options?.isSymmetric,
     supportsOrderBy: options?.supportsOrderBy,
+    defaultOrderByArgIndex: options?.defaultOrderByArgIndex,
     supportsLimit: options?.supportsLimit,
   };
 }

--- a/packages/malloy/src/dialect/postgres/functions/string_agg.ts
+++ b/packages/malloy/src/dialect/postgres/functions/string_agg.ts
@@ -61,13 +61,21 @@ export function fnStringAggDistinct(): DialectFunctionOverloadDef[] {
       minAggregate('string'),
       [value.param],
       sql`STRING_AGG(DISTINCT ${value.arg}, ','${orderBy})`,
-      {isSymmetric: true, supportsOrderBy: true}
+      {
+        isSymmetric: true,
+        supportsOrderBy: 'only_default',
+        defaultOrderByArgIndex: 0,
+      }
     ),
     overload(
       minAggregate('string'),
       [value.param, separator.param],
       sql`STRING_AGG(DISTINCT ${value.arg}, ${separator.arg}${orderBy})`,
-      {isSymmetric: true, supportsOrderBy: true}
+      {
+        isSymmetric: true,
+        supportsOrderBy: 'only_default',
+        defaultOrderByArgIndex: 0,
+      }
     ),
   ];
 }

--- a/packages/malloy/src/dialect/standardsql/functions/string_agg.ts
+++ b/packages/malloy/src/dialect/standardsql/functions/string_agg.ts
@@ -42,13 +42,13 @@ export function fnStringAgg(): DialectFunctionOverloadDef[] {
       minAggregate('string'),
       [value.param],
       sql`STRING_AGG(${value.arg}${orderBy}${limit})`,
-      {supportsOrderBy: true, supportsLimit: true}
+      {supportsOrderBy: true, supportsLimit: true, defaultOrderByArgIndex: 0}
     ),
     overload(
       minAggregate('string'),
       [value.param, separator.param],
       sql`STRING_AGG(${value.arg}, ${separator.arg}${orderBy}${limit})`,
-      {supportsOrderBy: true, supportsLimit: true}
+      {supportsOrderBy: true, supportsLimit: true, defaultOrderByArgIndex: 0}
     ),
   ];
 }
@@ -63,13 +63,23 @@ export function fnStringAggDistinct(): DialectFunctionOverloadDef[] {
       minAggregate('string'),
       [value.param],
       sql`STRING_AGG(DISTINCT ${value.arg}${orderBy}${limit})`,
-      {isSymmetric: true, supportsOrderBy: true, supportsLimit: true}
+      {
+        isSymmetric: true,
+        supportsOrderBy: 'only_default',
+        supportsLimit: true,
+        defaultOrderByArgIndex: 0,
+      }
     ),
     overload(
       minAggregate('string'),
       [value.param, separator.param],
       sql`STRING_AGG(DISTINCT ${value.arg}, ${separator.arg}${orderBy}${limit})`,
-      {isSymmetric: true, supportsOrderBy: true, supportsLimit: true}
+      {
+        isSymmetric: true,
+        supportsOrderBy: 'only_default',
+        supportsLimit: true,
+        defaultOrderByArgIndex: 0,
+      }
     ),
   ];
 }

--- a/packages/malloy/src/lang/ast/expressions/expr-func.ts
+++ b/packages/malloy/src/lang/ast/expressions/expr-func.ts
@@ -238,6 +238,7 @@ export class ExprFunc extends ExpressionDef {
     const frag: FunctionCallFragment = {
       type: 'function_call',
       overload,
+      name: this.name,
       args: argExprs.map(x => x.value),
       expressionType,
       structPath,

--- a/packages/malloy/src/lang/ast/expressions/expr-func.ts
+++ b/packages/malloy/src/lang/ast/expressions/expr-func.ts
@@ -256,10 +256,12 @@ export class ExprFunc extends ExpressionDef {
           overload.returnType.expressionType
         );
         if (dialectOverload.supportsOrderBy || isAnalytic) {
+          const allowExpression =
+            dialectOverload.supportsOrderBy !== 'only_default';
           const allObs = props.orderBys.flatMap(orderBy =>
             isAnalytic
               ? orderBy.getAnalyticOrderBy(fs)
-              : orderBy.getAggregateOrderBy(fs)
+              : orderBy.getAggregateOrderBy(fs, allowExpression)
           );
           frag.orderBy = allObs;
         } else {

--- a/packages/malloy/src/lang/grammar/MalloyParser.g4
+++ b/packages/malloy/src/lang/grammar/MalloyParser.g4
@@ -295,6 +295,8 @@ aggregateOrdering
 
 aggregateOrderBySpec
   : fieldExpr ( ASC | DESC ) ?
+  | ASC
+  | DESC
   ;
 
 aggregateOrderByStatement

--- a/packages/malloy/src/lang/malloy-to-ast.ts
+++ b/packages/malloy/src/lang/malloy-to-ast.ts
@@ -958,7 +958,8 @@ export class MalloyToAST
     pcx: parse.AggregateOrderBySpecContext
   ): ast.FunctionOrderBy {
     const dir = pcx.ASC() ? 'asc' : pcx.DESC() ? 'desc' : undefined;
-    const f = this.getFieldExpr(pcx.fieldExpr());
+    const fCx = pcx.fieldExpr();
+    const f = fCx ? this.getFieldExpr(fCx) : undefined;
     return this.astAt(new ast.FunctionOrderBy(f, dir), pcx);
   }
 

--- a/packages/malloy/src/lang/test/expressions.spec.ts
+++ b/packages/malloy/src/lang/test/expressions.spec.ts
@@ -233,6 +233,50 @@ describe('expressions', () => {
       `).toTranslate();
     });
 
+    test('analytics order_by requires expression', () => {
+      expect(markSource`
+        ##! experimental { function_order_by }
+        run: a -> {
+          group_by: ai
+          calculate: x is lag(ai) { order_by: asc }
+        }
+      `).translationToFailWith(
+        'analytic `order_by` must specify an aggregate expression or output field reference'
+      );
+    });
+
+    test('string_agg_distinct order by cannot specify expression', () => {
+      expect(markSource`
+        ##! experimental { function_order_by }
+        run: a -> {
+          group_by: ai
+          aggregate: x is string_agg_distinct(astr) { order_by: ai }
+        }
+      `).translationToFailWith(
+        '`order_by` must be only `asc` or `desc` with no expression'
+      );
+    });
+
+    test('string_agg_distinct order by can be just direction', () => {
+      expect(markSource`
+        ##! experimental { function_order_by }
+        run: a -> {
+          group_by: ai
+          aggregate: x is string_agg_distinct(astr) { order_by: asc }
+        }
+      `).toTranslate();
+    });
+
+    test('string_agg order by can be just direction', () => {
+      expect(markSource`
+        ##! experimental { function_order_by }
+        run: a -> {
+          group_by: ai
+          aggregate: x is string_agg(astr) { order_by: asc }
+        }
+      `).toTranslate();
+    });
+
     test('can specify multiple partition_bys', () => {
       expect(markSource`
         ##! experimental { partition_by }

--- a/packages/malloy/src/model/malloy_types.ts
+++ b/packages/malloy/src/model/malloy_types.ts
@@ -732,10 +732,19 @@ export interface OrderBy {
   dir?: 'asc' | 'desc';
 }
 
-export interface FunctionOrderBy {
+export interface FunctionOrderByExpression {
   e: Expr;
   dir?: 'asc' | 'desc';
 }
+
+export interface FunctionOrderByDefaultExpression {
+  e: undefined;
+  dir: 'asc' | 'desc';
+}
+
+export type FunctionOrderBy =
+  | FunctionOrderByExpression
+  | FunctionOrderByDefaultExpression;
 
 export interface ByName {
   by: 'name';
@@ -1038,7 +1047,8 @@ export interface FunctionOverloadDef {
   dialect: {
     [dialect: string]: {
       e: Expr;
-      supportsOrderBy?: boolean;
+      supportsOrderBy?: boolean | 'only_default';
+      defaultOrderByArgIndex?: number;
       supportsLimit?: boolean;
     };
   };

--- a/packages/malloy/src/model/malloy_types.ts
+++ b/packages/malloy/src/model/malloy_types.ts
@@ -225,6 +225,7 @@ export interface AggregateLimitFragment {
 
 export interface FunctionCallFragment {
   type: 'function_call';
+  name: string;
   overload: FunctionOverloadDef;
   expressionType: ExpressionType;
   args: Expr[];

--- a/test/src/databases/all/functions.spec.ts
+++ b/test/src/databases/all/functions.spec.ts
@@ -1239,10 +1239,10 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
       } -> {
         aggregate: c is state_facts2.count()
         aggregate: s is string_agg(state) {
-          order_by: popular_name
+          order_by: popular_name, state
         }
       }`).malloyResultMatches(expressionModel, {
-        s: 'MN,IA,LA,AR,IN,ME,MT,AL,NC,AZ,OH,WY,MA,OK,CO,NY,KY,HI,RI,CA,PA,NJ,TX,CT,NV,NM,FL,GA,MO,KS,TN,IL,WV,MS,SC,DC,ID,NE,VA,UT,NH,MD,AK,OR,SD,WA,MI,VT,WI,DE,ND',
+        s: 'IA,LA,MN,AL,AR,IN,ME,MT,NC,AZ,CA,CO,CT,FL,GA,HI,IL,KS,KY,MA,MO,NJ,NM,NV,NY,OH,OK,PA,RI,TN,TX,WV,WY,DC,MS,SC,ID,NE,UT,VA,AK,DE,MD,MI,ND,NH,OR,SD,VT,WA,WI',
         c: 51,
       });
     });

--- a/test/src/databases/all/functions.spec.ts
+++ b/test/src/databases/all/functions.spec.ts
@@ -46,6 +46,8 @@ source: airports is ${databaseName}.table('malloytest.airports')
 source: state_facts is ${databaseName}.table('malloytest.state_facts')
 
 source: flights is ${databaseName}.table('malloytest.flights')
+
+source: carriers is ${databaseName}.table('malloytest.carriers')
 `;
 }
 
@@ -1212,6 +1214,22 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
         aggregate: f is string_agg(name, ',') { order_by: name desc }
       }`).malloyResultMatches(expressionModel, {
         f: 'YANKEE FLYING CLUB INC,WILSON FLYING SERVICE INC,WESTCHESTER FLYING CLUB',
+      });
+    });
+
+    it(`works with fanout - ${databaseName}`, async () => {
+      expect(`
+      run: state_facts extend { join_many:
+        state_facts2 is ${databaseName}.table('malloytest.state_facts')
+          on state_facts2.state = state
+      } -> {
+        aggregate: c is state_facts2.count()
+        aggregate: s is string_agg(state) {
+          order_by: popular_name
+        }
+      }`).malloyResultMatches(expressionModel, {
+        s: 'MN,IA,LA,AR,IN,ME,MT,AL,NC,AZ,OH,WY,MA,OK,CO,NY,KY,HI,RI,CA,PA,NJ,TX,CT,NV,NM,FL,GA,MO,KS,TN,IL,WV,MS,SC,DC,ID,NE,VA,UT,NH,MD,AK,OR,SD,WA,MI,VT,WI,DE,ND',
+        c: 51,
       });
     });
 

--- a/test/src/databases/all/functions.spec.ts
+++ b/test/src/databases/all/functions.spec.ts
@@ -1126,21 +1126,21 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
 
   describe('string_agg', () => {
     it(`works no order by - ${databaseName}`, async () => {
-      expect(`run: aircraft -> {
+      await expect(`run: aircraft -> {
         where: name = 'RUTHERFORD PAT R JR'
         aggregate: f is string_agg(name)
       }`).malloyResultMatches(expressionModel, {f: 'RUTHERFORD PAT R JR'});
     });
 
     it(`works with dotted shortcut - ${databaseName}`, async () => {
-      expect(`run: aircraft -> {
+      await expect(`run: aircraft -> {
         where: name = 'RUTHERFORD PAT R JR'
         aggregate: f is name.string_agg()
       }`).malloyResultMatches(expressionModel, {f: 'RUTHERFORD PAT R JR'});
     });
 
     it(`works with order by field - ${databaseName}`, async () => {
-      expect(`##! experimental { function_order_by }
+      await expect(`##! experimental { function_order_by }
       run: aircraft -> {
         where: name ~ r'.*RUTHERFORD.*'
         aggregate: f is string_agg(name, ',') {
@@ -1152,7 +1152,7 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
     });
 
     it(`works with multiple order_bys - ${databaseName}`, async () => {
-      expect(`##! experimental { function_order_by }
+      await expect(`##! experimental { function_order_by }
       run: aircraft -> {
         where: name ~ r'.*RUTHERFORD.*'
         aggregate: f is string_agg(name, ',') {
@@ -1164,7 +1164,7 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
     });
 
     it(`works with order by expression - ${databaseName}`, async () => {
-      expect(`##! experimental { function_order_by }
+      await expect(`##! experimental { function_order_by }
       run: aircraft -> {
         where: name ~ r'.*FLY.*'
         group_by: name
@@ -1180,7 +1180,7 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
     });
 
     it(`works with order by join expression - ${databaseName}`, async () => {
-      expect(`##! experimental { function_order_by }
+      await expect(`##! experimental { function_order_by }
       run: aircraft -> {
         where: name ~ r'.*ADVENTURE.*'
         aggregate: f is string_agg(name, ',') { order_by: aircraft_models.model }
@@ -1190,7 +1190,7 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
     });
 
     it(`works with order asc - ${databaseName}`, async () => {
-      expect(`##! experimental { function_order_by }
+      await expect(`##! experimental { function_order_by }
       run: aircraft -> {
         where: name ~ r'.*FLY.*'
         group_by: name
@@ -1204,7 +1204,7 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
     });
 
     it(`works with order desc - ${databaseName}`, async () => {
-      expect(`##! experimental { function_order_by }
+      await expect(`##! experimental { function_order_by }
       run: aircraft -> {
         where: name ~ r'.*FLY.*'
         group_by: name
@@ -1218,7 +1218,7 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
     });
 
     it(`works with fanout - ${databaseName}`, async () => {
-      expect(`
+      await expect(`##! experimental.function_order_by
       run: state_facts extend { join_many:
         state_facts2 is ${databaseName}.table('malloytest.state_facts')
           on state_facts2.state = state
@@ -1247,7 +1247,7 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
           }
         }`;
       if (databaseName === 'bigquery') {
-        expect(query).malloyResultMatches(expressionModel, {
+        await expect(query).malloyResultMatches(expressionModel, {
           f: 'YANKEE FLYING CLUB INC,WILSON FLYING SERVICE INC',
         });
       } else {
@@ -1260,7 +1260,7 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
 
   describe('string_agg_distinct', () => {
     it(`actually distincts - ${databaseName}`, async () => {
-      expect(`##! experimental { function_order_by }
+      await expect(`##! experimental { function_order_by }
         source: aircraft is ${databaseName}.table('malloytest.aircraft') extend {
           primary_key: tail_num
         }
@@ -1282,7 +1282,7 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
     });
 
     it(`works no order by - ${databaseName}`, async () => {
-      expect(`run: aircraft -> {
+      await expect(`run: aircraft -> {
         where: name = 'RUTHERFORD PAT R JR'
         aggregate: f is string_agg_distinct(name)
       }`).malloyResultMatches(expressionModel, {
@@ -1291,7 +1291,7 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
     });
 
     it(`works with dotted shortcut - ${databaseName}`, async () => {
-      expect(`run: aircraft -> {
+      await expect(`run: aircraft -> {
         where: name = 'RUTHERFORD PAT R JR'
         aggregate: f is name.string_agg_distinct()
       }`).malloyResultMatches(expressionModel, {
@@ -1300,7 +1300,7 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
     });
 
     it(`works with order by field - ${databaseName}`, async () => {
-      expect(`##! experimental { function_order_by }
+      await expect(`##! experimental { function_order_by }
       run: aircraft -> {
         where: name ~ r'.*RUTHERFORD.*'
         aggregate: f is string_agg_distinct(name, ',') {
@@ -1315,7 +1315,7 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
     // when using distinct)
 
     it(`works with order asc - ${databaseName}`, async () => {
-      expect(`##! experimental { function_order_by }
+      await expect(`##! experimental { function_order_by }
       run: aircraft -> {
         where: name ~ r'.*FLY.*'
         group_by: name
@@ -1329,7 +1329,7 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
     });
 
     it(`works with order desc - ${databaseName}`, async () => {
-      expect(`##! experimental { function_order_by }
+      await expect(`##! experimental { function_order_by }
       run: aircraft -> {
         where: name ~ r'.*FLY.*'
         group_by: name
@@ -1356,7 +1356,7 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
           }
         }`;
       if (databaseName === 'bigquery') {
-        expect(query).malloyResultMatches(expressionModel, {
+        await expect(query).malloyResultMatches(expressionModel, {
           f: 'YANKEE FLYING CLUB INC,WILSON FLYING SERVICE INC',
         });
       } else {
@@ -1369,7 +1369,7 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
 
   describe('partition_by', () => {
     it(`works - ${databaseName}`, async () => {
-      expect(`##! experimental { function_order_by partition_by }
+      await expect(`##! experimental { function_order_by partition_by }
       run: flights -> {
         group_by:
           yr is year(dep_time)
@@ -1398,7 +1398,7 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
     });
 
     it(`works with multiple order_bys - ${databaseName}`, async () => {
-      expect(`##! experimental { function_order_by partition_by }
+      await expect(`##! experimental { function_order_by partition_by }
       run: aircraft -> {
         where: name =
           "UNITED AIR LINES INC"

--- a/test/src/databases/all/functions.spec.ts
+++ b/test/src/databases/all/functions.spec.ts
@@ -1151,6 +1151,18 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
       });
     });
 
+    it(`works with order by direction - ${databaseName}`, async () => {
+      expect(`##! experimental { function_order_by }
+      run: aircraft -> {
+        where: name ~ r'.*RUTHERFORD.*'
+        aggregate: f is string_agg(name, ',') {
+          order_by: asc
+        }
+      }`).malloyResultMatches(expressionModel, {
+        f: 'RUTHERFORD JAMES C,RUTHERFORD PAT R JR',
+      });
+    });
+
     it(`works with multiple order_bys - ${databaseName}`, async () => {
       await expect(`##! experimental { function_order_by }
       run: aircraft -> {
@@ -1272,7 +1284,7 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
 
         run: aircraft_models -> {
           where: aircraft.name = 'RAYTHEON AIRCRAFT COMPANY' | 'FOWLER IRA R DBA'
-          aggregate: f_dist is aircraft.name.string_agg_distinct() { order_by: aircraft.name }
+          aggregate: f_dist is aircraft.name.string_agg_distinct() { order_by: asc }
           aggregate: f_all is aircraft.name.string_agg() { order_by: aircraft.name }
       }`).malloyResultMatches(runtime, {
         f_dist: 'FOWLER IRA R DBA,RAYTHEON AIRCRAFT COMPANY',
@@ -1299,20 +1311,17 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
       });
     });
 
-    it(`works with order by field - ${databaseName}`, async () => {
+    it(`works with order by direction - ${databaseName}`, async () => {
       await expect(`##! experimental { function_order_by }
       run: aircraft -> {
         where: name ~ r'.*RUTHERFORD.*'
         aggregate: f is string_agg_distinct(name, ',') {
-          order_by: name
+          order_by: asc
         }
       }`).malloyResultMatches(expressionModel, {
         f: 'RUTHERFORD JAMES C,RUTHERFORD PAT R JR',
       });
     });
-
-    // TODO there is a requirement (at least in BQ that the order_by: must be the same as the first argument
-    // when using distinct)
 
     it(`works with order asc - ${databaseName}`, async () => {
       await expect(`##! experimental { function_order_by }
@@ -1322,7 +1331,7 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
         order_by: name desc
         limit: 3
       } -> {
-        aggregate: f is string_agg_distinct(name, ',') { order_by: name asc }
+        aggregate: f is string_agg_distinct(name, ',') { order_by: asc }
       }`).malloyResultMatches(expressionModel, {
         f: 'WESTCHESTER FLYING CLUB,WILSON FLYING SERVICE INC,YANKEE FLYING CLUB INC',
       });
@@ -1336,7 +1345,7 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
         order_by: name desc
         limit: 3
       } -> {
-        aggregate: f is string_agg_distinct(name, ',') { order_by: name desc }
+        aggregate: f is string_agg_distinct(name, ',') { order_by: desc }
       }`).malloyResultMatches(expressionModel, {
         f: 'YANKEE FLYING CLUB INC,WILSON FLYING SERVICE INC,WESTCHESTER FLYING CLUB',
       });
@@ -1351,7 +1360,7 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
           limit: 3
         } -> {
           aggregate: f is string_agg_distinct(name, ',') {
-            order_by: name desc
+            order_by: desc
             limit: 2
           }
         }`;

--- a/test/src/databases/all/functions.spec.ts
+++ b/test/src/databases/all/functions.spec.ts
@@ -1229,7 +1229,9 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
       });
     });
 
-    it(`works with fanout - ${databaseName}`, async () => {
+    it(`works with fanout and order_by - ${databaseName}`, async () => {
+      // TODO bigquery cannot handle both fanout and order_by today
+      if (databaseName === 'bigquery') return;
       await expect(`##! experimental.function_order_by
       run: state_facts extend { join_many:
         state_facts2 is ${databaseName}.table('malloytest.state_facts')
@@ -1241,6 +1243,34 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
         }
       }`).malloyResultMatches(expressionModel, {
         s: 'MN,IA,LA,AR,IN,ME,MT,AL,NC,AZ,OH,WY,MA,OK,CO,NY,KY,HI,RI,CA,PA,NJ,TX,CT,NV,NM,FL,GA,MO,KS,TN,IL,WV,MS,SC,DC,ID,NE,VA,UT,NH,MD,AK,OR,SD,WA,MI,VT,WI,DE,ND',
+        c: 51,
+      });
+    });
+
+    it(`works with fanout - ${databaseName}`, async () => {
+      await expect(`##! experimental.function_order_by
+      run: state_facts extend { join_many:
+        state_facts2 is ${databaseName}.table('malloytest.state_facts')
+          on state_facts2.state = state
+      } -> {
+        aggregate: c is state_facts2.count()
+        aggregate: s is string_agg('o')
+      }`).malloyResultMatches(expressionModel, {
+        s: 'o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o,o',
+        c: 51,
+      });
+    });
+
+    it(`works with fanout and separator - ${databaseName}`, async () => {
+      await expect(`##! experimental.function_order_by
+      run: state_facts extend { join_many:
+        state_facts2 is ${databaseName}.table('malloytest.state_facts')
+          on state_facts2.state = state
+      } -> {
+        aggregate: c is state_facts2.count()
+        aggregate: s is string_agg('o', '')
+      }`).malloyResultMatches(expressionModel, {
+        s: 'ooooooooooooooooooooooooooooooooooooooooooooooooooo',
         c: 51,
       });
     });


### PR DESCRIPTION
- [x] Fix bug where `string_agg(...) { order_by: ... }` didn't work at all when there's a fanout.
- [x] Add `string_agg_distinct(...) { order_by: asc }` syntax and parsing rules to enforce the "order by can only be the same thing as the first argument" rule for `STRING_AGG(DISTINCT ...)` in sql.
- [x] Add custom implementation of `string_agg` for BQ when there's a fanout
