### PR TITLE
Fix multiline lens range

### DIFF
--- a/packages/malloy/src/lang/parse-malloy.ts
+++ b/packages/malloy/src/lang/parse-malloy.ts
@@ -943,7 +943,7 @@ export abstract class MalloyTranslation {
       const lastLine = this.parseStep.sourceInfo.lines.length - 1;
       for (let lineNo = startToken.line - 1; lineNo <= lastLine; lineNo++) {
         const at = this.parseStep.sourceInfo.at[lineNo];
-        if (stopToken.stopIndex >= at.begin && stopToken.stopIndex <= at.end) {
+        if (stopToken.stopIndex >= at.begin && stopToken.stopIndex < at.end) {
           return {
             start,
             end: {
@@ -1013,9 +1013,9 @@ export class MalloyChildTranslator extends MalloyTranslation {
 }
 
 /**
- * The main interface to Malloy tranlsation. It has a call pattern
+ * The main interface to Malloy translation. It has a call pattern
  * similar to a server. Once a translator is instantiated
- * you can request tralnsations repeatedly. Responses to that request
+ * you can request translations repeatedly. Responses to that request
  * will either be "NeedResponse" or "TranslateResponse" objects. The
  * correct pattern is to call "translation" in a loop, calling
  * "update" in response to each "NeedResponse" until a "TranslateResponse"

--- a/packages/malloy/src/lang/test/document-symbol-walker.spec.ts
+++ b/packages/malloy/src/lang/test/document-symbol-walker.spec.ts
@@ -306,6 +306,26 @@ test('run lenses go before block annotations', () => {
   );
 });
 
+test('multiline unnamed queries include last line', () => {
+  // The trailing } being in column 0 is significant
+  testLens(
+    markSource`${`run: flights -> {
+  group_by: carrier
+}`}`,
+    [0]
+  );
+});
+
+test('multiline named queries include last line', () => {
+  // The trailing } being in column 0 is significant
+  testLens(
+    markSource`${`query: by_carrier is flights -> {
+  group_by: carrier
+}`}`,
+    [0]
+  );
+});
+
 test('(regression) query does not use source block range', () => {
   testLens(
     markSource`source: a is DB.table('b') extend {


### PR DESCRIPTION
If a `}` appears in column zero, the parser stopIndex appears as both the end of the second to the last line and the beginning of the last line.

So for
```
run: flights -> {
  group_by: carrier
}
```
the values in `MalloyTranslation.rangeFromTokens()` are:
```
> stopToken.stopIndex
38
> this.parseStep.sourceInfo.at
(3) [{…}, {…}, {…}]
0 = {begin: 0, end: 18}
1 = {begin: 18, end: 38}
2 = {begin: 38, end: 39}
```
It appears that end is meant to be exclusive.

This didn't show up in any of our existing test cases because if there is a space before the `}` which just happens to be how we formatted all the test Malloy, then `stopIndex` is unambiguously on one line.