### PR TITLE
Fix support for running individual dbs

### DIFF
--- a/packages/malloy-db-bigquery/src/bigquery.spec.ts
+++ b/packages/malloy-db-bigquery/src/bigquery.spec.ts
@@ -31,7 +31,7 @@ import {fileURLToPath} from 'url';
 const envDatabases = (
   process.env['MALLOY_DATABASES'] ||
   process.env['MALLOY_DATABASE'] ||
-  ''
+  'bigquery'
 ).split(',');
 
 let describe = globalThis.describe;

--- a/packages/malloy-db-bigquery/src/bigquery.spec.ts
+++ b/packages/malloy-db-bigquery/src/bigquery.spec.ts
@@ -28,6 +28,17 @@ import * as util from 'util';
 import * as fs from 'fs';
 import {fileURLToPath} from 'url';
 
+const envDatabases = (
+  process.env['MALLOY_DATABASES'] ||
+  process.env['MALLOY_DATABASE'] ||
+  ''
+).split(',');
+
+let describe = globalThis.describe;
+if (!envDatabases.includes('bigquery')) {
+  describe = describe.skip;
+}
+
 describe('db:BigQuery', () => {
   let bq: BigQueryConnection;
   let runtime: malloy.Runtime;

--- a/packages/malloy-db-duckdb/src/duckdb.spec.ts
+++ b/packages/malloy-db-duckdb/src/duckdb.spec.ts
@@ -28,7 +28,7 @@ import {SQLBlock} from '@malloydata/malloy';
 const envDatabases = (
   process.env['MALLOY_DATABASES'] ||
   process.env['MALLOY_DATABASE'] ||
-  ''
+  'duckdb'
 ).split(',');
 
 let describe = globalThis.describe;

--- a/packages/malloy-db-duckdb/src/duckdb.spec.ts
+++ b/packages/malloy-db-duckdb/src/duckdb.spec.ts
@@ -25,6 +25,17 @@ import {DuckDBCommon} from './duckdb_common';
 import {DuckDBConnection} from './duckdb_connection';
 import {SQLBlock} from '@malloydata/malloy';
 
+const envDatabases = (
+  process.env['MALLOY_DATABASES'] ||
+  process.env['MALLOY_DATABASE'] ||
+  ''
+).split(',');
+
+let describe = globalThis.describe;
+if (!envDatabases.includes('duckdb')) {
+  describe = describe.skip;
+}
+
 /*
  * !IMPORTANT
  *
@@ -62,39 +73,39 @@ describe('DuckDBConnection', () => {
 
     it('caches table schema', async () => {
       await connection.fetchSchemaForTables({'test1': 'table1'}, {});
-      expect(runRawSQL).toBeCalledTimes(1);
+      expect(runRawSQL).toHaveBeenCalledTimes(1);
       await new Promise(resolve => setTimeout(resolve));
       await connection.fetchSchemaForTables({'test1': 'table1'}, {});
-      expect(runRawSQL).toBeCalledTimes(1);
+      expect(runRawSQL).toHaveBeenCalledTimes(1);
     });
 
     it('refreshes table schema', async () => {
       await connection.fetchSchemaForTables({'test2': 'table2'}, {});
-      expect(runRawSQL).toBeCalledTimes(1);
+      expect(runRawSQL).toHaveBeenCalledTimes(1);
       await new Promise(resolve => setTimeout(resolve));
       await connection.fetchSchemaForTables(
         {'test2': 'table2'},
         {refreshTimestamp: Date.now() + 10}
       );
-      expect(runRawSQL).toBeCalledTimes(2);
+      expect(runRawSQL).toHaveBeenCalledTimes(2);
     });
 
     it('caches sql schema', async () => {
       await connection.fetchSchemaForSQLBlock(SQL_BLOCK_1, {});
-      expect(runRawSQL).toBeCalledTimes(1);
+      expect(runRawSQL).toHaveBeenCalledTimes(1);
       await new Promise(resolve => setTimeout(resolve));
       await connection.fetchSchemaForSQLBlock(SQL_BLOCK_1, {});
-      expect(runRawSQL).toBeCalledTimes(1);
+      expect(runRawSQL).toHaveBeenCalledTimes(1);
     });
 
     it('refreshes sql schema', async () => {
       await connection.fetchSchemaForSQLBlock(SQL_BLOCK_2, {});
-      expect(runRawSQL).toBeCalledTimes(1);
+      expect(runRawSQL).toHaveBeenCalledTimes(1);
       await new Promise(resolve => setTimeout(resolve));
       await connection.fetchSchemaForSQLBlock(SQL_BLOCK_2, {
         refreshTimestamp: Date.now() + 10,
       });
-      expect(runRawSQL).toBeCalledTimes(2);
+      expect(runRawSQL).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/packages/malloy-db-duckdb/src/duckdb_wasm_connection.spec.ts
+++ b/packages/malloy-db-duckdb/src/duckdb_wasm_connection.spec.ts
@@ -25,6 +25,17 @@ import {SQLBlock} from '@malloydata/malloy';
 import {DuckDBCommon} from './duckdb_common';
 import {DuckDBWASMConnection} from './duckdb_wasm_connection_node';
 
+const envDatabases = (
+  process.env['MALLOY_DATABASES'] ||
+  process.env['MALLOY_DATABASE'] ||
+  ''
+).split(',');
+
+let describe = globalThis.describe;
+if (!envDatabases.includes('duckdb_wasm')) {
+  describe = describe.skip;
+}
+
 describe('DuckDBWasmConnection', () => {
   let connection: DuckDBWASMConnection;
   let findTables: jest.SpyInstance;

--- a/packages/malloy-db-duckdb/src/duckdb_wasm_connection.spec.ts
+++ b/packages/malloy-db-duckdb/src/duckdb_wasm_connection.spec.ts
@@ -28,7 +28,7 @@ import {DuckDBWASMConnection} from './duckdb_wasm_connection_node';
 const envDatabases = (
   process.env['MALLOY_DATABASES'] ||
   process.env['MALLOY_DATABASE'] ||
-  ''
+  'duckdb_wasm'
 ).split(',');
 
 let describe = globalThis.describe;

--- a/packages/malloy-db-postgres/src/postgres.spec.ts
+++ b/packages/malloy-db-postgres/src/postgres.spec.ts
@@ -24,6 +24,17 @@
 import {PostgresConnection} from './postgres_connection';
 import {SQLBlock} from '@malloydata/malloy';
 
+const envDatabases = (
+  process.env['MALLOY_DATABASES'] ||
+  process.env['MALLOY_DATABASE'] ||
+  ''
+).split(',');
+
+let describe = globalThis.describe;
+if (!envDatabases.includes('postgres')) {
+  describe = describe.skip;
+}
+
 /*
  * !IMPORTANT
  *

--- a/packages/malloy-db-postgres/src/postgres.spec.ts
+++ b/packages/malloy-db-postgres/src/postgres.spec.ts
@@ -27,7 +27,7 @@ import {SQLBlock} from '@malloydata/malloy';
 const envDatabases = (
   process.env['MALLOY_DATABASES'] ||
   process.env['MALLOY_DATABASE'] ||
-  ''
+  'postgres'
 ).split(',');
 
 let describe = globalThis.describe;

--- a/packages/malloy-db-snowflake/src/snowflake_connection.spec.ts
+++ b/packages/malloy-db-snowflake/src/snowflake_connection.spec.ts
@@ -28,11 +28,14 @@ import * as util from 'util';
 import * as fs from 'fs';
 import {SnowflakeExecutor} from './snowflake_executor';
 
-const envDatabases =
-  process.env['MALLOY_DATABASES'] || process.env['MALLOY_DATABASE'];
+const envDatabases = (
+  process.env['MALLOY_DATABASES'] ||
+  process.env['MALLOY_DATABASE'] ||
+  ''
+).split(',');
 
 let describe = globalThis.describe;
-if (envDatabases && !envDatabases.includes('snowflake')) {
+if (!envDatabases.includes('snowflake')) {
   describe = describe.skip;
 }
 

--- a/packages/malloy-db-snowflake/src/snowflake_executor.spec.ts
+++ b/packages/malloy-db-snowflake/src/snowflake_executor.spec.ts
@@ -24,11 +24,14 @@
 import {SnowflakeExecutor} from './snowflake_executor';
 import {QueryData, RunSQLOptions} from '@malloydata/malloy';
 
-const envDatabases =
-  process.env['MALLOY_DATABASES'] || process.env['MALLOY_DATABASE'];
+const envDatabases = (
+  process.env['MALLOY_DATABASES'] ||
+  process.env['MALLOY_DATABASE'] ||
+  ''
+).split(',');
 
 let describe = globalThis.describe;
-if (envDatabases && !envDatabases.includes('snowflake')) {
+if (!envDatabases.includes('snowflake')) {
   describe = describe.skip;
 }
 

--- a/test/package.json
+++ b/test/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@malloydata/malloy-tests",
   "license": "MIT",
+  "engines": {
+    "node": ">=18"
+  },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "homepage": "https://github.com/malloydata/malloy#readme",

--- a/test/src/databases/all/db_index.spec.ts
+++ b/test/src/databases/all/db_index.spec.ts
@@ -25,7 +25,7 @@
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 
 import {RuntimeList, allDatabases} from '../../runtimes';
-import {databasesFromEnvironmentOr, testIf} from '../../util';
+import {databasesFromEnvironmentOr, onlyIf} from '../../util';
 import '../../util/db-jest-matchers';
 
 const runtimes = new RuntimeList(databasesFromEnvironmentOr(allDatabases));
@@ -96,16 +96,16 @@ runtimes.runtimeMap.forEach((runtime, databaseName) => {
   });
 
   // bigquery doesn't support row count based sampling.
-  testIf(databaseName !== 'bigquery')(
+  test(
     `index rows count - ${databaseName}`,
-    async () => {
+    onlyIf(databaseName !== 'bigquery', async () => {
       await expect(`
         run: ${databaseName}.table('malloytest.state_facts') extend {
           dimension: one is 'one'
         } -> {index:one, state; sample: 10 }
             -> {select: fieldName, weight, fieldValue; order_by: 2 desc; where: fieldName = 'one'}
       `).malloyResultMatches(runtime, {fieldName: 'one', weight: 10});
-    }
+    })
   );
 
   it(`index rows count - ${databaseName}`, async () => {

--- a/test/src/databases/all/expr.spec.ts
+++ b/test/src/databases/all/expr.spec.ts
@@ -24,7 +24,7 @@
 
 import {RuntimeList, allDatabases} from '../../runtimes';
 import '../../util/db-jest-matchers';
-import {databasesFromEnvironmentOr, mkSqlEqWith, testIf} from '../../util';
+import {databasesFromEnvironmentOr, mkSqlEqWith, onlyIf} from '../../util';
 import {fail} from 'assert';
 
 const runtimes = new RuntimeList(databasesFromEnvironmentOr(allDatabases));
@@ -119,13 +119,16 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
   });
 
   // filtered turtle expressions
-  testIf(runtime.supportsNesting)('model: filtered turtle', async () => {
-    await expect(`
+  test(
+    'model: filtered turtle',
+    onlyIf(runtime.supportsNesting, async () => {
+      await expect(`
       run: aircraft->{
         nest: b is by_manufacturer + { where: aircraft_models.manufacturer ?~'B%'}
       }
     `).malloyResultMatches(expressionModel, {'b.manufacturer': 'BEECH'});
-  });
+    })
+  );
 
   // having.
   it('model: simple having', async () => {
@@ -139,8 +142,10 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
     `).malloyResultMatches(expressionModel, {aircraft_count: 91});
   });
 
-  testIf(runtime.supportsNesting)('model: having in a nest', async () => {
-    await expect(`
+  test(
+    'model: having in a nest',
+    onlyIf(runtime.supportsNesting, async () => {
+      await expect(`
       run: aircraft->{
         top: 10
         order_by: 1
@@ -155,10 +160,13 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
         }
       }
     `).malloyResultMatches(expressionModel, {'by_state.state': 'VA'});
-  });
+    })
+  );
 
-  testIf(runtime.supportsNesting)('model: turtle having on main', async () => {
-    await expect(`
+  test(
+    'model: turtle having on main',
+    onlyIf(runtime.supportsNesting, async () => {
+      await expect(`
       run: aircraft->{
         order_by: 2 asc
         having: aircraft_count ? >500
@@ -178,14 +186,15 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
         }
       }
     `).malloyResultMatches(expressionModel, {
-      'by_state.by_city.city': 'ALBUQUERQUE',
-    });
-  });
+        'by_state.by_city.city': 'ALBUQUERQUE',
+      });
+    })
+  );
 
   // bigquery doesn't like to partition by floats,
-  testIf(runtime.supportsNesting)(
+  test(
     'model: having float group by partition',
-    async () => {
+    onlyIf(runtime.supportsNesting, async () => {
       await expect(`${modelText(databaseName)}
         run: aircraft_models->{
           order_by: 1
@@ -198,7 +207,7 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
             aggregate: aircraft_model_count
           }
       }`).malloyResultMatches(runtime, {aircraft_model_count: 448});
-    }
+    })
   );
 
   it('model: aggregate functions distinct min max', async () => {
@@ -232,9 +241,9 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
 
   // TODO not sure why this test needs to be skipped on postgres, feels like an oversight
   // NOTE: unless underlying type is stored as a timestamp snowflake does not support extraction
-  testIf(!['postgres', 'snowflake'].includes(databaseName))(
+  test(
     'model: dates named',
-    async () => {
+    onlyIf(!['postgres', 'snowflake'].includes(databaseName), async () => {
       await expect(`
       run: ${databaseName}.table('malloytest.alltypes')->{
         group_by:
@@ -261,7 +270,7 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
         t_timestamp_month: new Date('2020-03-01'),
         t_timestamp_year: new Date('2020-01-01'),
       });
-    }
+    })
   );
 
   it('named query metadata undefined', async () => {
@@ -316,21 +325,24 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
     `).malloyResultMatches(expressionModel, {a: 312});
   });
 
-  testIf(!['postgres', 'snowflake'].includes(runtime.connection.name))(
+  test(
     'sql safe cast',
-    async () => {
-      await expect(`
+    onlyIf(
+      !['postgres', 'snowflake'].includes(runtime.connection.name),
+      async () => {
+        await expect(`
       run: ${databaseName}.sql('SELECT 1') -> { select:
         bad_date is '123':::date
         bad_number is 'abc':::number
         good_number is "312":::"integer"
       }
     `).malloyResultMatches(expressionModel, {
-        bad_date: null,
-        bad_number: null,
-        good_number: 312,
-      });
-    }
+          bad_date: null,
+          bad_number: null,
+          good_number: 312,
+        });
+      }
+    )
   );
 
   it('many_field.sum() has correct locality', async () => {
@@ -540,9 +552,9 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
     });
   });
 
-  testIf(runtime.supportsNesting)(
+  test(
     'query with aliasname used twice',
-    async () => {
+    onlyIf(runtime.supportsNesting, async () => {
       await expect(`
         run: aircraft->{
           group_by: first is substr(city,1,1)
@@ -562,7 +574,7 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
             order_by: 2 desc, 1
         }
       `).malloyResultMatches(expressionModel, {first_three: 'SAB'});
-    }
+    })
   );
 
   it('joined filtered sources', async () => {

--- a/test/src/databases/all/join.spec.ts
+++ b/test/src/databases/all/join.spec.ts
@@ -24,7 +24,7 @@
 /* eslint-disable no-console */
 
 import {RuntimeList, allDatabases} from '../../runtimes';
-import {databasesFromEnvironmentOr, testIf} from '../../util';
+import {databasesFromEnvironmentOr, onlyIf} from '../../util';
 import '../../util/db-jest-matchers';
 
 const runtimes = new RuntimeList(databasesFromEnvironmentOr(allDatabases));
@@ -194,9 +194,9 @@ describe('join expression tests', () => {
     `).malloyResultMatches(joinModel, {f_sum2: 60462});
     });
 
-    testIf(runtime.supportsNesting)(
+    test(
       `model: unnest is left join - ${database}`,
-      async () => {
+      onlyIf(runtime.supportsNesting, async () => {
         await expect(`
           // produce a table with 4 rows that has a nested element
           query: a_states is ${database}.table('malloytest.state_facts')-> {
@@ -220,7 +220,7 @@ describe('join expression tests', () => {
             limit: 5
           }
         `).malloyResultMatches(joinModel, [{}, {}, {}, {}, {}]);
-      }
+      })
     );
 
     // not sure how to solve this one yet, just check for > 4 rows

--- a/test/src/databases/all/nomodel.spec.ts
+++ b/test/src/databases/all/nomodel.spec.ts
@@ -25,7 +25,7 @@
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 
 import {RuntimeList, allDatabases} from '../../runtimes';
-import {databasesFromEnvironmentOr, testIf} from '../../util';
+import {databasesFromEnvironmentOr, onlyIf} from '../../util';
 import '../../util/db-jest-matchers';
 
 const runtimes = new RuntimeList(databasesFromEnvironmentOr(allDatabases));
@@ -526,9 +526,9 @@ runtimes.runtimeMap.forEach((runtime, databaseName) => {
     });
   });
 
-  testIf(runtime.supportsNesting)(
+  test(
     `number as null- ${databaseName}`,
-    async () => {
+    onlyIf(runtime.supportsNesting, async () => {
       // a cross join produces a Many to Many result.
       // symmetric aggregate are needed on both sides of the join
       // Check the row count and that sums on each side work properly.
@@ -541,7 +541,7 @@ runtimes.runtimeMap.forEach((runtime, databaseName) => {
           }
         }
       `).malloyResultMatches(runtime, {'ugly.foo': null});
-    }
+    })
   );
 
   // average should only include non-null values in the denominator
@@ -586,9 +586,9 @@ runtimes.runtimeMap.forEach((runtime, databaseName) => {
       }`).malloyResultMatches(runtime, {births_per_100k: 9742});
   });
 
-  testIf(runtime.supportsNesting)(
+  test(
     `ungrouped top level with nested  - ${databaseName}`,
-    async () => {
+    onlyIf(runtime.supportsNesting, async () => {
       await expect(`
       run: ${databaseName}.table('malloytest.state_facts') extend {
         measure: total_births is births.sum()
@@ -602,7 +602,7 @@ runtimes.runtimeMap.forEach((runtime, databaseName) => {
         }
         limit: 1000
       }`).malloyResultMatches(runtime, {births_per_100k: 9742});
-    }
+    })
   );
 
   it(`ungrouped - eliminate rows  - ${databaseName}`, async () => {
@@ -620,9 +620,9 @@ runtimes.runtimeMap.forEach((runtime, databaseName) => {
     ]);
   });
 
-  testIf(runtime.supportsNesting)(
+  test(
     `ungrouped nested with no grouping above - ${databaseName}`,
-    async () => {
+    onlyIf(runtime.supportsNesting, async () => {
       await expect(`
         run: ${databaseName}.table('malloytest.state_facts') extend {
           measure: total_births is births.sum()
@@ -634,12 +634,12 @@ runtimes.runtimeMap.forEach((runtime, databaseName) => {
             aggregate: births_per_100k
           }
         }`).malloyResultMatches(runtime, {'by_name.births_per_100k': 66703});
-    }
+    })
   );
 
-  testIf(runtime.supportsNesting)(
+  test(
     `ungrouped - partial grouping - ${databaseName}`,
-    async () => {
+    onlyIf(runtime.supportsNesting, async () => {
       await expect(`
         run: ${databaseName}.table('malloytest.airports') extend {
           measure: c is count()
@@ -668,12 +668,12 @@ runtimes.runtimeMap.forEach((runtime, databaseName) => {
         'fac_type.all_of_this_type': 1782,
         'fac_type.all_top': 2421,
       });
-    }
+    })
   );
 
-  testIf(runtime.supportsNesting)(
+  test(
     `ungrouped - all nested - ${databaseName}`,
-    async () => {
+    onlyIf(runtime.supportsNesting, async () => {
       await expect(`
         run: ${databaseName}.table('malloytest.airports') extend {
           measure: c is count()
@@ -697,12 +697,12 @@ runtimes.runtimeMap.forEach((runtime, databaseName) => {
         'fac_type.all_': 1845,
         'fac_type.all_major': 1819,
       });
-    }
+    })
   );
 
-  testIf(runtime.supportsNesting)(
+  test(
     `ungrouped nested  - ${databaseName}`,
-    async () => {
+    onlyIf(runtime.supportsNesting, async () => {
       await expect(`
         run: ${databaseName}.table('malloytest.state_facts') extend {
           measure: total_births is births.sum()
@@ -715,12 +715,12 @@ runtimes.runtimeMap.forEach((runtime, databaseName) => {
           }
         }
       `).malloyResultMatches(runtime, {'by_state.births_per_100k': 36593});
-    }
+    })
   );
 
-  testIf(runtime.supportsNesting)(
+  test(
     `ungrouped nested expression  - ${databaseName}`,
-    async () => {
+    onlyIf(runtime.supportsNesting, async () => {
       await expect(`
         run: ${databaseName}.table('malloytest.state_facts') extend {
           measure: total_births is births.sum()
@@ -733,12 +733,12 @@ runtimes.runtimeMap.forEach((runtime, databaseName) => {
           }
         }
       `).malloyResultMatches(runtime, {'by_state.births_per_100k': 36593});
-    }
+    })
   );
 
-  testIf(runtime.supportsNesting)(
+  test(
     `ungrouped nested group by float  - ${databaseName}`,
-    async () => {
+    onlyIf(runtime.supportsNesting, async () => {
       await expect(`
         run: ${databaseName}.table('malloytest.state_facts') extend {
           measure: total_births is births.sum()
@@ -751,7 +751,7 @@ runtimes.runtimeMap.forEach((runtime, databaseName) => {
           }
         }
       `).malloyResultMatches(runtime, {'by_state.ug': 62742230});
-    }
+    })
   );
 
   it(`run simple sql - ${databaseName}`, async () => {
@@ -818,9 +818,9 @@ SELECT row_to_json(finalStage) as row FROM __stage0 AS finalStage`);
     });
   });
 
-  testIf(runtime.supportsNesting)(
+  test(
     `all with parameters - nest  - ${databaseName}`,
-    async () => {
+    onlyIf(runtime.supportsNesting, async () => {
       await expect(`
         run: ${databaseName}.table('malloytest.state_facts') extend {
           measure: total_births is births.sum()
@@ -840,12 +840,12 @@ SELECT row_to_json(finalStage) as row FROM __stage0 AS finalStage`);
         'by_stuff.all_births': 119809719,
         'by_stuff.all_name': 61091215,
       });
-    }
+    })
   );
 
-  testIf(runtime.supportsNesting)(
+  test(
     `single value to udf - ${databaseName}`,
-    async () => {
+    onlyIf(runtime.supportsNesting, async () => {
       await expect(`
         run: ${databaseName}.table('malloytest.state_facts') extend {
           view: fun is {
@@ -853,12 +853,12 @@ SELECT row_to_json(finalStage) as row FROM __stage0 AS finalStage`);
           } -> { select: t1 is t+1 }
         } -> { nest: fun }
       `).malloyResultMatches(runtime, {'fun.t1': 52});
-    }
+    })
   );
 
-  testIf(runtime.supportsNesting)(
+  test(
     `Multi value to udf - ${databaseName}`,
-    async () => {
+    onlyIf(runtime.supportsNesting, async () => {
       await expect(`
         run: ${databaseName}.table('malloytest.state_facts') extend {
           view: fun is {
@@ -869,12 +869,12 @@ SELECT row_to_json(finalStage) as row FROM __stage0 AS finalStage`);
           nest: fun
         }
       `).malloyResultMatches(runtime, {'fun.t1': 52});
-    }
+    })
   );
 
-  testIf(runtime.supportsNesting)(
+  test(
     `Multi value to udf group by - ${databaseName}`,
-    async () => {
+    onlyIf(runtime.supportsNesting, async () => {
       await expect(`
         run: ${databaseName}.table('malloytest.state_facts') extend {
           view: fun is {
@@ -885,7 +885,7 @@ SELECT row_to_json(finalStage) as row FROM __stage0 AS finalStage`);
           nest: fun
         }
       `).malloyResultMatches(runtime, {'fun.t1': 52});
-    }
+    })
   );
 
   const sql1234 = `${databaseName}.sql('SELECT 1 as ${q`a`}, 2 as ${q`b`} UNION ALL SELECT 3, 4')`;
@@ -978,9 +978,9 @@ SELECT row_to_json(finalStage) as row FROM __stage0 AS finalStage`);
       `).malloyResultMatches(runtime, {x: 30});
   });
 
-  testIf(runtime.supportsNesting)(
+  test(
     `array unnest - ${databaseName}`,
-    async () => {
+    onlyIf(runtime.supportsNesting, async () => {
       const splitFN = getSplitFunction(databaseName);
       await expect(`
       run: ${databaseName}.sql("""
@@ -994,13 +994,13 @@ SELECT row_to_json(finalStage) as row FROM __stage0 AS finalStage`);
         aggregate: c is count()
       }
       `).malloyResultMatches(runtime, {c: 145});
-    }
+    })
   );
 
   // make sure we can count the total number of elements when fanning out.
-  testIf(runtime.supportsNesting)(
+  test(
     `array unnest x 2 - ${databaseName}`,
-    async () => {
+    onlyIf(runtime.supportsNesting, async () => {
       const splitFN = getSplitFunction(databaseName);
       await expect(`
       run: ${databaseName}.sql("""
@@ -1016,13 +1016,15 @@ SELECT row_to_json(finalStage) as row FROM __stage0 AS finalStage`);
           c is words.count()
           a is abreak.count()
       }`).malloyResultMatches(runtime, {b: 3552, c: 4586, a: 6601});
-    }
+    })
   );
 
-  testIf(runtime.supportsNesting)(`nest null - ${databaseName}`, async () => {
-    const result = await runtime
-      .loadQuery(
-        `
+  test(
+    `nest null - ${databaseName}`,
+    onlyIf(runtime.supportsNesting, async () => {
+      const result = await runtime
+        .loadQuery(
+          `
         run: ${databaseName}.table('malloytest.airports') -> {
           where: faa_region = null
           group_by: faa_region
@@ -1040,18 +1042,19 @@ SELECT row_to_json(finalStage) as row FROM __stage0 AS finalStage`);
           }
         }
       `
-      )
-      .run();
+        )
+        .run();
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const d: any = result.data.toObject();
-    expect(d[0]['by_state']).not.toBe(null);
-    expect(d[0]['by_state1']).not.toBe(null);
-  });
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const d: any = result.data.toObject();
+      expect(d[0]['by_state']).not.toBe(null);
+      expect(d[0]['by_state1']).not.toBe(null);
+    })
+  );
 
