### PR TITLE
Add support for inline (records) in malloyResultMatcher

### DIFF
--- a/test/src/databases/all/expr.spec.ts
+++ b/test/src/databases/all/expr.spec.ts
@@ -150,7 +150,8 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
     `).malloyResultMatches(expressionModel, {
       'o.by_state.state': 'TX',
       'o.by_state.airport_count': 1845,
-      //'o.inline.inline_sum': 19701,   // this should work.. @mtoy
+      'o.airport_count': 11146,
+      'o.inline/inline_sum': 11146,
       'airport_count': 19701,
     });
   });

--- a/test/src/util/db-jest-matchers.ts
+++ b/test/src/util/db-jest-matchers.ts
@@ -55,14 +55,14 @@ declare global {
        *   * The empty match {} accepts ANY data, but will errror if there is not a row
        *   * If the query is tagged with # test.debug then the test will fail and the result will be printed
        *   * If the query is tagged with # test.verbose then the result will be printed only if the test fails
-       *   * nestName.colName expects nestName to be a query which returns multiple rows, it will match
+       *   * A match key of nestName.colName expects nestName to be a query which returns multiple rows, it will match
        *     fields from the first row of the rows of nestName
-       *   * nestName/colName expects nestName to be a record/struct type
+       *   * A match key of nestName/colName expects nestName to be a record/struct type
        *
        * In addition, the query is checked for the following tags
        *
-       *   * test.verbose -- If the test fails, also dump the result data structure
-       *   * test.debug -- Test will fail, and trhe result data strudcture will be dumped.
+       *   * test.verbose -- If the test fails, also pretty-print the result data
+       *   * test.debug -- Force test failure, and the result data will be printed
        *
        * @param querySrc Malloy source, last query in source will be run
        * @param runtime Database connection runtime OR Model ( for the call to loadQuery )


### PR DESCRIPTION
`/` now means "match a record/struct field in a result column"

I also removed `-- debug` and replaced with `# test.debug` and prettied up the output

Docs for malloyResultMatches are now ...

```TypeScript
      /**
       * Jest matcher for running a Malloy query, checks that each row
       * contains the values matching the template. If you only want to
       * check the first row, use the first form. If you want to check
       * multiple rows, use the second.
       *
       *     await expect('query').malloyResultMatches(runtime, {colName: colValue});
       *     await expect('query').malloyResultMatches(runtime, [{colName: colValue}]);
       *
       *   * If you use an array, the number of rows in the result must match the rows in the match
       *   * The empty match {} accepts ANY data, but will errror if there is not a row
       *   * If the query is tagged with # test.debug then the test will fail and the result will be printed
       *   * If the query is tagged with # test.verbose then the result will be printed only if the test fails
       *   * A match key of nestName.colName expects nestName to be a query which returns multiple rows, it will match
       *     fields from the first row of the rows of nestName
       *   * A match key of nestName/colName expects nestName to be a record/struct type
       *
       * In addition, the query is checked for the following tags
       *
       *   * test.verbose -- If the test fails, also pretty-print the result data
       *   * test.debug -- Force test failure, and the result data will be printed
       *
       * @param querySrc Malloy source, last query in source will be run
       * @param runtime Database connection runtime OR Model ( for the call to loadQuery )
       * @param expected Key value pairs or array of key value pairs
       */
      malloyResultMatches(
        runtime: Runner,
        matchVals: ExpectedResult
      ): Promise<R>;
```