### PR TITLE
rename unsupported to "sql native"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28287,26 +28287,10 @@
       "version": "0.0.155",
       "license": "MIT",
       "dependencies": {
-        "@malloydata/malloy": "^0.0.130",
+        "@malloydata/malloy": "^0.0.155",
         "@prestodb/presto-js-client": "^1.0.0",
         "gaxios": "^4.2.0",
         "trino-client": "^0.2.2"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "packages/malloy-db-trino/node_modules/@malloydata/malloy": {
-      "version": "0.0.130",
-      "resolved": "https://registry.npmjs.org/@malloydata/malloy/-/malloy-0.0.130.tgz",
-      "integrity": "sha512-1WLuz1iKvmSvWpcvVvNsOpoaDip2TTUoHqlVa3hUqpyxCZE7bBINsK6Memi/9oP/2cgfgOfMfuFq/yMb9MnzOw==",
-      "dependencies": {
-        "antlr4ts": "^0.5.0-alpha.4",
-        "assert": "^2.0.0",
-        "jest-diff": "^29.6.2",
-        "lodash": "^4.17.20",
-        "luxon": "^2.4.0",
-        "uuid": "^8.3.2"
       },
       "engines": {
         "node": ">=16"

--- a/packages/malloy-db-bigquery/src/bigquery_connection.ts
+++ b/packages/malloy-db-bigquery/src/bigquery_connection.ts
@@ -565,7 +565,7 @@ export class BigQueryConnection
         structDef.fields.push(innerStructDef);
       } else {
         const malloyType = this.dialect.sqlTypeToMalloyType(type) ?? {
-          type: 'unsupported',
+          type: 'sql native',
           rawType: type.toLowerCase(),
         };
         structDef.fields.push({name, ...malloyType} as FieldTypeDef);

--- a/packages/malloy-db-duckdb/src/duckdb_common.ts
+++ b/packages/malloy-db-duckdb/src/duckdb_common.ts
@@ -281,7 +281,7 @@ export abstract class DuckDBCommon
             structDef.fields.push({...malloyType, name});
           } else {
             structDef.fields.push({
-              type: 'unsupported',
+              type: 'sql native',
               rawType: duckDBType.toLowerCase(),
               name,
             });

--- a/packages/malloy-db-postgres/src/postgres_connection.ts
+++ b/packages/malloy-db-postgres/src/postgres_connection.ts
@@ -341,7 +341,7 @@ export class PostgresConnection
         s.fields.push({...malloyType, name});
       } else {
         s.fields.push({
-          type: 'unsupported',
+          type: 'sql native',
           rawType: postgresDataType.toLowerCase(),
           name,
         });

--- a/packages/malloy-db-snowflake/src/snowflake_connection.ts
+++ b/packages/malloy-db-snowflake/src/snowflake_connection.ts
@@ -193,7 +193,7 @@ export class SnowflakeConnection
     } else if (type === 'varchar') {
       return 'string';
     } else {
-      return 'unsupported';
+      return 'sql native';
     }
   }
 
@@ -239,7 +239,7 @@ export class SnowflakeConnection
         structDef.fields.push(innerStructDef);
       } else {
         const malloyType = this.dialect.sqlTypeToMalloyType(type) ?? {
-          type: 'unsupported',
+          type: 'sql native',
           rawType: type.toLowerCase(),
         };
         structDef.fields.push({name, ...malloyType} as FieldTypeDef);
@@ -273,7 +273,7 @@ export class SnowflakeConnection
         s.fields.push({...malloyType, name});
       } else {
         s.fields.push({
-          type: 'unsupported',
+          type: 'sql native',
           rawType: snowflakeDataType,
           name,
         });

--- a/packages/malloy-db-trino/package.json
+++ b/packages/malloy-db-trino/package.json
@@ -22,7 +22,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@malloydata/malloy": "^0.0.130",
+    "@malloydata/malloy": "^0.0.155",
     "@prestodb/presto-js-client": "^1.0.0",
     "gaxios": "^4.2.0",
     "trino-client": "^0.2.2"

--- a/packages/malloy-db-trino/src/trino_connection.ts
+++ b/packages/malloy-db-trino/src/trino_connection.ts
@@ -656,14 +656,14 @@ export abstract class TrinoPrestoConnection
         } else {
           malloyType.fields.push({
             name: 'unknown',
-            type: 'unsupported',
+            type: 'sql native',
             rawType: innerType.toLowerCase(),
           });
         }
       }
     } else {
       malloyType = this.sqlToMalloyType(trinoType) ?? {
-        type: 'unsupported',
+        type: 'sql native',
         rawType: trinoType.toLowerCase(),
       };
     }

