### PR TITLE
Allow `partititon_by` and `order_by` on analytic functions without the `partition_by` and `function_order_by` experiments

### DIFF
--- a/packages/malloy/src/lang/ast/expressions/expr-func.ts
+++ b/packages/malloy/src/lang/ast/expressions/expr-func.ts
@@ -256,6 +256,13 @@ export class ExprFunc extends ExpressionDef {
         const isAnalytic = expressionIsAnalytic(
           overload.returnType.expressionType
         );
+        if (!isAnalytic) {
+          if (!this.inExperiment('aggregate_order_by', true)) {
+            props.orderBys[0].log(
+              'Enable experiment `aggregate_order_by` to use `order_by` with an aggregate function'
+            );
+          }
+        }
         if (dialectOverload.supportsOrderBy || isAnalytic) {
           const allowExpression =
             dialectOverload.supportsOrderBy !== 'only_default';
@@ -267,7 +274,7 @@ export class ExprFunc extends ExpressionDef {
           frag.orderBy = allObs;
         } else {
           props.orderBys[0].log(
-            `Function ${this.name} does not support order_by`
+            `Function \`${this.name}\` does not support \`order_by\``
           );
         }
       }

--- a/packages/malloy/src/lang/doc/experimental.md
+++ b/packages/malloy/src/lang/doc/experimental.md
@@ -27,7 +27,6 @@ Add yours to the list, make sure no one else is using yours.
 * `compilerTestExperimentParse`
 * `compilerTestExperimentTranslate`
 * `join_types`
-* `function_order_by`
-* `partition_by`
+* `aggregate_order_by`
 * `aggregate_limit`
 * `sql_functions`

--- a/packages/malloy/src/lang/malloy-to-ast.ts
+++ b/packages/malloy/src/lang/malloy-to-ast.ts
@@ -967,7 +967,6 @@ export class MalloyToAST
   }
 
   visitAggregateOrderByStatement(pcx: parse.AggregateOrderByStatementContext) {
-    this.inExperiment('function_order_by', pcx);
     return this.visitAggregateOrdering(pcx.aggregateOrdering());
   }
 
