### PR TITLE
Implement parameter inheriting

### DIFF
--- a/packages/malloy/src/lang/ast/expressions/expr-id-reference.ts
+++ b/packages/malloy/src/lang/ast/expressions/expr-id-reference.ts
@@ -21,9 +21,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import {
-  expressionIsAggregate,
-} from '../../../model/malloy_types';
+import {expressionIsAggregate} from '../../../model/malloy_types';
 import {errorFor} from '../ast-utils';
 import {ExprValue} from '../types/expr-value';
 import {FieldReference} from '../query-items/field-references';

--- a/packages/malloy/src/lang/ast/field-space/dynamic-space.ts
+++ b/packages/malloy/src/lang/ast/field-space/dynamic-space.ts
@@ -42,7 +42,7 @@ export abstract class DynamicSpace extends StaticSpace {
   protected source: SpaceSeed;
   completions: (() => void)[] = [];
   private complete = false;
-  private parameters: HasParameter[] = [];
+  private _parameterSpace: ParameterSpace | undefined = undefined;
   protected newTimezone?: string;
 
   constructor(extending: SourceSpec) {
@@ -63,18 +63,27 @@ export abstract class DynamicSpace extends StaticSpace {
     super.setEntry(name, value);
   }
 
-  addParameters(parameters: HasParameter[]): DynamicSpace {
+  addParameters(
+    parameters: HasParameter[],
+    inheritFromParameters: Record<string, model.Parameter> | undefined
+  ): DynamicSpace {
     for (const parameter of parameters) {
       if (this.entry(parameter.name) === undefined) {
-        this.parameters.push(parameter);
-        this.setEntry(parameter.name, new AbstractParameter(parameter));
+        this.setEntry(
+          parameter.name,
+          new AbstractParameter(parameter, inheritFromParameters)
+        );
       }
     }
+    this._parameterSpace = new ParameterSpace(
+      parameters,
+      inheritFromParameters
+    );
     return this;
   }
 
   parameterSpace(): ParameterSpace {
-    return new ParameterSpace(this.parameters);
+    return this._parameterSpace ?? new ParameterSpace([], undefined);
   }
 
   newEntry(name: string, logTo: MalloyElement, entry: SpaceEntry): void {

--- a/packages/malloy/src/lang/ast/field-space/parameter-space.ts
+++ b/packages/malloy/src/lang/ast/field-space/parameter-space.ts
@@ -6,7 +6,7 @@
  */
 
 import {Dialect} from '../../../dialect';
-import {StructDef} from '../../../model';
+import {Parameter, StructDef} from '../../../model';
 import {HasParameter} from '../parameters/has-parameter';
 import {FieldName, FieldSpace, QueryFieldSpace} from '../types/field-space';
 import {LookupResult} from '../types/lookup-result';
@@ -17,10 +17,16 @@ export class ParameterSpace implements FieldSpace {
   readonly type = 'fieldSpace';
 
   private readonly _map: Record<string, SpaceEntry>;
-  constructor(parameters: HasParameter[]) {
+  constructor(
+    parameters: HasParameter[],
+    readonly inheritFromParameters: Record<string, Parameter> | undefined
+  ) {
     this._map = {};
     for (const parameter of parameters) {
-      this._map[parameter.name] = new AbstractParameter(parameter);
+      this._map[parameter.name] = new AbstractParameter(
+        parameter,
+        inheritFromParameters
+      );
     }
   }
 

--- a/packages/malloy/src/lang/ast/field-space/refined-space.ts
+++ b/packages/malloy/src/lang/ast/field-space/refined-space.ts
@@ -45,12 +45,10 @@ export class RefinedSpace extends DynamicSpace {
       const oldMap = edited.entries();
       for (const name of names) {
         const existing = oldMap.find(([symb]) => symb === name.refString);
-        if (existing === undefined) {
-          if (parameters?.entry(name.refString)) {
-            name.log(`Illegal \`${choose.edit}:\` of parameter`);
-          } else {
-            name.log(`\`${name.refString}\` is not defined`);
-          }
+        if (parameters?.entry(name.refString)) {
+          name.log(`Illegal \`${choose.edit}:\` of parameter`);
+        } else if (existing === undefined) {
+          name.log(`\`${name.refString}\` is not defined`);
         }
       }
       edited.dropEntries();

--- a/packages/malloy/src/lang/ast/parameters/has-parameter.ts
+++ b/packages/malloy/src/lang/ast/parameters/has-parameter.ts
@@ -50,7 +50,9 @@ export class HasParameter extends MalloyElement {
     }
   }
 
-  parameter(): Parameter {
+  parameter(
+    inheritFromParameters: Record<string, Parameter> | undefined
+  ): Parameter {
     if (this.default !== undefined) {
       const constant = this.default.constantValue();
       if (
@@ -71,7 +73,9 @@ export class HasParameter extends MalloyElement {
             type: this.type,
           };
         } else {
-          this.default.log("Default value cannot have type `null` unless parameter type is also specified")
+          this.default.log(
+            'Default value cannot have type `null` unless parameter type is also specified'
+          );
           return {
             value: constant.value,
             name: this.name,
@@ -96,7 +100,15 @@ export class HasParameter extends MalloyElement {
       };
     }
     if (this.type === undefined) {
-      this.log('Parameter must have default value or declared type');
+      if (inheritFromParameters !== undefined) {
+        const inherited = inheritFromParameters[this.name];
+        if (inherited !== undefined) {
+          return {...inherited};
+        }
+      }
+      this.log(
+        'Parameter must have default value or declared type, or must be able to inherit from extended source parameters'
+      );
     }
     return {
       value: null,

--- a/packages/malloy/src/lang/ast/query-elements/query-head-struct.ts
+++ b/packages/malloy/src/lang/ast/query-elements/query-head-struct.ts
@@ -35,7 +35,10 @@ import {ParameterSpace} from '../field-space/parameter-space';
 
 export class QueryHeadStruct extends Source {
   elementType = 'internalOnlyQueryHead';
-  constructor(readonly fromRef: StructRef, readonly sourceArguments: Record<string, Argument> | undefined) {
+  constructor(
+    readonly fromRef: StructRef,
+    readonly sourceArguments: Record<string, Argument> | undefined
+  ) {
     super();
   }
 

--- a/packages/malloy/src/lang/ast/query-elements/query-reference.ts
+++ b/packages/malloy/src/lang/ast/query-elements/query-reference.ts
@@ -56,7 +56,10 @@ export class QueryReference extends MalloyElement implements QueryElement {
       return oops();
     }
     if (query.type === 'query') {
-      const queryHead = new QueryHeadStruct(query.structRef, query.sourceArguments);
+      const queryHead = new QueryHeadStruct(
+        query.structRef,
+        query.sourceArguments
+      );
       this.has({queryHead: queryHead});
       const inputStruct = queryHead.structDef(undefined);
       const outputStruct = getFinalStruct(this, inputStruct, query.pipeline);

--- a/packages/malloy/src/lang/ast/source-elements/named-source.ts
+++ b/packages/malloy/src/lang/ast/source-elements/named-source.ts
@@ -154,7 +154,8 @@ export class NamedSource extends Source {
         );
       } else {
         const paramSpace =
-          parameterSpace ?? new ParameterSpace(parametersOut ?? []);
+          parameterSpace ??
+          new ParameterSpace(parametersOut ?? [], parametersIn);
         const pVal = argument.value.getExpression(paramSpace);
         let value = pVal.value;
         if (pVal.dataType !== parameter.type && isCastType(parameter.type)) {
@@ -213,14 +214,14 @@ export class NamedSource extends Source {
 
     const outParameters = {};
     for (const parameter of pList ?? []) {
-      const compiled = parameter.parameter();
+      const compiled = parameter.parameter(base.parameters);
       outParameters[compiled.name] = compiled;
     }
 
     const outArguments = this.evaluateArguments(
       parameterSpace,
       base.parameters,
-      pList,
+      pList
     );
 
     const ret = {...base, parameters: outParameters, arguments: outArguments};

--- a/packages/malloy/src/lang/ast/source-elements/refined-source.ts
+++ b/packages/malloy/src/lang/ast/source-elements/refined-source.ts
@@ -105,11 +105,11 @@ export class RefinedSource extends Source {
       }
     }
 
-    const paramSpace = pList ? new ParameterSpace(pList) : undefined;
-    const from = structuredClone(this.source.structDef(paramSpace));
-    // Note that this is explicitly not:
-    // const from = structuredClone(this.source.withParameters(parameterSpace, pList));
-    // Because the parameters are added to the resulting struct, not the base struct
+    let paramSpace = pList ? new ParameterSpace(pList, undefined) : undefined;
+    const from = structuredClone(
+      this.source.withParameters(parameterSpace, pList)
+    );
+    paramSpace = pList ? new ParameterSpace(pList, from.parameters) : undefined;
     if (primaryKey) {
       from.primaryKey = primaryKey.field.name;
     }
@@ -118,7 +118,7 @@ export class RefinedSource extends Source {
       fs.setTimezone(newTimezone);
     }
     if (pList) {
-      fs.addParameters(pList);
+      fs.addParameters(pList, from.parameters);
     }
     fs.pushFields(...fields);
     if (primaryKey) {

--- a/packages/malloy/src/lang/ast/source-elements/source.ts
+++ b/packages/malloy/src/lang/ast/source-elements/source.ts
@@ -49,7 +49,7 @@ export abstract class Source extends MalloyElement {
     if (pList === undefined) return undefined;
     const parameters = {};
     for (const hasP of pList) {
-      const pVal = hasP.parameter();
+      const pVal = hasP.parameter(undefined);
       parameters[pVal.name] = pVal;
     }
     return parameters;

--- a/packages/malloy/src/lang/ast/types/space-param.ts
+++ b/packages/malloy/src/lang/ast/types/space-param.ts
@@ -32,14 +32,17 @@ export abstract class SpaceParam extends SpaceEntry {
 }
 
 export class AbstractParameter extends SpaceParam {
-  constructor(readonly astParam: HasParameter) {
+  constructor(
+    readonly astParam: HasParameter,
+    readonly inheritFromParameters: Record<string, Parameter> | undefined
+  ) {
     super();
   }
 
   _parameter: Parameter | undefined = undefined;
   parameter(): Parameter {
     if (this._parameter !== undefined) return this._parameter;
-    this._parameter = this.astParam.parameter();
+    this._parameter = this.astParam.parameter(this.inheritFromParameters);
     return this._parameter;
   }
 

--- a/packages/malloy/src/lang/test/parameters.spec.ts
+++ b/packages/malloy/src/lang/test/parameters.spec.ts
@@ -40,14 +40,16 @@ describe('parameters', () => {
       ##! experimental.parameters
       source: ab_new(param) is ab
     `).translationToFailWith(
-      'Parameter must have default value or declared type'
+      'Parameter must have default value or declared type, or must be able to inherit from extended source parameters'
     );
   });
   test('error if paramter type is null', () => {
     expect(markSource`
       ##! experimental.parameters
       source: ab_new(param is null) is ab
-    `).translationToFailWith('Default value cannot have type `null` unless parameter type is also specified');
+    `).translationToFailWith(
+      'Default value cannot have type `null` unless parameter type is also specified'
+    );
   });
   test('allowed to write null::string', () => {
     expect(`
@@ -93,6 +95,13 @@ describe('parameters', () => {
       ##! experimental.parameters
       source: ab_new(param::number) is ab
       source: ab_new_new(param::number) is ab_new(param) extend {}
+    `).toTranslate();
+  });
+  test('can inherit parameter from extended base source', () => {
+    expect(`
+      ##! experimental.parameters
+      source: ab_new(param::number) is ab
+      source: ab_new_new(param) is ab_new(param) extend {}
     `).toTranslate();
   });
   test.skip('can pass parameter into source of query', () => {
@@ -415,17 +424,6 @@ describe('parameters', () => {
       'No matching overload for function upper(number)',
       'Illegal shadowing of field `ai` by parameter with the same name'
     );
-  });
-  test('can shadow field that is excepted', () => {
-    expect(
-      `
-        ##! experimental.parameters
-        source: ab_new(ai::string) is ab extend {
-          except: ai
-          dimension: foo is upper(ai)
-        }
-      `
-    ).toTranslate();
   });
   test('error when declaring parameter with same name as field (not extended)', () => {
     expect(

--- a/test/src/databases/all/expr.spec.ts
+++ b/test/src/databases/all/expr.spec.ts
@@ -25,7 +25,6 @@
 import {RuntimeList, allDatabases} from '../../runtimes';
 import '../../util/db-jest-matchers';
 import {databasesFromEnvironmentOr, mkSqlEqWith} from '../../util';
-import {fail} from 'assert';
 
 const runtimes = new RuntimeList(databasesFromEnvironmentOr(allDatabases));
 


### PR DESCRIPTION
_I'm not 100% sure about this behavior yet, so adding the DO NOT MERGE label, and this implementation also feels a bit icky in a way I can't put my finger on yet._

Allows a source to be defined in a way that inherits a parameter from the extended source:

```malloy
source: state_facts(
  state_filter::string is "CA"
) is duckdb.table('malloytest.state_facts') extend {
  where: state = state_filter
}

// inherits the default value 'CA' from `state_facts`
source: state_facts_ext(state_filter) is state_facts(state_filter)

// should only return one row, `{ state: 'CA' }`
run: state_facts_ext -> { group_by: state }
```

