### PR TITLE
Add `sum_moving` function

### DIFF
--- a/packages/malloy/src/dialect/functions/all_functions.ts
+++ b/packages/malloy/src/dialect/functions/all_functions.ts
@@ -87,6 +87,7 @@ import {
   fnSqlString,
   fnSqlTimestamp,
 } from './sql';
+import { fnSumMoving } from './sum_moving';
 
 /**
  * This is a function map containing default implementations of all Malloy
@@ -164,6 +165,7 @@ FUNCTIONS.add('min_window', fnMinWindow);
 FUNCTIONS.add('max_window', fnMaxWindow);
 FUNCTIONS.add('sum_window', fnSumWindow);
 FUNCTIONS.add('avg_moving', fnAvgRolling);
+FUNCTIONS.add('sum_moving', fnSumMoving);
 
 FUNCTIONS.add('sql_number', fnSqlNumber);
 FUNCTIONS.add('sql_string', fnSqlString);

--- a/packages/malloy/src/dialect/functions/all_functions.ts
+++ b/packages/malloy/src/dialect/functions/all_functions.ts
@@ -87,7 +87,7 @@ import {
   fnSqlString,
   fnSqlTimestamp,
 } from './sql';
-import { fnSumMoving } from './sum_moving';
+import {fnSumMoving} from './sum_moving';
 
 /**
  * This is a function map containing default implementations of all Malloy

--- a/packages/malloy/src/dialect/functions/sum_moving.ts
+++ b/packages/malloy/src/dialect/functions/sum_moving.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files
+ * (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import {
+  overload,
+  sql,
+  DialectFunctionOverloadDef,
+  minAnalytic,
+  maxAggregate,
+  output,
+  makeParam,
+  maxScalar,
+  literal,
+} from './util';
+
+export function fnSumMoving(): DialectFunctionOverloadDef[] {
+  const value = makeParam('value', output(maxAggregate('number')));
+  const preceding = makeParam('preceding', literal(maxScalar('number')));
+  const following = makeParam('following', literal(maxScalar('number')));
+  return [
+    overload(
+      minAnalytic('number'),
+      [value.param, preceding.param],
+      sql`SUM(${value.arg})`,
+      {
+        needsWindowOrderBy: true,
+        between: {preceding: 'preceding', following: 0},
+      }
+    ),
+    overload(
+      minAnalytic('number'),
+      [value.param, preceding.param, following.param],
+      sql`SUM(${value.arg})`,
+      {
+        needsWindowOrderBy: true,
+        between: {preceding: 'preceding', following: 'following'},
+      }
+    ),
+  ];
+}


### PR DESCRIPTION
Fixes https://github.com/malloydata/malloy/issues/1492

Adds a `sum_moving` function similar to the `avg_moving` function:

Two overloads:
* `sum_moving(x, n)` — sum of `x` for the current row plus `n` preceding rows
* `sum_moving(x, n, m)` — sum of `x` for the current row plus `n` preceding rows and `m` following rows