### PR TITLE
allow join_many: with

### DIFF
--- a/packages/malloy/src/lang/malloy-to-ast.ts
+++ b/packages/malloy/src/lang/malloy-to-ast.ts
@@ -498,12 +498,6 @@ export class MalloyToAST
               'join_many: requires ON expression'
             );
           }
-        } else if (join instanceof ast.KeyJoin) {
-          this.contextError(
-            pcx,
-            'foreign-key-in-join-many',
-            'Foreign key join not legal in join_many:'
-          );
         }
       }
     }

--- a/packages/malloy/src/lang/parse-log.ts
+++ b/packages/malloy/src/lang/parse-log.ts
@@ -325,7 +325,6 @@ type MessageParameterTypes = {
   'failed-to-parse-time-literal': string;
   'table-function': string;
   'missing-on-in-join-many': string;
-  'foreign-key-in-join-many': string;
   'join-statement-in-view': string;
   'unknown-matrix-operation': string;
   'declare': string;

--- a/packages/malloy/src/lang/test/source.spec.ts
+++ b/packages/malloy/src/lang/test/source.spec.ts
@@ -178,11 +178,6 @@ describe('source:', () => {
           'source: nab is a extend { join_many: b on astr = b.astr }'
         ).toTranslate();
       });
-      test('many with', () => {
-        expect(
-          model`source: nab is a extend { ${'join_many: b with astr'} }`
-        ).toLog(errorMessage('Foreign key join not legal in join_many:'));
-      });
       test('many is on', () => {
         expect(
           'source: y is a extend { join_many: x is b on astr = x.astr }'
@@ -233,6 +228,13 @@ describe('source:', () => {
         expect(`
           source: awith is a extend {
             join_one: has_primary_key is a -> { group_by: one_val is astr } with astr
+          }
+        `).toTranslate();
+      });
+      test('join-many: with is ok', () => {
+        expect(`
+          source: awithmany is a extend {
+            join_many: manyb is a with astr
           }
         `).toTranslate();
       });


### PR DESCRIPTION
User reported confusion at getting an error on `join_many: .. with` and the user was correctly confused, no reason to disallow that.