### PR TITLE
Make streaming test deterministic

### DIFF
--- a/test/src/databases/streaming/streaming.spec.ts
+++ b/test/src/databases/streaming/streaming.spec.ts
@@ -43,8 +43,7 @@ class StringAccumulator implements WriteStream {
 }
 
 const [describe, databases] = describeIfDatabaseAvailable([
-  // FIXME
-  // 'bigquery',
+  'bigquery',
   'postgres',
   'duckdb',
   'duckdb_wasm',
@@ -66,14 +65,14 @@ describe('Streaming tests', () => {
         .loadModel(
           `source: airports is ${databaseName}.table('malloytest.airports')`
         )
-        .loadQuery('run: airports -> { select: code }')
+        .loadQuery('run: airports -> { select: code; order_by: code }')
         .runStream({rowLimit: 10});
       const rows: DataRecord[] = [];
       for await (const row of stream) {
         rows.push(row);
       }
       expect(rows.length).toBe(10);
-      expect(rows[0].cell('code').string.value).toBe('1Q9');
+      expect(rows[0].cell('code').string.value).toBe('00A');
     });
 
     it(`stream to JSON - ${databaseName}`, async () => {
@@ -81,7 +80,7 @@ describe('Streaming tests', () => {
         .loadModel(
           `source: airports is ${databaseName}.table('malloytest.airports')`
         )
-        .loadQuery('run: airports -> { select: code }')
+        .loadQuery('run: airports -> { select: code; order_by: code }')
         .runStream({rowLimit: 1});
       const accummulator = new StringAccumulator();
       const jsonWriter = new JSONWriter(accummulator);
@@ -89,7 +88,7 @@ describe('Streaming tests', () => {
       expect(accummulator.accumulatedValue).toBe(
         `[
   {
-    "code": "1Q9"
+    "code": "00A"
   }
 ]
 `
@@ -101,12 +100,12 @@ describe('Streaming tests', () => {
         .loadModel(
           `source: airports is ${databaseName}.table('malloytest.airports')`
         )
-        .loadQuery('run: airports -> { select: code }')
+        .loadQuery('run: airports -> { select: code; order_by: code }')
         .runStream({rowLimit: 1});
       const accummulator = new StringAccumulator();
       const csvWriter = new CSVWriter(accummulator);
       await csvWriter.process(stream);
-      expect(accummulator.accumulatedValue).toBe('code\n1Q9\n');
+      expect(accummulator.accumulatedValue).toBe('code\n00A\n');
     });
   });
 });


### PR DESCRIPTION
Tests were relying on natural table order which changed when I cloned the table into our new test db.