--- a/packages/malloy/src/lang/ast/expressions/expr-cast.ts
+++ b/packages/malloy/src/lang/ast/expressions/expr-cast.ts
@@ -40,7 +40,7 @@ export class ExprCast extends ExpressionDef {
 
   getExpression(fs: FieldSpace): ExprValue {
     const expr = this.expr.getExpression(fs);
-    let dataType: AtomicFieldType = 'unsupported';
+    let dataType: AtomicFieldType = 'sql native';
     if (typeof this.castType === 'string') {
       dataType = this.castType;
     } else {
@@ -51,7 +51,7 @@ export class ExprCast extends ExpressionDef {
           // but `TypeDesc` does not support them.
           dataType =
             fs.dialectObj()?.sqlTypeToMalloyType(this.castType.raw)?.type ??
-            'unsupported';
+            'sql native';
         } else {
           this.log(
             `Cast type \`${this.castType.raw}\` is invalid for ${dialect.name} dialect`

--- a/packages/malloy/src/lang/ast/types/space-field.ts
+++ b/packages/malloy/src/lang/ast/types/space-field.ts
@@ -44,8 +44,8 @@ export abstract class SpaceField extends SpaceEntry {
       ref.expressionType = def.expressionType;
     }
     if (
-      ref.dataType === 'unsupported' &&
-      def.type === 'unsupported' &&
+      ref.dataType === 'sql native' &&
+      def.type === 'sql native' &&
       def.rawType
     ) {
       ref.rawType = def.rawType;

--- a/packages/malloy/src/lang/test/expressions.spec.ts
+++ b/packages/malloy/src/lang/test/expressions.spec.ts
@@ -1006,12 +1006,12 @@ describe('expressions', () => {
     expect(expr`${name} = NULL`).toTranslate();
   });
 });
-describe('unspported fields in schema', () => {
-  test('unsupported reference in result allowed', () => {
+describe('sql native fields in schema', () => {
+  test('sql native reference in result allowed', () => {
     const uModel = new TestTranslator('run: a->{ group_by: aun }');
     expect(uModel).toTranslate();
   });
-  test('unsupported reference can be compared to NULL', () => {
+  test('sql native reference can be compared to NULL', () => {
     const uModel = new TestTranslator(
       'run: a->{ where: aun != NULL; select: * }'
     );
@@ -1023,7 +1023,7 @@ describe('unspported fields in schema', () => {
       'run: ab->{ where: aun = b.aun  select: * }'
     );
     expect(uModel).translationToFailWith(
-      'Unsupported type not allowed in expression'
+      "Unsupported SQL native type 'undefined' not allowed in expression"
     );
   });
   test('flag unsupported compare', () => {
@@ -1032,7 +1032,7 @@ describe('unspported fields in schema', () => {
       'run: ab->{ where: aun > b.aun  select: * }'
     );
     expect(uModel).translationToFailWith(
-      'Unsupported type not allowed in expression'
+      "Unsupported SQL native type 'undefined' not allowed in expression"
     );
   });
   test('allow unsupported equality when raw types match', () => {
@@ -1045,7 +1045,9 @@ describe('unspported fields in schema', () => {
     const uModel = new TestTranslator(
       'source: x is a extend { dimension: notUn is not aun }'
     );
-    expect(uModel).translationToFailWith("'not' Can't use type unsupported");
+    expect(uModel).translationToFailWith(
+      "'not' Can't be used with unsupported SQL native type 'undefined'"
+    );
   });
   test('allow unsupported to be cast', () => {
     const uModel = new TestTranslator(

--- a/packages/malloy/src/lang/test/field-symbols.spec.ts
+++ b/packages/malloy/src/lang/test/field-symbols.spec.ts
@@ -102,7 +102,7 @@ describe('structdef comprehension', () => {
   test('import unsupported field', () => {
     const field: model.FieldDef = {
       name: 't',
-      type: 'unsupported',
+      type: 'sql native',
     };
     const struct = mkStructDef(field);
     const space = new StaticSpace(struct);

--- a/packages/malloy/src/lang/test/test-translator.ts
+++ b/packages/malloy/src/lang/test/test-translator.ts
@@ -66,8 +66,8 @@ const mockSchema: Record<string, StructDef> = {
       {type: 'date', name: 'ad'},
       {type: 'boolean', name: 'abool'},
       {type: 'timestamp', name: 'ats'},
-      {type: 'unsupported', name: 'aun'},
-      {type: 'unsupported', name: 'aweird', rawType: 'weird'},
+      {type: 'sql native', name: 'aun'},
+      {type: 'sql native', name: 'aweird', rawType: 'weird'},
       {
         type: 'struct',
         name: 'astruct',

--- a/packages/malloy/src/malloy.ts
+++ b/packages/malloy/src/malloy.ts
@@ -1520,7 +1520,7 @@ export class Explore extends Entity implements Taggable {
               return [name, new BooleanField(fieldDef, this, sourceField)];
             } else if (fieldDef.type === 'json') {
               return [name, new JSONField(fieldDef, this, sourceField)];
-            } else if (fieldDef.type === 'unsupported') {
+            } else if (fieldDef.type === 'sql native') {
               return [name, new UnsupportedField(fieldDef, this, sourceField)];
             }
           }
@@ -1667,7 +1667,7 @@ export enum AtomicFieldType {
   Date = 'date',
   Timestamp = 'timestamp',
   Json = 'json',
-  Unsupported = 'unsupported',
+  NativeSQL = 'sql native',
   Error = 'error',
 }
 
@@ -1699,8 +1699,8 @@ export class AtomicField extends Entity implements Taggable {
         return AtomicFieldType.Number;
       case 'json':
         return AtomicFieldType.Json;
-      case 'unsupported':
-        return AtomicFieldType.Unsupported;
+      case 'sql native':
+        return AtomicFieldType.NativeSQL;
       case 'error':
         return AtomicFieldType.Error;
     }

--- a/packages/malloy/src/malloy.ts
+++ b/packages/malloy/src/malloy.ts
@@ -60,7 +60,7 @@ import {
   expressionIsCalculation,
   isSQLBlockStruct,
   isSQLFragment,
-  FieldUnsupportedDef,
+  FeldNativeUnsupportedDef,
   QueryRunStats,
   ImportLocation,
   Annotation,
@@ -1667,7 +1667,7 @@ export enum AtomicFieldType {
   Date = 'date',
   Timestamp = 'timestamp',
   Json = 'json',
-  NativeSQL = 'sql native',
+  NativeUnsupported = 'sql native',
   Error = 'error',
 }
 
@@ -1700,7 +1700,7 @@ export class AtomicField extends Entity implements Taggable {
       case 'json':
         return AtomicFieldType.Json;
       case 'sql native':
-        return AtomicFieldType.NativeSQL;
+        return AtomicFieldType.NativeUnsupported;
       case 'error':
         return AtomicFieldType.Error;
     }
@@ -1941,9 +1941,9 @@ export class JSONField extends AtomicField {
 }
 
 export class UnsupportedField extends AtomicField {
-  private fieldUnsupportedDef: FieldUnsupportedDef;
+  private fieldUnsupportedDef: FeldNativeUnsupportedDef;
   constructor(
-    fieldUnsupportedDef: FieldUnsupportedDef,
+    fieldUnsupportedDef: FeldNativeUnsupportedDef,
     parent: Explore,
     source?: AtomicField
   ) {

--- a/packages/malloy/src/model/malloy_query.ts
+++ b/packages/malloy/src/model/malloy_query.ts
@@ -2737,7 +2737,7 @@ class QueryQuery extends QueryField {
                 annotation,
               });
               break;
-            case 'unsupported':
+            case 'sql native':
               fields.push({...fi.f.fieldDef, resultMetadata, location});
               break;
             default:
@@ -4359,7 +4359,7 @@ class QueryStruct extends QueryNode {
         return new QueryFieldBoolean(field, this);
       case 'json':
         return new QueryFieldJSON(field, this);
-      case 'unsupported':
+      case 'sql native':
         return new QueryFieldUnsupported(field, this);
       // case "reduce":
       // case "project":

--- a/packages/malloy/src/model/malloy_types.ts
+++ b/packages/malloy/src/model/malloy_types.ts
@@ -667,15 +667,15 @@ export interface FieldJSONDef extends FieldAtomicDef, FieldJSONTypeDef {
   type: 'json';
 }
 
-export interface FieldUnsupportedTypeDef {
+export interface FieldNativeUnsupportedTypeDef {
   type: 'sql native';
   rawType?: string;
 }
 
 /** Scalar unsupported Field */
-export interface FieldUnsupportedDef
+export interface FeldNativeUnsupportedDef
   extends FieldAtomicDef,
-    FieldUnsupportedTypeDef {
+    FieldNativeUnsupportedTypeDef {
   type: 'sql native';
 }
 
@@ -1098,7 +1098,7 @@ export type FieldTypeDef =
   | FieldNumberDef
   | FieldBooleanDef
   | FieldJSONDef
-  | FieldUnsupportedDef
+  | FeldNativeUnsupportedDef
   | FieldErrorDef;
 
 export type FieldAtomicTypeDef =
@@ -1108,7 +1108,7 @@ export type FieldAtomicTypeDef =
   | FieldNumberTypeDef
   | FieldBooleanTypeDef
   | FieldJSONTypeDef
-  | FieldUnsupportedTypeDef
+  | FieldNativeUnsupportedTypeDef
   | FieldErrorTypeDef;
 
 export function isFieldTypeDef(f: FieldDef): f is FieldTypeDef {

--- a/packages/malloy/src/model/malloy_types.ts
+++ b/packages/malloy/src/model/malloy_types.ts
@@ -582,7 +582,7 @@ export function isTimeFieldType(s: string): s is TimeFieldType {
   return s === 'date' || s === 'timestamp';
 }
 export type CastType = 'string' | 'number' | TimeFieldType | 'boolean' | 'json';
-export type AtomicFieldType = CastType | 'unsupported' | 'error';
+export type AtomicFieldType = CastType | 'sql native' | 'error';
 export function isAtomicFieldType(s: string): s is AtomicFieldType {
   return [
     'string',
@@ -591,7 +591,7 @@ export function isAtomicFieldType(s: string): s is AtomicFieldType {
     'timestamp',
     'boolean',
     'json',
-    'unsupported',
+    'sql native',
     'error',
   ].includes(s);
 }
@@ -668,7 +668,7 @@ export interface FieldJSONDef extends FieldAtomicDef, FieldJSONTypeDef {
 }
 
 export interface FieldUnsupportedTypeDef {
-  type: 'unsupported';
+  type: 'sql native';
   rawType?: string;
 }
 
@@ -676,7 +676,7 @@ export interface FieldUnsupportedTypeDef {
 export interface FieldUnsupportedDef
   extends FieldAtomicDef,
     FieldUnsupportedTypeDef {
-  type: 'unsupported';
+  type: 'sql native';
 }
 
 export interface FieldErrorTypeDef {


### PR DESCRIPTION
Fixes https://github.com/malloydata/malloy/issues/1781

I picked `Unsupported SQL native type 'XXX'` to describe the type, and added an entry to the error dictionary -- https://github.com/malloydata/malloydata.github.io/pull/176