### PR TITLE
fix: warn when malloy-render already exists

### DIFF
--- a/packages/malloy-render/src/component/render-webcomponent.ts
+++ b/packages/malloy-render/src/component/render-webcomponent.ts
@@ -16,15 +16,21 @@ const withStyles = ComponentType => {
   };
 };
 
-compose(
-  register('malloy-render', {
-    result: undefined,
-    queryResult: undefined,
-    modelDef: undefined,
-  }),
-  withStyles,
-  withSolid
-)(MalloyRender);
+if (!customElements.get('malloy-render')) {
+  compose(
+    register('malloy-render', {
+      result: undefined,
+      queryResult: undefined,
+      modelDef: undefined,
+    }),
+    withStyles,
+    withSolid
+  )(MalloyRender);
+} else {
+  console.warn(
+    "The custom element 'malloy-render' has already been defined. Make sure you are not loading multiple versions of the malloy-render package as they could conflict."
+  );
+}
 
 declare global {
   interface HTMLElementTagNameMap {


### PR DESCRIPTION
Throw a warning when malloy-render is accidentally loaded twice, instead of throwing an error. Developers should avoid situations where the component library is instantiated twice but its not always a show stopper