### PR TITLE
feat: fallback to fromSQL date parsing

### DIFF
--- a/packages/malloy-render/package.json
+++ b/packages/malloy-render/package.json
@@ -25,7 +25,7 @@
     "build": "npm run build-types && npm run build-source && npm run build-webcomponent",
     "clean": "tsc --build --clean",
     "prepublishOnly": "npm run build",
-    "storybook": "storybook dev -p 6006",
+    "storybook": "rm -rf ./node_modules/.cache && storybook dev -p 6006",
     "build-storybook": "storybook build",
     "build-source": "vite build --outDir 'dist/module' --config vite.config.ts",
     "build-webcomponent": "vite build --outDir 'dist/webcomponent' --config vite.config.webcomponent.ts && vite build --outDir 'dist/register' --config vite.config.webcomponent-register.ts",

--- a/packages/malloy-render/src/component/apply-renderer.tsx
+++ b/packages/malloy-render/src/component/apply-renderer.tsx
@@ -53,96 +53,98 @@ export function applyRenderer(props: RendererProps) {
   const renderAs = shouldRenderAs(field, tag);
   let renderValue: JSXElement = '';
   const propsToPass = customProps[renderAs] || {};
-  switch (renderAs) {
-    case 'cell': {
-      const resultCellValue = dataColumn.value;
-      if (valueIsNumber(field, resultCellValue)) {
-        // TS doesn't support typeguards for multiple parameters, so unfortunately have to assert AtomicField here. https://github.com/microsoft/TypeScript/issues/26916
-        renderValue = renderNumericField(field as AtomicField, resultCellValue);
-      } else if (resultCellValue === null) {
-        renderValue = NULL_SYMBOL;
-      } else if (valueIsString(field, resultCellValue)) {
-        renderValue = resultCellValue;
-      } else if (
-        field.isAtomicField() &&
-        (field.isDate() || field.isTimestamp())
-      ) {
-        renderValue = renderTime(props);
-      } else {
-        // try to force to string
-        renderValue = String(resultCellValue);
+  if (dataColumn.isNull()) {
+    renderValue = NULL_SYMBOL;
+  } else {
+    switch (renderAs) {
+      case 'cell': {
+        const resultCellValue = dataColumn.value;
+        if (valueIsNumber(field, resultCellValue)) {
+          // TS doesn't support typeguards for multiple parameters, so unfortunately have to assert AtomicField here. https://github.com/microsoft/TypeScript/issues/26916
+          renderValue = renderNumericField(
+            field as AtomicField,
+            resultCellValue
+          );
+        } else if (valueIsString(field, resultCellValue)) {
+          renderValue = resultCellValue;
+        } else if (
+          field.isAtomicField() &&
+          (field.isDate() || field.isTimestamp())
+        ) {
+          renderValue = renderTime(props);
+        } else {
+          // try to force to string
+          renderValue = String(resultCellValue);
+        }
+        break;
       }
-      break;
-    }
-    case 'link': {
-      // renderAs will only return link for AtomicFields. TODO: add additional typeguard here?
-      renderValue = renderLink(field as AtomicField, dataColumn);
-      break;
-    }
-    case 'list': {
-      // TODO: typeguard here?
-      renderValue = renderList(props);
-      break;
-    }
-    case 'image': {
-      renderValue = renderImage(props);
-      break;
-    }
-    case 'chart': {
-      renderValue = (
-        <Chart
-          field={field as ExploreField}
-          data={resultMetadata.getData(dataColumn)}
-          metadata={resultMetadata}
-          {...propsToPass}
-        />
-      );
-      break;
-    }
-    case 'dashboard': {
-      if (dataColumn.isArray())
-        renderValue = <Dashboard data={dataColumn} {...propsToPass} />;
-      else if (dataColumn.isNull()) renderValue = NULL_SYMBOL;
-      else
-        throw new Error(
-          `Malloy render: wrong data type passed to the dashboard renderer for field ${dataColumn.field.name}`
-        );
-      break;
-    }
-    case 'line_chart':
-    case 'scatter_chart':
-    case 'shape_map':
-    case 'segment_map': {
-      if (dataColumn.isArray())
-        renderValue = <LegacyChart type={renderAs} data={dataColumn} />;
-      else if (dataColumn.isNull()) renderValue = NULL_SYMBOL;
-      else
-        throw new Error(
-          `Malloy render: wrong data type passed to the ${renderAs} renderer for field ${dataColumn.field.name}`
-        );
-      break;
-    }
-    case 'table': {
-      if (dataColumn.isArrayOrRecord())
+      case 'link': {
+        // renderAs will only return link for AtomicFields. TODO: add additional typeguard here?
+        renderValue = renderLink(field as AtomicField, dataColumn);
+        break;
+      }
+      case 'list': {
+        // TODO: typeguard here?
+        renderValue = renderList(props);
+        break;
+      }
+      case 'image': {
+        renderValue = renderImage(props);
+        break;
+      }
+      case 'chart': {
         renderValue = (
-          <MalloyTable
-            data={dataColumn as DataArrayOrRecord}
+          <Chart
+            field={field as ExploreField}
+            data={resultMetadata.getData(dataColumn)}
+            metadata={resultMetadata}
             {...propsToPass}
           />
         );
-      else if (dataColumn.isNull()) renderValue = NULL_SYMBOL;
-      else
-        throw new Error(
-          `Malloy render: wrong data type passed to the table renderer for field ${dataColumn.field.name}`
-        );
-      break;
-    }
-    default: {
-      try {
-        renderValue = String(dataColumn.value);
-      } catch (err) {
-        // eslint-disable-next-line no-console
-        console.warn('Couldnt get value for ', field, dataColumn);
+        break;
+      }
+      case 'dashboard': {
+        if (dataColumn.isArray())
+          renderValue = <Dashboard data={dataColumn} {...propsToPass} />;
+        else
+          throw new Error(
+            `Malloy render: wrong data type passed to the dashboard renderer for field ${dataColumn.field.name}`
+          );
+        break;
+      }
+      case 'line_chart':
+      case 'scatter_chart':
+      case 'shape_map':
+      case 'segment_map': {
+        if (dataColumn.isArray())
+          renderValue = <LegacyChart type={renderAs} data={dataColumn} />;
+        else
+          throw new Error(
+            `Malloy render: wrong data type passed to the ${renderAs} renderer for field ${dataColumn.field.name}`
+          );
+        break;
+      }
+      case 'table': {
+        if (dataColumn.isArrayOrRecord())
+          renderValue = (
+            <MalloyTable
+              data={dataColumn as DataArrayOrRecord}
+              {...propsToPass}
+            />
+          );
+        else
+          throw new Error(
+            `Malloy render: wrong data type passed to the table renderer for field ${dataColumn.field.name}`
+          );
+        break;
+      }
+      default: {
+        try {
+          renderValue = String(dataColumn.value);
+        } catch (err) {
+          // eslint-disable-next-line no-console
+          console.warn('Couldnt get value for ', field, dataColumn);
+        }
       }
     }
   }

--- a/packages/malloy/src/malloy.ts
+++ b/packages/malloy/src/malloy.ts
@@ -3532,7 +3532,10 @@ function valueToDate(value: Date): Date {
     // which represents the same instant in time, but we don't have the data
     // flow to implement that. This may be a problem at some future day,
     // so here is a comment, for that day.
-    const parsed = DateTime.fromISO(value, {zone: 'UTC'});
+    let parsed = DateTime.fromISO(value, {zone: 'UTC'});
+    if (!parsed.isValid) {
+      parsed = DateTime.fromSQL(value, {zone: 'UTC'});
+    }
     return parsed.toJSDate();
   }
 }


### PR DESCRIPTION
If fromISO date parsing fails, we can try falling back to fromSQL. This should properly parse systems like Presto

The `applyRenderer` file change has to do with handling null values, not specifically about fixing time issues although will prevent us from bombing out if a timestamp field has a null value in it. 