### PR TITLE
Revert "allow join_many: with (#1950)"

### DIFF
--- a/packages/malloy/src/lang/malloy-to-ast.ts
+++ b/packages/malloy/src/lang/malloy-to-ast.ts
@@ -498,6 +498,12 @@ export class MalloyToAST
               'join_many: requires ON expression'
             );
           }
+        } else if (join instanceof ast.KeyJoin) {
+          this.contextError(
+            pcx,
+            'foreign-key-in-join-many',
+            'Foreign key join not legal in join_many:'
+          );
         }
       }
     }

--- a/packages/malloy/src/lang/parse-log.ts
+++ b/packages/malloy/src/lang/parse-log.ts
@@ -325,6 +325,7 @@ type MessageParameterTypes = {
   'failed-to-parse-time-literal': string;
   'table-function': string;
   'missing-on-in-join-many': string;
+  'foreign-key-in-join-many': string;
   'join-statement-in-view': string;
   'unknown-matrix-operation': string;
   'declare': string;

--- a/packages/malloy/src/lang/test/source.spec.ts
+++ b/packages/malloy/src/lang/test/source.spec.ts
@@ -178,6 +178,11 @@ describe('source:', () => {
           'source: nab is a extend { join_many: b on astr = b.astr }'
         ).toTranslate();
       });
+      test('many with', () => {
+        expect(
+          model`source: nab is a extend { ${'join_many: b with astr'} }`
+        ).toLog(errorMessage('Foreign key join not legal in join_many:'));
+      });
       test('many is on', () => {
         expect(
           'source: y is a extend { join_many: x is b on astr = x.astr }'
@@ -228,13 +233,6 @@ describe('source:', () => {
         expect(`
           source: awith is a extend {
             join_one: has_primary_key is a -> { group_by: one_val is astr } with astr
-          }
-        `).toTranslate();
-      });
-      test('join-many: with is ok', () => {
-        expect(`
-          source: awithmany is a extend {
-            join_many: manyb is a with astr
           }
         `).toTranslate();
       });


### PR DESCRIPTION
The work was based on a mis-understanding of a comment from lloyd which made me believe this was trivial and OK

This reverts commit 9f3b0dbdf3a3e1e6cfea40b74fc07615adbb194f.

There is a desire for a future where a "key only" join could exist and be a many or a one join based on the sources involved. Someday that discussion will happen. For now, backing the wrong thing out.