### PR TITLE
Add dialect namespace with dialect functions

### DIFF
--- a/packages/malloy/src/dialect/dialect.ts
+++ b/packages/malloy/src/dialect/dialect.ts
@@ -160,6 +160,10 @@ export abstract class Dialect {
     name: string
   ): DialectFunctionOverloadDef[] | undefined;
 
+  abstract getDialectFunctions(): {
+    [name: string]: DialectFunctionOverloadDef[];
+  };
+
   // return a quoted string for use as a table path.
   abstract quoteTablePath(tablePath: string): string;
 

--- a/packages/malloy/src/dialect/duckdb/duckdb.ts
+++ b/packages/malloy/src/dialect/duckdb/duckdb.ts
@@ -36,6 +36,7 @@ import {DialectFunctionOverloadDef} from '../functions';
 import {DUCKDB_FUNCTIONS} from './functions';
 import {DialectFieldList, inDays} from '../dialect';
 import {PostgresBase} from '../pg_impl';
+import {DUCKDB_DIALECT_FUNCTIONS} from './functions/dialect_functions';
 
 // need to refactor runSQL to take a SQLBlock instead of just a sql string.
 const hackSplitComment = '-- hack: split on this';
@@ -337,6 +338,10 @@ export class DuckDBDialect extends PostgresBase {
 
   getGlobalFunctionDef(name: string): DialectFunctionOverloadDef[] | undefined {
     return DUCKDB_FUNCTIONS.get(name);
+  }
+
+  getDialectFunctions(): {[name: string]: DialectFunctionOverloadDef[]} {
+    return DUCKDB_DIALECT_FUNCTIONS;
   }
 
   malloyTypeToSQLType(malloyType: FieldAtomicTypeDef): string {

--- a/packages/malloy/src/dialect/duckdb/functions/dialect_functions.ts
+++ b/packages/malloy/src/dialect/duckdb/functions/dialect_functions.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ */
+
+import {
+  DialectFunctionOverloadDef,
+  anyExprType,
+  arg,
+  minScalar,
+  overload,
+  param,
+  sql,
+} from '../../functions/util';
+
+export const DUCKDB_DIALECT_FUNCTIONS: {
+  [name: string]: DialectFunctionOverloadDef[];
+} = {
+  to_timestamp: [
+    overload(
+      minScalar('timestamp'),
+      [param('epoch_seconds', anyExprType('number'))],
+      sql`TO_TIMESTAMP(${arg('epoch_seconds')})`
+    ),
+  ],
+};

--- a/packages/malloy/src/dialect/postgres/functions/dialect_functions.ts
+++ b/packages/malloy/src/dialect/postgres/functions/dialect_functions.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ */
+
+import {DialectFunctionOverloadDef} from '../../functions/util';
+
+export const POSTGRES_DIALECT_FUNCTIONS: {
+  [name: string]: DialectFunctionOverloadDef[];
+} = {};

--- a/packages/malloy/src/dialect/postgres/postgres.ts
+++ b/packages/malloy/src/dialect/postgres/postgres.ts
@@ -36,6 +36,7 @@ import {POSTGRES_FUNCTIONS} from './functions';
 import {DialectFunctionOverloadDef} from '../functions';
 import {DialectFieldList, QueryInfo} from '../dialect';
 import {PostgresBase} from '../pg_impl';
+import {POSTGRES_DIALECT_FUNCTIONS} from './functions/dialect_functions';
 
 const pgMakeIntervalMap: Record<string, string> = {
   'year': 'years',
@@ -392,6 +393,10 @@ export class PostgresDialect extends PostgresBase {
 
   getGlobalFunctionDef(name: string): DialectFunctionOverloadDef[] | undefined {
     return POSTGRES_FUNCTIONS.get(name);
+  }
+
+  getDialectFunctions(): {[name: string]: DialectFunctionOverloadDef[]} {
+    return POSTGRES_DIALECT_FUNCTIONS;
   }
 
   malloyTypeToSQLType(malloyType: FieldAtomicTypeDef): string {

--- a/packages/malloy/src/dialect/snowflake/functions/dialect_functions.ts
+++ b/packages/malloy/src/dialect/snowflake/functions/dialect_functions.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ */
+
+import {DialectFunctionOverloadDef} from '../../functions/util';
+
+export const SNOWFLAKE_DIALECT_FUNCTIONS: {
+  [name: string]: DialectFunctionOverloadDef[];
+} = {};

--- a/packages/malloy/src/dialect/snowflake/snowflake.ts
+++ b/packages/malloy/src/dialect/snowflake/snowflake.ts
@@ -39,6 +39,7 @@ import {
 import {SNOWFLAKE_FUNCTIONS} from './functions';
 import {DialectFunctionOverloadDef} from '../functions';
 import {Dialect, DialectFieldList, QueryInfo, qtz} from '../dialect';
+import {SNOWFLAKE_DIALECT_FUNCTIONS} from './functions/dialect_functions';
 
 const extractionMap: Record<string, string> = {
   'day_of_week': 'dayofweek',
@@ -443,6 +444,10 @@ ${indent(sql)}
 
   getGlobalFunctionDef(name: string): DialectFunctionOverloadDef[] | undefined {
     return SNOWFLAKE_FUNCTIONS.get(name);
+  }
+
+  getDialectFunctions(): {[name: string]: DialectFunctionOverloadDef[]} {
+    return SNOWFLAKE_DIALECT_FUNCTIONS;
   }
 
   malloyTypeToSQLType(malloyType: FieldAtomicTypeDef): string {

--- a/packages/malloy/src/dialect/standardsql/functions/dialect_functions.ts
+++ b/packages/malloy/src/dialect/standardsql/functions/dialect_functions.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ */
+
+import {
+  DialectFunctionOverloadDef,
+  anyExprType,
+  arg,
+  minScalar,
+  overload,
+  param,
+  sql,
+} from '../../functions/util';
+
+export const STANDARDSQL_DIALECT_FUNCTIONS: {
+  [name: string]: DialectFunctionOverloadDef[];
+} = {
+  date_from_unix_date: [
+    overload(
+      minScalar('date'),
+      [param('unix_date', anyExprType('number'))],
+      sql`DATE_FROM_UNIX_DATE(${arg('unix_date')})`
+    ),
+  ],
+};

--- a/packages/malloy/src/dialect/standardsql/standardsql.ts
+++ b/packages/malloy/src/dialect/standardsql/standardsql.ts
@@ -39,6 +39,7 @@ import {
 import {STANDARDSQL_FUNCTIONS} from './functions';
 import {DialectFunctionOverloadDef} from '../functions';
 import {Dialect, DialectFieldList, QueryInfo} from '../dialect';
+import {STANDARDSQL_DIALECT_FUNCTIONS} from './functions/dialect_functions';
 
 // These are the units that "TIMESTAMP_ADD" "TIMESTAMP_DIFF" accept
 function timestampMeasureable(units: string): boolean {
@@ -519,6 +520,10 @@ ${indent(sql)}
 
   getGlobalFunctionDef(name: string): DialectFunctionOverloadDef[] | undefined {
     return STANDARDSQL_FUNCTIONS.get(name);
+  }
+
+  getDialectFunctions(): {[name: string]: DialectFunctionOverloadDef[]} {
+    return STANDARDSQL_DIALECT_FUNCTIONS;
   }
 
   malloyTypeToSQLType(malloyType: FieldAtomicTypeDef): string {

--- a/packages/malloy/src/dialect/trino/functions/dialect_functions.ts
+++ b/packages/malloy/src/dialect/trino/functions/dialect_functions.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ */
+
+import {
+  DialectFunctionOverloadDef,
+  anyExprType,
+  arg,
+  minScalar,
+  overload,
+  param,
+  sql,
+} from '../../functions/util';
+
+export const TRINO_DIALECT_FUNCTIONS: {
+  [name: string]: DialectFunctionOverloadDef[];
+} = {
+  from_unixtime: [
+    overload(
+      minScalar('timestamp'),
+      [param('unixtime', anyExprType('number'))],
+      sql`FROM_UNIXTIME(${arg('unixtime')})`
+    ),
+  ],
+};

--- a/packages/malloy/src/dialect/trino/trino.ts
+++ b/packages/malloy/src/dialect/trino/trino.ts
@@ -45,6 +45,7 @@ import {
   isDialectFieldStruct,
 } from '../dialect';
 import {PostgresBase, timeExtractMap} from '../pg_impl';
+import {TRINO_DIALECT_FUNCTIONS} from './functions/dialect_functions';
 
 // These are the units that "TIMESTAMP_ADD" "TIMESTAMP_DIFF" accept
 function timestampMeasureable(units: string): boolean {
@@ -500,6 +501,12 @@ ${indent(sql)}
   getGlobalFunctionDef(name: string): DialectFunctionOverloadDef[] | undefined {
     // TODO: implement
     return TRINO_FUNCTIONS.get(name);
+  }
+
+  getDialectFunctions(): {
+    [name: string]: DialectFunctionOverloadDef[];
+  } {
+    return TRINO_DIALECT_FUNCTIONS;
   }
 
   malloyTypeToSQLType(malloyType: FieldAtomicTypeDef): string {

--- a/packages/malloy/src/lang/ast/expressions/expr-func.ts
+++ b/packages/malloy/src/lang/ast/expressions/expr-func.ts
@@ -81,6 +81,36 @@ export class ExprFunc extends ExpressionDef {
     return this.getPropsExpression(fs);
   }
 
+  private findFunctionDef(
+    dialect: string | undefined
+  ):
+    | {found: FunctionDef; error: undefined}
+    | {found: undefined; error: string} {
+    // TODO this makes functions case-insensitive. This is weird that this is the only place
+    // where case insensitivity is thing.
+    const normalizedName = this.name.toLowerCase();
+    const dialectFunc = dialect
+      ? this.getDialectNamespace(dialect)?.getEntry(normalizedName)?.entry
+      : undefined;
+    const func = dialectFunc ?? this.modelEntry(normalizedName)?.entry;
+    if (func === undefined) {
+      this.log(
+        `Unknown function '${this.name}'. Use '${this.name}!(...)' to call a SQL function directly.`
+      );
+      return {found: undefined, error: 'unknown function'};
+    } else if (func.type !== 'function') {
+      this.log(`Cannot call '${this.name}', which is of type ${func.type}`);
+      return {found: undefined, error: 'called non function'};
+    }
+    if (func.name !== this.name) {
+      this.log(
+        `Case insensitivity for function names is deprecated, use '${func.name}' instead`,
+        'warn'
+      );
+    }
+    return {found: func, error: undefined};
+  }
+
   getPropsExpression(
     fs: FieldSpace,
     props?: {
@@ -116,24 +146,10 @@ export class ExprFunc extends ExpressionDef {
         ),
       };
     }
-
-    // TODO this makes functions case-insensitive. This is weird that this is the only place
-    // where case insensitivity is thing.
-    const func = this.modelEntry(this.name.toLowerCase())?.entry;
+    const dialect = fs.dialectObj()?.name;
+    const {found: func, error} = this.findFunctionDef(dialect);
     if (func === undefined) {
-      this.log(
-        `Unknown function '${this.name}'. Use '${this.name}!(...)' to call a SQL function directly.`
-      );
-      return errorFor('unknown function');
-    } else if (func.type !== 'function') {
-      this.log(`Cannot call '${this.name}', which is of type ${func.type}`);
-      return errorFor('called non function');
-    }
-    if (func.name !== this.name) {
-      this.log(
-        `Case insensitivity for function names is deprecated, use '${func.name}' instead`,
-        'warn'
-      );
+      return errorFor(error);
     }
     // Find the 'implicit argument' for aggregate functions called like `some_join.some_field.agg(...args)`
     // where the full arg list is `(some_field, ...args)`.
@@ -244,7 +260,6 @@ export class ExprFunc extends ExpressionDef {
       structPath,
     };
     let funcCall: Expr = frag;
-    const dialect = fs.dialectObj()?.name;
     const dialectOverload = dialect ? overload.dialect[dialect] : undefined;
     // TODO add in an error if you use an asymmetric function in BQ
     // and the function uses joins

--- a/packages/malloy/src/lang/ast/types/dialect-name-space.ts
+++ b/packages/malloy/src/lang/ast/types/dialect-name-space.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ */
+
+import {Dialect} from '../../../dialect';
+import {FunctionDef} from '../../../model';
+import {ModelEntry} from './model-entry';
+import {NameSpace} from './name-space';
+
+/**
+ * This is the dialect namespace, which sits below the global namespace.
+ */
+export class DialectNameSpace implements NameSpace {
+  private entries: Map<string, FunctionDef> = new Map();
+  constructor(dialect: Dialect) {
+    const dialectFunctions = dialect.getDialectFunctions();
+    for (const name in dialectFunctions) {
+      const overloads = dialectFunctions[name];
+      this.entries.set(name, {
+        type: 'function',
+        name,
+        overloads: overloads.map(overload => {
+          return {
+            returnType: overload.returnType,
+            params: overload.params,
+            dialect: {
+              [dialect.name]: {
+                e: overload.e,
+                supportsOrderBy: overload.supportsOrderBy,
+                defaultOrderByArgIndex: overload.defaultOrderByArgIndex,
+                supportsLimit: overload.supportsLimit,
+              },
+            },
+            needsWindowOrderBy: overload.needsWindowOrderBy,
+            between: overload.between,
+            isSymmetric: overload.isSymmetric,
+          };
+        }),
+      });
+    }
+  }
+  getEntry(name: string): ModelEntry | undefined {
+    const func = this.entries.get(name);
+    if (func === undefined) {
+      return undefined;
+    }
+    return {
+      entry: func,
+      exported: false,
+    };
+  }
+
+  setEntry(_name: string, _value: ModelEntry, _exported: boolean): void {
+    throw new Error('The dialect namespace is immutable!');
+  }
+}

--- a/packages/malloy/src/lang/ast/types/malloy-element.ts
+++ b/packages/malloy/src/lang/ast/types/malloy-element.ts
@@ -38,6 +38,7 @@ import {Tag} from '../../../tags';
 import {LogSeverity, MessageLogger} from '../../parse-log';
 import {MalloyTranslation} from '../../parse-malloy';
 import {ModelDataRequest} from '../../translate-response';
+import {DialectNameSpace} from './dialect-name-space';
 import {DocumentCompileResult} from './document-compile-result';
 import {GlobalNameSpace} from './global-name-space';
 import {ModelEntry} from './model-entry';
@@ -119,6 +120,10 @@ export abstract class MalloyElement {
       return this.parent.namespace();
     }
     throw new Error('INTERNAL ERROR: Translation without document scope');
+  }
+
+  getDialectNamespace(dialectName: string): NameSpace | undefined {
+    return this.document()?.getDialectNamespace(dialectName);
   }
 
   modelEntry(reference: string | ModelEntryReference): ModelEntry | undefined {
@@ -642,5 +647,16 @@ export class Document extends MalloyElement implements NameSpace {
         'error'
       );
     }
+  }
+
+  private readonly dialectNameSpaces = new Map<string, NameSpace>();
+  getDialectNamespace(dialectName: string): NameSpace | undefined {
+    if (this.dialectNameSpaces.has(dialectName)) {
+      return this.dialectNameSpaces.get(dialectName);
+    }
+    const dialect = getDialect(dialectName);
+    const ns = new DialectNameSpace(dialect);
+    this.dialectNameSpaces.set(dialectName, ns);
+    return ns;
   }
 }

--- a/packages/malloy/src/lang/test/query.spec.ts
+++ b/packages/malloy/src/lang/test/query.spec.ts
@@ -747,6 +747,18 @@ describe('query:', () => {
         calculate: a is lag(big_i)
       }`).toTranslate();
     });
+    describe('dialect functions', () => {
+      test('can use function enabled in this dialect (standardsql)', () => {
+        expect(`run: a -> {
+          group_by: d is date_from_unix_date(1000)
+        }`).toTranslate();
+      });
+      test('cannot use function enabled in a different dialect (duckdb)', () => {
+        expect(`run: a -> {
+          group_by: ts is to_timestamp(1000)
+        }`).translationToFailWith(/Unknown function/);
+      });
+    });
   });
 
   describe('qops', () => {

--- a/test/src/databases/all/functions.spec.ts
+++ b/test/src/databases/all/functions.spec.ts
@@ -1245,6 +1245,25 @@ expressionModels.forEach((x, databaseName) => {
       }
     });
   });
+
+  describe('dialect functions', () => {
+    describe('duckdb', () => {
+      const duckdb = it.when(databaseName === 'duckdb');
+      duckdb('to_timestamp', async () => {
+        await funcTest('to_timestamp(1725555835) = @2024-09-05 17:03:55', true);
+      });
+    });
+
+    describe('trino', () => {
+      const trino = it.when(databaseName === 'trino');
+      trino('from_unixtime', async () => {
+        await funcTest(
+          'from_unixtime(1725555835) = @2024-09-05 17:03:55',
+          true
+        );
+      });
+    });
+  });
 });
 
 describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {


### PR DESCRIPTION
This adds a new namespace underneath the global namespace, which dynamically contains function definitions specific to the current dialect.

This PR does not add very many function definition, just sets the groundwork for it.

There are no name conflicts between the "global" namespace (where Malloy standard functions live) and this dialect namespace. If there were, you would always get the global version, since they are always stacked and there is no way to explicitly access one namespace or another. The intent is that in the future, you can explicitly reference `dialect.function_name` to access the conflicting version — e.g. `dialect.starts_with(x, "prefix")` would give you three-state boolean null behavior rather than the "Malloy standard" two-state boolean null behavior.