### PR TITLE
feat: flip renderer tag

### DIFF
--- a/packages/malloy-render/src/html/html_view.ts
+++ b/packages/malloy-render/src/html/html_view.ts
@@ -38,7 +38,7 @@ export class HTMLView {
   constructor(private document: Document) {}
 
   async render(result: Result, options: RendererOptions): Promise<HTMLElement> {
-    const isNextRenderer = result.modelTag.has('renderer_next');
+    const isNextRenderer = !result.modelTag.has('renderer_legacy');
     if (isNextRenderer) {
       const hasNextRenderer =
         !!this.document.defaultView?.customElements.get('malloy-render');


### PR DESCRIPTION
Flips the renderer tags so now the official renderer is the new renderer, and the legacy one requires a model tag of `## renderer_legacy`