### PR TITLE
Rendering link Templates.

### DIFF
--- a/packages/malloy-render/src/html/link.ts
+++ b/packages/malloy-render/src/html/link.ts
@@ -36,6 +36,13 @@ export class HTMLLinkRenderer implements Renderer {
       return createNullElement(this.document);
     }
 
+    const {tag} = data.field.tagParse();
+    const linkTag = tag.tag('link');
+
+    if (!linkTag) {
+      return createErrorElement(this.document, 'Missing tag for Link renderer');
+    }
+
     if (!data.isString()) {
       return createErrorElement(
         this.document,
@@ -43,8 +50,18 @@ export class HTMLLinkRenderer implements Renderer {
       );
     }
 
+    // if a URL template is provided, replace the data were '$$$' appears.
+    const urlTemplate = linkTag.text('url_template');
+
     const element = this.document.createElement('a');
     element.href = data.value;
+    if (urlTemplate) {
+      if (urlTemplate.indexOf('$$') > 0) {
+        element.href = urlTemplate.replace('$$', data.value);
+      } else {
+        element.href = urlTemplate + data.value;
+      }
+    }
     element.target = '_blank';
     element.appendChild(
       this.document.createTextNode(data.value.replace(/\//g, '/\u200C'))

--- a/packages/malloy-render/src/html/link.ts
+++ b/packages/malloy-render/src/html/link.ts
@@ -56,7 +56,7 @@ export class HTMLLinkRenderer implements Renderer {
     const element = this.document.createElement('a');
     element.href = data.value;
     if (urlTemplate) {
-      if (urlTemplate.indexOf('$$') > 0) {
+      if (urlTemplate.indexOf('$$') > -1) {
         element.href = urlTemplate.replace('$$', data.value);
       } else {
         element.href = urlTemplate + data.value;


### PR DESCRIPTION
Often in an HTML table you want to link to some external resource.  This simple mechanism allows create linkage in the result table with simple text substitution.

```
run: flights -> {

  // by default appends to the end of the template

  # link.url_template="http://faa.gov/lookup?code="
  group_by: origin_code

  // can also do substitution. $$ is replaced.
  // link.url_template="" and link{url_template=""} are equivalent

  # link{url_template="http://faa.gov/carriers/$$/full_detail"}
  group_by: carrier
}
```