-  testIf(runtime.supportsNesting)(
+  test(
     `number as null- ${databaseName}`,
-    async () => {
+    onlyIf(runtime.supportsNesting, async () => {
       const result = await runtime
         .loadQuery(
           `
@@ -1068,7 +1071,7 @@ SELECT row_to_json(finalStage) as row FROM __stage0 AS finalStage`);
         )
         .run();
       expect(result.data.path(0, 'ugly', 0, 'foo').value).toBe(null);
-    }
+    })
   );
 
   it(`removes surpuflous order_by - solo aggregates - ${databaseName}`, async () => {
@@ -1168,8 +1171,10 @@ SELECT row_to_json(finalStage) as row FROM __stage0 AS finalStage`);
       `).malloyResultMatches(runtime, {back});
     });
 
-    testIf(runtime.supportsNesting)('spaces in names', async () => {
-      await expect(`
+    test(
+      'spaces in names',
+      onlyIf(runtime.supportsNesting, async () => {
+        await expect(`
         source: \`space race\` is ${databaseName}.table('malloytest.state_facts') extend {
           join_one: \`j space\` is ${databaseName}.table('malloytest.state_facts') on \`j space\`.state=state
           view: \`q u e r y\` is {
@@ -1188,6 +1193,7 @@ SELECT row_to_json(finalStage) as row FROM __stage0 AS finalStage`);
         }
         run: \`space race\` -> \`q u e r y\`
       `).malloyResultMatches(runtime, {'c o u n t': 24});
