### PR TITLE
Add a unique reference ID to resultMetadata

### DIFF
--- a/packages/malloy/src/malloy.ts
+++ b/packages/malloy/src/malloy.ts
@@ -1820,6 +1820,14 @@ export class AtomicField extends Entity implements Taggable {
     return sourceField ? [sourceField] : [];
   }
 
+  /**
+   * A unique ID of this field within the context of a result; undefined
+   * for fields that are not derived from a Result.
+   */
+  public get referenceId(): string | undefined {
+    return this.fieldTypeDef.resultMetadata?.referenceId;
+  }
+
   // was the field generated from a measure in the previous query
   public sourceWasMeasure(): boolean {
     return this.fieldTypeDef.resultMetadata?.fieldKind === 'measure';

--- a/packages/malloy/src/model/malloy_types.ts
+++ b/packages/malloy/src/model/malloy_types.ts
@@ -421,6 +421,7 @@ export interface ResultMetadataDef {
   sourceClasses: string[];
   filterList?: FilterCondition[];
   fieldKind: 'measure' | 'dimension' | 'struct';
+  referenceId?: string;
 }
 
 // struct specific metadta

--- a/test/src/databases/duckdb/reference-id.spec.ts
+++ b/test/src/databases/duckdb/reference-id.spec.ts
@@ -13,38 +13,105 @@ import {Explore, Field} from '@malloydata/malloy';
 const [describe, databases] = describeIfDatabaseAvailable(['duckdb']);
 const dbs = new RuntimeList(databases);
 
-describe.each(dbs.runtimeList)('%s', (dbName, runtime) => {
-  it('reference id is correct', async () => {
-    const query = `
-      run: duckdb.sql("SELECT 1 as one") -> {
-        group_by: one
-        nest: a is {
-          group_by: one
-        }
-        nest: b is {
-          group_by: one is "fake"
-        }
-        nest: c is {
-          # this reference has an annotation
-          group_by: one
-        }
-      }
-    `;
+function referenceId(field: Field | Explore) {
+  if (field.isExplore() || field.isQueryField()) {
+    return undefined;
+  }
+  return field.referenceId;
+}
 
-    const result = await runtime.loadQuery(query).run();
-    function referenceId(field: Field | Explore) {
-      if (field.isExplore() || field.isQueryField()) {
-        return undefined;
-      }
-      return field.referenceId;
-    }
-    const actual = referenceId(result.data.path(0, 'one').field);
-    expect(actual).not.toBeUndefined();
-    expect(referenceId(result.data.path(0, 'a', 0, 'one').field)).toBe(actual);
-    const bOne = referenceId(result.data.path(0, 'b', 0, 'one').field);
-    expect(bOne).not.toBe(undefined);
-    expect(bOne).not.toBe(actual);
-    expect(referenceId(result.data.path(0, 'c', 0, 'one').field)).toBe(actual);
+describe.each(dbs.runtimeList)('%s', (dbName, runtime) => {
+  describe('reference id', () => {
+    it('is correct for field references in table', async () => {
+      const query = `
+        run: duckdb.sql("SELECT 1 as one") -> {
+          group_by: one
+          nest: a is {
+            group_by: one
+          }
+          nest: b is {
+            group_by: one is "fake"
+          }
+          nest: c is {
+            # this reference has an annotation
+            group_by: one
+          }
+        }
+      `;
+
+      const result = await runtime.loadQuery(query).run();
+      const actual = referenceId(result.data.path(0, 'one').field);
+      expect(actual).not.toBeUndefined();
+      expect(referenceId(result.data.path(0, 'a', 0, 'one').field)).toBe(
+        actual
+      );
+      const bOne = referenceId(result.data.path(0, 'b', 0, 'one').field);
+      expect(bOne).not.toBe(undefined);
+      expect(bOne).not.toBe(actual);
+      expect(referenceId(result.data.path(0, 'c', 0, 'one').field)).toBe(
+        actual
+      );
+    });
+
+    it('is correct for field references from extend block', async () => {
+      const query = `
+        run: duckdb.sql("SELECT 1 as one") -> {
+          extend: {
+            dimension: two is 2
+          }
+          group_by: two
+          nest: a is {
+            group_by: two
+          }
+          nest: b is {
+            group_by: two is "fake"
+          }
+          nest: c is {
+            # this reference has an annotation
+            group_by: two
+          }
+        }
+      `;
+
+      const result = await runtime.loadQuery(query).run();
+      const actual = referenceId(result.data.path(0, 'two').field);
+      expect(actual).not.toBeUndefined();
+      expect(referenceId(result.data.path(0, 'a', 0, 'two').field)).toBe(
+        actual
+      );
+      const bTwo = referenceId(result.data.path(0, 'b', 0, 'two').field);
+      expect(bTwo).not.toBe(undefined);
+      expect(bTwo).not.toBe(actual);
+      expect(referenceId(result.data.path(0, 'c', 0, 'two').field)).toBe(
+        actual
+      );
+    });
+
+    it.skip('is unequal for different nest/extend blocks', async () => {
+      const query = `
+        run: duckdb.sql("SELECT 1 as one") -> {
+          nest: a is {
+            extend: {
+              dimension: three is 3
+            }
+            group_by: three
+          }
+          nest: b is {
+            extend: {
+              dimension: three is 4
+            }
+            group_by: three
+          }
+        }
+      `;
+
+      const result = await runtime.loadQuery(query).run();
+      const actual = referenceId(result.data.path(0, 'a', 0, 'three').field);
+      expect(actual).not.toBeUndefined();
+      expect(referenceId(result.data.path(0, 'b', 0, 'three').field)).toBe(
+        actual
+      );
+    });
   });
 });
 

--- a/test/src/databases/duckdb/reference-id.spec.ts
+++ b/test/src/databases/duckdb/reference-id.spec.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ */
+
+import {RuntimeList} from '../../runtimes';
+import '../../util/db-jest-matchers';
+import {describeIfDatabaseAvailable} from '../../util';
+import {Explore, Field} from '@malloydata/malloy';
+
+const [describe, databases] = describeIfDatabaseAvailable(['duckdb']);
+const dbs = new RuntimeList(databases);
+
+describe.each(dbs.runtimeList)('%s', (dbName, runtime) => {
+  it('reference id is correct', async () => {
+    const query = `
+      run: duckdb.sql("SELECT 1 as one") -> {
+        group_by: one
+        nest: a is {
+          group_by: one
+        }
+        nest: b is {
+          group_by: one is "fake"
+        }
+        nest: c is {
+          # this reference has an annotation
+          group_by: one
+        }
+      }
+    `;
+
+    const result = await runtime.loadQuery(query).run();
+    function referenceId(field: Field | Explore) {
+      if (field.isExplore() || field.isQueryField()) {
+        return undefined;
+      }
+      return field.referenceId;
+    }
+    const actual = referenceId(result.data.path(0, 'one').field);
+    expect(actual).not.toBeUndefined();
+    expect(referenceId(result.data.path(0, 'a', 0, 'one').field)).toBe(actual);
+    const bOne = referenceId(result.data.path(0, 'b', 0, 'one').field);
+    expect(bOne).not.toBe(undefined);
+    expect(bOne).not.toBe(actual);
+    expect(referenceId(result.data.path(0, 'c', 0, 'one').field)).toBe(actual);
+  });
+});
+
+afterAll(async () => {
+  await dbs.closeAll();
+});


### PR DESCRIPTION
Each field in a result will now have a `referenceId` in the `resultMetadata`. This id should be the same for fields which are references to the same definition. Fields which are inline definitions in the query also get a reference id, it will just be unique.