### PR TITLE
Escape table names with wildcards and urls

### DIFF
--- a/packages/malloy/src/dialect/duckdb/duckdb.ts
+++ b/packages/malloy/src/dialect/duckdb/duckdb.ts
@@ -94,7 +94,7 @@ export class DuckDBDialect extends Dialect {
   }
 
   quoteTablePath(tableName: string): string {
-    return tableName.match(/\//) ? `'${tableName}'` : tableName;
+    return tableName.match(/[/*:]/) ? `'${tableName}'` : tableName;
   }
 
   sqlGroupSetTable(groupSetCount: number): string {


### PR DESCRIPTION
support tables like `years_*.csv` in addition to `./years_*.csv`