### PR TITLE
[snowflake] upgrade snowflake package and fix breaking changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4225,7 +4225,6 @@
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^5.1.2",
@@ -4241,7 +4240,6 @@
     },
     "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
       "version": "6.0.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -4252,7 +4250,6 @@
     },
     "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
       "version": "6.2.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -4263,12 +4260,10 @@
     },
     "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
       "version": "9.2.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@isaacs/cliui/node_modules/string-width": {
       "version": "5.1.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "eastasianwidth": "^0.2.0",
@@ -4284,7 +4279,6 @@
     },
     "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
       "version": "7.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"
@@ -4298,7 +4292,6 @@
     },
     "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
       "version": "8.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.1.0",
@@ -6091,7 +6084,6 @@
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -10292,9 +10284,9 @@
       }
     },
     "node_modules/@types/snowflake-sdk": {
-      "version": "1.6.20",
-      "resolved": "https://registry.npmjs.org/@types/snowflake-sdk/-/snowflake-sdk-1.6.20.tgz",
-      "integrity": "sha512-Dr7oIXrWthlk9wVWpZgpm49BT8cFFXz43u7SkJKyiZK3WHiHQo4b+m2/p3WIpkYzZCcOZZ/t1B09XMd7+u1Wjw==",
+      "version": "1.6.24",
+      "resolved": "https://registry.npmjs.org/@types/snowflake-sdk/-/snowflake-sdk-1.6.24.tgz",
+      "integrity": "sha512-CgRp971LQJr970YSySCeIoNfX/29s9ZUnwhVjl8uL62kC7UoTNdNRwwyGCQ7Ca/fECRu8nK47pZpw8xmVWDn9Q==",
       "dependencies": {
         "@types/node": "*",
         "generic-pool": "^3.9.0"
@@ -11249,11 +11241,11 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
-      "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
+      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
       "dependencies": {
-        "follow-redirects": "^1.15.4",
+        "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }
@@ -13775,7 +13767,6 @@
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/ecdsa-sig-formatter": {
@@ -15312,7 +15303,6 @@
     },
     "node_modules/foreground-child": {
       "version": "3.1.1",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "cross-spawn": "^7.0.0",
@@ -15327,7 +15317,6 @@
     },
     "node_modules/foreground-child/node_modules/signal-exit": {
       "version": "4.0.2",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -22128,6 +22117,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.0.tgz",
+      "integrity": "sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw=="
+    },
     "node_modules/packet-reader": {
       "version": "1.0.0",
       "license": "MIT"
@@ -22488,25 +22482,24 @@
       "license": "MIT"
     },
     "node_modules/path-scurry": {
-      "version": "1.10.1",
-      "license": "BlueOak-1.0.0",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
       "dependencies": {
-        "lru-cache": "^9.1.1 || ^10.0.0",
+        "lru-cache": "^10.2.0",
         "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": ">=16 || 14 >=14.18"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "9.1.2",
-      "license": "ISC",
-      "engines": {
-        "node": "14 || >=16.14"
-      }
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
     },
     "node_modules/path-scurry/node_modules/minipass": {
       "version": "6.0.2",
@@ -24600,31 +24593,28 @@
       }
     },
     "node_modules/snowflake-sdk": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/snowflake-sdk/-/snowflake-sdk-1.10.0.tgz",
-      "integrity": "sha512-FDRHHkfRVmFqrDGWZSjBLEch1CYcVahXZK4kd/KMp/wr14o2FSagc6C7vPkw+0RXkcGnrkUKdancC7yfkz9rrA==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/snowflake-sdk/-/snowflake-sdk-1.11.0.tgz",
+      "integrity": "sha512-CwjjFfdQDZ1dtYJ0k5ON/fPA7U18GXCk6zap7qfSiTsaY7TfUXOX85ZPTzhEc1zx1M7NittuUH8+mePv2PsQRg==",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.388.0",
         "@aws-sdk/node-http-handler": "^3.374.0",
         "@azure/storage-blob": "^12.11.0",
         "@google-cloud/storage": "^7.7.0",
         "@techteamer/ocsp": "1.0.1",
-        "agent-base": "^6.0.2",
         "asn1.js-rfc2560": "^5.0.0",
         "asn1.js-rfc5280": "^3.0.0",
-        "axios": "^1.6.5",
+        "axios": "^1.6.8",
         "big-integer": "^1.6.43",
         "bignumber.js": "^9.1.2",
         "binascii": "0.0.2",
         "bn.js": "^5.2.1",
         "browser-request": "^0.3.3",
-        "debug": "^3.2.6",
         "expand-tilde": "^2.0.2",
-        "extend": "^3.0.2",
         "fast-xml-parser": "^4.2.5",
         "fastest-levenshtein": "^1.0.16",
         "generic-pool": "^3.8.2",
-        "glob": "^9.0.0",
+        "glob": "^10.0.0",
         "https-proxy-agent": "^7.0.2",
         "jsonwebtoken": "^9.0.0",
         "mime-types": "^2.1.29",
@@ -24654,26 +24644,20 @@
         "balanced-match": "^1.0.0"
       }
     },
-    "node_modules/snowflake-sdk/node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
     "node_modules/snowflake-sdk/node_modules/glob": {
-      "version": "9.3.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.5.tgz",
-      "integrity": "sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==",
+      "version": "10.4.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
       "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "minimatch": "^8.0.2",
-        "minipass": "^4.2.4",
-        "path-scurry": "^1.6.1"
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
       },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -24718,10 +24702,24 @@
         }
       }
     },
+    "node_modules/snowflake-sdk/node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
     "node_modules/snowflake-sdk/node_modules/minimatch": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.4.tgz",
-      "integrity": "sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==",
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -24733,11 +24731,11 @@
       }
     },
     "node_modules/snowflake-sdk/node_modules/minipass": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
-      "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
       "engines": {
-        "node": ">=8"
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/snowflake-sdk/node_modules/open": {
@@ -25190,7 +25188,6 @@
     "node_modules/string-width-cjs": {
       "name": "string-width",
       "version": "4.2.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -25233,7 +25230,6 @@
     "node_modules/strip-ansi-cjs": {
       "name": "strip-ansi",
       "version": "6.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -27926,7 +27922,6 @@
     "node_modules/wrap-ansi-cjs": {
       "name": "wrap-ansi",
       "version": "7.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -28273,9 +28268,9 @@
       "license": "MIT",
       "dependencies": {
         "@malloydata/malloy": "^0.0.150",
-        "@types/snowflake-sdk": "^1.6.16",
+        "@types/snowflake-sdk": "^1.6.24",
         "generic-pool": "^3.9.0",
-        "snowflake-sdk": "^1.9.0",
+        "snowflake-sdk": "^1.11.0",
         "toml": "^3.0.0"
       },
       "engines": {

--- a/packages/malloy-db-snowflake/package.json
+++ b/packages/malloy-db-snowflake/package.json
@@ -22,9 +22,9 @@
   },
   "dependencies": {
     "@malloydata/malloy": "^0.0.150",
-    "@types/snowflake-sdk": "^1.6.16",
+    "@types/snowflake-sdk": "^1.6.24",
     "generic-pool": "^3.9.0",
-    "snowflake-sdk": "^1.9.0",
+    "snowflake-sdk": "^1.11.0",
     "toml": "^3.0.0"
   }
 }


### PR DESCRIPTION
Between snowflake-sdk 1.9.0 and 1.11.0 seems like there are a few breaking changes
1) Statement type is replaced with RowStatement
2) Further StatementOption {parameter passed to execute} expects a 'complete' function.

Testing:
Ran basic unit tests in malloy-db-snowflake