### PR TITLE
chore: export render types

### DIFF
--- a/packages/malloy-render/src/index.ts
+++ b/packages/malloy-render/src/index.ts
@@ -23,5 +23,6 @@
 
 export {HTMLView, JSONView} from './html/html_view';
 export * from './data_styles';
+export type {MalloyRenderProps} from './component/render';
 // Needed for test only.
 export {getDrillQuery} from './drill';


### PR DESCRIPTION
Exporting Malloy Render component props type so that frameworks / apps using typescript can use `<malloy-render />` with type safety