### PR TITLE
Add join with parameters shortcut

### DIFF
--- a/packages/malloy/src/lang/grammar/MalloyParser.g4
+++ b/packages/malloy/src/lang/grammar/MalloyParser.g4
@@ -282,9 +282,15 @@ isExplore
 
 matrixOperation : (LEFT | RIGHT | FULL| INNER);
 
+joinFrom
+  : joinNameDef
+  | joinNameDef sourceArguments
+  | joinNameDef isExplore
+  ;
+
 joinDef
-  : ANNOTATION* joinNameDef isExplore? matrixOperation? WITH fieldExpr        # joinWith
-  | ANNOTATION* joinNameDef isExplore? (matrixOperation? ON joinExpression)?  # joinOn
+  : ANNOTATION* joinFrom matrixOperation? WITH fieldExpr        # joinWith
+  | ANNOTATION* joinFrom (matrixOperation? ON joinExpression)?  # joinOn
   ;
 
 joinExpression: fieldExpr;

--- a/packages/malloy/src/lang/parse-tree-walkers/document-symbol-walker.ts
+++ b/packages/malloy/src/lang/parse-tree-walkers/document-symbol-walker.ts
@@ -266,7 +266,7 @@ class DocumentSymbolWalker implements MalloyParserListener {
   handleJoinDef(pcx: parser.JoinWithContext | parser.JoinOnContext) {
     const symbol = {
       range: this.translator.rangeFromContext(pcx),
-      name: pcx.joinNameDef().id().text,
+      name: pcx.joinFrom().joinNameDef().id().text,
       type: 'join',
       children: [],
     };

--- a/packages/malloy/src/lang/test/parameters.spec.ts
+++ b/packages/malloy/src/lang/test/parameters.spec.ts
@@ -290,7 +290,27 @@ describe('parameters', () => {
       run: ab_new(param is ${'ai'}) -> { select: * }
     `).translationToFailWith('`ai` is not defined');
   });
-  test('can pass through parameter to joined source', () => {
+  test('can pass through parameter to joined source (shorthand)', () => {
+    expect(`
+      ##! experimental.parameters
+      source: ab_ext_1(a_1::string) is ab extend {
+        where: ai = a_1
+      }
+
+      source: ab_ext_2(a_2::string) is ab extend {
+        where: ai = a_2
+        join_many: ab_ext_1(a_1 is a_2) on 1 = 1
+      }
+
+      run: ab_ext_2(a_2 is "CA") -> {
+        group_by:
+          a1 is ai,
+          a2 is ab_ext_1.ai
+        aggregate: c is count()
+      }
+    `).toTranslate();
+  });
+  test('can pass through parameter to joined source (longhand)', () => {
     expect(`
       ##! experimental.parameters
       source: ab_ext_1(a_1::string) is ab extend {


### PR DESCRIPTION
Makes a new shortcut for joining with parameters:

```malloy
source: my_source(param is 1) is ... {
  join_one: other_source(param) on 1 = 1

  // equivalent to / shorthand for:
  join_one: other_source is other_source(param) on 1 = 1

  // equivalent to / shorthand for:
  join_one: other_source is other_source(param is param) on 1 = 1
}
```