@@ -1536,7 +1535,6 @@ export class MalloyToAST
   }
 
   visitPartitionByStatement(pcx: parse.PartitionByStatementContext) {
-    this.inExperiment('partition_by', pcx);
     return this.astAt(
       new ast.PartitionBy(
         pcx

--- a/test/src/databases/all/functions.spec.ts
+++ b/test/src/databases/all/functions.spec.ts
@@ -1156,7 +1156,7 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
     });
 
     it(`works with order by field - ${databaseName}`, async () => {
-      await expect(`##! experimental { function_order_by }
+      await expect(`##! experimental { aggregate_order_by }
       run: aircraft -> {
         where: name ~ r'.*RUTHERFORD.*'
         aggregate: f is string_agg(name, ',') {
@@ -1168,7 +1168,7 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
     });
 
     it(`works with order by direction - ${databaseName}`, async () => {
-      expect(`##! experimental { function_order_by }
+      expect(`##! experimental { aggregate_order_by }
       run: aircraft -> {
         where: name ~ r'.*RUTHERFORD.*'
         aggregate: f is string_agg(name, ',') {
@@ -1180,7 +1180,7 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
     });
 
     it(`works with multiple order_bys - ${databaseName}`, async () => {
-      await expect(`##! experimental { function_order_by }
+      await expect(`##! experimental { aggregate_order_by }
       run: aircraft -> {
         where: name ~ r'.*RUTHERFORD.*'
         aggregate: f is string_agg(name, ',') {
@@ -1192,7 +1192,7 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
     });
 
     it(`works with order by expression - ${databaseName}`, async () => {
-      await expect(`##! experimental { function_order_by }
+      await expect(`##! experimental { aggregate_order_by }
       run: aircraft -> {
         where: name ~ r'.*FLY.*'
         group_by: name
@@ -1208,7 +1208,7 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
     });
 
     it(`works with order by join expression - ${databaseName}`, async () => {
-      await expect(`##! experimental { function_order_by }
+      await expect(`##! experimental { aggregate_order_by }
       run: aircraft -> {
         where: name ~ r'.*ADVENTURE.*'
         aggregate: f is string_agg(name, ',') { order_by: aircraft_models.model }
@@ -1218,7 +1218,7 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
     });
 
     it(`works with order asc - ${databaseName}`, async () => {
-      await expect(`##! experimental { function_order_by }
+      await expect(`##! experimental { aggregate_order_by }
       run: aircraft -> {
         where: name ~ r'.*FLY.*'
         group_by: name
@@ -1232,7 +1232,7 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
     });
 
     it(`works with order desc - ${databaseName}`, async () => {
-      await expect(`##! experimental { function_order_by }
+      await expect(`##! experimental { aggregate_order_by }
       run: aircraft -> {
         where: name ~ r'.*FLY.*'
         group_by: name
@@ -1248,7 +1248,7 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
     it(`works with fanout and order_by - ${databaseName}`, async () => {
       // TODO bigquery cannot handle both fanout and order_by today
       if (databaseName === 'bigquery') return;
-      await expect(`##! experimental.function_order_by
+      await expect(`##! experimental.aggregate_order_by
       run: state_facts extend { join_many:
         state_facts2 is ${databaseName}.table('malloytest.state_facts')
           on state_facts2.state = state
@@ -1264,7 +1264,7 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
     });
 
     it(`works with fanout - ${databaseName}`, async () => {
-      await expect(`##! experimental.function_order_by
+      await expect(`##! experimental.aggregate_order_by
       run: state_facts extend { join_many:
         state_facts2 is ${databaseName}.table('malloytest.state_facts')
           on state_facts2.state = state
@@ -1278,7 +1278,7 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
     });
 
     it(`works with fanout and separator - ${databaseName}`, async () => {
-      await expect(`##! experimental.function_order_by
+      await expect(`##! experimental.aggregate_order_by
       run: state_facts extend { join_many:
         state_facts2 is ${databaseName}.table('malloytest.state_facts')
           on state_facts2.state = state
@@ -1292,7 +1292,7 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
     });
 
     it(`works with limit - ${databaseName}`, async () => {
-      const query = `##! experimental { function_order_by aggregate_limit }
+      const query = `##! experimental { aggregate_order_by aggregate_limit }
       run: aircraft -> {
           where: name ~ r'.*FLY.*'
           group_by: name
@@ -1318,7 +1318,7 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
 
   describe('string_agg_distinct', () => {
     it(`actually distincts - ${databaseName}`, async () => {
-      await expect(`##! experimental { function_order_by }
+      await expect(`##! experimental { aggregate_order_by }
         source: aircraft is ${databaseName}.table('malloytest.aircraft') extend {
           primary_key: tail_num
         }
@@ -1358,7 +1358,7 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
     });
 
     it(`works with order by direction - ${databaseName}`, async () => {
-      await expect(`##! experimental { function_order_by }
+      await expect(`##! experimental { aggregate_order_by }
       run: aircraft -> {
         where: name ~ r'.*RUTHERFORD.*'
         aggregate: f is string_agg_distinct(name, ',') {
@@ -1370,7 +1370,7 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
     });
 
     it(`works with order asc - ${databaseName}`, async () => {
-      await expect(`##! experimental { function_order_by }
+      await expect(`##! experimental { aggregate_order_by }
       run: aircraft -> {
         where: name ~ r'.*FLY.*'
         group_by: name
@@ -1384,7 +1384,7 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
     });
 
     it(`works with order desc - ${databaseName}`, async () => {
-      await expect(`##! experimental { function_order_by }
+      await expect(`##! experimental { aggregate_order_by }
       run: aircraft -> {
         where: name ~ r'.*FLY.*'
         group_by: name
@@ -1398,7 +1398,7 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
     });
 
     it(`works with limit - ${databaseName}`, async () => {
-      const query = `##! experimental { function_order_by aggregate_limit }
+      const query = `##! experimental { aggregate_order_by aggregate_limit }
         run: aircraft -> {
           where: name ~ r'.*FLY.*'
           group_by: name
@@ -1424,7 +1424,7 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
 
   describe('partition_by', () => {
     it(`works - ${databaseName}`, async () => {
-      await expect(`##! experimental { function_order_by partition_by }
+      await expect(`
       run: flights -> {
         group_by:
           yr is year(dep_time)
@@ -1453,7 +1453,7 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
     });
 
     it(`works with multiple order_bys - ${databaseName}`, async () => {
-      await expect(`##! experimental { function_order_by partition_by }
+      await expect(`
       run: aircraft -> {
         where: name =
           "UNITED AIR LINES INC"


### PR DESCRIPTION
Also add the `aggregate_order_by` experiment for using `order_by` on an aggregate.