### PR TITLE
add experimental rule to catch missing close brace

### DIFF
--- a/packages/malloy/src/lang/grammar/MalloyParser.g4
+++ b/packages/malloy/src/lang/grammar/MalloyParser.g4
@@ -27,6 +27,13 @@ options { tokenVocab=MalloyLexer; }
 
 malloyDocument: (malloyStatement | SEMI)* EOF;
 
+closeCurly
+  : CCURLY
+  // ANTLR VSCode plugin loses it's tiny mind if { } aren't matched
+  // even in the error string below
+  | { this.notifyErrorListeners("'{' missing a '}'"); }
+  ;
+
 malloyStatement
   : defineSourceStatement
   | defineQuery
@@ -67,7 +74,7 @@ sqlString
   ;
 
 sqlInterpolation
-  : OPEN_CODE sqExpr (CCURLY | CLOSE_CODE)
+  : OPEN_CODE sqExpr (closeCurly | CLOSE_CODE)
   ;
 
 importStatement
@@ -77,7 +84,7 @@ importStatement
 importSelect
   : OCURLY
     importItem (COMMA importItem)*
-    CCURLY FROM
+    closeCurly FROM
   ;
 
 importItem
@@ -127,11 +134,11 @@ connectionId
 
 queryProperties
   : filterShortcut
-  | OCURLY (queryStatement | SEMI)* CCURLY
+  | OCURLY (queryStatement | SEMI)* closeCurly
   ;
 
 filterShortcut
-  : OCURLY QMARK fieldExpr CCURLY
+  : OCURLY QMARK fieldExpr closeCurly
   ;
 
 queryName : id;
@@ -161,7 +168,7 @@ parameterNameDef: id;
 sourceNameDef: id;
 
 exploreProperties
-  : OCURLY (exploreStatement | SEMI)* CCURLY
+  : OCURLY (exploreStatement | SEMI)* closeCurly
   | filterShortcut
   ;
 
@@ -269,7 +276,7 @@ queryExtendStatement
   ;
 
 queryExtendStatementList
-  : OCURLY (queryExtendStatement | SEMI)* CCURLY
+  : OCURLY (queryExtendStatement | SEMI)* closeCurly
   ;
 
 joinList
@@ -301,7 +308,7 @@ filterStatement
   ;
 
 fieldProperties
-  : OCURLY (fieldPropertyStatement | SEMI)* CCURLY
+  : OCURLY (fieldPropertyStatement | SEMI)* closeCurly
   ;
 
 aggregateOrdering
@@ -538,7 +545,7 @@ fieldExpr
   : fieldPath                                              # exprFieldPath
   | literal                                                # exprLiteral
   | OBRACK fieldExpr (COMMA fieldExpr)* COMMA? CBRACK      # exprArrayLiteral
-  | OCURLY recordElement (COMMA recordElement)* CCURLY     # exprLiteralRecord
+  | OCURLY recordElement (COMMA recordElement)* closeCurly     # exprLiteralRecord
   | fieldExpr fieldProperties                              # exprFieldProps
   | fieldExpr timeframe                                    # exprDuration
   | fieldExpr DOT timeframe                                # exprTimeTrunc
@@ -626,7 +633,7 @@ starQualified
   : OCURLY (
       (EXCEPT fieldNameList)
     | COMMA
-  )+ CCURLY
+  )+ closeCurly
   ;
 
 taggedRef

--- a/packages/malloy/src/lang/test/parse.spec.ts
+++ b/packages/malloy/src/lang/test/parse.spec.ts
@@ -123,6 +123,9 @@ describe('model statements', () => {
 });
 
 describe('error handling', () => {
+  test('no close brace', () => {
+    expect('run: a -> { group_by: ai').toLog(errorMessage("'{' missing a '}'"));
+  });
   test('field and query with same name does not overflow', () => {
     expect(`
       source: flights is _db_.table('malloytest.flights') extend {


### PR DESCRIPTION
Adding this rule to the grammar ...

```
closeCurly
  : CCURLY
  | { this.notifyErrorListeners("'{' missing a '}'"); }
  ;
```

Makes turns this error message ...

```
    line 2: extraneous input '<EOF>' expecting {AGGREGATE, CALCULATE, DECLARE, DIMENSION, EXTENDQ,
    GROUP_BY, HAVING, INDEX, JOIN_CROSS, JOIN_ONE, JOIN_MANY, LIMIT, MEASURE, NEST, ORDER_BY,
    PROJECT, QUERY, RUN, SAMPLE, SELECT, SOURCE, TOP, WHERE, VIEW, TIMEZONE, ALL, AVG, CASE, CAST,
    COUNT, DAY, EXCLUDE, FALSE, HOUR, IS, MAX, MIN, MINUTE, MONTH, NOT, NOW, NULL, PICK, QUARTER,
    SECOND, SOURCE_KW, SUM, TABLE, TRUE, WEEK, YEAR, HACKY_REGEX, SQ_STRING, DQ_STRING,
    BQ_STRING, DOC_ANNOTATION, ANNOTATION, '(', '[', '{', '}', '-', ';', LITERAL_TIMESTAMP, LITERAL_HOUR,
    LITERAL_DAY, LITERAL_QUARTER, LITERAL_MONTH, LITERAL_WEEK, LITERAL_YEAR, IDENTIFIER,
    NUMERIC_LITERAL, INTEGER_LITERAL, '"""'}
```

Into `'{' missing a '}'`

But I worry that would somehow break the parser for legal sentences, so we might have to back this out.