### PR TITLE
feat: expose table scroll

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4068,6 +4068,14 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/@lit-labs/observers": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@lit-labs/observers/-/observers-2.0.2.tgz",
+      "integrity": "sha512-eZb5+W9Cb0e/Y5m1DNxBSGTvGB2TAVTGMnTxL/IzFhPQEcZIAHewW1eVBhN8W07A5tirRaAmmF6fGL1V20p3gQ==",
+      "dependencies": {
+        "@lit/reactive-element": "^1.0.0 || ^2.0.0"
+      }
+    },
     "node_modules/@lit-labs/ssr-dom-shim": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.1.2.tgz",
@@ -25800,6 +25808,7 @@
       "version": "0.0.124",
       "license": "MIT",
       "dependencies": {
+        "@lit-labs/observers": "^2.0.2",
         "@lit/context": "^1.1.0",
         "@malloydata/malloy": "^0.0.124",
         "@types/luxon": "^2.4.0",

--- a/packages/malloy-render/package.json
+++ b/packages/malloy-render/package.json
@@ -24,6 +24,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
+    "@lit-labs/observers": "^2.0.2",
     "@lit/context": "^1.1.0",
     "@malloydata/malloy": "^0.0.124",
     "@types/luxon": "^2.4.0",

--- a/packages/malloy-render/src/component/render.ts
+++ b/packages/malloy-render/src/component/render.ts
@@ -24,7 +24,7 @@
 import {ModelDef, QueryResult, Result, Tag} from '@malloydata/malloy';
 import {LitElement, html, css, PropertyValues} from 'lit';
 import {customElement, property, state} from 'lit/decorators.js';
-import './table';
+import {Table} from './table';
 import './bar-chart';
 import {provide} from '@lit/context';
 import {resultContext} from './result-context';
@@ -81,6 +81,11 @@ export class MalloyRender extends LitElement {
           'liga' 1,
           'calt' 1;
       }
+    }
+
+    #root {
+      width: 100%;
+      height: 100%;
     }
   `;
 
@@ -207,11 +212,23 @@ export class MalloyRender extends LitElement {
     );
   }
 
+  public getTableScrollState() {
+    const mt = this.shadowRoot?.querySelector<Table>('#root > malloy-table');
+    return mt
+      ? {
+          isAtTop: mt.isAtTop,
+          isAtBottom: mt.isAtBottom,
+        }
+      : null;
+  }
+
   override render() {
-    return html`<malloy-table
-      exportparts="table-container: container"
-      .data=${this._result.data}
-    ></malloy-table>`;
+    return html`<div id="root">
+      <malloy-table
+        exportparts="table-container: container"
+        .data=${this._result.data}
+      ></malloy-table>
+    </div>`;
   }
 }
 

--- a/packages/malloy-render/src/component/render.ts
+++ b/packages/malloy-render/src/component/render.ts
@@ -24,6 +24,8 @@
 import {ModelDef, QueryResult, Result, Tag} from '@malloydata/malloy';
 import {LitElement, html, css, PropertyValues} from 'lit';
 import {customElement, property, state} from 'lit/decorators.js';
+import './table';
+// eslint-disable-next-line no-duplicate-imports -- need to import this type, but also run the side effect for registering the web component. The side effect doesn't work without above.
 import {Table} from './table';
 import './bar-chart';
 import {provide} from '@lit/context';

--- a/packages/malloy-render/src/component/table.ts
+++ b/packages/malloy-render/src/component/table.ts
@@ -31,8 +31,10 @@ import {
   nothing,
 } from 'lit';
 import {customElement, eventOptions, property, state} from 'lit/decorators.js';
+import {ref, Ref, createRef} from 'lit/directives/ref.js';
 import {classMap} from 'lit/directives/class-map.js';
 import {createContext, provide, consume} from '@lit/context';
+import {ResizeController} from '@lit-labs/observers/resize-controller.js';
 import {
   getFieldKey,
   isFirstChild,
@@ -190,6 +192,37 @@ export class Table extends LitElement {
   @property({attribute: false})
   metadata!: RenderResultMetadata;
 
+  @property({reflect: true, type: Boolean})
+  isAtTop = true;
+
+  @property({reflect: true, type: Boolean})
+  isAtBottom = true;
+
+  scrollRef: Ref<HTMLDivElement> = createRef();
+  private handleScrollCheck() {
+    const scroller = this.scrollRef.value;
+    if (scroller) {
+      this.isAtTop = scroller.scrollTop === 0;
+      this.isAtBottom =
+        scroller.scrollTop + scroller.clientHeight >= scroller.scrollHeight;
+    }
+  }
+  override firstUpdated() {
+    if (this.scrollRef.value) this._scrollerSize.observe(this.scrollRef.value);
+  }
+
+  private _scrollerSize = new ResizeController(this, {
+    target: null,
+    callback: () => this.handleScrollCheck(),
+  });
+
+  @eventOptions({passive: true})
+  private _handleScroll(e: Event) {
+    const target = e.target as HTMLElement;
+    this._scrolling = target.scrollTop > 0;
+    this.handleScrollCheck();
+  }
+
   override connectedCallback() {
     super.connectedCallback();
     if (typeof this.parentCtx === 'undefined') {
@@ -203,12 +236,6 @@ export class Table extends LitElement {
         layout: this.parentCtx.layout,
       };
     }
-  }
-
-  @eventOptions({passive: true})
-  private _handleScroll(e: Event) {
-    const target = e.target as HTMLElement;
-    this._scrolling = target.scrollTop > 0;
   }
 
   // If rendering a pinned header, render it within the current ShadowDOM root so we can use CSS to style the nested table headers when scrolling
@@ -383,6 +410,7 @@ export class Table extends LitElement {
       @scroll=${this._handleScroll}
       class="table-wrapper"
       part=${this.ctx.root ? 'table-container' : nothing}
+      ref=${ref(this.scrollRef)}
     >
       ${renderStickyHeader()}
       <table>


### PR DESCRIPTION
The VSCode Extension does not have great support for scrollable content within a cell output, so we have to implement our own solution for passing wheel events to the cell content vs. the notebook frame. In order to know when a wheel event over a cell should be consumed by the cell vs. the notebook, we need to know about the scroll position of the malloy table. We need to know whether the table is scrolled all the way to the top and/or the bottom. We can use this to then determine in VSCode whether the table has more room to scroll up/down, or if scrolling should resume on the notebook.