### PR TITLE
Init required extension

### DIFF
--- a/test/bin/postgres_init.sh
+++ b/test/bin/postgres_init.sh
@@ -7,3 +7,4 @@ initdb -d .tmp/data/malloytestdb --no-locale --encoding=UTF8
 pg_ctl -D .tmp/data/malloytestdb -l .tmp/logfile -o "--unix_socket_directories='$PWD/.tmp'" start
 createdb $USER
 gunzip -c ../data/postgres/malloytest-postgres.sql.gz | psql
+echo CREATE EXTENSION tsm_system_rows\; | psql


### PR DESCRIPTION
Initialize the expected `tsm_system_rows` when creating the test database. I tested that this survives `postgres_stop.sh`, `postgres_start.sh` and is repeatable over multiple `postgres_init.sh` invocations.
