### PR TITLE
Passing a timeDiff to a function always returns zero

### DIFF
--- a/packages/malloy/src/model/utils.ts
+++ b/packages/malloy/src/model/utils.ts
@@ -200,8 +200,8 @@ export function exprMap(expr: Expr, func: (fragment: Fragment) => Expr): Expr {
                   value: exprMap(fragment.left.value, func),
                 },
                 right: {
-                  ...fragment.left,
-                  value: exprMap(fragment.left.value, func),
+                  ...fragment.right,
+                  value: exprMap(fragment.right.value, func),
                 },
               };
             default:
@@ -309,8 +309,8 @@ export function exprWalk(expr: Expr, func: (fragment: Fragment) => void): void {
                 value: exprWalk(fragment.left.value, func),
               },
               right: {
-                ...fragment.left,
-                value: exprWalk(fragment.left.value, func),
+                ...fragment.right,
+                value: exprWalk(fragment.right.value, func),
               },
             };
           default:

--- a/test/src/databases/all/time.spec.ts
+++ b/test/src/databases/all/time.spec.ts
@@ -93,12 +93,15 @@ describe.each(runtimes.runtimeList)('%s date and time', (dbName, runtime) => {
       ).isSqlEq();
     });
 
-    test('timeDiff passed to a function preserves rhs', async () => {
-      await expect(`
+    test.when(!brokenIn('snowflake', dbName))(
+      'timeDiff passed to a function preserves rhs',
+      async () => {
+        await expect(`
         run: ${dbName}.sql("SELECT 1")
         -> { select: yd is floor(days(@2001 to @2002)) }
       `).malloyResultMatches(runtime, {yd: 365});
-    });
+      }
+    );
 
     // MTOY TODO remove or implment
     // These all are complicated by civul time issues, skipping for now

--- a/test/src/databases/all/time.spec.ts
+++ b/test/src/databases/all/time.spec.ts
@@ -93,6 +93,13 @@ describe.each(runtimes.runtimeList)('%s date and time', (dbName, runtime) => {
       ).isSqlEq();
     });
 
+    test('timeDiff passed to a function preserves rhs', async () => {
+      await expect(`
+        run: ${dbName}.sql("SELECT 1")
+        -> { select: yd is floor(days(@2001 to @2002)) }
+      `).malloyResultMatches(runtime, {yd: 365});
+    });
+
     // MTOY TODO remove or implment
     // These all are complicated by civul time issues, skipping for now
     // test.skip('weeks', async () => {


### PR DESCRIPTION
```
days(@2001 to @2002) => 365
floor(days(@2001 to @2002)) => 0
```

... due to a bug in function expression walker where the the rhs of the diff is replaced with the lhs
