### PR TITLE
feat: duration formatting

### DIFF
--- a/packages/malloy-render/src/component/render-numeric-field.ts
+++ b/packages/malloy-render/src/component/render-numeric-field.ts
@@ -36,12 +36,13 @@ const multiplierMap = new Map<DurationUnit, number>([
   [DurationUnit.Days, Number.MAX_VALUE],
 ]);
 
-function formatTimeUnit(value: number, unit: DurationUnit) {
+function formatTimeUnit(value: number, unit: DurationUnit, numFormat?: string) {
   let unitString = unit.toString();
   if (value === 1) {
     unitString = unitString.substring(0, unitString.length - 1);
   }
-  return `${value} ${unitString}`;
+  const formattedValue = numFormat ? format(numFormat, value) : value;
+  return `${formattedValue} ${unitString}`;
 }
 
 export function renderNumericField(f: AtomicField, value: number) {
@@ -65,6 +66,7 @@ export function renderNumericField(f: AtomicField, value: number) {
   } else if (tag.has('percent')) displayValue = format('#,##0.00%', value);
   else if (tag.has('duration')) {
     const duration_unit = tag.text('duration');
+    const numFormat = tag.text('number');
     const targetUnit = duration_unit ?? DurationUnit.Seconds;
 
     let currentDuration = value;
@@ -86,7 +88,7 @@ export function renderNumericField(f: AtomicField, value: number) {
 
       if (currentUnitValue > 0) {
         durationParts = [
-          formatTimeUnit(currentUnitValue, unit),
+          formatTimeUnit(currentUnitValue, unit, numFormat),
           ...durationParts,
         ];
       }
@@ -98,7 +100,7 @@ export function renderNumericField(f: AtomicField, value: number) {
 
     if (durationParts.length > 0) {
       displayValue = durationParts.slice(0, 2).join(' ');
-    } else displayValue = formatTimeUnit(0, targetUnit as DurationUnit);
+    } else displayValue = formatTimeUnit(0, targetUnit as DurationUnit, numFormat);
   } else if (tag.has('number'))
     displayValue = format(tag.text('number')!, value);
   else displayValue = (value as number).toLocaleString();

--- a/packages/malloy-render/src/component/render-numeric-field.ts
+++ b/packages/malloy-render/src/component/render-numeric-field.ts
@@ -41,7 +41,7 @@ function formatTimeUnit(value: number, unit: DurationUnit, numFormat?: string) {
   if (value === 1) {
     unitString = unitString.substring(0, unitString.length - 1);
   }
-  const formattedValue = numFormat ? format(numFormat, value) : value;
+  const formattedValue = numFormat ? format(numFormat, value) : value.toLocaleString();
   return `${formattedValue} ${unitString}`;
 }
 

--- a/packages/malloy-render/src/component/render-numeric-field.ts
+++ b/packages/malloy-render/src/component/render-numeric-field.ts
@@ -26,7 +26,7 @@ import {Currency, DurationUnit} from '../data_styles';
 import {format} from 'ssf';
 import { getText } from '../html/duration';
 
-export function renderNumericField(f: AtomicField, value: number) {
+export function renderNumericField(f: AtomicField, value: number): string {
   let displayValue: string | number = value;
   const {tag} = f.tagParse();
   if (tag.has('currency')) {
@@ -48,7 +48,7 @@ export function renderNumericField(f: AtomicField, value: number) {
   else if (tag.has('duration')) {
     const duration_unit = tag.text('duration');
     const targetUnit = duration_unit ?? DurationUnit.Seconds;
-    return getText(f, value, {durationUnit: targetUnit});
+    return getText(f, value, {durationUnit: targetUnit}) ?? value.toLocaleString();
   } else if (tag.has('number'))
     displayValue = format(tag.text('number')!, value);
   else displayValue = (value as number).toLocaleString();

--- a/packages/malloy-render/src/component/render-numeric-field.ts
+++ b/packages/malloy-render/src/component/render-numeric-field.ts
@@ -26,26 +26,6 @@ import {Currency, DurationUnit} from '../data_styles';
 import {format} from 'ssf';
 import { getText } from '../html/duration';
 
-// Map of unit to how many units of the make up the following time unit.
-const multiplierMap = new Map<DurationUnit, number>([
-  [DurationUnit.Nanoseconds, 1000],
-  [DurationUnit.Microseconds, 1000],
-  [DurationUnit.Milliseconds, 1000],
-  [DurationUnit.Seconds, 60],
-  [DurationUnit.Minutes, 60],
-  [DurationUnit.Hours, 24],
-  [DurationUnit.Days, Number.MAX_VALUE],
-]);
-
-function formatTimeUnit(value: number, unit: DurationUnit, numFormat?: string) {
-  let unitString = unit.toString();
-  if (value === 1) {
-    unitString = unitString.substring(0, unitString.length - 1);
-  }
-  const formattedValue = numFormat ? format(numFormat, value) : value.toLocaleString();
-  return `${formattedValue} ${unitString}`;
-}
-
 export function renderNumericField(f: AtomicField, value: number) {
   let displayValue: string | number = value;
   const {tag} = f.tagParse();

--- a/packages/malloy-render/src/component/render-numeric-field.ts
+++ b/packages/malloy-render/src/component/render-numeric-field.ts
@@ -24,7 +24,7 @@
 import {AtomicField} from '@malloydata/malloy';
 import {Currency, DurationUnit} from '../data_styles';
 import {format} from 'ssf';
-import { getText } from '../html/duration';
+import {getText} from '../html/duration';
 
 export function renderNumericField(f: AtomicField, value: number): string {
   let displayValue: string | number = value;
@@ -48,7 +48,9 @@ export function renderNumericField(f: AtomicField, value: number): string {
   else if (tag.has('duration')) {
     const duration_unit = tag.text('duration');
     const targetUnit = duration_unit ?? DurationUnit.Seconds;
-    return getText(f, value, {durationUnit: targetUnit}) ?? value.toLocaleString();
+    return (
+      getText(f, value, {durationUnit: targetUnit}) ?? value.toLocaleString()
+    );
   } else if (tag.has('number'))
     displayValue = format(tag.text('number')!, value);
   else displayValue = (value as number).toLocaleString();

--- a/packages/malloy-render/src/component/render-numeric-field.ts
+++ b/packages/malloy-render/src/component/render-numeric-field.ts
@@ -24,6 +24,7 @@
 import {AtomicField} from '@malloydata/malloy';
 import {Currency, DurationUnit} from '../data_styles';
 import {format} from 'ssf';
+import { getText } from '../html/duration';
 
 // Map of unit to how many units of the make up the following time unit.
 const multiplierMap = new Map<DurationUnit, number>([
@@ -66,41 +67,8 @@ export function renderNumericField(f: AtomicField, value: number) {
   } else if (tag.has('percent')) displayValue = format('#,##0.00%', value);
   else if (tag.has('duration')) {
     const duration_unit = tag.text('duration');
-    const numFormat = tag.text('number');
     const targetUnit = duration_unit ?? DurationUnit.Seconds;
-
-    let currentDuration = value;
-    let currentUnitValue = 0;
-    let durationParts: string[] = [];
-    let foundUnit = false;
-
-    for (const [unit, multiplier] of multiplierMap) {
-      if (unit === targetUnit) {
-        foundUnit = true;
-      }
-
-      if (!foundUnit) {
-        continue;
-      }
-
-      currentUnitValue = currentDuration % multiplier;
-      currentDuration = Math.floor((currentDuration /= multiplier));
-
-      if (currentUnitValue > 0) {
-        durationParts = [
-          formatTimeUnit(currentUnitValue, unit, numFormat),
-          ...durationParts,
-        ];
-      }
-
-      if (currentDuration === 0) {
-        break;
-      }
-    }
-
-    if (durationParts.length > 0) {
-      displayValue = durationParts.slice(0, 2).join(' ');
-    } else displayValue = formatTimeUnit(0, targetUnit as DurationUnit, numFormat);
+    return getText(f, value, {durationUnit: targetUnit});
   } else if (tag.has('number'))
     displayValue = format(tag.text('number')!, value);
   else displayValue = (value as number).toLocaleString();

--- a/packages/malloy-render/src/data_styles.ts
+++ b/packages/malloy-render/src/data_styles.ts
@@ -125,6 +125,10 @@ export enum DurationUnit {
   Days = 'days',
 }
 
+export function isDurationUnit(unit: string): unit is DurationUnit {
+  return Object.values(DurationUnit).includes(unit as DurationUnit);
+}
+
 export interface DurationRenderOptions extends TextRenderOptions {
   duration_unit?: DurationUnit;
 }

--- a/packages/malloy-render/src/html/duration.ts
+++ b/packages/malloy-render/src/html/duration.ts
@@ -32,17 +32,24 @@ import {
 import {RendererOptions} from '../renderer_types';
 import {Renderer} from '../renderer';
 import {RendererFactory} from '../renderer_factory';
-import { format } from 'ssf';
+import {format} from 'ssf';
 
-export function formatTimeUnit(value: number, unit: DurationUnit, options: { numFormat?: string; terse?: boolean } = {}) {
+export function formatTimeUnit(
+  value: number,
+  unit: DurationUnit,
+  options: {numFormat?: string; terse?: boolean} = {}
+) {
   let unitString = unit.toString();
-    if(options.terse) unitString = terseDurationUnitsMap.get(unit) ?? unitString;
-    else if (value === 1) {
-      unitString = unitString.substring(0, unitString.length - 1);
-    }
+  if (options.terse) {
+    unitString = terseDurationUnitsMap.get(unit) ?? unitString;
+  } else if (value === 1) {
+    unitString = unitString.substring(0, unitString.length - 1);
+  }
 
-  const formattedValue = options.numFormat ? format(options.numFormat, value) : value.toLocaleString();
-  return `${formattedValue}${options.terse ? "" : " "}${unitString}`;
+  const formattedValue = options.numFormat
+    ? format(options.numFormat, value)
+    : value.toLocaleString();
+  return `${formattedValue}${options.terse ? '' : ' '}${unitString}`;
 }
 
 const terseDurationUnitsMap = new Map<DurationUnit, string>([
@@ -65,15 +72,20 @@ const multiplierMap = new Map<DurationUnit, number>([
   [DurationUnit.Days, Number.MAX_VALUE],
 ]);
 
-export function getText(field: AtomicField, value: number, options: {
-  durationUnit?: string
-}): string | null {
-
-
-  const targetUnit = options.durationUnit && isDurationUnit(options.durationUnit) ? options.durationUnit : DurationUnit.Seconds;
+export function getText(
+  field: AtomicField,
+  value: number,
+  options: {
+    durationUnit?: string;
+  }
+): string | null {
+  const targetUnit =
+    options.durationUnit && isDurationUnit(options.durationUnit)
+      ? options.durationUnit
+      : DurationUnit.Seconds;
   const tag = field.tagParse().tag;
-  const numFormat = tag.text("number");
-  const terse = tag.has("duration","terse");
+  const numFormat = tag.text('number');
+  const terse = tag.has('duration', 'terse');
 
   let currentDuration = value;
   let currentUnitValue = 0;
@@ -129,7 +141,9 @@ export class HTMLDurationRenderer extends HTMLTextRenderer {
         `Cannot format field ${data.field.name} as a duration unit since its not a number`
       );
     }
-    return getText(data.field, data.number.value, {durationUnit: this.options.duration_unit});
+    return getText(data.field, data.number.value, {
+      durationUnit: this.options.duration_unit,
+    });
   }
 }
 

--- a/packages/malloy-render/src/html/duration.ts
+++ b/packages/malloy-render/src/html/duration.ts
@@ -107,7 +107,7 @@ export class HTMLDurationRenderer extends HTMLTextRenderer {
     if (value === 1) {
       unitString = unitString.substring(0, unitString.length - 1);
     }
-    const formattedValue = numFormat ? format(numFormat, value) : value;
+    const formattedValue = numFormat ? format(numFormat, value) : value.toLocaleString();
     return `${formattedValue} ${unitString}`;
   }
 }

--- a/packages/malloy-render/src/html/duration.ts
+++ b/packages/malloy-render/src/html/duration.ts
@@ -21,17 +21,95 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import {DataColumn, Explore, Field} from '@malloydata/malloy';
+import {AtomicField, DataColumn, Explore, Field} from '@malloydata/malloy';
 import {HTMLTextRenderer} from './text';
 import {
   DurationRenderOptions,
   DurationUnit,
+  isDurationUnit,
   StyleDefaults,
 } from '../data_styles';
 import {RendererOptions} from '../renderer_types';
 import {Renderer} from '../renderer';
 import {RendererFactory} from '../renderer_factory';
 import { format } from 'ssf';
+
+export function formatTimeUnit(value: number, unit: DurationUnit, options: { numFormat?: string; terse?: boolean } = {}) {
+  let unitString = unit.toString();
+    if(options.terse) unitString = terseDurationUnitsMap.get(unit) ?? unitString;
+    else if (value === 1) {
+      unitString = unitString.substring(0, unitString.length - 1);
+    }
+
+  const formattedValue = options.numFormat ? format(options.numFormat, value) : value.toLocaleString();
+  return `${formattedValue}${options.terse ? "" : " "}${unitString}`;
+}
+
+const terseDurationUnitsMap = new Map<DurationUnit, string>([
+  [DurationUnit.Nanoseconds, 'ns'],
+  [DurationUnit.Microseconds, 'µs'],
+  [DurationUnit.Milliseconds, 'ms'],
+  [DurationUnit.Seconds, 's'],
+  [DurationUnit.Minutes, 'm'],
+  [DurationUnit.Hours, 'h'],
+  [DurationUnit.Days, 'd'],
+]);
+
+const multiplierMap = new Map<DurationUnit, number>([
+  [DurationUnit.Nanoseconds, 1000],
+  [DurationUnit.Microseconds, 1000],
+  [DurationUnit.Milliseconds, 1000],
+  [DurationUnit.Seconds, 60],
+  [DurationUnit.Minutes, 60],
+  [DurationUnit.Hours, 24],
+  [DurationUnit.Days, Number.MAX_VALUE],
+]);
+
+export function getText(field: AtomicField, value: number, options: {
+  durationUnit?: string
+}): string | null {
+
+
+  const targetUnit = options.durationUnit && isDurationUnit(options.durationUnit) ? options.durationUnit : DurationUnit.Seconds;
+  const tag = field.tagParse().tag;
+  const numFormat = tag.text("number");
+  const terse = tag.has("duration","terse");
+
+  let currentDuration = value;
+  let currentUnitValue = 0;
+  let durationParts: string[] = [];
+  let foundUnit = false;
+
+  for (const [unit, multiplier] of multiplierMap) {
+    if (unit === targetUnit) {
+      foundUnit = true;
+    }
+
+    if (!foundUnit) {
+      continue;
+    }
+
+    currentUnitValue = currentDuration % multiplier;
+    currentDuration = Math.floor((currentDuration /= multiplier));
+
+    if (currentUnitValue > 0) {
+      durationParts = [
+        formatTimeUnit(currentUnitValue, unit, {numFormat, terse}),
+        ...durationParts,
+      ];
+    }
+
+    if (currentDuration === 0) {
+      break;
+    }
+  }
+
+  if (durationParts.length > 0) {
+    return durationParts.slice(0, 2).join(' ');
+  }
+
+  return formatTimeUnit(0, targetUnit, {numFormat, terse});
+}
 
 export class HTMLDurationRenderer extends HTMLTextRenderer {
   constructor(
@@ -40,17 +118,6 @@ export class HTMLDurationRenderer extends HTMLTextRenderer {
   ) {
     super(document);
   }
-
-  // Map of unit to how many units of the make up the following time unit.
-  static multiplierMap = new Map<DurationUnit, number>([
-    [DurationUnit.Nanoseconds, 1000],
-    [DurationUnit.Microseconds, 1000],
-    [DurationUnit.Milliseconds, 1000],
-    [DurationUnit.Seconds, 60],
-    [DurationUnit.Minutes, 60],
-    [DurationUnit.Hours, 24],
-    [DurationUnit.Days, Number.MAX_VALUE],
-  ]);
 
   override getText(data: DataColumn): string | null {
     if (data.isNull()) {
@@ -62,53 +129,7 @@ export class HTMLDurationRenderer extends HTMLTextRenderer {
         `Cannot format field ${data.field.name} as a duration unit since its not a number`
       );
     }
-
-    const targetUnit = this.options.duration_unit ?? DurationUnit.Seconds;
-    const numFormat = data.field.tagParse().tag.text("number");
-
-    let currentDuration = data.number.value;
-    let currentUnitValue = 0;
-    let durationParts: string[] = [];
-    let foundUnit = false;
-
-    for (const [unit, multiplier] of HTMLDurationRenderer.multiplierMap) {
-      if (unit === targetUnit) {
-        foundUnit = true;
-      }
-
-      if (!foundUnit) {
-        continue;
-      }
-
-      currentUnitValue = currentDuration % multiplier;
-      currentDuration = Math.floor((currentDuration /= multiplier));
-
-      if (currentUnitValue > 0) {
-        durationParts = [
-          this.formatTimeUnit(currentUnitValue, unit, numFormat),
-          ...durationParts,
-        ];
-      }
-
-      if (currentDuration === 0) {
-        break;
-      }
-    }
-
-    if (durationParts.length > 0) {
-      return durationParts.slice(0, 2).join(' ');
-    }
-
-    return this.formatTimeUnit(0, targetUnit, numFormat);
-  }
-
-  formatTimeUnit(value: number, unit: DurationUnit, numFormat?: string) {
-    let unitString = unit.toString();
-    if (value === 1) {
-      unitString = unitString.substring(0, unitString.length - 1);
-    }
-    const formattedValue = numFormat ? format(numFormat, value) : value.toLocaleString();
-    return `${formattedValue} ${unitString}`;
+    return getText(data.field, data.number.value, {durationUnit: this.options.duration_unit});
   }
 }
 

--- a/packages/malloy-render/src/html/duration.ts
+++ b/packages/malloy-render/src/html/duration.ts
@@ -31,6 +31,7 @@ import {
 import {RendererOptions} from '../renderer_types';
 import {Renderer} from '../renderer';
 import {RendererFactory} from '../renderer_factory';
+import { format } from 'ssf';
 
 export class HTMLDurationRenderer extends HTMLTextRenderer {
   constructor(
@@ -63,6 +64,8 @@ export class HTMLDurationRenderer extends HTMLTextRenderer {
     }
 
     const targetUnit = this.options.duration_unit ?? DurationUnit.Seconds;
+    const numFormat = data.field.tagParse().tag.text("number");
+
     let currentDuration = data.number.value;
     let currentUnitValue = 0;
     let durationParts: string[] = [];
@@ -82,7 +85,7 @@ export class HTMLDurationRenderer extends HTMLTextRenderer {
 
       if (currentUnitValue > 0) {
         durationParts = [
-          this.formatTimeUnit(currentUnitValue, unit),
+          this.formatTimeUnit(currentUnitValue, unit, numFormat),
           ...durationParts,
         ];
       }
@@ -96,15 +99,16 @@ export class HTMLDurationRenderer extends HTMLTextRenderer {
       return durationParts.slice(0, 2).join(' ');
     }
 
-    return this.formatTimeUnit(0, targetUnit);
+    return this.formatTimeUnit(0, targetUnit, numFormat);
   }
 
-  formatTimeUnit(value: number, unit: DurationUnit) {
+  formatTimeUnit(value: number, unit: DurationUnit, numFormat?: string) {
     let unitString = unit.toString();
     if (value === 1) {
       unitString = unitString.substring(0, unitString.length - 1);
     }
-    return `${value} ${unitString}`;
+    const formattedValue = numFormat ? format(numFormat, value) : value;
+    return `${formattedValue} ${unitString}`;
   }
 }
 

--- a/packages/malloy-render/src/stories/basic.stories.ts
+++ b/packages/malloy-render/src/stories/basic.stories.ts
@@ -33,6 +33,6 @@ export const FlattenNestedMeasures = {
 export const Formats = {
   args: {
     source: 'products',
-    view: 'formats'
-  }
-}
+    view: 'formats',
+  },
+};

--- a/packages/malloy-render/src/stories/basic.stories.ts
+++ b/packages/malloy-render/src/stories/basic.stories.ts
@@ -29,3 +29,10 @@ export const FlattenNestedMeasures = {
     view: 'flatten',
   },
 };
+
+export const Formats = {
+  args: {
+    source: 'products',
+    view: 'formats'
+  }
+}

--- a/packages/malloy-render/src/stories/static/basic.malloy
+++ b/packages/malloy-render/src/stories/static/basic.malloy
@@ -1,6 +1,6 @@
 source: products is duckdb.table("data/products.parquet") extend {
 
-  view: records is{
+  view: records is {
     select: *
     limit: 1000
   }
@@ -51,5 +51,17 @@ source: products is duckdb.table("data/products.parquet") extend {
           }
         where: distribution_center_id=1 or distribution_center_id=2
       }
+  }
+
+  view: formats is {
+    group_by:
+      `Test number` is "0.0123730499"
+      Default is 0.0123730499
+      # duration
+      `# duration` is 0.0123730499
+      # number="0.###"
+      `# number=0.###` is 0.0123730499
+      # duration number="0.###"
+      `# duration number=0.###` is 0.0123730499
   }
 };

--- a/packages/malloy-render/src/stories/static/basic.malloy
+++ b/packages/malloy-render/src/stories/static/basic.malloy
@@ -59,6 +59,8 @@ source: products is duckdb.table("data/products.parquet") extend {
       Default is 0.0123730499
       # duration
       `# duration` is 0.0123730499
+      # duration.terse
+      `# duration.terse` is 0.0123730499
       # number="0.##"
       `# number=0.##` is 0.0123730499
       # duration number="0.##"

--- a/packages/malloy-render/src/stories/static/basic.malloy
+++ b/packages/malloy-render/src/stories/static/basic.malloy
@@ -59,9 +59,9 @@ source: products is duckdb.table("data/products.parquet") extend {
       Default is 0.0123730499
       # duration
       `# duration` is 0.0123730499
-      # number="0.###"
-      `# number=0.###` is 0.0123730499
-      # duration number="0.###"
-      `# duration number=0.###` is 0.0123730499
+      # number="0.##"
+      `# number=0.##` is 0.0123730499
+      # duration number="0.##"
+      `# duration number=0.##` is 0.0123730499
   }
 };

--- a/packages/malloy-render/src/stories/static/tables.malloy
+++ b/packages/malloy-render/src/stories/static/tables.malloy
@@ -61,6 +61,8 @@ source: products is duckdb.table("data/products.parquet") extend {
       avg_retail_number is retail_price.avg()
       # duration
       avg_retail_duration is round(retail_price.avg())
+      # duration.terse
+      avg_retail_duration_terse is round(retail_price.avg())
   }
 }
 


### PR DESCRIPTION
## Changes
Adds:
- ability to format a duration when the `# number` tag is included
- ability to list durations in a terse format using `# duration.terse`

Fixes:
- if bad duration name is supplied, it is ignored and the default duration (seconds) is used

Cleanup:
- extracts duration functions into 1 place and exports them for re-use across both old and new renderer

## Examples
Old renderer
![CleanShot 2024-07-12 at 11 07 13@2x](https://github.com/user-attachments/assets/47eadf1b-0e20-4fc1-a22d-b6cec7933d34)

New renderer
![CleanShot 2024-07-12 at 11 07 49@2x](https://github.com/user-attachments/assets/69f8d33c-7fb7-40ca-be3b-47fde2cacf3f)


