### PR TITLE
Revert "Fix issue where nested fields of the same field overwrite their tag"

### DIFF
--- a/packages/malloy/src/model/malloy_query.ts
+++ b/packages/malloy/src/model/malloy_query.ts
@@ -4505,12 +4505,12 @@ class QueryStruct extends QueryNode {
     refAnnoatation: Annotation | undefined
   ): QuerySomething {
     const field = this.getQueryFieldByName(name);
-    if (refAnnoatation !== undefined) {
+    if (refAnnoatation) {
       // Made the field object from the source, but the annotations were computed by the compiler
       // and have noth the source and reference annotations included, use those.
       const newDef = {...field.fieldDef};
       newDef.annotation = refAnnoatation;
-      return this.makeQueryField(newDef);
+      field.fieldDef = newDef;
     }
     return field;
   }

--- a/test/src/databases/all/expr.spec.ts
+++ b/test/src/databases/all/expr.spec.ts
@@ -81,6 +81,17 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
     });
   });
 
+  it('bug with wrong join being used with annotation', async () => {
+    await expect(`
+      run: aircraft -> {
+        # foo
+        group_by: aircraft_models.seats
+      }
+    `).malloyResultMatches(expressionModel, {
+      seats: 0,
+    });
+  });
+
   // Floor was broken (wouldn't compile because the expression returned isn't an aggregate.)
   it('Floor() -or any function bustage with aggregates', async () => {
     await expect(`

--- a/test/src/tags.spec.ts
+++ b/test/src/tags.spec.ts
@@ -522,29 +522,4 @@ describe('tags in results', () => {
     expect(plotTag!.numeric('x')).toEqual(2);
     expect(x).toEqual(2);
   });
-  test('nested fields of same field do not share tags', async () => {
-    const loaded = runtime.loadQuery(`
-      source: one is duckdb.sql("SELECT 1 as one")
-      run: one -> {
-        nest: a is {
-          # a
-          group_by: one
-        }
-        nest: b is {
-          # b
-          group_by: one
-        }
-      }
-    `);
-    const result = await loaded.run();
-    const shape = result.resultExplore;
-    const a = shape.getFieldByName('a');
-    expect(a.isExploreField()).toBe(true);
-    if (a.isExploreField()) {
-      const one = a.getFieldByName('one');
-      expect(one.tagParse().tag).tagsAre({
-        a: {},
-      });
-    }
-  });
 });

--- a/test/src/tags.spec.ts
+++ b/test/src/tags.spec.ts
@@ -522,4 +522,29 @@ describe('tags in results', () => {
     expect(plotTag!.numeric('x')).toEqual(2);
     expect(x).toEqual(2);
   });
+  test.skip('nested fields of same field do not share tags', async () => {
+    const loaded = runtime.loadQuery(`
+      source: one is duckdb.sql("SELECT 1 as one")
+      run: one -> {
+        nest: a is {
+          # a
+          group_by: one
+        }
+        nest: b is {
+          # b
+          group_by: one
+        }
+      }
+    `);
+    const result = await loaded.run();
+    const shape = result.resultExplore;
+    const a = shape.getFieldByName('a');
+    expect(a.isExploreField()).toBe(true);
+    if (a.isExploreField()) {
+      const one = a.getFieldByName('one');
+      expect(one.tagParse().tag).tagsAre({
+        a: {},
+      });
+    }
+  });
 });


### PR DESCRIPTION
Reverts malloydata/malloy#1912

This approach does not work with joined fields

```
it('bug with wrong join being used with annotation', async () => {
    await expect(`
      run: aircraft -> {
        # foo
        group_by: aircraft_models.seats
      }
    `).malloyResultMatches(expressionModel, {
      seats: 0,
    });
  });
```