### PR TITLE
feat: nested table as subgrids

### DIFF
--- a/packages/malloy-render/src/component/render-list.tsx
+++ b/packages/malloy-render/src/component/render-list.tsx
@@ -31,7 +31,7 @@ export function renderList(props: RendererProps) {
 
   // TODO: width estimator for list renderer? and others
   return (
-    <div style="text-wrap: wrap;">
+    <div class="malloy-list" style="text-wrap: wrap;">
       <For each={rows}>
         {(row, idx) => (
           <span>

--- a/packages/malloy-render/src/component/render-result-metadata.ts
+++ b/packages/malloy-render/src/component/render-result-metadata.ts
@@ -71,7 +71,7 @@ export function getResultMetadata(result: Result) {
   ): [FieldHeaderRangeMap, number, number] {
     let fieldMap: FieldHeaderRangeMap = {};
 
-    explore.allFields.forEach((field, index) => {
+    explore.allFields.forEach(field => {
       if (!field.isExploreField()) {
         fieldMap[getCachedFieldKey(field)] = {
           abs: [start, start],

--- a/packages/malloy-render/src/component/table/table-layout.ts
+++ b/packages/malloy-render/src/component/table/table-layout.ts
@@ -32,11 +32,11 @@ type LayoutEntry = {
 export type TableLayout = Record<string, LayoutEntry>;
 
 const NAMED_COLUMN_WIDTHS = {
-  xs: 28,
-  sm: 64,
-  md: 128,
-  lg: 256,
-  xl: 384,
+  'xs': 28,
+  'sm': 64,
+  'md': 128,
+  'lg': 256,
+  'xl': 384,
   '2xl': 512,
 };
 

--- a/packages/malloy-render/src/component/table/table-layout.ts
+++ b/packages/malloy-render/src/component/table/table-layout.ts
@@ -21,25 +21,24 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import {Field} from '@malloydata/malloy';
-import {clamp, getFieldKey, getTextWidth} from '../util';
-import {renderNumericField} from '../render-numeric-field';
-import {hasAny} from '../tag-utils';
 import {FieldRenderMetadata, RenderResultMetadata} from '../types';
-
-const MIN_COLUMN_WIDTH = 32;
-const MAX_COLUMN_WIDTH = 384;
-const COLUMN_BUFFER = 12;
-// TODO: get from theme
-const ROW_HEIGHT = 28;
 
 type LayoutEntry = {
   metadata: FieldRenderMetadata;
-  width: number;
+  width: number | null;
   height: number | null;
 };
 
 export type TableLayout = Record<string, LayoutEntry>;
+
+const NAMED_COLUMN_WIDTHS = {
+  xs: 28,
+  sm: 64,
+  md: 128,
+  lg: 256,
+  xl: 384,
+  '2xl': 512,
+};
 
 export function getTableLayout(metadata: RenderResultMetadata): TableLayout {
   const layout = {};
@@ -48,62 +47,19 @@ export function getTableLayout(metadata: RenderResultMetadata): TableLayout {
     const field = fieldMeta.field;
     const layoutEntry: LayoutEntry = {
       metadata: fieldMeta,
-      width: !field.isExplore() ? getColumnWidth(field, metadata) : 0,
+      width: null,
       height: null,
     };
-
     const {tag} = field.tagParse();
-    if (hasAny(tag, 'bar', 'bar_chart') && field.isExploreField()) {
-      layoutEntry.width = fieldMeta.vegaChartProps!.totalWidth;
-      layoutEntry.height = fieldMeta.vegaChartProps!.totalHeight;
-    }
-    // TODO: figure out better width / height detection?
-    else if (hasAny(tag, 'list', 'list_detail') && field.isExploreField()) {
-      layoutEntry.width = 320;
-    }
-    // TODO: better width / height detection
-    else if (tag.has('image')) {
-      const overrideWidth = tag.text('width');
-      const overrideHeight = tag.text('height');
-      if (overrideWidth?.endsWith('px'))
-        layoutEntry.width = parseInt(overrideWidth);
-      if (overrideHeight?.endsWith('px'))
-        layoutEntry.height = parseInt(overrideHeight);
-    } else if (!field.isExplore() && field.isAtomicField()) {
-      layoutEntry.height = ROW_HEIGHT;
-    }
+    // Allow overriding size
+    const textWidth = tag.text('width');
+    if (textWidth && NAMED_COLUMN_WIDTHS[textWidth])
+      layoutEntry.width = NAMED_COLUMN_WIDTHS[textWidth];
+    else if (tag.numeric('width')) layoutEntry.width = tag.numeric('width')!;
 
-    const overrideWidth = tag.numeric('width');
-    const overrideHeight = tag.numeric('height');
-    if (overrideWidth) layoutEntry.width = overrideWidth;
-    if (overrideHeight) layoutEntry.height = overrideHeight;
+    if (tag.numeric('height')) layoutEntry.height = tag.numeric('height')!;
 
     layout[key] = layoutEntry;
   }
   return layout;
-}
-
-function getColumnWidth(f: Field, metadata: RenderResultMetadata) {
-  const fieldKey = getFieldKey(f);
-  const fieldMeta = metadata.fields[fieldKey];
-  let width = 0;
-  if (f.isAtomicField()) {
-    // TODO: get font styles from theme
-    const font = '12px Inter, sans-serif';
-    const titleWidth = getTextWidth(f.name, font);
-    if (f.isAtomicField() && f.isString()) {
-      width =
-        Math.max(getTextWidth(fieldMeta.maxString!, font), titleWidth) +
-        COLUMN_BUFFER;
-    } else if (f.isAtomicField() && f.isNumber()) {
-      const formattedValue =
-        fieldMeta.max === null ? '∅' : renderNumericField(f, fieldMeta.max);
-      width =
-        Math.max(getTextWidth(formattedValue, font), titleWidth) +
-        COLUMN_BUFFER;
-    } else width = 130;
-    width = clamp(MIN_COLUMN_WIDTH, MAX_COLUMN_WIDTH, width);
-  }
-
-  return width;
 }

--- a/packages/malloy-render/src/component/table/table.css
+++ b/packages/malloy-render/src/component/table/table.css
@@ -1,49 +1,57 @@
-.malloy-table .sticky-header {
-  position: sticky;
-  top: 0px;
-  z-index: 100;
-}
-
-.malloy-table .sticky-header-content {
-  position: absolute;
-  top: 0px;
-  left: 0px;
-  pointer-events: none;
-}
-
-.malloy-table .sticky-header-content th {
-  pointer-events: all;
-}
-
-.malloy-table table {
-  border-collapse: collapse;
-  background: var(--malloy-render--table-background);
-}
-
-.malloy-table th {
-  transition: background-color 0.25s;
-}
-
-.malloy-table table * {
+.malloy-table * {
   box-sizing: border-box;
 }
 
+.malloy-table {
+  background: var(--malloy-render--table-background);
+}
+
+.malloy-table {
+  display: grid;
+  grid: auto / subgrid;
+}
+
+.malloy-table.root {
+  width: fit-content;
+  max-width: 100%;
+  height: fit-content;
+  max-height: 100%;
+  position: relative;
+  overflow: auto;
+}
+
+.malloy-table .pinned-header-row {
+  display: grid;
+  grid: auto / subgrid;
+  position: sticky;
+  top: 0px;
+  z-index: 1000;
+  pointer-events: none;
+}
+
+.malloy-table .table-row {
+  display: grid;
+  grid: auto / subgrid;
+}
+
+.malloy-table .th {
+  transition: background-color 0.25s;
+}
+
 .malloy-table .column-cell {
-  height: var(--malloy-render--table-row-height);
-  overflow: hidden;
+  min-height: var(--malloy-render--table-row-height);
   white-space: nowrap;
   text-align: left;
   padding: 0px;
   vertical-align: top;
-  position: relative;
 }
 
-.malloy-table td.column-cell {
+.malloy-table .td.column-cell {
   font-weight: var(--malloy-render--table-body-weight);
   color: var(--malloy-render--table-body-color);
 }
 
-.malloy-table th.column-cell {
+.malloy-table .th.column-cell {
   font-weight: var(--malloy-render--table-header-weight);
   color: var(--malloy-render--table-header-color);
 }
@@ -53,54 +61,63 @@
   font-variant-numeric: tabular-nums;
 }
 
-.malloy-table .cell-wrapper {
-  display: flex;
-  align-items: start;
-  overflow: hidden;
-}
-
 .malloy-table .cell-content {
   border-top: var(--malloy-render--table-border);
   height: 100%;
-  line-height: var(--malloy-render--table-row-height);
+  /* -1px for the top border */
+  line-height: calc(var(--malloy-render--table-row-height) - 1px);
   flex: 1;
   overflow: hidden;
   text-overflow: ellipsis;
+  margin-inline: 0px;
+  padding-inline: var(--malloy-render--table-gutter-size);
 }
 
-.malloy-table .cell-gutter {
-  border-top: var(--malloy-render--table-border);
-  height: var(--malloy-render--table-row-height);
-  width: var(--malloy-render--table-gutter-size);
-  transition: border-color 0.25s;
+.malloy-table .cell-content.hide-start-gutter {
+  margin-left: var(--malloy-render--table-gutter-size);
+  padding-left: 0px;
 }
 
-.malloy-table .cell-gutter.hide-gutter-border {
-  border-color: transparent;
+.malloy-table .cell-content.hide-end-gutter {
+  margin-right: var(--malloy-render--table-gutter-size);
+  padding-right: 0px;
 }
 
-.malloy-table.pinned-header table {
-  background: transparent;
+/* If scrolled, show all gutter borders in pinned header */
+.malloy-table.scrolled .pinned-header {
+  .cell-content.hide-start-gutter,
+  .cell-content.hide-end-gutter {
+    margin-inline: 0px;
+    padding-inline: var(--malloy-render--table-gutter-size);
+  }
 }
 
-.malloy-table.pinned-header th {
+.malloy-table .pinned-header.th {
   background: var(--malloy-render--table-background);
+  pointer-events: all;
 }
 
-.malloy-table.root {
-  width: 100%;
-  height: 100%;
-  position: relative;
-  overflow: auto;
-}
-
-.malloy-table.scrolled .pinned-header .cell-content,
-.malloy-table.scrolled .pinned-header .cell-gutter,
-.malloy-table.scrolled .pinned-header .cell-gutter.hide-gutter-border {
+.malloy-table.scrolled .pinned-header .cell-content {
   border-top: var(--malloy-render--table-pinned-border);
 }
 
-.malloy-table.scrolled .pinned-header th {
+.malloy-table.scrolled .pinned-header.th {
+  position: relative;
   background: var(--malloy-render--table-pinned-background);
-  box-shadow: 0 0 0.5em rgba(0, 0, 0, 0.5);
+}
+
+.malloy-table.scrolled .pinned-header:after {
+  content: '';
+  border-bottom: var(--malloy-render--table-pinned-border);
+  width: 100%;
+  height: 0px;
+  display: inline-block;
+  position: absolute;
+  left: 0px;
+  right: 0px;
+}
+
+/* TODO figure out better strategy for tweaking renderers inside table */
+.malloy-table .malloy-list {
+  line-height: var(--malloy-render--table-row-height);
 }

--- a/packages/malloy-render/src/component/table/table.tsx
+++ b/packages/malloy-render/src/component/table/table.tsx
@@ -8,14 +8,25 @@ import {
   Switch,
   Match,
   JSXElement,
+  JSX,
 } from 'solid-js';
 import {DataArray, DataRecord, Field} from '@malloydata/malloy';
-import {getFieldKey, isFirstChild, isLastChild} from '../util';
+import {
+  getFieldKey,
+  getRangeSize,
+  isFirstChild,
+  isLastChild,
+  shouldRenderAs,
+} from '../util';
 import {getTableLayout} from './table-layout';
 import {useResultContext} from '../result-context';
 import {TableContext, useTableContext} from './table-context';
 import './table.css';
 import {applyRenderer} from '../apply-renderer';
+
+const IS_CHROMIUM = navigator.userAgent.toLowerCase().indexOf('chrome') >= 0;
+// CSS Subgrid + Sticky Positioning only seems to work reliably in Chrome
+const SUPPORTS_STICKY = IS_CHROMIUM;
 
 const Cell = (props: {
   field: Field;
@@ -28,12 +39,14 @@ const Cell = (props: {
     const layout = useTableContext()!.layout;
     const width = layout[getFieldKey(props.field)].width;
     const height = layout[getFieldKey(props.field)].height;
-    let style = '';
+    const style: JSX.CSSProperties = {};
     if (!props.isHeader) {
-      if (typeof width !== 'undefined') {
-        style += `width: ${width}px; min-width: ${width}px; max-width: ${width}px;`;
+      if (width) {
+        style.width = `${width}px`;
+        style['min-width'] = `${width}px`;
+        style['max-width'] = `${width}px;`;
         if (typeof height === 'number') {
-          style += `height: ${height}px;`;
+          style.height = `${height}px;`;
         }
       }
     }
@@ -41,33 +54,23 @@ const Cell = (props: {
   };
 
   return (
-    <div class="cell-wrapper">
-      <div
-        class="cell-gutter"
-        classList={{
-          'hide-gutter-border': props.hideStartGutter,
-        }}
-      ></div>
-      <div
-        class="cell-content"
-        classList={{
-          header: props.isHeader,
-        }}
-        style={style()}
-      >
-        {props.value}
-      </div>
-      <div
-        class="cell-gutter"
-        classList={{
-          'hide-gutter-border': props.hideEndGutter,
-        }}
-      ></div>
+    <div
+      class="cell-content"
+      classList={{
+        header: props.isHeader,
+        'hide-start-gutter': props.hideStartGutter,
+        'hide-end-gutter': props.hideEndGutter,
+      }}
+      style={style()}
+      title={typeof props.value === 'string' ? props.value : ''}
+    >
+      {props.value}
     </div>
   );
 };
 
-const HeaderField = (props: {field: Field}) => {
+const HeaderField = (props: {field: Field; isPinned?: boolean}) => {
+  const resultMetadata = useResultContext();
   const isFirst = isFirstChild(props.field);
   const isParentFirst = isFirstChild(props.field.parentExplore);
   const isParentNotAField = !props.field.parentExplore.isExploreField();
@@ -77,11 +80,21 @@ const HeaderField = (props: {field: Field}) => {
   const isParentLast = isLastChild(props.field.parentExplore);
   const hideEndGutter = isLast && (isParentLast || isParentNotAField);
 
+  const columnRange = props.isPinned
+    ? resultMetadata.field(props.field).absoluteColumnRange
+    : resultMetadata.field(props.field).relativeColumnRange;
+
   return (
-    <th
-      class="column-cell"
+    <div
+      class="column-cell th"
       classList={{
         numeric: props.field.isAtomicField() && props.field.isNumber(),
+        'pinned-header': props.isPinned,
+      }}
+      style={{
+        'grid-column': `${columnRange[0] + 1} / span ${getRangeSize(
+          columnRange
+        )}`,
       }}
     >
       <Cell
@@ -91,11 +104,12 @@ const HeaderField = (props: {field: Field}) => {
         hideEndGutter={hideEndGutter}
         isHeader
       />
-    </th>
+    </div>
   );
 };
 
 const TableField = (props: {field: Field; row: DataRecord}) => {
+  const resultMetadata = useResultContext();
   const tableCtx = useTableContext()!;
   let renderValue: JSXElement = '';
   let renderAs = '';
@@ -115,12 +129,29 @@ const TableField = (props: {field: Field; row: DataRecord}) => {
   // Hide table content in pinned header
   if (tableCtx.pinnedHeader && renderAs !== 'table') renderValue = '';
 
+  const columnRange = resultMetadata.field(props.field).relativeColumnRange;
+  const style: JSX.CSSProperties = {
+    'grid-column': `${columnRange[0] + 1} / span ${getRangeSize(columnRange)}`,
+    height: 'fit-content',
+  };
+
+  if (renderAs === 'table') {
+    style.display = 'grid';
+    style.grid = 'auto / subgrid';
+  }
+  // TODO: review what should be sticky
+  else if (SUPPORTS_STICKY && props.field.isAtomicField()) {
+    style.position = 'sticky';
+    style.top = `${(resultMetadata.field(props.field).depth + 1) * 28}px`;
+  }
+
   return (
-    <td
-      class="column-cell"
+    <div
+      class="column-cell td"
       classList={{
         numeric: props.field.isAtomicField() && props.field.isNumber(),
       }}
+      style={style}
     >
       <Switch>
         {/* When table, skip cell wrapper */}
@@ -134,7 +165,7 @@ const TableField = (props: {field: Field; row: DataRecord}) => {
           />
         </Match>
       </Switch>
-    </td>
+    </div>
   );
 };
 
@@ -145,6 +176,7 @@ const MalloyTableRoot = (_props: {
 }) => {
   const props = mergeProps({rowLimit: Infinity, pinnedHeader: false}, _props);
   const tableCtx = useTableContext()!;
+  const resultMetadata = useResultContext();
 
   const [scrolling, setScrolling] = createSignal(false);
   const handleScroll = (e: Event) => {
@@ -152,6 +184,62 @@ const MalloyTableRoot = (_props: {
     setScrolling(target.scrollTop > 0);
   };
 
+  const pinnedFields = createMemo(() => {
+    const fields = Object.entries(resultMetadata.fieldHeaderRangeMap)
+      .sort((a, b) => {
+        if (a[1].depth < b[1].depth) return -1;
+        else if (a[1].depth > b[1].depth) return 1;
+        else if (a[1].abs[0] < b[1].abs[0]) return -1;
+        else if (a[1].abs[0] > b[1].abs[0]) return 1;
+        else return 0;
+      })
+      .filter(([key, value]) => {
+        const isNotRoot = value.depth >= 0;
+        const isPartOfTable =
+          shouldRenderAs(resultMetadata.fields[key].field.parentExplore!) ===
+          'table';
+        return isNotRoot && isPartOfTable;
+      })
+      .map(([key, value]) => ({
+        fieldKey: key,
+        field: resultMetadata.fields[key].field,
+        ...value,
+      }));
+    return fields;
+  });
+
+  const maxDepth = createMemo(() =>
+    Math.max(...pinnedFields().map(f => f.depth))
+  );
+
+  const getContainerStyle: () => JSX.CSSProperties = () => {
+    const fieldMeta = resultMetadata.field(props.data.field);
+    if (tableCtx.root) {
+      return {
+        'grid-template-columns': `repeat(${resultMetadata.totalHeaderSize}, max-content)`,
+      };
+    }
+    return {
+      'grid-column': `1 / span ${getRangeSize(fieldMeta.relativeColumnRange)}`,
+    };
+  };
+
+  const getRowStyle: (idx: number) => JSX.CSSProperties = (idx: number) => {
+    const fieldMeta = resultMetadata.field(props.data.field);
+    const rowStyle = {
+      'grid-column': `1 / span ${getRangeSize(fieldMeta.relativeColumnRange)}`,
+    };
+
+    // Offset first row to hide behind pinned headers
+    if (idx === 0 && tableCtx.root)
+      rowStyle[
+        'margin-top'
+      ] = `calc(-${maxDepth()} * var(--malloy-render--table-row-height))`;
+
+    return rowStyle;
+  };
+
+  // TODO: Get this from resultMetadata cache?
   const data = createMemo(() => {
     const data: DataRecord[] = [];
     let i = 0;
@@ -165,41 +253,45 @@ const MalloyTableRoot = (_props: {
 
   return (
     <div
-      onScroll={handleScroll}
       class="malloy-table"
       classList={{
         'root': tableCtx.root,
-        'pinned-header': tableCtx.pinnedHeader,
         'scrolled': scrolling(),
       }}
+      onScroll={handleScroll}
+      style={getContainerStyle()}
     >
+      {/* pinned header */}
       <Show when={tableCtx.root}>
-        <div class="sticky-header">
-          <div class="sticky-header-content">
-            <MalloyTable data={props.data} rowLimit={1} pinnedHeader={true} />
-          </div>
-        </div>
-      </Show>
-      <table>
-        <thead>
-          <tr>
-            {props.data.field.allFields.map(f => (
-              <HeaderField field={f} />
-            ))}
-          </tr>
-        </thead>
-        <tbody>
-          <For each={data()}>
-            {row => (
-              <tr>
-                {props.data.field.allFields.map(f => (
-                  <TableField field={f} row={row} />
-                ))}
-              </tr>
+        <div
+          class="pinned-header-row"
+          style={`grid-column: 1 / span ${resultMetadata.totalHeaderSize};`}
+        >
+          <For each={pinnedFields()}>
+            {pinnedField => (
+              <HeaderField field={pinnedField.field as Field} isPinned />
             )}
           </For>
-        </tbody>
-      </table>
+        </div>
+      </Show>
+      {/* header */}
+      <Show when={!tableCtx.root}>
+        <div class="table-row" style={getRowStyle(-1)}>
+          <For each={props.data.field.allFields}>
+            {field => <HeaderField field={field} />}
+          </For>
+        </div>
+      </Show>
+      {/* rows */}
+      <For each={data()}>
+        {(row, idx) => (
+          <div class="table-row" style={getRowStyle(idx())}>
+            <For each={props.data.field.allFields}>
+              {field => <TableField field={field} row={row} />}
+            </For>
+          </div>
+        )}
+      </For>
     </div>
   );
 };

--- a/packages/malloy-render/src/component/table/table.tsx
+++ b/packages/malloy-render/src/component/table/table.tsx
@@ -57,7 +57,7 @@ const Cell = (props: {
     <div
       class="cell-content"
       classList={{
-        header: props.isHeader,
+        'header': props.isHeader,
         'hide-start-gutter': props.hideStartGutter,
         'hide-end-gutter': props.hideEndGutter,
       }}
@@ -88,7 +88,7 @@ const HeaderField = (props: {field: Field; isPinned?: boolean}) => {
     <div
       class="column-cell th"
       classList={{
-        numeric: props.field.isAtomicField() && props.field.isNumber(),
+        'numeric': props.field.isAtomicField() && props.field.isNumber(),
         'pinned-header': props.isPinned,
       }}
       style={{
@@ -132,7 +132,7 @@ const TableField = (props: {field: Field; row: DataRecord}) => {
   const columnRange = resultMetadata.field(props.field).relativeColumnRange;
   const style: JSX.CSSProperties = {
     'grid-column': `${columnRange[0] + 1} / span ${getRangeSize(columnRange)}`,
-    height: 'fit-content',
+    'height': 'fit-content',
   };
 
   if (renderAs === 'table') {

--- a/packages/malloy-render/src/component/types.ts
+++ b/packages/malloy-render/src/component/types.ts
@@ -10,6 +10,11 @@ export type VegaChartProps = {
   totalHeight: number;
 };
 
+export type FieldHeaderRangeMap = Record<
+  string,
+  {abs: [number, number]; rel: [number, number]; depth: number}
+>;
+
 export interface FieldRenderMetadata {
   field: Field | Explore;
   min: number | null;
@@ -18,6 +23,9 @@ export interface FieldRenderMetadata {
   maxString: string | null;
   values: Set<string>;
   maxRecordCt: number | null;
+  absoluteColumnRange: [number, number];
+  relativeColumnRange: [number, number];
+  depth: number;
   vegaChartProps?: VegaChartProps;
 }
 
@@ -27,4 +35,6 @@ export interface RenderResultMetadata {
   getFieldKey: (f: Field | Explore) => string;
   field: (f: Field | Explore) => FieldRenderMetadata;
   getData: (cell: DataColumn) => QueryData;
+  fieldHeaderRangeMap: FieldHeaderRangeMap;
+  totalHeaderSize: number;
 }

--- a/packages/malloy-render/src/component/util.ts
+++ b/packages/malloy-render/src/component/util.ts
@@ -77,3 +77,7 @@ export function shouldRenderAs(f: Field | Explore, tagOverride?: Tag) {
 export function getFieldKey(f: Field | Explore) {
   return JSON.stringify(f.fieldPath);
 }
+
+export function getRangeSize(range: [number, number]) {
+  return range[1] - range[0] + 1;
+}

--- a/packages/malloy-render/src/stories/static/image.malloy
+++ b/packages/malloy-render/src/stories/static/image.malloy
@@ -16,4 +16,19 @@ source: logos is duckdb.table("data/logos.csv") extend {
           logo
       }
   }
+
+  view: img_from_grandparent is {
+    group_by:
+      brand
+      nest: l2 is {
+        group_by: foo is brand,
+        nest: details is {
+          group_by:
+            product
+            # image image.height=40px image.alt=fallback image.alt.field='../../brand'
+            logo
+        }
+      }
+
+  }
 };

--- a/packages/malloy-render/src/stories/static/list.malloy
+++ b/packages/malloy-render/src/stories/static/list.malloy
@@ -33,7 +33,6 @@ source: logos is duckdb.table("data/logos.csv") extend {
 
   view: nested_list is {
     group_by: brand
-    # width=600
     nest: list_detail_renderers
   }
 };

--- a/packages/malloy-render/src/stories/static/tables.malloy
+++ b/packages/malloy-render/src/stories/static/tables.malloy
@@ -5,10 +5,46 @@ source: products is duckdb.table("data/products.parquet") extend {
     limit: 1000
   }
 
+  view: long_column is {
+    select:
+      brand,
+      # width=lg
+      name
+  }
+
   # bar_chart
   view: category_bar is {
     group_by: category
     aggregate: avg_retail is retail_price.avg()
+  }
+
+  view: simple_nested is {
+    group_by: category
+    aggregate: avg_retail is retail_price.avg()
+    limit: 2
+    nest:
+      nested_column_1 is {
+        group_by: brand
+        aggregate: avg_retail is retail_price.avg()
+        limit: 10
+      },
+      # list_detail width=xl
+      nested_column_2 is {
+        group_by: brand
+        aggregate: avg_retail is retail_price.avg()
+        limit: 10
+      }
+      another_nested is {
+        group_by: department
+        aggregate: avg_retail is retail_price.avg()
+        nest:
+          deeply_nested is {
+            group_by: `sku`
+            aggregate: total_cost is cost.sum()
+            limit: 3
+          }
+        limit: 5
+      }
   }
 
   view: nested is {
@@ -47,6 +83,22 @@ source: products is duckdb.table("data/products.parquet") extend {
           limit: 3
         }
         limit: 5
+      }
+  }
+
+  view: nested_2 is {
+    group_by: category
+    aggregate: avg_retail is retail_price.avg()
+    nest:
+      by_department is {
+        group_by: department
+        aggregate: avg_retail is retail_price.avg()
+        limit: 10
+        nest: nested_column_2 is {
+          group_by: brand
+          aggregate: avg_retail is retail_price.avg()
+          limit: 10
+        }
       }
   }
 

--- a/packages/malloy-render/src/stories/tables.stories.ts
+++ b/packages/malloy-render/src/stories/tables.stories.ts
@@ -44,10 +44,24 @@ export const Products2Column = {
   },
 };
 
+export const SimpleNested = {
+  args: {
+    source: 'products',
+    view: 'simple_nested',
+  },
+};
+
 export const Nested = {
   args: {
     source: 'products',
     view: 'nested',
+  },
+};
+
+export const Nested2 = {
+  args: {
+    source: 'products',
+    view: 'nested_2',
   },
 };
 
@@ -62,5 +76,12 @@ export const NullTest = {
   args: {
     source: 'null_test',
     view: '{ select: * }',
+  },
+};
+
+export const LongColumn = {
+  args: {
+    source: 'products',
+    view: 'long_column',
   },
 };


### PR DESCRIPTION
Rearchitects the table renderer using CSS Subgrids instead of nested tables. The benefits:
- No longer need to hardcode column widths so that nested tables match; subgrid CSS handles this so everything can be autosized
- Works more effectively with sticky cells; now we can have text/numeric cells pin as a user scrolls a deeply nested structure
- Allows the removal of extra cell elements like our cell gutters, which were necessary due to the idiosyncrasies of table elements

This PR also adds the ability to manually width columns using presets or hardcoded pixels like so:
```
# width=md
a_med_width_col
# width=300
a_300px_col
``` 