### PR TITLE
Possible framework for better errors with better documentation

### DIFF
--- a/packages/malloy/src/lang/log-message-data-types.ts
+++ b/packages/malloy/src/lang/log-message-data-types.ts
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ */
+
+import {FieldValueType} from '../model';
+
+export interface Generic {
+  code: 'generic';
+  message: string;
+}
+
+export interface InternalError {
+  code: 'internal-error';
+  message: string;
+}
+
+export interface PickWhenTypeMismatch {
+  code: 'pick-type-mismatch/when-does-not-match';
+  // TODO 'sql native' should be a `FieldValueType` like `{ kind: 'sql native', rawType: string}`
+  returnType: FieldValueType;
+  whenType: FieldValueType;
+}
+
+export interface PickElseTypeMismatch {
+  code: 'pick-type-mismatch/else-does-not-match';
+  elseType: FieldValueType;
+  returnType: FieldValueType;
+}
+
+export interface PickDefaultTypeMismatch {
+  code: 'pick-type-mismatch/default-does-not-match';
+  defaultType: FieldValueType;
+  returnType: FieldValueType;
+}
+
+export interface PickWhenNotBoolean {
+  code: 'pick-type-mismatch/when-not-boolean';
+  whenType: FieldValueType;
+}
+
+export type PickTypeMismatch =
+  | PickWhenTypeMismatch
+  | PickElseTypeMismatch
+  | PickDefaultTypeMismatch
+  | PickWhenNotBoolean;
+
+export interface PickMissingElse {
+  code: 'invalid-pick/missing-else';
+}
+
+export interface PickNoValue {
+  code: 'invalid-pick/no-value';
+}
+
+export interface PickPartial {
+  code: 'invalid-pick/illegal-partial';
+}
+
+export type InvalidPick = PickMissingElse | PickNoValue | PickPartial;
+
+export interface ExperimentalFeatureNotEnabled {
+  code: 'experimental/feature-not-enabled';
+  experimentId: string;
+}
+
+export interface ExperimentalDialectNotEnabled {
+  code: 'experimental/dialect-not-enabled';
+  dialectName: string;
+}
+
+export type ExperimentNotEnabled =
+  | ExperimentalFeatureNotEnabled
+  | ExperimentalDialectNotEnabled;
+
+export interface GlobalRedefinition {
+  code: 'global-redefinition';
+  name: string;
+}
+
+export type Any =
+  | Generic
+  | InternalError
+  | InvalidPick
+  | PickTypeMismatch
+  | ExperimentNotEnabled
+  | GlobalRedefinition;
+
+export function writeLogMessage(data: Any): string {
+  switch (data.code) {
+    case 'generic':
+      return data.message;
+    case 'internal-error':
+      return `INTERNAL ERROR IN TRANSLATION: ${data.message}`;
+    case 'pick-type-mismatch/when-does-not-match':
+      return `pick type \`${data.whenType}\`, expected \`${data.returnType}\``;
+    case 'pick-type-mismatch/when-not-boolean':
+      return `when expression must be boolean, bot \`${data.whenType}\``;
+    case 'pick-type-mismatch/else-does-not-match':
+      return `else type \`${data.elseType}\`, expected \`${data.returnType}\``;
+    case 'pick-type-mismatch/default-does-not-match':
+      return `pick default type \`${data.defaultType}\`, expected \`${data.returnType}\``;
+    case 'invalid-pick/missing-else':
+      return 'pick incomplete, missing `else`';
+    case 'invalid-pick/no-value':
+      return 'pick with no value can only be used with apply';
+    case 'invalid-pick/illegal-partial':
+      return 'pick with partial when can only be used with apply';
+    case 'experimental/feature-not-enabled':
+      return `Experimental flag '${data.experimentId}' is not set, feature not available`;
+    case 'experimental/dialect-not-enabled':
+      return `Requires compiler flag '##! experimental.dialect.${data.dialectName}'`;
+    case 'global-redefinition':
+      return `Cannot redefine '${data.name}', which is in global namespace`;
+  }
+  throw new Error(`Unknown log message code ${data}`);
+}

--- a/packages/malloy/src/lang/parse-log.ts
+++ b/packages/malloy/src/lang/parse-log.ts
@@ -22,6 +22,7 @@
  */
 
 import {DocumentLocation} from '../model/malloy_types';
+import {Any as LogMessageData} from './log-message-data-types';
 
 export type LogSeverity = 'error' | 'warn' | 'debug';
 
@@ -29,6 +30,7 @@ export type LogSeverity = 'error' | 'warn' | 'debug';
  * Default severity is "error"
  */
 export interface LogMessage {
+  data: LogMessageData;
   message: string;
   at?: DocumentLocation;
   severity: LogSeverity;

--- a/packages/malloy/src/lang/test/expressions.spec.ts
+++ b/packages/malloy/src/lang/test/expressions.spec.ts
@@ -921,7 +921,9 @@ describe('expressions', () => {
         source: na is a extend { dimension: d is
           pick 7 when true and true
         }
-      `).translationToFailWith("pick incomplete, missing 'else'");
+      `).translationToFailWith({
+        code: 'invalid-pick/missing-else',
+      });
     });
     test('n-ary with mismatch when clauses', () => {
       expect(markSource`


### PR DESCRIPTION
Very much a WIP at this stage

Basic idea is turn all error messages into objects with a `code` (e.g. `invalid-pick/missing-else`) and optionally some data.

Then, like with the previous work on this topic, that `code` is used in links to documentation.

Major difference is that _all_ errors would be required to have a code. This allows us to force documentation to be up-to-date by ensuring that all error types are listed.

Thoughts:
- This could also allow complicated errors to store multiple locations in them (e.g. "invalid [usage], defined [here]")
- 