### PR TITLE
Move vite to dev dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3533,6 +3533,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "aix"
@@ -3611,6 +3612,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -7984,6 +7986,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -7996,6 +7999,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -8008,6 +8012,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -8020,6 +8025,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -8032,6 +8038,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -8044,6 +8051,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -8056,6 +8064,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -8068,6 +8077,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -8080,6 +8090,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -8092,6 +8103,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -8104,6 +8116,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -8116,6 +8129,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -8128,6 +8142,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -13324,6 +13339,7 @@
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
       "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
       "dependencies": {
         "@babel/parser": "^7.20.7",
         "@babel/types": "^7.20.7",
@@ -13334,6 +13350,7 @@
     },
     "node_modules/@types/babel__generator": {
       "version": "7.6.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.0.0"
@@ -13341,6 +13358,7 @@
     },
     "node_modules/@types/babel__template": {
       "version": "7.4.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.1.0",
@@ -14858,6 +14876,7 @@
       "version": "0.37.17",
       "resolved": "https://registry.npmjs.org/babel-plugin-jsx-dom-expressions/-/babel-plugin-jsx-dom-expressions-0.37.17.tgz",
       "integrity": "sha512-1bv8rOTzs6TR3DVyVZ7ElxyPEhnS556FMWRIsB3gBPfkn/cSKaLvXLGk+X1lvI+SzcUo4G+UcmJrn3vr1ig8mQ==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-module-imports": "7.18.6",
         "@babel/plugin-syntax-jsx": "^7.18.6",
@@ -14873,6 +14892,7 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz",
       "integrity": "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==",
+      "dev": true,
       "dependencies": {
         "@babel/types": "^7.18.6"
       },
@@ -14964,6 +14984,7 @@
       "version": "1.8.15",
       "resolved": "https://registry.npmjs.org/babel-preset-solid/-/babel-preset-solid-1.8.15.tgz",
       "integrity": "sha512-P2yOQbB7Hn/m4YvpXV6ExHIMcgNWXWXcvY4kJzG3yqAB3hKS58OZRsvJ7RObsZWqXRvZTITBIwnpK0BMGu+ZIQ==",
+      "dev": true,
       "dependencies": {
         "babel-plugin-jsx-dom-expressions": "^0.37.17"
       },
@@ -20184,7 +20205,8 @@
     "node_modules/html-entities": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.3.3.tgz",
-      "integrity": "sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA=="
+      "integrity": "sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA==",
+      "dev": true
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
@@ -21079,6 +21101,7 @@
       "version": "4.1.16",
       "resolved": "https://registry.npmjs.org/is-what/-/is-what-4.1.16.tgz",
       "integrity": "sha512-ZhMwEosbFJkA0YhFnNDgTM4ZxDRsS6HqTo7qsZM08fehyRYIYa0yHu5R6mgo1n/8MgaPBXiPimPD77baVFYg+A==",
+      "dev": true,
       "engines": {
         "node": ">=12.13"
       },
@@ -24237,6 +24260,7 @@
       "version": "5.1.7",
       "resolved": "https://registry.npmjs.org/merge-anything/-/merge-anything-5.1.7.tgz",
       "integrity": "sha512-eRtbOb1N5iyH0tkQDAoQ4Ipsp/5qSR79Dzrz8hEPxRX10RWWR/iQXdoKmBSRCThY1Fh5EhISDtpSc93fpxUniQ==",
+      "dev": true,
       "dependencies": {
         "is-what": "^4.1.8"
       },
@@ -28095,6 +28119,7 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/solid-refresh/-/solid-refresh-0.6.3.tgz",
       "integrity": "sha512-F3aPsX6hVw9ttm5LYlth8Q15x6MlI/J3Dn+o3EQyRTtTxidepSTwAYdozt01/YA+7ObcciagGEyXIopGZzQtbA==",
+      "dev": true,
       "dependencies": {
         "@babel/generator": "^7.23.6",
         "@babel/helper-module-imports": "^7.22.15",
@@ -29966,7 +29991,8 @@
     "node_modules/validate-html-nesting": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/validate-html-nesting/-/validate-html-nesting-1.2.2.tgz",
-      "integrity": "sha512-hGdgQozCsQJMyfK5urgFcWEqsSSrK63Awe0t/IMR0bZ0QMtnuaiHzThW81guu3qx9abLi99NEuiaN6P9gVYsNg=="
+      "integrity": "sha512-hGdgQozCsQJMyfK5urgFcWEqsSSrK63Awe0t/IMR0bZ0QMtnuaiHzThW81guu3qx9abLi99NEuiaN6P9gVYsNg==",
+      "dev": true
     },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
@@ -30420,6 +30446,7 @@
       "version": "5.1.7",
       "resolved": "https://registry.npmjs.org/vite/-/vite-5.1.7.tgz",
       "integrity": "sha512-sgnEEFTZYMui/sTlH1/XEnVNHMujOahPLGMxn1+5sIT45Xjng1Ec1K78jRP15dSmVgg5WBin9yO81j3o9OxofA==",
+      "dev": true,
       "dependencies": {
         "esbuild": "^0.19.3",
         "postcss": "^8.4.35",
@@ -30477,6 +30504,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -30492,6 +30520,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -30507,6 +30536,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -30522,6 +30552,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -30537,6 +30568,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -30552,6 +30584,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -30567,6 +30600,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -30582,6 +30616,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -30597,6 +30632,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -30612,6 +30648,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -30627,6 +30664,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -30642,6 +30680,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -30657,6 +30696,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -30672,6 +30712,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -30687,6 +30728,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -30702,6 +30744,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "netbsd"
@@ -30717,6 +30760,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "openbsd"
@@ -30732,6 +30776,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "sunos"
@@ -30747,6 +30792,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -30762,6 +30808,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -30777,6 +30824,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -30789,6 +30837,7 @@
       "version": "0.19.11",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.19.11.tgz",
       "integrity": "sha512-HJ96Hev2hX/6i5cDVwcqiJBBtuo9+FeIJOtZ9W1kA5M6AMJRHUZlpYZ1/SbEwtO0ioNAW8rUooVpC/WehY2SfA==",
+      "dev": true,
       "hasInstallScript": true,
       "bin": {
         "esbuild": "bin/esbuild"
@@ -30826,6 +30875,7 @@
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.9.5.tgz",
       "integrity": "sha512-E4vQW0H/mbNMw2yLSqJyjtkHY9dslf/p0zuT1xehNRqUTBOFMqEjguDvqhXr7N7r/4ttb2jr4T41d3dncmIgbQ==",
+      "dev": true,
       "dependencies": {
         "@types/estree": "1.0.5"
       },
@@ -30857,6 +30907,7 @@
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-0.2.5.tgz",
       "integrity": "sha512-SgHtMLoqaeeGnd2evZ849ZbACbnwQCIwRH57t18FxcXoZop0uQu0uzlIhJBlF/eWVzuce0sHeqPcDo+evVcg8Q==",
+      "dev": true,
       "peerDependencies": {
         "vite": "^3.0.0 || ^4.0.0 || ^5.0.0"
       },
@@ -31657,7 +31708,6 @@
       "dependencies": {
         "@malloydata/malloy": "^0.0.176",
         "@tanstack/solid-virtual": "^3.10.4",
-        "@types/luxon": "^2.4.0",
         "component-register": "^0.8.6",
         "lodash": "^4.17.20",
         "luxon": "^2.4.0",
@@ -31666,9 +31716,7 @@
         "ssf": "^0.11.2",
         "us-atlas": "^3.0.0",
         "vega": "^5.21.0",
-        "vega-lite": "^5.2.0",
-        "vite": "^5.1.5",
-        "vite-plugin-solid": "^2.10.1"
+        "vega-lite": "^5.2.0"
       },
       "devDependencies": {
         "@storybook/addon-essentials": "^7.5.0",
@@ -31681,7 +31729,9 @@
         "@storybook/types": "^7.5.3",
         "@types/luxon": "^2.4.0",
         "esbuild": "0.19.11",
-        "storybook": "^7.5.0"
+        "storybook": "^7.5.0",
+        "vite": "^5.1.5",
+        "vite-plugin-solid": "^2.10.1"
       },
       "engines": {
         "node": ">=18"
@@ -32125,6 +32175,7 @@
       "version": "2.10.1",
       "resolved": "https://registry.npmjs.org/vite-plugin-solid/-/vite-plugin-solid-2.10.1.tgz",
       "integrity": "sha512-kfVdNLWaJqaJVL52U6iCCKNW/nXE7bS1VVGOWPGllOkJfcNILymVSY0LCBLSnyy0iYnRtrXpiHm14rMuzeC7CA==",
+      "dev": true,
       "dependencies": {
         "@babel/core": "^7.23.3",
         "@types/babel__core": "^7.20.4",

--- a/packages/malloy-render/package.json
+++ b/packages/malloy-render/package.json
@@ -36,7 +36,6 @@
   "dependencies": {
     "@malloydata/malloy": "^0.0.176",
     "@tanstack/solid-virtual": "^3.10.4",
-    "@types/luxon": "^2.4.0",
     "component-register": "^0.8.6",
     "lodash": "^4.17.20",
     "luxon": "^2.4.0",
@@ -45,9 +44,7 @@
     "ssf": "^0.11.2",
     "us-atlas": "^3.0.0",
     "vega": "^5.21.0",
-    "vega-lite": "^5.2.0",
-    "vite": "^5.1.5",
-    "vite-plugin-solid": "^2.10.1"
+    "vega-lite": "^5.2.0"
   },
   "devDependencies": {
     "@storybook/addon-essentials": "^7.5.0",
@@ -60,6 +57,8 @@
     "@storybook/types": "^7.5.3",
     "@types/luxon": "^2.4.0",
     "esbuild": "0.19.11",
-    "storybook": "^7.5.0"
+    "storybook": "^7.5.0",
+    "vite": "^5.1.5",
+    "vite-plugin-solid": "^2.10.1"
   }
 }


### PR DESCRIPTION
Having it as a dependency results in a lot of unused dependencies when importing the package.