### PR TITLE
feat: path fields in render tags

### DIFF
--- a/packages/malloy-render/src/html/link.ts
+++ b/packages/malloy-render/src/html/link.ts
@@ -50,24 +50,20 @@ export class HTMLLinkRenderer implements Renderer {
       );
     }
 
-    const keyColumn = linkTag.tag('key_column')?.text();
-    let key: string = data.value || '';
-    if (keyColumn && data.parentRecord) {
-      const d = data.parentRecord.cell(keyColumn);
-      if (d && d.isString()) {
-        key = d.value
-      }
-    }
+    // Read href component from field value or override with field tag if it exists
+    const hrefComponent =
+      getDynamicValue<string>({tag: linkTag, data}) ?? data.value;
+
     // if a URL template is provided, replace the data were '$$$' appears.
     const urlTemplate = linkTag.text('url_template');
 
     const element = this.document.createElement('a');
-    element.href = data.value;
+    element.href = hrefComponent;
     if (urlTemplate) {
       if (urlTemplate.indexOf('$$') > -1) {
-        element.href = urlTemplate.replace('$$', key);
+        element.href = urlTemplate.replace('$$', hrefComponent);
       } else {
-        element.href = urlTemplate + key;
+        element.href = urlTemplate + hrefComponent;
       }
     }
     element.target = '_blank';

--- a/packages/malloy-render/src/stories/link.stories.ts
+++ b/packages/malloy-render/src/stories/link.stories.ts
@@ -1,0 +1,31 @@
+import script from './static/link.malloy?raw';
+import {renderMalloy} from './render-malloy-legacy';
+
+export default {
+  title: 'Malloy Legacy/Link',
+  render: ({source, view}, {globals: {connection}}) => {
+    return renderMalloy({script, source, view, connection});
+  },
+  argTypes: {},
+};
+
+export const Link = {
+  args: {
+    source: 'logos',
+    view: 'link',
+  },
+};
+
+export const LinkFromTemplate = {
+  args: {
+    source: 'logos',
+    view: 'link_template',
+  },
+};
+
+export const LinkFromKeyColumn = {
+  args: {
+    source: 'logos',
+    view: 'link_template_key_column',
+  },
+};

--- a/packages/malloy-render/src/stories/static/image.malloy
+++ b/packages/malloy-render/src/stories/static/image.malloy
@@ -9,17 +9,10 @@ source: logos is duckdb.table("data/logos.csv") extend {
   view: img_from_parent is {
     group_by:
       brand
-      # image image.height=40px image.alt=fallback image.alt.field='^brand'
-      logo
-  }
-
-  view: img_from_grandparent is {
-    group_by:
-      brand
       nest: details is {
         group_by:
           product
-          # image image.height=40px image.alt=fallback image.alt.field='^^brand'
+          # image image.height=40px image.alt=fallback image.alt.field='../brand'
           logo
       }
   }

--- a/packages/malloy-render/src/stories/static/link.malloy
+++ b/packages/malloy-render/src/stories/static/link.malloy
@@ -1,0 +1,22 @@
+source: logos is duckdb.table("data/logos.csv") extend {
+  view: link is {
+    group_by:
+      brand
+      # link
+      logo
+  }
+
+  view: link_template is {
+    group_by:
+      brand
+      # link { url_template="https://www.google.com/search?q=$$" }
+      `Google search` is brand
+  }
+
+  view: link_template_key_column is {
+    group_by:
+      brand
+      # link { url_template="https://www.google.com/search?q=$$" field="brand" }
+      `Google search` is 'Google search'
+  }
+};

--- a/test/src/render/render.spec.ts
+++ b/test/src/render/render.spec.ts
@@ -656,7 +656,7 @@ describe('rendering results', () => {
           link_append is "4"
           # link.url_template="http://123.com/$$/5"
           link_substitue is "4"
-          # link{url_template="http://123.com/$$/5", key_column=key}
+          # link{url_template="http://123.com/$$/5" field=key}
           link_with_key is 'HTML Text'
           key is "4"
         }
@@ -668,7 +668,6 @@ describe('rendering results', () => {
       const html = await new HTMLView(document).render(result, {
         dataStyles: {},
       });
-      // console.log(html.outerHTML);
 
       expect(html).toMatchSnapshot();
     });


### PR DESCRIPTION
- Changes the `field` ref in tags to use / paths
- Updates link tag to optionally use `field` lookups for the href component, both for full URL and templated URL