### PR TITLE
add timeframes to truncated dates

### DIFF
--- a/packages/malloy/src/lang/ast/query-items/field-declaration.ts
+++ b/packages/malloy/src/lang/ast/query-items/field-declaration.ts
@@ -136,10 +136,9 @@ export abstract class AtomicFieldDeclaration
       if (this.exprSrc) {
         template.code = this.exprSrc;
       }
-      // TODO this should work for dates too
       if (
-        (isGranularResult(exprValue) && template.type === 'timestamp') ||
-        template.type === 'date'
+        isGranularResult(exprValue) &&
+        (template.type === 'timestamp' || template.type === 'date')
       ) {
         template.timeframe = exprValue.timeframe;
       }

--- a/packages/malloy/src/lang/ast/query-items/field-declaration.ts
+++ b/packages/malloy/src/lang/ast/query-items/field-declaration.ts
@@ -137,7 +137,10 @@ export abstract class AtomicFieldDeclaration
         template.code = this.exprSrc;
       }
       // TODO this should work for dates too
-      if (isGranularResult(exprValue) && template.type === 'timestamp') {
+      if (
+        (isGranularResult(exprValue) && template.type === 'timestamp') ||
+        template.type === 'date'
+      ) {
         template.timeframe = exprValue.timeframe;
       }
       if (this.note) {

--- a/packages/malloy/src/lang/test/expressions.spec.ts
+++ b/packages/malloy/src/lang/test/expressions.spec.ts
@@ -29,6 +29,8 @@ import {
   BetaExpression,
   model,
   makeModelFunc,
+  getQueryField,
+  getQueryFieldDef,
 } from './test-translator';
 import './parse-expects';
 
@@ -80,25 +82,21 @@ describe('expressions', () => {
       ['second', 'minute', 'hour', 'day', 'week', 'month', 'quarter', 'year'],
     ];
     test.each(timeframes)('timestamp truncate %s', unit => {
-      const truncSrc = model`run: a->{select: ats.${unit}}`;
+      const truncSrc = model`run: a->{select: tts is ats.${unit}}`;
       expect(truncSrc).toTranslate();
       const tQuery = truncSrc.translator.getQuery(0);
       expect(tQuery).toBeDefined();
-      const tOp = tQuery!.pipeline[0] as QuerySegment;
-      expect(tOp.type).toEqual('project');
-      const tField = tOp.queryFields[0];
+      const tField = getQueryFieldDef(tQuery!.pipeline[0], 'tts');
       expect(tField['timeframe']).toEqual(unit);
     });
 
     const dateTF = [['week', 'month', 'quarter', 'year']];
     test.each(dateTF)('date truncate %s', unit => {
-      const truncSrc = model`run: a->{select: ad.${unit}}`;
+      const truncSrc = model`run: a->{select: td is ad.${unit}}`;
       expect(truncSrc).toTranslate();
       const tQuery = truncSrc.translator.getQuery(0);
       expect(tQuery).toBeDefined();
-      const tOp = tQuery!.pipeline[0] as QuerySegment;
-      expect(tOp.type).toEqual('project');
-      const tField = tOp.queryFields[0];
+      const tField = getQueryFieldDef(tQuery!.pipeline[0], 'td');
       expect(tField['timeframe']).toEqual(unit);
     });
 

--- a/packages/malloy/src/lang/test/expressions.spec.ts
+++ b/packages/malloy/src/lang/test/expressions.spec.ts
@@ -21,7 +21,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import {Expr, QuerySegment} from '../../model';
+import {Expr} from '../../model';
 import {
   expr,
   TestTranslator,
@@ -29,7 +29,6 @@ import {
   BetaExpression,
   model,
   makeModelFunc,
-  getQueryField,
   getQueryFieldDef,
 } from './test-translator';
 import './parse-expects';


### PR DESCRIPTION
```
      // TODO this should work for dates too
      if (isGranularResult(exprValue) && template.type === 'timestamp') {
```

Not my finest hour :)
