### PR TITLE
feat: dashboards, hidden fields, rename columns

### DIFF
--- a/packages/malloy-render/src/component/apply-renderer.tsx
+++ b/packages/malloy-render/src/component/apply-renderer.tsx
@@ -15,6 +15,7 @@ import {Chart} from './chart';
 import MalloyTable from './table/table';
 import {renderList} from './render-list';
 import {renderImage} from './render-image';
+import {Dashboard} from './dashboard/dashboard';
 
 export type RendererProps = {
   field: Field;
@@ -65,6 +66,10 @@ export function applyRenderer(props: RendererProps) {
           {...propsToPass}
         />
       );
+      break;
+    }
+    case 'dashboard': {
+      renderValue = <Dashboard data={dataColumn as DataArray} />;
       break;
     }
     case 'table': {

--- a/packages/malloy-render/src/component/dashboard/dashboard.css
+++ b/packages/malloy-render/src/component/dashboard/dashboard.css
@@ -1,0 +1,84 @@
+.malloy-dashboard {
+  background: #f7f9fc;
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+  display: grid;
+  grid-template-rows: auto;
+  gap: 48px;
+}
+
+.malloy-dashboard {
+  * {
+    box-sizing: border-box;
+  }
+
+  .dashboard-row-header {
+    position: sticky;
+    top: 0px;
+    background: #f7f9fc;
+    padding: 16px;
+    padding-bottom: 0px;
+    width: 100%;
+    z-index: 200;
+  }
+
+  .dashboard-row-header-separator {
+    height: 1px;
+    background: #e3e5e9;
+  }
+
+  .dashboard-row-header-dimension-list {
+    display: flex;
+    gap: 24px;
+  }
+
+  .dashboard-row-body {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 16px;
+    padding: 16px;
+    padding-top: 12px;
+  }
+
+  .dashboard-item {
+    background: white;
+    border-radius: 3px;
+    padding: 16px;
+    width: fit-content;
+    height: fit-content;
+    display: grid;
+    grid-template-rows: max-content 1fr;
+    gap: 12px;
+    box-shadow:
+      rgb(255, 255, 255) 0px 0px 0px 0px,
+      rgb(229, 231, 235) 0px 0px 0px 1px,
+      rgba(0, 0, 0, 0.1) 0px 1px 3px 0px,
+      rgba(0, 0, 0, 0.1) 0px 1px 2px -1px;
+  }
+
+  .dashboard-item-title {
+    font-weight: 400;
+    font-size: 12px;
+    color: rgb(100, 102, 107);
+  }
+
+  .dashboard-item-value-measure {
+    font-size: 20px;
+  }
+
+  .dashboard-dimension-wrapper {
+    display: grid;
+    grid-template-rows: auto;
+    gap: 4px;
+    margin-bottom: 8px;
+  }
+
+  .dashboard-dimension-name {
+    font-size: 12px;
+  }
+  .dashboard-dimension-value {
+    font-size: 14px;
+    font-weight: 600;
+  }
+}

--- a/packages/malloy-render/src/component/dashboard/dashboard.tsx
+++ b/packages/malloy-render/src/component/dashboard/dashboard.tsx
@@ -1,0 +1,120 @@
+import {DataArray, DataRecord, Field} from '@malloydata/malloy';
+import './dashboard.css';
+import {createMemo, For} from 'solid-js';
+import {applyRenderer} from '../apply-renderer';
+import {useResultContext} from '../result-context';
+import {RenderResultMetadata} from '../types';
+
+function DashboardItem(props: {
+  field: Field;
+  row: DataRecord;
+  resultMetadata: RenderResultMetadata;
+  getFieldDisplayName: (f: Field) => string;
+  isMeasure?: boolean;
+}) {
+  return (
+    <div class="dashboard-item">
+      <div class="dashboard-item-title">
+        {props.getFieldDisplayName(props.field)}
+      </div>
+      <div
+        class="dashboard-item-value"
+        classList={{
+          'dashboard-item-value-measure': props.isMeasure,
+        }}
+      >
+        {
+          applyRenderer({
+            field: props.field,
+            dataColumn: props.row.cell(props.field),
+            tag: props.field.tagParse().tag,
+            resultMetadata: props.resultMetadata,
+          }).renderValue
+        }
+      </div>
+    </div>
+  );
+}
+
+export function Dashboard(props: {data: DataArray}) {
+  const field = () => props.data.field;
+
+  const dimensions = () =>
+    field().allFields.filter(f => {
+      const isHidden = f.tagParse().tag.has('hidden');
+      return !isHidden && f.isAtomicField() && f.sourceWasDimension();
+    });
+
+  const nonDimensions = () => {
+    const measureFields: Field[] = [];
+    const otherFields: Field[] = [];
+
+    for (const f of field().allFields) {
+      if (f.tagParse().tag.has('hidden')) continue;
+      if (f.isAtomicField() && f.sourceWasMeasureLike()) {
+        measureFields.push(f);
+      } else if (!f.isAtomicField() || !f.sourceWasDimension())
+        otherFields.push(f);
+    }
+    return [...measureFields, ...otherFields];
+  };
+
+  const data = createMemo(() => {
+    const data: DataRecord[] = [];
+    for (const row of props.data) {
+      data.push(row);
+    }
+    return data;
+  });
+
+  const resultMetadata = useResultContext();
+  const disableAutoRename =
+    resultMetadata.resultTag.tag('dashboard', 'auto_rename')?.text() === 'off';
+  const getFieldDisplayName = (f: Field) => {
+    return disableAutoRename ? f.name : f.name.replace(/_/g, ' ');
+  };
+
+  return (
+    <div class="malloy-dashboard">
+      <For each={data()}>
+        {row => (
+          <div class="dashboard-row">
+            <div class="dashboard-row-header">
+              <div class="dashboard-row-header-dimension-list">
+                <For each={dimensions()}>
+                  {d => (
+                    <div class="dashboard-dimension-wrapper">
+                      <div class="dashboard-dimension-name">
+                        {getFieldDisplayName(d)}
+                      </div>
+                      <div class="dashboard-dimension-value">
+                        {row.cell(d).value as string}
+                      </div>
+                    </div>
+                  )}
+                </For>
+              </div>
+              <div class="dashboard-row-header-separator" />
+              {/* <hr class="dashboard-row-head" /> */}
+            </div>
+            <div class="dashboard-row-body">
+              <For each={nonDimensions()}>
+                {field => (
+                  <DashboardItem
+                    field={field}
+                    row={row}
+                    resultMetadata={resultMetadata}
+                    getFieldDisplayName={getFieldDisplayName}
+                    isMeasure={
+                      field.isAtomicField() && field.sourceWasMeasureLike()
+                    }
+                  />
+                )}
+              </For>
+            </div>
+          </div>
+        )}
+      </For>
+    </div>
+  );
+}

--- a/packages/malloy-render/src/component/register-webcomponent.ts
+++ b/packages/malloy-render/src/component/register-webcomponent.ts
@@ -3,6 +3,7 @@ import {withSolid} from 'solid-element';
 import {MalloyRender, MalloyRenderProps} from './render';
 import css from './render.css?raw';
 import tableCss from './table/table.css?raw';
+import dashboardCss from './dashboard/dashboard.css?raw';
 
 const withStyles = ComponentType => {
   return (props, options) => {
@@ -10,7 +11,7 @@ const withStyles = ComponentType => {
     const stylesheet = new CSSStyleSheet();
     stylesheet.replaceSync(css);
     const tableStylesheet = new CSSStyleSheet();
-    tableStylesheet.replaceSync(tableCss);
+    tableStylesheet.replaceSync([tableCss, dashboardCss].join('\n'));
     element.renderRoot.adoptedStyleSheets = [stylesheet, tableStylesheet];
     return ComponentType(props, options);
   };

--- a/packages/malloy-render/src/component/render.tsx
+++ b/packages/malloy-render/src/component/render.tsx
@@ -42,8 +42,8 @@ export function MalloyRenderInner(props: {
 }) {
   const metadata = createMemo(() => getResultMetadata(props.result));
   const tags = () => {
-    const modelTag = props.result.modelTag;
-    const resultTag = props.result.tagParse().tag;
+    const modelTag = metadata().modelTag;
+    const resultTag = metadata().resultTag;
     const modelTheme = modelTag.tag('theme');
     const localTheme = resultTag.tag('theme');
     return {

--- a/packages/malloy-render/src/component/table/table-context.ts
+++ b/packages/malloy-render/src/component/table/table-context.ts
@@ -5,6 +5,7 @@ type TableContext = {
   root: boolean;
   pinnedHeader: boolean;
   layout: TableLayout;
+  autoRenameColumns: boolean;
 };
 
 export const TableContext = createContext<TableContext>();

--- a/packages/malloy-render/src/component/table/table.css
+++ b/packages/malloy-render/src/component/table/table.css
@@ -25,7 +25,7 @@
   grid: auto / subgrid;
   position: sticky;
   top: 0px;
-  z-index: 1000;
+  z-index: 100;
   pointer-events: none;
 }
 

--- a/packages/malloy-render/src/component/types.ts
+++ b/packages/malloy-render/src/component/types.ts
@@ -1,4 +1,4 @@
-import {DataColumn, Explore, Field, QueryData} from '@malloydata/malloy';
+import {DataColumn, Explore, Field, QueryData, Tag} from '@malloydata/malloy';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Vega does not have good TS support
 export type VegaSpec = any;
@@ -23,9 +23,6 @@ export interface FieldRenderMetadata {
   maxString: string | null;
   values: Set<string>;
   maxRecordCt: number | null;
-  absoluteColumnRange: [number, number];
-  relativeColumnRange: [number, number];
-  depth: number;
   vegaChartProps?: VegaChartProps;
 }
 
@@ -35,6 +32,6 @@ export interface RenderResultMetadata {
   getFieldKey: (f: Field | Explore) => string;
   field: (f: Field | Explore) => FieldRenderMetadata;
   getData: (cell: DataColumn) => QueryData;
-  fieldHeaderRangeMap: FieldHeaderRangeMap;
-  totalHeaderSize: number;
+  modelTag: Tag;
+  resultTag: Tag;
 }

--- a/packages/malloy-render/src/component/util.ts
+++ b/packages/malloy-render/src/component/util.ts
@@ -71,6 +71,7 @@ export function shouldRenderAs(f: Field | Explore, tagOverride?: Tag) {
   }
   if (hasAny(tag, 'list', 'list_detail')) return 'list';
   if (hasAny(tag, 'bar_chart')) return 'chart';
+  if (tag.has('dashboard')) return 'dashboard';
   else return 'table';
 }
 

--- a/packages/malloy-render/src/stories/dashboard.stories.ts
+++ b/packages/malloy-render/src/stories/dashboard.stories.ts
@@ -1,0 +1,30 @@
+import {Meta} from '@storybook/html';
+import script from './static/dashboard.malloy?raw';
+import {createLoader} from './util';
+import './themes.css';
+import '../component/render-webcomponent';
+
+const meta: Meta = {
+  title: 'Malloy Next/Dashboard',
+  render: ({classes}, context) => {
+    const parent = document.createElement('div');
+    parent.style.height = 'calc(100vh - 40px)';
+    parent.style.position = 'relative';
+    const el = document.createElement('malloy-render');
+    if (classes) el.classList.add(classes);
+    el.result = context.loaded['result'];
+    parent.appendChild(el);
+    return parent;
+  },
+  loaders: [createLoader(script)],
+  argTypes: {},
+};
+
+export default meta;
+
+export const Dashboard = {
+  args: {
+    source: 'products',
+    view: 'dash',
+  },
+};

--- a/packages/malloy-render/src/stories/static/dashboard.malloy
+++ b/packages/malloy-render/src/stories/static/dashboard.malloy
@@ -1,0 +1,18 @@
+source: products is duckdb.table("data/products.parquet") extend {
+
+  # dashboard
+  view: dash is {
+    group_by:
+      category
+    # currency
+    aggregate:
+      avg_retail is retail_price.avg()
+      sum_retail is retail_price.sum()
+    nest:
+      by_brand is {
+        group_by: brand
+        aggregate: avg_retail is retail_price.avg()
+        limit: 10
+      }
+  }
+}


### PR DESCRIPTION
- Implements dashboard renderer in renderer_next
- Moves FieldHeaderRangeMap calcs from Result Metadata to TableLayout, because it should be specific to tables which can nested within a larger data structure being rendered as say, a dashboard
- Adds auto field name renaming, per feedback from @lloydtabb 
- Adds support for hidden fields in renderer_next tables




New dashboards:

https://github.com/user-attachments/assets/6f850fc5-bce5-421c-82de-251db1f6c62c


