### PR TITLE
[snowflake] add support for safe cast in snowflake dialect

### DIFF
--- a/packages/malloy-db-snowflake/src/snowflake_executor.spec.ts
+++ b/packages/malloy-db-snowflake/src/snowflake_executor.spec.ts
@@ -29,7 +29,7 @@ const [describe] = describeIfDatabaseAvailable(['snowflake']);
 
 class SnowflakeExecutorTestSetup {
   private executor_: SnowflakeExecutor;
-  constructor(private executor: SnowflakeExecutor) {
+  constructor(executor: SnowflakeExecutor) {
     this.executor_ = executor;
   }
 

--- a/packages/malloy-db-snowflake/src/snowflake_executor.ts
+++ b/packages/malloy-db-snowflake/src/snowflake_executor.ts
@@ -170,10 +170,12 @@ export class SnowflakeExecutor {
 
   private async _setSessionParams(conn: Connection) {
     // set some default session parameters
+    // ensure we do not ignore case for quoted identifiers
+    await this._execute("ALTER SESSION SET QUOTED_IDENTIFIERS_IGNORE_CASE = FALSE;", conn);
     // set utc as the default timezone which is the malloy convention
     await this._execute("ALTER SESSION SET TIMEZONE = 'UTC';", conn);
     // ensure week starts on Sunday which is the malloy convention
-    await this._execute('ALTER SESSION SET WEEK_START = 7;', conn);
+    await this._execute("ALTER SESSION SET WEEK_START = 7;", conn);
     // so javascript can parse the dates
     await this._execute(
       "ALTER SESSION SET TIMESTAMP_NTZ_OUTPUT_FORMAT='YYYY-MM-DDTHH24:MI:SS.FF3TZH:TZM';",

--- a/test/snowflake/uploaddata.sql
+++ b/test/snowflake/uploaddata.sql
@@ -1,7 +1,7 @@
 -- to run
 
 -- cd test/snowflake
--- snowsql -f uploadddate.sql
+-- snowsql -f uploaddata.sql
 
 
 drop database malloytest;

--- a/test/src/databases/all/expr.spec.ts
+++ b/test/src/databases/all/expr.spec.ts
@@ -388,12 +388,12 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
     `).malloyResultMatches(expressionModel, {a: 312});
   });
 
-  test.when(!['postgres', 'snowflake'].includes(runtime.connection.name))(
+  test.when(!['postgres'].includes(runtime.connection.name))(
     'sql safe cast',
     async () => {
       await expect(`
       run: ${databaseName}.sql('SELECT 1 as one') -> { select:
-        bad_date is '123':::date
+        bad_date is '12a':::date
         bad_number is 'abc':::number
         good_number is "312":::"integer"
       }


### PR DESCRIPTION
- ensure output col names from snowflake are of same case as the malloy identifiers
- snowflake connection and executor tests succeed now
- add support for safe cast
- ensure safe cast expr test passes for snowflake