### PR TITLE
Only treat granular results as ranges with apply operator

### DIFF
--- a/packages/malloy/src/lang/ast/expressions/apply.ts
+++ b/packages/malloy/src/lang/ast/expressions/apply.ts
@@ -24,6 +24,10 @@
 import {Comparison} from '../types/comparison';
 import {ExprCompare} from './expr-compare';
 import {ExpressionDef} from '../types/expression-def';
+import {ExprValue} from '../types/expr-value';
+import {FieldSpace} from '../types/field-space';
+import {isGranularResult} from '../types/granular-result';
+import {ExprGranularTime} from './expr-granular-time';
 
 export class Apply extends ExprCompare {
   elementType = 'apply';
@@ -32,5 +36,17 @@ export class Apply extends ExprCompare {
     readonly right: ExpressionDef
   ) {
     super(left, Comparison.EqualTo, right);
+  }
+
+  getExpression(fs: FieldSpace): ExprValue {
+    if (!this.right.granular()) {
+      const rhs = this.right.requestExpression(fs);
+      if (rhs && isGranularResult(rhs)) {
+        // Need to wrap granular computations to get granular behavior
+        const newRight = new ExprGranularTime(this.right, rhs.timeframe, false);
+        return newRight.apply(fs, this.op, this.left);
+      }
+    }
+    return super.getExpression(fs);
   }
 }

--- a/packages/malloy/src/lang/ast/expressions/apply.ts
+++ b/packages/malloy/src/lang/ast/expressions/apply.ts
@@ -39,13 +39,16 @@ export class Apply extends ExprCompare {
   }
 
   getExpression(fs: FieldSpace): ExprValue {
+    let right = this.right;
     if (!this.right.granular()) {
       const rhs = this.right.requestExpression(fs);
       if (rhs && isGranularResult(rhs)) {
         // Need to wrap granular computations to get granular behavior
-        const newRight = new ExprGranularTime(this.right, rhs.timeframe, false);
-        return newRight.apply(fs, this.op, this.left);
+        right = new ExprGranularTime(this.right, rhs.timeframe, false);
       }
+    }
+    if (right instanceof ExprGranularTime) {
+      return right.toRange(fs).apply(fs, this.op, this.left);
     }
     return super.getExpression(fs);
   }

--- a/packages/malloy/src/lang/ast/expressions/expr-compare.ts
+++ b/packages/malloy/src/lang/ast/expressions/expr-compare.ts
@@ -49,14 +49,6 @@ export class ExprCompare extends BinaryBoolean<Comparison> {
   }
 
   getExpression(fs: FieldSpace): ExprValue {
-    if (!this.right.granular()) {
-      const rhs = this.right.requestExpression(fs);
-      if (rhs && isGranularResult(rhs)) {
-        const newRight = new ExprGranularTime(this.right, rhs.timeframe, false);
-        return newRight.apply(fs, this.op, this.left);
-      }
-    }
-
     return this.right.apply(fs, this.op, this.left);
   }
 }

--- a/packages/malloy/src/lang/ast/expressions/expr-compare.ts
+++ b/packages/malloy/src/lang/ast/expressions/expr-compare.ts
@@ -26,9 +26,7 @@ import {Comparison} from '../types/comparison';
 import {ExprValue} from '../types/expr-value';
 import {ExpressionDef} from '../types/expression-def';
 import {FieldSpace} from '../types/field-space';
-import {isGranularResult} from '../types/granular-result';
 import {BinaryBoolean} from './binary-boolean';
-import {ExprGranularTime} from './expr-granular-time';
 
 const compareTypes = {
   '~': [FT.stringT],

--- a/packages/malloy/src/lang/ast/expressions/expr-granular-time.ts
+++ b/packages/malloy/src/lang/ast/expressions/expr-granular-time.ts
@@ -99,27 +99,27 @@ export class ExprGranularTime extends ExpressionDef {
     };
   }
 
