### PR TITLE
feat: row limit banner

### DIFF
--- a/packages/malloy-render/src/component/table/table.css
+++ b/packages/malloy-render/src/component/table/table.css
@@ -68,11 +68,11 @@
   line-height: var(--malloy-render--table-row-height);
   border-top: var(--malloy-render--table-border);
   font-style: italic;
-  padding-left: calc(
+  margin-left: calc(
     var(--malloy-render--table-gutter-size) *
       var(--table-gutter-left-multiplier)
   );
-  padding-right: calc(
+  margin-right: calc(
     var(--malloy-render--table-gutter-size) *
       var(--table-gutter-right-multiplier)
   );

--- a/packages/malloy-render/src/component/table/table.css
+++ b/packages/malloy-render/src/component/table/table.css
@@ -63,6 +63,21 @@
   grid-column: 1 / span var(--table-row-span);
 }
 
+.malloy-table .limit-row {
+  height: var(--malloy-render--table-row-height);
+  line-height: var(--malloy-render--table-row-height);
+  border-top: var(--malloy-render--table-border);
+  font-style: italic;
+  padding-left: calc(
+    var(--malloy-render--table-gutter-size) *
+      var(--table-gutter-left-multiplier)
+  );
+  padding-right: calc(
+    var(--malloy-render--table-gutter-size) *
+      var(--table-gutter-right-multiplier)
+  );
+}
+
 .malloy-table .th {
   transition: background-color 0.25s;
 }

--- a/packages/malloy-render/src/component/table/table.tsx
+++ b/packages/malloy-render/src/component/table/table.tsx
@@ -555,7 +555,7 @@ const MalloyTableRoot = (_props: {
           )}
         </For>
         <Show when={rowsAreLimited()}>
-          <div class="table-row limit-row">
+          <div class="table-row limit-row table-gutter-left table-gutter-right">
             Limiting nested table to {props.rowLimit} records
           </div>
         </Show>

--- a/packages/malloy-render/src/component/table/table.tsx
+++ b/packages/malloy-render/src/component/table/table.tsx
@@ -267,11 +267,15 @@ const MalloyTableRoot = (_props: {
   };
 
   // TODO: Get this from resultMetadata cache?
+  const [rowsAreLimited, setRowsAreLimited] = createSignal(false);
   const data = createMemo(() => {
     const data: DataRecord[] = [];
     let i = 0;
     for (const row of props.data) {
-      if (i >= props.rowLimit) break;
+      if (i >= props.rowLimit) {
+        setRowsAreLimited(true);
+        break;
+      }
       data.push(row);
       i++;
     }
@@ -550,6 +554,11 @@ const MalloyTableRoot = (_props: {
             </div>
           )}
         </For>
+        <Show when={rowsAreLimited()}>
+          <div class="table-row limit-row">
+            Limiting nested table to {props.rowLimit} records
+          </div>
+        </Show>
       </Show>
     </div>
   );


### PR DESCRIPTION
When limiting nested table rows, show a placeholder row at the bottom indicating that the data was limited