### PR TITLE
export dist/dialect in malloy

### DIFF
--- a/packages/malloy/package.json
+++ b/packages/malloy/package.json
@@ -4,12 +4,16 @@
   "license": "MIT",
   "exports": {
     ".": "./dist/index.js",
+    "./dialect": "./dist/dialect/index.js",
     "./test": "./dist/test/index.js"
   },
   "typesVersions": {
     "*": {
       "index": [
         "./dist/index.d.ts"
+      ],
+      "dialect": [
+        "./dist/dialect/index.d.ts"
       ],
       "test": [
         "./dist/test/index.d.ts"

--- a/scripts/snowflake_tables.sh
+++ b/scripts/snowflake_tables.sh
@@ -17,6 +17,7 @@ pushd ${DATA_DIR}
 # -- Create a file format that sets the file type as Parquet.
 format="CREATE OR REPLACE FILE FORMAT PARQUET_SCHEMA_DETECTION
   TYPE = PARQUET
+  USE_LOGICAL_TYPE = TRUE
   BINARY_AS_TEXT = FALSE;"
 echo -ne "${format}\n\n"
 


### PR DESCRIPTION
- export `dist/dialect` as "dialect" in malloy.
this enables unblocks importing from malloy service
```
>> malloy-service/src/server.ts
import {Dialect, registerDialect} from '@malloydata/malloy/dialect'
```
- also fix the snowflake_tables script {just for posterity} of how to infer types for parquet format