-  apply(fs: FieldSpace, op: string, left: ExpressionDef): ExprValue {
-    return this.getRange(fs).apply(fs, op, left);
+  // apply(fs: FieldSpace, op: string, left: ExpressionDef): ExprValue {
+  //   return this.getRange(fs).apply(fs, op, left);
 
-    /*
-      write tests for each of these cases ....
+  //   /*
+  //     write tests for each of these cases ....
 
-      vt  rt  gt  use
-      dt  dt  dt  dateRange
-      dt  dt  ts  == or timeStampRange
-      dt  ts  dt  timestampRange
-      dt  ts  ts  timeStampRange
+  //     vt  rt  gt  use
+  //     dt  dt  dt  dateRange
+  //     dt  dt  ts  == or timeStampRange
+  //     dt  ts  dt  timestampRange
+  //     dt  ts  ts  timeStampRange
 
-      ts  ts  ts  timestampRange
-      ts  ts  dt  timestampRange
-      ts  dt  ts  timestampRange
-      ts  dt  dt  either
+  //     ts  ts  ts  timestampRange
+  //     ts  ts  dt  timestampRange
+  //     ts  dt  ts  timestampRange
+  //     ts  dt  dt  either
 
-    */
-  }
+  //   */
+  // }
 
-  protected getRange(fs: FieldSpace): Range {
+  toRange(fs: FieldSpace): Range {
     const begin = this.getExpression(fs);
     if (begin.dataType === 'timestamp') {
       const beginTS = ExprTime.fromValue('timestamp', begin);

--- a/packages/malloy/src/lang/test/expressions.spec.ts
+++ b/packages/malloy/src/lang/test/expressions.spec.ts
@@ -144,6 +144,23 @@ describe('expressions', () => {
         'Cannot measure from date to timestamp'
       );
     });
+    test('compare to truncation uses straight comparison', () => {
+      // Because equality comparisons with truncation end up being range checks
+      const compare = expr`@2024-02-01 = @2023-12-27.quarter + 1`;
+      expect(compare).toTranslate();
+      const compare_expr = compare.translator.generated().value;
+
+      expect(compare_expr[0]).toMatchObject({
+        function: 'timeLiteral',
+        literal: '2024-02-01',
+      });
+      expect(compare_expr[1]).toEqual('=');
+
+      const plus1 = expr`@2023-12-27.quarter + 1`;
+      expect(plus1).toTranslate();
+      const compare_to = plus1.translator.generated().value;
+      expect(compare_expr[2]).toEqual(compare_to[0]);
+    });
     test('comparison promotes date literal to timestamp', () => {
       expect(expr`@2001 = ats`).toTranslate();
     });

--- a/packages/malloy/src/lang/test/test-translator.ts
+++ b/packages/malloy/src/lang/test/test-translator.ts
@@ -511,14 +511,14 @@ export interface MarkedSource {
   translator?: TestTranslator;
 }
 
-interface HasTranslator extends MarkedSource {
-  translator: TestTranslator;
+interface HasTranslator<TT extends TestTranslator> extends MarkedSource {
+  translator: TT;
 }
 
 export function expr(
   unmarked: TemplateStringsArray,
   ...marked: string[]
-): HasTranslator {
+): HasTranslator<BetaExpression> {
   const ms = markSource(unmarked, ...marked);
   return {
     ...ms,
@@ -529,7 +529,7 @@ export function expr(
 export function model(
   unmarked: TemplateStringsArray,
   ...marked: string[]
-): HasTranslator {
+): HasTranslator<TestTranslator> {
   const ms = markSource(unmarked, ...marked);
   return {
     ...ms,
@@ -545,7 +545,7 @@ export function makeModelFunc(options: {
   return function model(
     unmarked: TemplateStringsArray,
     ...marked: string[]
-  ): HasTranslator {
+  ): HasTranslator<TestTranslator> {
     const ms = markSource(unmarked, ...marked);
     return {
       ...ms,


### PR DESCRIPTION
Before this change, any comparison of a time field with granularity would treat the time result as a range. After this change, only the apply operator ( `?` ) will treat a granular time entity as a range