### PR TITLE
Move NOT in nullsafe not

### DIFF
--- a/packages/malloy/src/lang/ast/expressions/utils.ts
+++ b/packages/malloy/src/lang/ast/expressions/utils.ts
@@ -85,7 +85,7 @@ export function compressExpr(expr: Expr): Expr {
 
 export function nullsafeNot(expr: Expr, op?: Equality): Expr {
   if (op === undefined || op === '!=' || op === '!~') {
-    return mkExpr`COALESCE(NOT(${expr}),FALSE)`;
+    return mkExpr`(NOT COALESCE(${expr},FALSE))`;
   }
   return expr;
 }


### PR DESCRIPTION
change `NOT X`

from `COALESCE(NOT X, FALSE)` to `NOT COALESCE(X, FALSE)`

Truth table should be ...

| X | NOT X |
| ---- | ---- |
| true | false |
| false | true |
| null | true |

- [ ] I don't there there was ever a set of tests for this, needs to be some.