### PR TITLE
rewrite symmetric aggregate implementation

### DIFF
--- a/packages/malloy/src/dialect/snowflake/snowflake.ts
+++ b/packages/malloy/src/dialect/snowflake/snowflake.ts
@@ -95,7 +95,7 @@ export class SnowflakeDialect extends Dialect {
   udfPrefix = '__udf';
   hasFinalStage = false;
   divisionIsInteger = false;
-  supportsSumDistinctFunction = false;
+  supportsSumDistinctFunction = true;
   supportsSafeCast = true;
   supportsNesting = true;
   defaultSampling = {rows: 50000};

--- a/packages/malloy/src/dialect/snowflake/snowflake.ts
+++ b/packages/malloy/src/dialect/snowflake/snowflake.ts
@@ -224,10 +224,22 @@ export class SnowflakeDialect extends Dialect {
     sqlDistinctKey = `${sqlDistinctKey}::STRING`;
     const upperPart = `to_number(substr(md5_hex(${sqlDistinctKey}), 1, 15), repeat('X', 15)) * 4294967296`;
     const lowerPart = `to_number(substr(md5_hex(${sqlDistinctKey}), 16, 8), repeat('X', 8))`;
-    const precisionShiftMultiplier = '0.000000001';
-    return `(${upperPart} + ${lowerPart}) * ${precisionShiftMultiplier}`;
+    return `(${upperPart} + ${lowerPart})`;
   }
 
+  sqlSumDistinct(key: string, value: string, funcName: string): string {
+    const hashKey = this.sqlSumDistinctHashedKey(key);
+    const scale = 100000000.0;
+    const v = `(COALESCE(${value},0)*${scale})`;
+
+    const sqlSum = `(SUM(DISTINCT ${hashKey} + ${v}) - SUM(DISTINCT ${hashKey}))/${scale}`;
+    if (funcName === 'SUM') {
+      return sqlSum;
+    } else if (funcName === 'AVG') {
+      return `(${sqlSum})/NULLIF(COUNT(DISTINCT CASE WHEN ${value} IS NOT NULL THEN ${key} END),0)`;
+    }
+    throw new Error(`Unknown Symmetric Aggregate function ${funcName}`);
+  }
   sqlGenerateUUID(): string {
     return 'UUID_STRING()';
   }

--- a/packages/malloy/src/dialect/trino/trino.ts
+++ b/packages/malloy/src/dialect/trino/trino.ts
@@ -93,7 +93,7 @@ export class TrinoDialect extends Dialect {
   udfPrefix = '__udf';
   hasFinalStage = false;
   divisionIsInteger = true;
-  supportsSumDistinctFunction = false;
+  supportsSumDistinctFunction = true;
   unnestWithNumbers = false;
   defaultSampling = {enable: false};
   supportUnnestArrayAgg = false;
@@ -220,11 +220,23 @@ export class TrinoDialect extends Dialect {
 
   sqlSumDistinctHashedKey(sqlDistinctKey: string): string {
     sqlDistinctKey = `CAST(${sqlDistinctKey} AS VARCHAR)`;
+    const dtype = 'DECIMAL';
 
-    const upperPart = `cast(from_base(substr(to_hex(md5(to_utf8(${sqlDistinctKey}))), 1, 15),16) as DECIMAL) * DECIMAL '4294967296' `;
-    const lowerPart = `cast(from_base(substr(to_hex(md5(to_utf8(${sqlDistinctKey}))), 16, 8),16) as DECIMAL) `;
-    const precisionShiftMultiplier = '0.000000001';
-    return `(${upperPart} + ${lowerPart}) * ${precisionShiftMultiplier}`;
+    const upperPart = `cast(from_base(substr(to_hex(md5(to_utf8(${sqlDistinctKey}))), 1, 15),16) as ${dtype}) * CAST('4294967296' AS ${dtype}) `;
+    const lowerPart = `cast(from_base(substr(to_hex(md5(to_utf8(${sqlDistinctKey}))), 16, 8),16) as ${dtype}) `;
+    return `(${upperPart} + ${lowerPart})`;
+  }
+
+  sqlSumDistinct(key: string, value: string, funcName: string): string {
+    const hashKey = this.sqlSumDistinctHashedKey(key);
+    const scale = 100000000;
+    const sqlSum = `CAST(SUM(DISTINCT ${hashKey} + CAST((${value}) * ${scale} as DECIMAL)) - SUM(DISTINCT ${hashKey}) AS DOUBLE)/${scale}`;
+    if (funcName === 'SUM') {
+      return sqlSum;
+    } else if (funcName === 'AVG') {
+      return `(${sqlSum})/NULLIF(COUNT(DISTINCT CASE WHEN ${value} IS NOT NULL THEN COUNT(DISTINCT ${key}) END),0)`;
+    }
+    throw new Error(`Unknown Symmetric Aggregate function ${funcName}`);
   }
 
   sqlGenerateUUID(): string {

--- a/packages/malloy/src/dialect/trino/trino.ts
+++ b/packages/malloy/src/dialect/trino/trino.ts
@@ -217,24 +217,26 @@ export class TrinoDialect extends Dialect {
       return `LEFT JOIN UNNEST(zip_with(${source},array[],(r,ignore) -> (r, ignore)))as ${alias}_outer(${alias},ignore) ON TRUE`;
     }
   }
+  static dtype = 'DECIMAL(38,0)';
 
   sqlSumDistinctHashedKey(sqlDistinctKey: string): string {
     sqlDistinctKey = `CAST(${sqlDistinctKey} AS VARCHAR)`;
-    const dtype = 'DECIMAL';
 
-    const upperPart = `cast(from_base(substr(to_hex(md5(to_utf8(${sqlDistinctKey}))), 1, 15),16) as ${dtype}) * CAST('4294967296' AS ${dtype}) `;
-    const lowerPart = `cast(from_base(substr(to_hex(md5(to_utf8(${sqlDistinctKey}))), 16, 8),16) as ${dtype}) `;
+    const upperPart = `cast(from_base(substr(to_hex(md5(to_utf8(${sqlDistinctKey}))), 1, 15),16) as ${TrinoDialect.dtype}) * CAST('4294967296' AS ${TrinoDialect.dtype}) `;
+    const lowerPart = `cast(from_base(substr(to_hex(md5(to_utf8(${sqlDistinctKey}))), 16, 8),16) as ${TrinoDialect.dtype}) `;
     return `(${upperPart} + ${lowerPart})`;
   }
 
   sqlSumDistinct(key: string, value: string, funcName: string): string {
     const hashKey = this.sqlSumDistinctHashedKey(key);
     const scale = 100000000;
-    const sqlSum = `CAST(SUM(DISTINCT ${hashKey} + CAST((${value}) * ${scale} as DECIMAL)) - SUM(DISTINCT ${hashKey}) AS DOUBLE)/${scale}`;
+    const v = `CAST(COALESCE(${value},0)*${scale} as ${TrinoDialect.dtype})`;
+
+    const sqlSum = `CAST(SUM(DISTINCT ${hashKey} + ${v}) - SUM(DISTINCT ${hashKey}) AS DOUBLE)/${scale}`;
     if (funcName === 'SUM') {
       return sqlSum;
     } else if (funcName === 'AVG') {
-      return `(${sqlSum})/NULLIF(COUNT(DISTINCT CASE WHEN ${value} IS NOT NULL THEN COUNT(DISTINCT ${key}) END),0)`;
+      return `(${sqlSum})/NULLIF(COUNT(DISTINCT CASE WHEN ${value} IS NOT NULL THEN ${key} END),0)`;
     }
     throw new Error(`Unknown Symmetric Aggregate function ${funcName}`);
   }

--- a/test/src/databases/all/nomodel.spec.ts
+++ b/test/src/databases/all/nomodel.spec.ts
@@ -201,7 +201,9 @@ runtimes.runtimeMap.forEach((runtime, databaseName) => {
     // symmetric aggregate are needed on both sides of the join
     // Check the row count and that sums on each side work properly.
     await expect(`
-      source: a is ${databaseName}.table('malloytest.state_facts')
+      source: a is ${databaseName}.table('malloytest.state_facts') extend {
+        dimension: x is airport_count/10000
+      }
       source: f is a extend {
         join_cross: a
       }
@@ -212,11 +214,15 @@ runtimes.runtimeMap.forEach((runtime, databaseName) => {
           right_count is a.count()
           left_sum is airport_count.sum()
           right_sum is a.airport_count.sum()
+          left_small_sum is x.sum() * 10000
+          right_small_sum is x.sum() * 10000
       }
     `).malloyResultMatches(runtime, {
       row_count: 51 * 51,
       left_sum: 19701,
       right_sum: 19701,
+      left_small_sum: 19701,
+      right_small_sum: 19701,
     });
   });
 

--- a/test/src/databases/all/nomodel.spec.ts
+++ b/test/src/databases/all/nomodel.spec.ts
@@ -214,8 +214,8 @@ runtimes.runtimeMap.forEach((runtime, databaseName) => {
           right_count is a.count()
           left_sum is airport_count.sum()
           right_sum is a.airport_count.sum()
-          left_small_sum is x.sum() * 10000
-          right_small_sum is x.sum() * 10000
+          left_small_sum is round(x.sum() * 10000)
+          right_small_sum is round(x.sum() * 10000)
       }
     `).malloyResultMatches(runtime, {
       row_count: 51 * 51,


### PR DESCRIPTION
We were getting some weird casting numeric problems.  We now do all calculations as integers and avoid overflows.