-    });
+      })
+    );
   });
 });

--- a/test/src/databases/all/orderby.spec.ts
+++ b/test/src/databases/all/orderby.spec.ts
@@ -23,7 +23,7 @@
  */
 
 import {RuntimeList, allDatabases} from '../../runtimes';
-import {databasesFromEnvironmentOr, testIf} from '../../util';
+import {databasesFromEnvironmentOr, onlyIf} from '../../util';
 import '../../util/db-jest-matchers';
 
 const runtimes = new RuntimeList(databasesFromEnvironmentOr(allDatabases));
@@ -87,9 +87,9 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
     `).malloyResultMatches(orderByModel, {});
   });
 
-  testIf(runtime.supportsNesting)(
+  test(
     `reserved words are quoted in turtles - ${databaseName}`,
-    async () => {
+    onlyIf(runtime.supportsNesting, async () => {
       await expect(`
       run: models->{
         nest: withx is {
@@ -102,7 +102,7 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
           fetch is withx.fetch
       }
     `).malloyResultMatches(orderByModel, {});
-    }
+    })
   );
 
   it.skip('reserved words in structure definitions', async () => {
@@ -142,9 +142,9 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
     `).malloyResultMatches(orderByModel, {model_count: 102});
   });
 
-  testIf(runtime.supportsNesting)(
+  test(
     `modeled having complex - ${databaseName}`,
-    async () => {
+    onlyIf(runtime.supportsNesting, async () => {
       await expect(`
         source: popular_names is models->{
           having: model_count > 100
@@ -161,7 +161,7 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
           select: manufacturer, model_count
         }
       `).malloyResultMatches(orderByModel, {model_count: 102});
-    }
+    })
   );
 
   it(`turtle references joined element - ${databaseName}`, async () => {

--- a/test/src/databases/bigquery-postgres/multi_connection.spec.ts
+++ b/test/src/databases/bigquery-postgres/multi_connection.spec.ts
@@ -29,16 +29,14 @@ import {EmptyURLReader} from '@malloydata/malloy';
 import {BigQueryTestConnection, PostgresTestConnection} from '../../runtimes';
 import {describeIfDatabaseAvailable} from '../../util';
 
-const res = describeIfDatabaseAvailable(['bigquery', 'postgres']);
-let [describe] = res;
-const [, databases] = res;
+const [, databases] = describeIfDatabaseAvailable(['bigquery', 'postgres']);
 
 // *** NOTE ***
 // this is a special case (for now): a test that REQUIRES two databases - bigquery AND postgres
-describe =
+const describe =
   databases.filter(d => ['postgres', 'bigquery'].includes(d)).length >= 2
-    ? describe
-    : describe.skip;
+    ? globalThis.describe
+    : globalThis.describe.skip;
 
 describe('Multi-connection', () => {
   const bqConnection = new BigQueryTestConnection(

--- a/test/src/databases/bigquery-postgres/streaming.spec.ts
+++ b/test/src/databases/bigquery-postgres/streaming.spec.ts
@@ -48,6 +48,9 @@ const [describe, databases] = describeIfDatabaseAvailable([
 ]);
 
 describe('Streaming tests', () => {
+  if (!databases.length) {
+    it.skip('skipped', () => {});
+  }
   const runtimes = new RuntimeList(databases);
 
   afterAll(async () => {

--- a/test/src/databases/duckdb/duckdb.spec.ts
+++ b/test/src/databases/duckdb/duckdb.spec.ts
@@ -29,7 +29,7 @@ import {describeIfDatabaseAvailable} from '../../util';
 // TODO identify which tests need to run on wasm and move them into their own file
 const runtimes = ['duckdb', 'duckdb_wasm'];
 
-const [_describe, databases] = describeIfDatabaseAvailable(runtimes);
+const [describe, databases] = describeIfDatabaseAvailable(runtimes);
 const allDucks = new RuntimeList(databases);
 
 describe.each(allDucks.runtimeList)('duckdb:%s', (dbName, runtime) => {

--- a/test/src/databases/duckdb/streaming.spec.ts
+++ b/test/src/databases/duckdb/streaming.spec.ts
@@ -90,6 +90,9 @@ function modelText(databaseName: string) {
 }
 
 describe('Streaming tests', () => {
+  if (!databases.length) {
+    it.skip('skipped', () => {});
+  }
   const runtimes = new RuntimeList(databases);
 
   afterAll(async () => {

--- a/test/src/render/render.spec.ts
+++ b/test/src/render/render.spec.ts
@@ -23,7 +23,7 @@
 
 import {ModelMaterializer} from '@malloydata/malloy';
 import {RuntimeList, runtimeFor} from '../runtimes';
-import {describeIfDatabaseAvailable} from '../util';
+import {describeIfDatabaseAvailable, onlyIf} from '../util';
 import {HTMLView} from '@malloydata/render';
 import {JSDOM} from 'jsdom';
 
@@ -66,130 +66,172 @@ describe('rendering results', () => {
     await runtimes.closeAll();
   });
 
-  test('can render table', async () => {
-    const runtime = runtimes.runtimeMap.get('bigquery');
-    expect(runtime).toBeDefined();
-    if (runtime) {
-      const src = `
+  test(
+    'can render table',
+    onlyIf(databases.includes('bigquery'), async () => {
+      const runtime = runtimes.runtimeMap.get('bigquery');
+      expect(runtime).toBeDefined();
+      if (runtime) {
+        const src = `
         run: bigquery.table('malloy-data.faa.flights') -> {
           group_by: carrier
           aggregate: flight_count is count()
         }
       `;
-      const result = await runtime.loadQuery(src).run();
-      const document = new JSDOM().window.document;
-      await new HTMLView(document).render(result, {
-        dataStyles: {},
-      });
-    }
-  });
+        const result = await runtime.loadQuery(src).run();
+        const document = new JSDOM().window.document;
+        await new HTMLView(document).render(result, {
+          dataStyles: {},
+        });
+      }
+    })
+  );
 
-  test('can render unsupported bigquery geo types', async () => {
-    await runUnsupportedRenderTest(
-      'bigquery',
-      runtimes,
-      "ST_GEOGFROMTEXT('LINESTRING(1 2, 3 4)')",
-      'LINESTRING(1 2, 3 4)'
-    );
-  });
+  test(
+    'can render unsupported bigquery geo types',
+    onlyIf(databases.includes('bigquery'), async () => {
+      await runUnsupportedRenderTest(
+        'bigquery',
+        runtimes,
+        "ST_GEOGFROMTEXT('LINESTRING(1 2, 3 4)')",
+        'LINESTRING(1 2, 3 4)'
+      );
+    })
+  );
 
-  test('can render unsupported bigquery ip types', async () => {
-    await runUnsupportedRenderTest(
-      'bigquery',
-      runtimes,
-      "NET.IP_FROM_STRING('192.168.1.1')",
-      '{"type":"Buffer","data":[192,168,1,1]}'
-    );
-  });
+  test(
+    'can render unsupported bigquery ip types',
+    onlyIf(databases.includes('bigquery'), async () => {
+      await runUnsupportedRenderTest(
+        'bigquery',
+        runtimes,
+        "NET.IP_FROM_STRING('192.168.1.1')",
+        '{"type":"Buffer","data":[192,168,1,1]}'
+      );
+    })
+  );
 
-  test('can render unsupported bigquery interval types', async () => {
-    await runUnsupportedRenderTest(
-      'bigquery',
-      runtimes,
-      'INTERVAL 1 YEAR',
-      '1-0 0 0:0:0'
-    );
-  });
+  test(
+    'can render unsupported bigquery interval types',
+    onlyIf(databases.includes('bigquery'), async () => {
+      await runUnsupportedRenderTest(
+        'bigquery',
+        runtimes,
+        'INTERVAL 1 YEAR',
+        '1-0 0 0:0:0'
+      );
+    })
+  );
 
-  test('can render unsupported bigquery time types', async () => {
-    await runUnsupportedRenderTest(
-      'bigquery',
-      runtimes,
-      'TIME(10, 10, 1)',
-      '10:10:01'
-    );
-  });
+  test(
+    'can render unsupported bigquery time types',
+    onlyIf(databases.includes('bigquery'), async () => {
+      await runUnsupportedRenderTest(
+        'bigquery',
+        runtimes,
+        'TIME(10, 10, 1)',
+        '10:10:01'
+      );
+    })
+  );
 
-  test('can render unsupported postgres interval types', async () => {
-    await runUnsupportedRenderTest(
-      'postgres',
-      runtimes,
-      'make_interval(days => 12)',
-      '12 days'
-    );
-  });
+  test(
+    'can render unsupported postgres interval types',
+    onlyIf(databases.includes('postgres'), async () => {
+      await runUnsupportedRenderTest(
+        'postgres',
+        runtimes,
+        'make_interval(days => 12)',
+        '12 days'
+      );
+    })
+  );
 
-  test('can render unsupported postgres uuid types', async () => {
-    await runUnsupportedRenderTest(
-      'postgres',
-      runtimes,
-      "CAST('a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11' AS UUID)",
-      'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11'
-    );
-  });
+  test(
+    'can render unsupported postgres uuid types',
+    onlyIf(databases.includes('postgres'), async () => {
+      await runUnsupportedRenderTest(
+        'postgres',
+        runtimes,
+        "CAST('a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11' AS UUID)",
+        'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11'
+      );
+    })
+  );
 
-  test('can render unsupported postgres inet types', async () => {
-    await runUnsupportedRenderTest(
-      'postgres',
-      runtimes,
-      "'192.168.1.1'::inet",
-      '192.168.1.1'
-    );
-  });
+  test(
+    'can render unsupported postgres inet types',
+    onlyIf(databases.includes('postgres'), async () => {
+      await runUnsupportedRenderTest(
+        'postgres',
+        runtimes,
+        "'192.168.1.1'::inet",
+        '192.168.1.1'
+      );
+    })
+  );
 
-  test('can render unsupported postgres macaddr types', async () => {
-    await runUnsupportedRenderTest(
-      'postgres',
-      runtimes,
-      "'00:04:E2:36:95:C0'::macaddr",
-      '00:04:e2:36:95:c0'
-    );
-  });
+  test(
+    'can render unsupported postgres macaddr types',
+    onlyIf(databases.includes('postgres'), async () => {
+      await runUnsupportedRenderTest(
+        'postgres',
+        runtimes,
+        "'00:04:E2:36:95:C0'::macaddr",
+        '00:04:e2:36:95:c0'
+      );
+    })
+  );
 
-  test('can render supported postgres types', async () => {
-    await runUnsupportedRenderTest('postgres', runtimes, '12345', '12,345');
-  });
+  test(
+    'can render supported postgres types',
+    onlyIf(databases.includes('postgres'), async () => {
+      await runUnsupportedRenderTest('postgres', runtimes, '12345', '12,345');
+    })
+  );
 
-  test('can render supported duckdb types', async () => {
-    await runUnsupportedRenderTest('duckdb', runtimes, '12345', '12,345');
-  });
+  test(
+    'can render supported duckdb types',
+    onlyIf(databases.includes('duckdb'), async () => {
+      await runUnsupportedRenderTest('duckdb', runtimes, '12345', '12,345');
+    })
+  );
 
-  test('can render unsupported duckdb blob types', async () => {
-    await runUnsupportedRenderTest(
-      'duckdb',
-      runtimes,
-      "'\\xAA'::BLOB",
-      '{"type":"Buffer","data":[170]}'
-    );
-  });
+  test(
+    'can render unsupported duckdb blob types',
+    onlyIf(databases.includes('duckdb'), async () => {
+      await runUnsupportedRenderTest(
+        'duckdb',
+        runtimes,
+        "'\\xAA'::BLOB",
+        '{"type":"Buffer","data":[170]}'
+      );
+    })
+  );
 
-  test('can render unsupported duckdb uuid types', async () => {
-    await runUnsupportedRenderTest(
-      'duckdb',
-      runtimes,
-      "'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11'::UUID",
-      'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11'
-    );
-  });
+  test(
+    'can render unsupported duckdb uuid types',
+    onlyIf(databases.includes('duckdb'), async () => {
+      await runUnsupportedRenderTest(
+        'duckdb',
+        runtimes,
+        "'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11'::UUID",
+        'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11'
+      );
+    })
+  );
 
-  test('can render null unsupported types', async () => {
-    await runUnsupportedRenderTest(
-      'bigquery',
-      runtimes,
-      'CAST(NULL AS GEOGRAPHY)',
-      '<span class="value-null">∅</span>'
-    );
-  });
+  test(
+    'can render null unsupported types',
+    onlyIf(databases.includes('bigquery'), async () => {
+      await runUnsupportedRenderTest(
+        'bigquery',
+        runtimes,
+        'CAST(NULL AS GEOGRAPHY)',
+        '<span class="value-null">∅</span>'
+      );
+    })
+  );
 
   describe('html renderer', () => {
     describe('complex query with tags', () => {


### PR DESCRIPTION
This introduces `onlyIf()`, a utility function to allow a test to be skipped by conditional, while still allowing test runners to pick up the test signature. 

It also hardens `describeIfDatabaseAvailable()` so that the `describe()` returned can handle `describe.each()`s with empty input arrays.

Database tests in packages don't have access to the utils script so a mini skip header is used for those.