### PR TITLE
Cast decimal literal to DOUBLE

### DIFF
--- a/packages/malloy-db-duckdb/src/duckdb_wasm_connection.spec.ts
+++ b/packages/malloy-db-duckdb/src/duckdb_wasm_connection.spec.ts
@@ -107,7 +107,8 @@ FROM read_parquet("inventory_items2.parquet")
   });
 
   // Test to check that DecimalBigNums are broken.
-  // Remove/update when fixed
+  // Remove/update when fixed, and remove the work-around in
+  // sqlLiteralNumber()
   it('DecimalBigNum is broken', async () => {
     const result = await connection.runSQL('SELECT 1.234 AS n1');
     expect(result).toEqual({'rows': [{'n1': 1234}], 'totalRows': 1});

--- a/packages/malloy-db-duckdb/src/duckdb_wasm_connection.spec.ts
+++ b/packages/malloy-db-duckdb/src/duckdb_wasm_connection.spec.ts
@@ -105,4 +105,11 @@ FROM read_parquet("inventory_items2.parquet")
       {}
     );
   });
+
+  // Test to check that DecimalBigNums are broken.
+  // Remove/update when fixed
+  it('DecimalBigNum is broken', async () => {
+    const result = await connection.runSQL('SELECT 1.234 AS n1');
+    expect(result).toEqual({'rows': [{'n1': 1234}], 'totalRows': 1});
+  });
 });

--- a/packages/malloy/src/dialect/duckdb/duckdb.ts
+++ b/packages/malloy/src/dialect/duckdb/duckdb.ts
@@ -105,6 +105,14 @@ export class DuckDBDialect extends Dialect {
     return `FIRST(${fieldName}) FILTER (WHERE ${fieldName} IS NOT NULL)`;
   }
 
+  // DuckDB WASM has an issue with returning invalid DecimalBigNum
+  // values unless we explicitly cast to DOUBLE
+  override sqlLiteralNumber(literal: string): string {
+    return literal.includes('.')
+      ? `${literal}::${this.defaultNumberType}`
+      : literal;
+  }
+
   mapFields(fieldList: DialectFieldList): string {
     return fieldList.join(', ');
   }

--- a/test/src/databases/duckdb/duckdb.spec.ts
+++ b/test/src/databases/duckdb/duckdb.spec.ts
@@ -90,6 +90,17 @@ describe.each(allDucks.runtimeList)('duckdb:%s', (dbName, runtime) => {
     );
   });
 
+  it('handles decimal literals', async () => {
+    const query = `
+    run: duckdb.sql("select 1") -> {
+      select:
+          n1 is 1.234
+          n2 is 1234.0 / 1000
+  }
+    `;
+    await expect(query).malloyResultMatches(runtime, {n1: 1.234, n2: 1.234});
+  });
+
   it('can open json files', async () => {
     await expect(`
       run: duckdb.table('test/data/duckdb/test.json') -> {


### PR DESCRIPTION
For DuckDB, DuckDB WASM specifically. Workaround for https://github.com/malloydata/malloy/issues/1715