### PR TITLE
Add config file for DCO App

### DIFF
--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,0 +1,6 @@
+allowRemediationCommits:
+  individual: true
+  thirdParty: true
+
+require:
+  members: false


### PR DESCRIPTION
Adds a configuration file that controls the behavior of the [DCO app](https://github.com/apps/dco).

Once this PR is merged, I am going to install the DCO app linked above, which will enforce non-org members to add a DCO sign-off message to their commits, which attests that they have read and agree to the [Developer Certificate of Origin](https://developercertificate.org/).

Doing so is easy, they simply need to add a `-s` flag to their commit message; e.g.,:

```
git commit -s -m 'This is my commit message'
```