### PR TITLE
feat: apply number format to duration

### DIFF
--- a/packages/malloy-render/src/component/render-numeric-field.ts
+++ b/packages/malloy-render/src/component/render-numeric-field.ts
@@ -36,12 +36,13 @@ const multiplierMap = new Map<DurationUnit, number>([
   [DurationUnit.Days, Number.MAX_VALUE],
 ]);
 
-function formatTimeUnit(value: number, unit: DurationUnit) {
+function formatTimeUnit(value: number, unit: DurationUnit, numFormat?: string) {
   let unitString = unit.toString();
   if (value === 1) {
     unitString = unitString.substring(0, unitString.length - 1);
   }
-  return `${value} ${unitString}`;
+  const formattedValue = numFormat ? format(numFormat, value) : value;
+  return `${formattedValue} ${unitString}`;
 }
 
 export function renderNumericField(f: AtomicField, value: number) {
@@ -65,6 +66,7 @@ export function renderNumericField(f: AtomicField, value: number) {
   } else if (tag.has('percent')) displayValue = format('#,##0.00%', value);
   else if (tag.has('duration')) {
     const duration_unit = tag.text('duration');
+    const numFormat = tag.text('number');
     const targetUnit = duration_unit ?? DurationUnit.Seconds;
 
     let currentDuration = value;
@@ -86,7 +88,7 @@ export function renderNumericField(f: AtomicField, value: number) {
 
       if (currentUnitValue > 0) {
         durationParts = [
-          formatTimeUnit(currentUnitValue, unit),
+          formatTimeUnit(currentUnitValue, unit, numFormat),
           ...durationParts,
         ];
       }
@@ -98,7 +100,7 @@ export function renderNumericField(f: AtomicField, value: number) {
 
     if (durationParts.length > 0) {
       displayValue = durationParts.slice(0, 2).join(' ');
-    } else displayValue = formatTimeUnit(0, targetUnit as DurationUnit);
+    } else displayValue = formatTimeUnit(0, targetUnit as DurationUnit, numFormat);
   } else if (tag.has('number'))
     displayValue = format(tag.text('number')!, value);
   else displayValue = (value as number).toLocaleString();

--- a/packages/malloy-render/src/component/render-numeric-field.ts
+++ b/packages/malloy-render/src/component/render-numeric-field.ts
@@ -41,7 +41,7 @@ function formatTimeUnit(value: number, unit: DurationUnit, numFormat?: string) {
   if (value === 1) {
     unitString = unitString.substring(0, unitString.length - 1);
   }
-  const formattedValue = numFormat ? format(numFormat, value) : value;
+  const formattedValue = numFormat ? format(numFormat, value) : value.toLocaleString();
   return `${formattedValue} ${unitString}`;
 }
 

--- a/packages/malloy-render/src/html/duration.ts
+++ b/packages/malloy-render/src/html/duration.ts
@@ -107,7 +107,7 @@ export class HTMLDurationRenderer extends HTMLTextRenderer {
     if (value === 1) {
       unitString = unitString.substring(0, unitString.length - 1);
     }
-    const formattedValue = numFormat ? format(numFormat, value) : value;
+    const formattedValue = numFormat ? format(numFormat, value) : value.toLocaleString();
     return `${formattedValue} ${unitString}`;
   }
 }

--- a/packages/malloy-render/src/html/duration.ts
+++ b/packages/malloy-render/src/html/duration.ts
@@ -31,6 +31,7 @@ import {
 import {RendererOptions} from '../renderer_types';
 import {Renderer} from '../renderer';
 import {RendererFactory} from '../renderer_factory';
+import { format } from 'ssf';
 
 export class HTMLDurationRenderer extends HTMLTextRenderer {
   constructor(
@@ -63,6 +64,8 @@ export class HTMLDurationRenderer extends HTMLTextRenderer {
     }
 
     const targetUnit = this.options.duration_unit ?? DurationUnit.Seconds;
+    const numFormat = data.field.tagParse().tag.text("number");
+
     let currentDuration = data.number.value;
     let currentUnitValue = 0;
     let durationParts: string[] = [];
@@ -82,7 +85,7 @@ export class HTMLDurationRenderer extends HTMLTextRenderer {
 
       if (currentUnitValue > 0) {
         durationParts = [
-          this.formatTimeUnit(currentUnitValue, unit),
+          this.formatTimeUnit(currentUnitValue, unit, numFormat),
           ...durationParts,
         ];
       }
@@ -96,15 +99,16 @@ export class HTMLDurationRenderer extends HTMLTextRenderer {
       return durationParts.slice(0, 2).join(' ');
     }
 
-    return this.formatTimeUnit(0, targetUnit);
+    return this.formatTimeUnit(0, targetUnit, numFormat);
   }
 
-  formatTimeUnit(value: number, unit: DurationUnit) {
+  formatTimeUnit(value: number, unit: DurationUnit, numFormat?: string) {
     let unitString = unit.toString();
     if (value === 1) {
       unitString = unitString.substring(0, unitString.length - 1);
     }
-    return `${value} ${unitString}`;
+    const formattedValue = numFormat ? format(numFormat, value) : value;
+    return `${formattedValue} ${unitString}`;
   }
 }
 

--- a/packages/malloy-render/src/stories/basic.stories.ts
+++ b/packages/malloy-render/src/stories/basic.stories.ts
@@ -29,3 +29,10 @@ export const FlattenNestedMeasures = {
     view: 'flatten',
   },
 };
+
+export const Formats = {
+  args: {
+    source: 'products',
+    view: 'formats'
+  }
+}

--- a/packages/malloy-render/src/stories/static/basic.malloy
+++ b/packages/malloy-render/src/stories/static/basic.malloy
@@ -1,6 +1,6 @@
 source: products is duckdb.table("data/products.parquet") extend {
 
-  view: records is{
+  view: records is {
     select: *
     limit: 1000
   }
@@ -51,5 +51,17 @@ source: products is duckdb.table("data/products.parquet") extend {
           }
         where: distribution_center_id=1 or distribution_center_id=2
       }
+  }
+
+  view: formats is {
+    group_by:
+      `Test number` is "0.0123730499"
+      Default is 0.0123730499
+      # duration
+      `# duration` is 0.0123730499
+      # number="0.###"
+      `# number=0.###` is 0.0123730499
+      # duration number="0.###"
+      `# duration number=0.###` is 0.0123730499
   }
 };

--- a/packages/malloy-render/src/stories/static/basic.malloy
+++ b/packages/malloy-render/src/stories/static/basic.malloy
@@ -59,9 +59,9 @@ source: products is duckdb.table("data/products.parquet") extend {
       Default is 0.0123730499
       # duration
       `# duration` is 0.0123730499
-      # number="0.###"
-      `# number=0.###` is 0.0123730499
-      # duration number="0.###"
-      `# duration number=0.###` is 0.0123730499
+      # number="0.##"
+      `# number=0.##` is 0.0123730499
+      # duration number="0.##"
+      `# duration number=0.##` is 0.0123730499
   }
 };


### PR DESCRIPTION
Allow mixing number formatting with duration formatting

<img width="801" alt="image" src="https://github.com/malloydata/malloy/assets/5554373/02dace24-ad76-4ff8-a82b-9e21e453eea7">
