### PR TITLE
Fix bug where `nest: a + b + { order_by: a }` could not look up `a`

### DIFF
--- a/packages/malloy/src/lang/ast/view-elements/qop-desc-view.ts
+++ b/packages/malloy/src/lang/ast/view-elements/qop-desc-view.ts
@@ -120,4 +120,8 @@ export class QOpDescView extends View {
     }
     return pipeline;
   }
+
+  getImplicitName(): string | undefined {
+    return undefined;
+  }
 }

--- a/packages/malloy/src/lang/ast/view-elements/reference-view.ts
+++ b/packages/malloy/src/lang/ast/view-elements/reference-view.ts
@@ -163,4 +163,8 @@ export class ReferenceView extends View {
     // TODO better error pipeline
     return pipeline;
   }
+
+  getImplicitName(): string | undefined {
+    return this.reference.nameString;
+  }
 }

--- a/packages/malloy/src/lang/ast/view-elements/view-arrow.ts
+++ b/packages/malloy/src/lang/ast/view-elements/view-arrow.ts
@@ -62,4 +62,8 @@ export class ViewArrow extends View {
     this.log('A multi-segment view cannot be used as a refinement');
     return [];
   }
+
+  getImplicitName(): string | undefined {
+    return this.operation.getImplicitName();
+  }
 }

--- a/packages/malloy/src/lang/ast/view-elements/view-refine.ts
+++ b/packages/malloy/src/lang/ast/view-elements/view-refine.ts
@@ -72,4 +72,8 @@ export class ViewRefine extends View {
     }
     return refine(this, pipeline, refineFrom[0]);
   }
+
+  getImplicitName(): string | undefined {
+    return this.base.getImplicitName();
+  }
 }

--- a/packages/malloy/src/lang/ast/view-elements/view.ts
+++ b/packages/malloy/src/lang/ast/view-elements/view.ts
@@ -57,4 +57,6 @@ export abstract class View extends MalloyElement {
     pipeline: PipeSegment[],
     isNestIn: QueryOperationSpace | undefined
   ): PipeSegment[];
+
+  abstract getImplicitName(): string | undefined;
 }

--- a/packages/malloy/src/lang/grammar/MalloyParser.g4
+++ b/packages/malloy/src/lang/grammar/MalloyParser.g4
@@ -384,8 +384,7 @@ nestedQueryList
   ;
 
 nestEntry
-  : tags fieldPath (PLUS vExpr)?    # nestExisting
-  | tags queryName isDefine vExpr   # nestDef
+  : tags (queryName isDefine)? vExpr   # nestDef
   ;
 
 aggregateStatement

--- a/packages/malloy/src/lang/test/document-symbol-walker.spec.ts
+++ b/packages/malloy/src/lang/test/document-symbol-walker.spec.ts
@@ -186,6 +186,32 @@ test('turtle children turtles are included', () => {
   );
 });
 
+test('refinement chain gets name correctly', () => {
+  testSymbol(
+    markSource`
+      source: flights is DB.table('my.table.flights') extend {
+        query: my_turtle is { nest: ${'something + something_else'} }
+      }
+    `,
+    'something',
+    'query',
+    [0, 0, 0]
+  );
+});
+
+test('arrow in nest infers name correctly', () => {
+  testSymbol(
+    markSource`
+      source: flights is DB.table('my.table.flights') extend {
+        query: my_turtle is { nest: ${'thingy -> something + something_else'} }
+      }
+    `,
+    'something',
+    'query',
+    [0, 0, 0]
+  );
+});
+
 test('join withs are included', () => {
   testSymbol(
     markSource`

--- a/packages/malloy/src/lang/test/lenses.spec.ts
+++ b/packages/malloy/src/lang/test/lenses.spec.ts
@@ -401,8 +401,33 @@ describe('partial views', () => {
         run: a -> {
           nest: astr + ai + { order_by: astr }
         }
+        run: a -> {
+          nest: astr + { order_by: astr }
+        }
+        run: a -> astr + { order_by: astr }
+        run: a -> astr + ai + { order_by: astr }
       `
     ).toTranslate();
+  });
+  test('name can be inferred with arrow', () => {
+    expect(
+      markSource`
+        run: a extend { view: foo is { group_by: astr } } -> {
+          nest: foo -> astr + { order_by: astr }
+        }
+      `
+    ).toTranslate();
+  });
+  test('nice error when nest has no name', () => {
+    expect(
+      markSource`
+        run: a -> {
+          nest: { group_by: astr }
+        }
+      `
+    ).translationToFailWith(
+      '`nest:` view requires a name (add `nest_name is ...`)'
+    );
   });
   test.skip('partial with index', () => {
     expect(

--- a/packages/malloy/src/lang/test/lenses.spec.ts
+++ b/packages/malloy/src/lang/test/lenses.spec.ts
@@ -395,6 +395,15 @@ describe('partial views', () => {
       `
     ).toTranslate();
   });
+  test('order by tacked on the end should work', () => {
+    expect(
+      markSource`
+        run: a -> {
+          nest: astr + ai + { order_by: astr }
+        }
+      `
+    ).toTranslate();
+  });
   test.skip('partial with index', () => {
     expect(
       markSource`


### PR DESCRIPTION
Fixes https://github.com/malloydata/malloy/issues/1605

Bug: `nest: a + b + { order_by: a }` failed to compile with an error that `a` could not be found in the output space (when evaluating the `order_by`.

This was actually an unfortunate parsing error. The rule for nests was:
```g4
nestEntry
  : tags fieldPath (PLUS vExpr)?    # nestExisting
  | tags queryName isDefine vExpr   # nestDef
  ;
```
But this meant that `nest: a + b + { order_by: a }` would be parsed the same as `nest: a + (b + { order_by: a })`, which should make it clear why "`a` is not in the output space."

My solution is to change the rule for nests to:
```g4
nestEntry
  : tags (queryName isDefine)? vExpr   # nestDef
  ;
```
This makes the `name is` part syntactically optional. Then, in the AST builder for the `nestDef`, we traverse the `View` tree to see if there's a valid inferable name (refinement `X + Y` asks `X` for its name, field reference `a` has a name, arrow `X -> Y` asks `Y` for its name, and query properties `{ ... }` has no name). If there is no inferable name, we yield an error telling you to add a name.

This has a nice side effect that now if you write `nest: { group_by: foo }` you no longer get a nasty parse error, but instead get a nice error telling you that you need a name.