### PR TITLE
Move `replaceMaterializedReferences` outside of `PreparedQuery`

### DIFF
--- a/packages/malloy/src/malloy.ts
+++ b/packages/malloy/src/malloy.ts
@@ -102,9 +102,9 @@ export interface CompileOptions {
   noThrowOnError?: boolean;
 }
 
-type PrepareQueryOptions = {
+interface PrepareResultOptions {
   replaceMaterializedReferences?: boolean;
-};
+}
 
 export class Malloy {
   // TODO load from file built during release
@@ -223,12 +223,14 @@ export class Malloy {
     model,
     refreshSchemaCache,
     noThrowOnError,
+    replaceMaterializedReferences,
   }: {
     urlReader: URLReader;
     connections: LookupConnection<InfoConnection>;
     parse: Parse;
     model?: Model;
-  } & CompileOptions): Promise<Model> {
+  } & CompileOptions &
+    PrepareResultOptions): Promise<Model> {
     let refreshTimestamp: number | undefined;
     if (refreshSchemaCache) {
       refreshTimestamp =
@@ -350,7 +352,8 @@ export class Malloy {
             const conn = await connections.lookupConnection(connectionName);
             const expanded = Malloy.compileSQLBlock(
               result.partialModel,
-              toCompile
+              toCompile,
+              {replaceMaterializedReferences}
             );
             const resolved = await conn.fetchSchemaForSQLBlock(expanded, {
               refreshTimestamp,
@@ -380,7 +383,8 @@ export class Malloy {
 
   static compileSQLBlock(
     partialModel: ModelDef | undefined,
-    toCompile: SQLBlockSource
+    toCompile: SQLBlockSource,
+    options?: {replaceMaterializedReferences?: boolean}
   ): SQLBlock {
     let queryModel: QueryModel | undefined = undefined;
     let selectStr = '';
@@ -399,7 +403,11 @@ export class Malloy {
           }
           queryModel = new QueryModel(partialModel);
         }
-        const compiledSql = queryModel.compileQuery(segment, false).sql;
+        const compiledSql = queryModel.compileQuery(
+          segment,
+          false,
+          options?.replaceMaterializedReferences
+        ).sql;
         selectStr += parenAlready ? compiledSql : `(${compiledSql})`;
         parenAlready = false;
       }
@@ -726,19 +734,10 @@ export class Model implements Taggable {
    * @param queryName Name of the query to retrieve.
    * @return A prepared query.
    */
-  public getPreparedQueryByName(
-    queryName: string,
-    options?: PrepareQueryOptions
-  ): PreparedQuery {
+  public getPreparedQueryByName(queryName: string): PreparedQuery {
     const query = this.modelDef.contents[queryName];
     if (query?.type === 'query') {
-      return new PreparedQuery(
-        query,
-        this.modelDef,
-        this.problems,
-        options?.replaceMaterializedReferences ?? false,
-        queryName
-      );
+      return new PreparedQuery(query, this.modelDef, this.problems, queryName);
     }
 
     throw new Error('Given query name does not refer to a named query.');
@@ -750,10 +749,7 @@ export class Model implements Taggable {
    * @param index The index of the query to retrieve.
    * @return A prepared query.
    */
-  public getPreparedQueryByIndex(
-    index: number,
-    options?: PrepareQueryOptions
-  ): PreparedQuery {
+  public getPreparedQueryByIndex(index: number): PreparedQuery {
     if (index < 0) {
       throw new Error(`Invalid index ${index}.`);
     } else if (index >= this.queryList.length) {
@@ -762,8 +758,7 @@ export class Model implements Taggable {
     return new PreparedQuery(
       this.queryList[index],
       this.modelDef,
-      this.problems,
-      options?.replaceMaterializedReferences ?? false
+      this.problems
     );
   }
 
@@ -803,7 +798,7 @@ export class Model implements Taggable {
    * @return A prepared query.
    */
   public get preparedQuery(): PreparedQuery {
-    return this.getPreparedQuery({});
+    return this.getPreparedQuery();
   }
 
   /**
@@ -811,15 +806,14 @@ export class Model implements Taggable {
    *
    * @return A prepared query.
    */
-  public getPreparedQuery(options?: PrepareQueryOptions): PreparedQuery {
+  public getPreparedQuery(): PreparedQuery {
     if (this.queryList.length === 0) {
       throw new Error('Model has no queries.');
     }
     return new PreparedQuery(
       this.queryList[this.queryList.length - 1],
       this.modelDef,
-      this.problems,
-      options?.replaceMaterializedReferences ?? false
+      this.problems
     );
   }
 
@@ -885,7 +879,6 @@ export class PreparedQuery implements Taggable {
     query: InternalQuery,
     model: ModelDef,
     public problems: LogMessage[],
-    public replaceMaterializedReferences: boolean,
     public name?: string
   ) {
     this._query = query;
@@ -908,11 +901,15 @@ export class PreparedQuery implements Taggable {
    * @return A fully-prepared query (which contains the generated SQL).
    */
   public get preparedResult(): PreparedResult {
+    return this.getPreparedResult();
+  }
+
+  public getPreparedResult(options?: PrepareResultOptions): PreparedResult {
     const queryModel = new QueryModel(this._modelDef);
     const translatedQuery = queryModel.compileQuery(
       this._query,
       false,
-      this.replaceMaterializedReferences
+      options?.replaceMaterializedReferences ?? false
     );
     return new PreparedResult(
       {
@@ -1536,10 +1533,7 @@ export class Explore extends Entity implements Taggable {
     return this.structDef.as || this.structDef.name;
   }
 
-  public getQueryByName(
-    name: string,
-    options?: PrepareQueryOptions
-  ): PreparedQuery {
+  public getQueryByName(name: string): PreparedQuery {
     const internalQuery: InternalQuery = {
       type: 'query',
       structRef: this.structDef,
@@ -1550,13 +1544,7 @@ export class Explore extends Entity implements Taggable {
         },
       ],
     };
-    return new PreparedQuery(
-      internalQuery,
-      this.modelDef,
-      [],
-      options?.replaceMaterializedReferences ?? false,
-      name
-    );
+    return new PreparedQuery(internalQuery, this.modelDef, [], name);
   }
 
   private get modelDef(): ModelDef {
@@ -2258,7 +2246,7 @@ export class Runtime {
    */
   public loadModel(
     source: ModelURL | ModelString,
-    options?: ParseOptions & CompileOptions
+    options?: ParseOptions & CompileOptions & PrepareResultOptions
   ): ModelMaterializer {
     const {refreshSchemaCache, noThrowOnError} = options || {};
     if (this.isTestRuntime) {
@@ -2268,36 +2256,48 @@ export class Runtime {
         options = {...options, testEnvironment: true};
       }
     }
-    return new ModelMaterializer(this, async () => {
-      const parse =
-        source instanceof URL
-          ? await Malloy.parse({
-              url: source,
-              urlReader: this.urlReader,
-              options,
-            })
-          : Malloy.parse({
-              source,
-              options,
-            });
-      return Malloy.compile({
-        urlReader: this.urlReader,
-        connections: this.connections,
-        parse,
-        refreshSchemaCache,
-        noThrowOnError,
-      });
-    });
+    return new ModelMaterializer(
+      this,
+      async () => {
+        const parse =
+          source instanceof URL
+            ? await Malloy.parse({
+                url: source,
+                urlReader: this.urlReader,
+                options,
+              })
+            : Malloy.parse({
+                source,
+                options,
+              });
+        return Malloy.compile({
+          urlReader: this.urlReader,
+          connections: this.connections,
+          parse,
+          refreshSchemaCache,
+          noThrowOnError,
+          replaceMaterializedReferences: options?.replaceMaterializedReferences,
+        });
+      },
+      options
+    );
   }
 
   // TODO Consider formalizing this. Perhaps as a `withModel` method,
   //      as well as a `Model.fromModelDefinition` if we choose to expose
   //      `ModelDef` to the world formally. For now, this should only
   //      be used in tests.
-  public _loadModelFromModelDef(modelDef: ModelDef): ModelMaterializer {
-    return new ModelMaterializer(this, async () => {
-      return new Model(modelDef, [], [], [], []);
-    });
+  public _loadModelFromModelDef(
+    modelDef: ModelDef,
+    options?: PrepareResultOptions
+  ): ModelMaterializer {
+    return new ModelMaterializer(
+      this,
+      async () => {
+        return new Model(modelDef, [], [], [], []);
+      },
+      options
+    );
   }
 
   /**
@@ -2309,9 +2309,9 @@ export class Runtime {
    */
   public loadQuery(
     query: QueryURL | QueryString,
-    options?: ParseOptions & CompileOptions & PrepareQueryOptions
+    options?: ParseOptions & CompileOptions & PrepareResultOptions
   ): QueryMaterializer {
-    return this.loadModel(query, options).loadFinalQuery(options);
+    return this.loadModel(query, options).loadFinalQuery();
   }
 
   /**
@@ -2326,9 +2326,9 @@ export class Runtime {
   public loadQueryByIndex(
     model: ModelURL | ModelString,
     index: number,
-    options?: ParseOptions & CompileOptions
+    options?: ParseOptions & CompileOptions & PrepareResultOptions
   ): QueryMaterializer {
-    return this.loadModel(model, options).loadQueryByIndex(index);
+    return this.loadModel(model, options).loadQueryByIndex(index, options);
   }
 
   /**
@@ -2343,9 +2343,9 @@ export class Runtime {
   public loadQueryByName(
     model: ModelURL | ModelString,
     name: string,
-    options?: ParseOptions & CompileOptions
+    options?: ParseOptions & CompileOptions & PrepareResultOptions
   ): QueryMaterializer {
-    return this.loadModel(model, options).loadQueryByName(name);
+    return this.loadModel(model, options).loadQueryByName(name, options);
   }
 
   /**
@@ -2360,7 +2360,7 @@ export class Runtime {
   public loadSQLBlockByName(
     model: ModelURL | ModelString,
     name: string,
-    options?: ParseOptions & CompileOptions
+    options?: ParseOptions & CompileOptions & PrepareResultOptions
   ): SQLBlockMaterializer {
     return this.loadModel(model, options).loadSQLBlockByName(name);
   }
@@ -2563,15 +2563,17 @@ class FluentState<T> {
   }
 
   protected makeQueryMaterializer(
-    materialize: () => Promise<PreparedQuery>
+    materialize: () => Promise<PreparedQuery>,
+    options?: PrepareResultOptions
   ): QueryMaterializer {
-    return new QueryMaterializer(this.runtime, materialize);
+    return new QueryMaterializer(this.runtime, materialize, options);
   }
 
   protected makeExploreMaterializer(
-    materialize: () => Promise<Explore>
+    materialize: () => Promise<Explore>,
+    options?: PrepareResultOptions
   ): ExploreMaterializer {
-    return new ExploreMaterializer(this.runtime, materialize);
+    return new ExploreMaterializer(this.runtime, materialize, options);
   }
 
   protected makePreparedResultMaterializer(
@@ -2593,16 +2595,33 @@ class FluentState<T> {
  * queries or explores (via e.g. `loadFinalQuery()`, `loadQuery`, `loadExploreByName`, etc.).
  */
 export class ModelMaterializer extends FluentState<Model> {
+  private readonly replaceMaterializedReferences: boolean;
+  constructor(
+    protected runtime: Runtime,
+    materialize: () => Promise<Model>,
+    options?: PrepareResultOptions
+  ) {
+    super(runtime, materialize);
+    this.replaceMaterializedReferences =
+      options?.replaceMaterializedReferences ?? false;
+  }
+
   /**
    * Load the final (unnamed) Malloy query contained within this loaded `Model`.
    *
    * @return A `QueryMaterializer` capable of materializing the requested query, running it,
    * or loading further related objects.
    */
-  public loadFinalQuery(options?: PrepareQueryOptions): QueryMaterializer {
-    return this.makeQueryMaterializer(async () => {
-      return (await this.materialize()).getPreparedQuery(options);
-    });
+  public loadFinalQuery(options?: PrepareResultOptions): QueryMaterializer {
+    return this.makeQueryMaterializer(
+      async () => {
+        return (await this.materialize()).getPreparedQuery();
+      },
+      {
+        replaceMaterializedReferences: this.replaceMaterializedReferences,
+        ...options,
+      }
+    );
   }
 
   /**
@@ -2612,10 +2631,19 @@ export class ModelMaterializer extends FluentState<Model> {
    * @return A `QueryMaterializer` capable of materializing the requested query, running it,
    * or loading further related objects.
    */
-  public loadQueryByIndex(index: number): QueryMaterializer {
-    return this.makeQueryMaterializer(async () => {
-      return (await this.materialize()).getPreparedQueryByIndex(index);
-    });
+  public loadQueryByIndex(
+    index: number,
+    options?: PrepareResultOptions
+  ): QueryMaterializer {
+    return this.makeQueryMaterializer(
+      async () => {
+        return (await this.materialize()).getPreparedQueryByIndex(index);
+      },
+      {
+        replaceMaterializedReferences: this.replaceMaterializedReferences,
+        ...options,
+      }
+    );
   }
 
   /**
@@ -2625,10 +2653,19 @@ export class ModelMaterializer extends FluentState<Model> {
    * @return A `QueryMaterializer` capable of materializing the requested query, running it,
    * or loading further related objects.
    */
-  public loadQueryByName(name: string): QueryMaterializer {
-    return this.makeQueryMaterializer(async () => {
-      return (await this.materialize()).getPreparedQueryByName(name);
-    });
+  public loadQueryByName(
+    name: string,
+    options?: PrepareResultOptions
+  ): QueryMaterializer {
+    return this.makeQueryMaterializer(
+      async () => {
+        return (await this.materialize()).getPreparedQueryByName(name);
+      },
+      {
+        replaceMaterializedReferences: this.replaceMaterializedReferences,
+        ...options,
+      }
+    );
   }
 
   /**
@@ -2640,7 +2677,7 @@ export class ModelMaterializer extends FluentState<Model> {
    */
   public loadQuery(
     query: QueryString | QueryURL,
-    options?: ParseOptions & CompileOptions
+    options?: ParseOptions & CompileOptions & PrepareResultOptions
   ): QueryMaterializer {
     const {refreshSchemaCache, noThrowOnError} = options || {};
     return this.makeQueryMaterializer(async () => {
@@ -2672,6 +2709,9 @@ export class ModelMaterializer extends FluentState<Model> {
         model,
         refreshSchemaCache,
         noThrowOnError,
+        replaceMaterializedReferences:
+          options?.replaceMaterializedReferences ??
+          this.replaceMaterializedReferences,
       });
       return queryModel.preparedQuery;
     });
@@ -2686,7 +2726,7 @@ export class ModelMaterializer extends FluentState<Model> {
    */
   public extendModel(
     query: QueryString | QueryURL,
-    options?: ParseOptions & CompileOptions
+    options?: ParseOptions & CompileOptions & PrepareResultOptions
   ): ModelMaterializer {
     if (this.runtime.isTestRuntime) {
       if (options === undefined) {
@@ -2695,31 +2735,38 @@ export class ModelMaterializer extends FluentState<Model> {
         options = {...options, testEnvironment: true};
       }
     }
-    return new ModelMaterializer(this.runtime, async () => {
-      const urlReader = this.runtime.urlReader;
-      const connections = this.runtime.connections;
-      const parse =
-        query instanceof URL
-          ? await Malloy.parse({
-              url: query,
-              urlReader,
-              options,
-            })
-          : Malloy.parse({
-              source: query,
-              options,
-            });
-      const model = await this.getModel();
-      const queryModel = await Malloy.compile({
-        urlReader,
-        connections,
-        parse,
-        model,
-        refreshSchemaCache: options?.refreshSchemaCache,
-        noThrowOnError: options?.noThrowOnError,
-      });
-      return queryModel;
-    });
+    return new ModelMaterializer(
+      this.runtime,
+      async () => {
+        const urlReader = this.runtime.urlReader;
+        const connections = this.runtime.connections;
+        const parse =
+          query instanceof URL
+            ? await Malloy.parse({
+                url: query,
+                urlReader,
+                options,
+              })
+            : Malloy.parse({
+                source: query,
+                options,
+              });
+        const model = await this.getModel();
+        const queryModel = await Malloy.compile({
+          urlReader,
+          connections,
+          parse,
+          model,
+          refreshSchemaCache: options?.refreshSchemaCache,
+          noThrowOnError: options?.noThrowOnError,
+          replaceMaterializedReferences:
+            options?.replaceMaterializedReferences ??
+            this.replaceMaterializedReferences,
+        });
+        return queryModel;
+      },
+      options
+    );
   }
 
   public async search(
@@ -2885,17 +2932,18 @@ export class ModelMaterializer extends FluentState<Model> {
   //      be used in tests.
   public _loadQueryFromQueryDef(
     query: InternalQuery,
-    options?: PrepareQueryOptions
+    options?: PrepareResultOptions
   ): QueryMaterializer {
-    return this.makeQueryMaterializer(async () => {
-      const model = await this.materialize();
-      return new PreparedQuery(
-        query,
-        model._modelDef,
-        model.problems,
-        options?.replaceMaterializedReferences ?? false
-      );
-    });
+    return this.makeQueryMaterializer(
+      async () => {
+        const model = await this.materialize();
+        return new PreparedQuery(query, model._modelDef, model.problems);
+      },
+      {
+        replaceMaterializedReferences: this.replaceMaterializedReferences,
+        ...options,
+      }
+    );
   }
 
   /**
@@ -2906,9 +2954,14 @@ export class ModelMaterializer extends FluentState<Model> {
    * or loading further related objects.
    */
   public loadExploreByName(name: string): ExploreMaterializer {
-    return this.makeExploreMaterializer(async () => {
-      return (await this.materialize()).getExploreByName(name);
-    });
+    return this.makeExploreMaterializer(
+      async () => {
+        return (await this.materialize()).getExploreByName(name);
+      },
+      {
+        replaceMaterializedReferences: this.replaceMaterializedReferences,
+      }
+    );
   }
 
   /**
@@ -2937,20 +2990,39 @@ export class ModelMaterializer extends FluentState<Model> {
  * prepared results or run the query (via e.g. `loadPreparedResult()` or `run()`).
  */
 export class QueryMaterializer extends FluentState<PreparedQuery> {
+  private readonly replaceMaterializedReferences: boolean;
+  constructor(
+    protected runtime: Runtime,
+    materialize: () => Promise<PreparedQuery>,
+    options?: PrepareResultOptions
+  ) {
+    super(runtime, materialize);
+    this.replaceMaterializedReferences =
+      options?.replaceMaterializedReferences ?? false;
+  }
+
   /**
    * Run this loaded `Query`.
    *
    * @return The query results from running this loaded query.
    */
-  async run(options?: RunSQLOptions): Promise<Result> {
+  async run(options?: RunSQLOptions & PrepareResultOptions): Promise<Result> {
     const connections = this.runtime.connections;
-    const preparedResult = await this.getPreparedResult();
+    const preparedResult = await this.getPreparedResult({
+      replaceMaterializedReferences: this.replaceMaterializedReferences,
+      ...options,
+    });
     const finalOptions = runSQLOptionsWithAnnotations(preparedResult, options);
     return Malloy.run({connections, preparedResult, options: finalOptions});
   }
 
-  async *runStream(options?: RunSQLOptions): AsyncIterableIterator<DataRecord> {
-    const preparedResult = await this.getPreparedResult();
+  async *runStream(
+    options?: RunSQLOptions & PrepareResultOptions
+  ): AsyncIterableIterator<DataRecord> {
+    const preparedResult = await this.getPreparedResult({
+      replaceMaterializedReferences: this.replaceMaterializedReferences,
+      ...options,
+    });
     const connections = this.runtime.connections;
     const finalOptions = runSQLOptionsWithAnnotations(preparedResult, options);
     const stream = Malloy.runStream({
@@ -2969,9 +3041,14 @@ export class QueryMaterializer extends FluentState<PreparedQuery> {
    * @return A `PreparedResultMaterializer` capable of materializing the requested
    * prepared query or running it.
    */
-  public loadPreparedResult(): PreparedResultMaterializer {
+  public loadPreparedResult(
+    options?: PrepareResultOptions
+  ): PreparedResultMaterializer {
     return this.makePreparedResultMaterializer(async () => {
-      return (await this.materialize()).preparedResult;
+      return (await this.materialize()).getPreparedResult({
+        replaceMaterializedReferences: this.replaceMaterializedReferences,
+        ...options,
+      });
     });
   }
 
@@ -2980,8 +3057,13 @@ export class QueryMaterializer extends FluentState<PreparedQuery> {
    *
    * @return A promise of the prepared result of this loaded query.
    */
-  public getPreparedResult(): Promise<PreparedResult> {
-    return this.loadPreparedResult().getPreparedResult();
+  public getPreparedResult(
+    options?: PrepareResultOptions
+  ): Promise<PreparedResult> {
+    return this.loadPreparedResult({
+      replaceMaterializedReferences: this.replaceMaterializedReferences,
+      ...options,
+    }).getPreparedResult();
   }
 
   /**
@@ -2989,8 +3071,13 @@ export class QueryMaterializer extends FluentState<PreparedQuery> {
    *
    * @return A promise of the SQL string.
    */
-  public async getSQL(): Promise<string> {
-    return (await this.getPreparedResult()).sql;
+  public async getSQL(options?: PrepareResultOptions): Promise<string> {
+    return (
+      await this.getPreparedResult({
+        replaceMaterializedReferences: this.replaceMaterializedReferences,
+        ...options,
+      })
+    ).sql;
   }
 
   /**
@@ -3007,9 +3094,14 @@ export class QueryMaterializer extends FluentState<PreparedQuery> {
    *
    * @return The estimated cost of running this loaded query.
    */
-  public async estimateQueryCost(): Promise<QueryRunStats> {
+  public async estimateQueryCost(
+    options?: PrepareResultOptions
+  ): Promise<QueryRunStats> {
     const connections = this.runtime.connections;
-    const preparedResult = await this.getPreparedResult();
+    const preparedResult = await this.getPreparedResult({
+      replaceMaterializedReferences: this.replaceMaterializedReferences,
+      ...options,
+    });
     return Malloy.estimateQueryCost({connections, preparedResult});
   }
 }
@@ -3146,6 +3238,17 @@ export class SQLBlockMaterializer extends FluentState<SQLBlockStructDef> {
  * related queries.
  */
 export class ExploreMaterializer extends FluentState<Explore> {
+  private readonly replaceMaterializedReferences: boolean;
+  constructor(
+    protected runtime: Runtime,
+    materialize: () => Promise<Explore>,
+    options?: PrepareResultOptions
+  ) {
+    super(runtime, materialize);
+    this.replaceMaterializedReferences =
+      options?.replaceMaterializedReferences ?? false;
+  }
+
   /**
    * Load a query contained within this loaded explore.
    *
@@ -3153,10 +3256,13 @@ export class ExploreMaterializer extends FluentState<Explore> {
    * @return A `QueryMaterializer` capable of materializing the requested query, running it,
    * or loading further related objects.
    */
-  public loadQueryByName(name: string): QueryMaterializer {
+  public loadQueryByName(
+    name: string,
+    options?: PrepareResultOptions
+  ): QueryMaterializer {
     return this.makeQueryMaterializer(async () => {
       return (await this.materialize()).getQueryByName(name);
-    });
+    }, options);
   }
 
   /**

--- a/test/src/databases/duckdb/materialization.spec.ts
+++ b/test/src/databases/duckdb/materialization.spec.ts
@@ -33,12 +33,12 @@ describe.each(allDucks.runtimeList)('duckdb:%s', (dbName, runtime) => {
     `;
 
     const qm = runtime.loadQuery(query, {replaceMaterializedReferences: true});
-    const pq = await qm.getPreparedQuery();
+    const preparedResult = await qm.getPreparedResult();
 
-    expect(pq.preparedResult.sql).toBe(
+    expect(preparedResult.sql).toBe(
       'SELECT \n   base."two"+1 as "three"\nFROM myMaterializedQuery-6037d4be-8b92-5ea7-95a0-27bd26c240ca as base\n'
     );
-    expect(pq.preparedResult.dependenciesToMaterialize).toStrictEqual({
+    expect(preparedResult.dependenciesToMaterialize).toStrictEqual({
       'myMaterializedQuery-6037d4be-8b92-5ea7-95a0-27bd26c240ca': {
         'id': '6037d4be-8b92-5ea7-95a0-27bd26c240ca',
         'path': 'internal://internal.malloy',
@@ -73,12 +73,12 @@ describe.each(allDucks.runtimeList)('duckdb:%s', (dbName, runtime) => {
     `;
 
     const qm = runtime.loadQuery(query, {replaceMaterializedReferences: true});
-    const pq = await qm.getPreparedQuery();
+    const preparedResult = await qm.getPreparedResult();
 
-    expect(pq.preparedResult.sql).toBe(
+    expect(preparedResult.sql).toBe(
       'SELECT \n   base."three"+1 as "four"\nFROM secondLevelMaterializedQuery-bd80d526-f867-587e-933e-89353d26d022 as base\n'
     );
-    expect(pq.preparedResult.dependenciesToMaterialize).toStrictEqual({
+    expect(preparedResult.dependenciesToMaterialize).toStrictEqual({
       'secondLevelMaterializedQuery-bd80d526-f867-587e-933e-89353d26d022': {
         id: 'bd80d526-f867-587e-933e-89353d26d022',
         path: 'internal://internal.malloy',
@@ -107,12 +107,12 @@ describe.each(allDucks.runtimeList)('duckdb:%s', (dbName, runtime) => {
     `;
 
     const qm = runtime.loadQuery(query, {replaceMaterializedReferences: false});
-    const pq = await qm.getPreparedQuery();
+    const preparedResult = await qm.getPreparedResult();
 
-    expect(pq.preparedResult.sql).toBe(
+    expect(preparedResult.sql).toBe(
       'WITH __stage0 AS (\n  SELECT \n     base."one"+1 as "two"\n  FROM (select 1 as one, \'word\' as word) as base\n)\nSELECT \n   base."two"+1 as "three"\nFROM __stage0 as base\n'
     );
-    expect(pq.preparedResult.dependenciesToMaterialize).toStrictEqual({});
+    expect(preparedResult.dependenciesToMaterialize).toStrictEqual({});
   });
 });
 


### PR DESCRIPTION
The refactor I was trying to describe is really hard to explain so I just did it...

The philosophy: the runtime API has two kinds of things, "Malloy entities" and "Malloy entity materializers" (e.g. `Model` vs `ModelMaterializer`). The Malloy entities contain nothing more than the result of compiling that entity. The materializers contain runtime information needed to re-compile, run, etc.. Therefore, it didn't fit the philosophy for a `PreparedQuery` (which just represents the internal `Query` IR object) have a `replaceMaterializedReferences` property, since this is a description of _how_ you want to compile the SQL, not _what_ the query is.

I will add comments to all the code changes to describe in more detail the philosophy.