### PR TITLE
feat: better pinned detection

### DIFF
--- a/packages/malloy-render/src/component/table/table.css
+++ b/packages/malloy-render/src/component/table/table.css
@@ -83,8 +83,8 @@
   padding-right: 0px;
 }
 
-/* If scrolled, show all gutter borders in pinned header */
-.malloy-table.scrolled .pinned-header {
+/* If pinned, show all gutter borders in pinned header */
+.malloy-table.pinned .pinned-header {
   .cell-content.hide-start-gutter,
   .cell-content.hide-end-gutter {
     margin-inline: 0px;
@@ -97,16 +97,16 @@
   pointer-events: all;
 }
 
-.malloy-table.scrolled .pinned-header .cell-content {
+.malloy-table.pinned .pinned-header .cell-content {
   border-top: var(--malloy-render--table-pinned-border);
 }
 
-.malloy-table.scrolled .pinned-header.th {
+.malloy-table.pinned .pinned-header.th {
   position: relative;
   background: var(--malloy-render--table-pinned-background);
 }
 
-.malloy-table.scrolled .pinned-header:after {
+.malloy-table.pinned .pinned-header:after {
   content: '';
   border-bottom: var(--malloy-render--table-pinned-border);
   width: 100%;

--- a/packages/malloy-render/src/component/table/table.tsx
+++ b/packages/malloy-render/src/component/table/table.tsx
@@ -9,6 +9,7 @@ import {
   Match,
   JSXElement,
   JSX,
+  onMount,
 } from 'solid-js';
 import {DataArray, DataRecord, Field} from '@malloydata/malloy';
 import {getRangeSize, isFirstChild, isLastChild} from '../util';
@@ -179,12 +180,6 @@ const MalloyTableRoot = (_props: {
   const tableCtx = useTableContext()!;
   const resultMetadata = useResultContext();
 
-  const [scrolling, setScrolling] = createSignal(false);
-  const handleScroll = (e: Event) => {
-    const target = e.target as HTMLElement;
-    setScrolling(target.scrollTop > 0);
-  };
-
   const pinnedFields = createMemo(() => {
     const fields = Object.entries(tableCtx.layout.fieldHeaderRangeMap)
       .sort((a, b) => {
@@ -259,18 +254,36 @@ const MalloyTableRoot = (_props: {
   const visibleFields = () =>
     props.data.field.allFields.filter(f => !isFieldHidden(f));
 
+  let pinnedDetector;
+  const [pinned, setPinned] = createSignal(false);
+  onMount(() => {
+    if (pinnedDetector) {
+      const observer = new IntersectionObserver(
+        ([e]) => {
+          setPinned(e.intersectionRatio < 1);
+        },
+        {threshold: [1]}
+      );
+      observer.observe(pinnedDetector);
+    }
+  });
+
   return (
     <div
       class="malloy-table"
       classList={{
         'root': tableCtx.root,
-        'scrolled': scrolling(),
+        'pinned': pinned(),
       }}
-      onScroll={handleScroll}
+      part={tableCtx.root ? 'table-container' : ''}
       style={getContainerStyle()}
     >
       {/* pinned header */}
       <Show when={tableCtx.root}>
+        <div
+          ref={pinnedDetector}
+          style="position: absolute; visibility: hidden;"
+        ></div>
         <div
           class="pinned-header-row"
           style={`grid-column: 1 / span ${tableCtx.layout.totalHeaderSize};`}


### PR DESCRIPTION
- uses an IntersectionObserver to detect pinning instead of a scroll event. This allows us to detect pinning even if the scrolling container is a parent of the table rather than the table container itself
- exports CSS part for the table container, so that you can override the scroll behavior

The above changes are needed to support embedding the renderer_next in VSCode output cells while enabling proper scrolling