### PR TITLE
chore: revert scroll

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4068,14 +4068,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/@lit-labs/observers": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@lit-labs/observers/-/observers-2.0.2.tgz",
-      "integrity": "sha512-eZb5+W9Cb0e/Y5m1DNxBSGTvGB2TAVTGMnTxL/IzFhPQEcZIAHewW1eVBhN8W07A5tirRaAmmF6fGL1V20p3gQ==",
-      "dependencies": {
-        "@lit/reactive-element": "^1.0.0 || ^2.0.0"
-      }
-    },
     "node_modules/@lit-labs/ssr-dom-shim": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.1.2.tgz",
@@ -25808,7 +25800,6 @@
       "version": "0.0.125",
       "license": "MIT",
       "dependencies": {
-        "@lit-labs/observers": "^2.0.2",
         "@lit/context": "^1.1.0",
         "@malloydata/malloy": "^0.0.125",
         "@types/luxon": "^2.4.0",

--- a/packages/malloy-render/package.json
+++ b/packages/malloy-render/package.json
@@ -24,7 +24,6 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
-    "@lit-labs/observers": "^2.0.2",
     "@lit/context": "^1.1.0",
     "@malloydata/malloy": "^0.0.125",
     "@types/luxon": "^2.4.0",

--- a/packages/malloy-render/src/component/render.ts
+++ b/packages/malloy-render/src/component/render.ts
@@ -24,8 +24,6 @@
 import {ModelDef, QueryResult, Result, Tag} from '@malloydata/malloy';
 import {LitElement, html, css, PropertyValues} from 'lit';
 import {customElement, property, state} from 'lit/decorators.js';
-import './table';
-// eslint-disable-next-line no-duplicate-imports -- need to import this type, but also run the side effect for registering the web component. The side effect doesn't work without above.
 import {Table} from './table';
 import './bar-chart';
 import {provide} from '@lit/context';

--- a/packages/malloy-render/src/component/render.ts
+++ b/packages/malloy-render/src/component/render.ts
@@ -24,7 +24,7 @@
 import {ModelDef, QueryResult, Result, Tag} from '@malloydata/malloy';
 import {LitElement, html, css, PropertyValues} from 'lit';
 import {customElement, property, state} from 'lit/decorators.js';
-import {Table} from './table';
+import './table';
 import './bar-chart';
 import {provide} from '@lit/context';
 import {resultContext} from './result-context';
@@ -81,11 +81,6 @@ export class MalloyRender extends LitElement {
           'liga' 1,
           'calt' 1;
       }
-    }
-
-    #root {
-      width: 100%;
-      height: 100%;
     }
   `;
 
@@ -212,23 +207,11 @@ export class MalloyRender extends LitElement {
     );
   }
 
-  public getTableScrollState() {
-    const mt = this.shadowRoot?.querySelector<Table>('#root > malloy-table');
-    return mt
-      ? {
-          isAtTop: mt.isAtTop,
-          isAtBottom: mt.isAtBottom,
-        }
-      : null;
-  }
-
   override render() {
-    return html`<div id="root">
-      <malloy-table
-        exportparts="table-container: container"
-        .data=${this._result.data}
-      ></malloy-table>
-    </div>`;
+    return html`<malloy-table
+      exportparts="table-container: container"
+      .data=${this._result.data}
+    ></malloy-table>`;
   }
 }
 

--- a/packages/malloy-render/src/component/table.ts
+++ b/packages/malloy-render/src/component/table.ts
@@ -31,10 +31,8 @@ import {
   nothing,
 } from 'lit';
 import {customElement, eventOptions, property, state} from 'lit/decorators.js';
-import {ref, Ref, createRef} from 'lit/directives/ref.js';
 import {classMap} from 'lit/directives/class-map.js';
 import {createContext, provide, consume} from '@lit/context';
-import {ResizeController} from '@lit-labs/observers/resize-controller.js';
 import {
   getFieldKey,
   isFirstChild,
@@ -192,37 +190,6 @@ export class Table extends LitElement {
   @property({attribute: false})
   metadata!: RenderResultMetadata;
 
-  @property({reflect: true, type: Boolean})
-  isAtTop = true;
-
-  @property({reflect: true, type: Boolean})
-  isAtBottom = true;
-
-  scrollRef: Ref<HTMLDivElement> = createRef();
-  private handleScrollCheck() {
-    const scroller = this.scrollRef.value;
-    if (scroller) {
-      this.isAtTop = scroller.scrollTop === 0;
-      this.isAtBottom =
-        scroller.scrollTop + scroller.clientHeight >= scroller.scrollHeight;
-    }
-  }
-  override firstUpdated() {
-    if (this.scrollRef.value) this._scrollerSize.observe(this.scrollRef.value);
-  }
-
-  private _scrollerSize = new ResizeController(this, {
-    target: null,
-    callback: () => this.handleScrollCheck(),
-  });
-
-  @eventOptions({passive: true})
-  private _handleScroll(e: Event) {
-    const target = e.target as HTMLElement;
-    this._scrolling = target.scrollTop > 0;
-    this.handleScrollCheck();
-  }
-
   override connectedCallback() {
     super.connectedCallback();
     if (typeof this.parentCtx === 'undefined') {
@@ -236,6 +203,12 @@ export class Table extends LitElement {
         layout: this.parentCtx.layout,
       };
     }
+  }
+
+  @eventOptions({passive: true})
+  private _handleScroll(e: Event) {
+    const target = e.target as HTMLElement;
+    this._scrolling = target.scrollTop > 0;
   }
 
   // If rendering a pinned header, render it within the current ShadowDOM root so we can use CSS to style the nested table headers when scrolling
@@ -410,7 +383,6 @@ export class Table extends LitElement {
       @scroll=${this._handleScroll}
       class="table-wrapper"
       part=${this.ctx.root ? 'table-container' : nothing}
-      ref=${ref(this.scrollRef)}
     >
       ${renderStickyHeader()}
       <table>


### PR DESCRIPTION
Removing the exposed scrolling API added to support scrolling improvements in VSCode because the solution we attempted in VSCode did not work