### PR TITLE
Joined filtered Sources

### DIFF
--- a/packages/malloy/src/dialect/postgres/postgres.ts
+++ b/packages/malloy/src/dialect/postgres/postgres.ts
@@ -103,6 +103,7 @@ export class PostgresDialect extends PostgresBase {
   supportsNesting = true;
   experimental = false;
   readsNestedData = false;
+  supportsComplexFilteredSources = false;
 
   quoteTablePath(tablePath: string): string {
     return tablePath

--- a/packages/malloy/src/dialect/snowflake/snowflake.ts
+++ b/packages/malloy/src/dialect/snowflake/snowflake.ts
@@ -110,6 +110,7 @@ export class SnowflakeDialect extends Dialect {
   dontUnionIndex = false;
   supportsQualify = false;
   supportsPipelinesInViews = false;
+  supportsComplexFilteredSources = false;
 
   // don't mess with the table pathing.
   quoteTablePath(tablePath: string): string {


### PR DESCRIPTION
In Presto,   the code below would fail because we complicate joining of sources with where clauses always using the the more complex path to avoid SQL errors.

We now just use the simple path for Presto but we probably need to add better error checking or another strategy.  See the notes in the code.  

This is a blocker so I'm going to land and revisit.

```
     source: sf is ${databaseName}.table('malloytest.state_facts') extend {
        measure: state_count is count()
        primary_key: state
      }

      source: al is sf extend {where: state = 'AL'}

      source: a is sf extend {
        where: state ~ 'A%'
        join_one: al with state
      }

      source: allx is sf extend {
        join_one: a with state
      }
      // # test.debug
      run: allx -> {
        aggregate:
          allx is state_count
          a is a.state_count
          al is a.al.state_count
```