### PR TITLE
Fix bug where `count()` at root gets a distinct key unnecessarily

### DIFF
--- a/packages/malloy/src/model/malloy_query.ts
+++ b/packages/malloy/src/model/malloy_query.ts
@@ -1838,7 +1838,7 @@ class FieldInstanceResultRoot extends FieldInstanceResult {
       //   aggregate: order_count is orders.count()
       if (join.leafiest) {
         if (
-          join.parent !== null &&
+          join.parent !== undefined &&
           join.uniqueKeyPossibleUses.has('count') &&
           !join.queryStruct.primaryKey()
         ) {

--- a/test/src/databases/all/nomodel.spec.ts
+++ b/test/src/databases/all/nomodel.spec.ts
@@ -436,6 +436,19 @@ runtimes.runtimeMap.forEach((runtime, databaseName) => {
     });
   });
 
+  it(`count at root should not use distinct key - ${databaseName}`, async () => {
+    const q = await runtime
+      .loadQuery(
+        `
+      source: states is ${databaseName}.table('malloytest.state_facts')
+
+      run: states -> { aggregate: c is count() }
+      `
+      )
+      .run();
+    expect(q.sql.toLowerCase()).not.toContain('distinct');
+  });
+
   it(`leafy nested count - ${databaseName}`, async () => {
     // in a joined table when the joined is leafiest
     //  we need to make sure we don't count rows that


### PR DESCRIPTION
Fixes https://github.com/malloydata/malloy/issues/1598