### PR TITLE
fix: add uuid to duckdb, postgres

### DIFF
--- a/packages/malloy/src/dialect/duckdb/duckdb.ts
+++ b/packages/malloy/src/dialect/duckdb/duckdb.ts
@@ -67,6 +67,7 @@ const duckDBToMalloyTypes: {[key: string]: FieldAtomicTypeDef} = {
   'TIME': {type: 'string'},
   'DECIMAL': {type: 'number', numberType: 'float'},
   'BOOLEAN': {type: 'boolean'},
+  'UUID': {type: 'string'},
 };
 
 export class DuckDBDialect extends Dialect {

--- a/packages/malloy/src/dialect/postgres/postgres.ts
+++ b/packages/malloy/src/dialect/postgres/postgres.ts
@@ -89,6 +89,7 @@ const postgresToMalloyTypes: {[key: string]: FieldAtomicTypeDef} = {
   'bytea': {type: 'string'},
   'pg_ndistinct': {type: 'number', numberType: 'integer'},
   'varchar': {type: 'string'},
+  'uuid': {type: 'string'},
 };
 
 export class PostgresDialect extends Dialect {


### PR DESCRIPTION
Adds uuid support to DuckDB and Postgres. I believe this fixes https://github.com/malloydata/malloy/issues/1764 and https://github.com/malloydata/malloy/issues/1761, but need some manual verification still