### PR TITLE
error at translation time on unsafe cast

### DIFF
--- a/packages/malloy/src/lang/ast/expressions/expr-cast.ts
+++ b/packages/malloy/src/lang/ast/expressions/expr-cast.ts
@@ -55,6 +55,12 @@ export class ExprCast extends ExpressionDef {
             `Cast type \`${this.castType.raw}\` is invalid for ${dialect.name} dialect`
           );
         }
+        if (this.safe && !dialect.supportsSafeCast) {
+          this.logError(
+            'dialect-cast-unsafe-only',
+            `The SQL dialect '${fs.dialectName()}' does not supply a safe cast operator`
+          );
+        }
       }
     }
     return {

--- a/packages/malloy/src/lang/parse-log.ts
+++ b/packages/malloy/src/lang/parse-log.ts
@@ -350,6 +350,7 @@ type MessageParameterTypes = {
   'sql-is-not-null': string;
   'sql-is-null': string;
   'illegal-record-property-type': string;
+  'dialect-cast-unsafe-only': string;
 };
 
 export const MESSAGE_FORMATTERS: PartialErrorCodeMessageMap = {

--- a/test/src/databases/all/expr.spec.ts
+++ b/test/src/databases/all/expr.spec.ts
@@ -410,18 +410,26 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
     `).malloyResultMatches(expressionModel, {a: 312});
   });
 
-  test.when(runtime.dialect.supportsSafeCast)('sql safe cast', async () => {
-    await expect(`
+  it('sql safe cast', async () => {
+    const safeCast = `
       run: ${databaseName}.sql('SELECT 1 as one') -> { select:
         bad_date is '12a':::date
         bad_number is 'abc':::number
         good_number is "312":::"${nativeInt}"
       }
-    `).malloyResultMatches(expressionModel, {
-      bad_date: null,
-      bad_number: null,
-      good_number: 312,
-    });
+    `;
+    if (runtime.dialect.supportsSafeCast) {
+      await expect(safeCast).malloyResultMatches(runtime, {
+        bad_date: null,
+        bad_number: null,
+        good_number: 312,
+      });
+    } else {
+      await expect(safeCast).toEmitDuringTranslation(runtime, {
+        id: 'translation-error',
+        data: {code: 'dialect-cast-unsafe-only'},
+      });
+    }
   });
 
   it('many_field.sum() has correct locality', async () => {


### PR DESCRIPTION
Reviewing the MySQL dialect I realized we throw at compile if a dialect doesn't support safe cast, but this is already a dialect property, and so the translator should flag these errors.