### PR TITLE
Set both token cases

### DIFF
--- a/packages/malloy-db-duckdb/src/duckdb_connection.ts
+++ b/packages/malloy-db-duckdb/src/duckdb_connection.ts
@@ -135,6 +135,7 @@ export class DuckDBConnection extends DuckDBCommon {
         if (this.isMotherDuck) {
           if (this.motherDuckToken) {
             process.env['motherduck_token'] = this.motherDuckToken;
+            process.env['MOTHERDUCK_TOKEN'] = this.motherDuckToken;
           }
           if (
             !process.env['motherduck_token'] &&


### PR DESCRIPTION
Windows users have reported having to manually set `MOTHERDUCK_TOKEN`, so set it as well when a token is passed in.