### PR TITLE
Allow literal record array to have implied keys

### DIFF
--- a/packages/malloy/src/lang/ast/expressions/expr-array-literal.ts
+++ b/packages/malloy/src/lang/ast/expressions/expr-array-literal.ts
@@ -10,6 +10,7 @@ import {ExprValue, computedExprValue} from '../types/expr-value';
 import {ExpressionDef} from '../types/expression-def';
 import {FieldSpace} from '../types/field-space';
 import * as TDU from '../typedesc-utils';
+import {RecordLiteral} from './expr-record-literal';
 
 export class ArrayLiteral extends ExpressionDef {
   elementType = 'array literal';
@@ -24,7 +25,10 @@ export class ArrayLiteral extends ExpressionDef {
     let firstValue: ExprValue | undefined = undefined;
     if (this.elements.length > 0) {
       for (const nextElement of this.elements) {
-        const v = nextElement.getExpression(fs);
+        const v =
+          firstValue && nextElement instanceof RecordLiteral
+            ? nextElement.getNextElement(fs, firstValue)
+            : nextElement.getExpression(fs);
         fromValues.push(v);
         if (v.type === 'error') {
           continue;

--- a/packages/malloy/src/lang/grammar/MalloyParser.g4
+++ b/packages/malloy/src/lang/grammar/MalloyParser.g4
@@ -610,8 +610,8 @@ caseWhen
 
 recordKey: id;
 recordElement
-  : fieldPath         # recordRef
-  | recordKey IS fieldExpr   # recordExpr
+  : fieldPath                   # recordRef
+  | (recordKey IS)? fieldExpr   # recordExpr
   ;
 
 argumentList

--- a/packages/malloy/src/lang/malloy-to-ast.ts
+++ b/packages/malloy/src/lang/malloy-to-ast.ts
@@ -1927,32 +1927,24 @@ export class MalloyToAST
   }
 
   visitRecordRef(pcx: parse.RecordRefContext) {
-    const pathCx = pcx.fieldPath();
-    const tailEl = pathCx.fieldName().at(-1);
-    if (tailEl) {
-      const elementKey = getId(tailEl);
-      const idRef = new ast.ExprIdReference(
-        this.getFieldPath(pathCx, ast.ExpressionFieldReference)
-      );
-      return new ast.RecordElement(elementKey, idRef);
-    }
-    throw this.internalError(
-      pathCx,
-      'IMPOSSIBLY A PATH CONTAINED ZERO ELEMENTS'
+    const idRef = new ast.ExprIdReference(
+      this.getFieldPath(pcx.fieldPath(), ast.ExpressionFieldReference)
     );
+    return this.astAt(new ast.RecordElement({path: idRef}), pcx);
   }
 
   visitRecordExpr(pcx: parse.RecordExprContext) {
-    const elementKey = getId(pcx.recordKey());
-    const elementVal = this.getFieldExpr(pcx.fieldExpr());
-    return new ast.RecordElement(elementKey, elementVal);
+    const value = this.getFieldExpr(pcx.fieldExpr());
+    const keyCx = pcx.recordKey();
+    const recInit = keyCx ? {key: getId(keyCx), value} : {value};
+    return this.astAt(new ast.RecordElement(recInit), pcx);
   }
 
   visitExprLiteralRecord(pcx: parse.ExprLiteralRecordContext) {
     const els = this.only<ast.RecordElement>(
       pcx.recordElement().map(elCx => this.astAt(this.visit(elCx), elCx)),
       visited => visited instanceof ast.RecordElement && visited,
-      'a key value pair'
+      'a legal record property description'
     );
     return new ast.RecordLiteral(els);
   }

--- a/packages/malloy/src/lang/parse-log.ts
+++ b/packages/malloy/src/lang/parse-log.ts
@@ -367,6 +367,7 @@ type MessageParameterTypes = {
   'sql-is-not-null': string;
   'sql-is-null': string;
   'illegal-record-property-type': string;
+  'record-literal-needs-keys': string;
   'not-yet-implemented': string;
   'sql-case': string;
   'case-then-type-does-not-match': {

--- a/packages/malloy/src/lang/test/literals.spec.ts
+++ b/packages/malloy/src/lang/test/literals.spec.ts
@@ -283,4 +283,22 @@ describe('literals', () => {
     });
     test('a string containing a tab', () => expect(expr`'\t'`).toParse());
   });
+  describe('compound literals', () => {
+    test('simple record literal', () => {
+      expect('{answer is 42}').compilesTo('{answer:42}');
+    });
+    test('record literal with path', () => {
+      expect('{aninline.column}').compilesTo('{column:aninline.column}');
+    });
+    test('array of records with same schema', () => {
+      expect(
+        '[{name is "one", val is 1},{name is "two", val is 2}]'
+      ).compilesTo('[{name:"one", val:1}, {name:"two", val:2}]');
+    });
+    test('array of records with head schema', () => {
+      expect('[{name is "one", val is 1},{"two", 2}]').compilesTo(
+        '[{name:"one", val:1}, {name:"two", val:2}]'
+      );
+    });
+  });
 });

--- a/packages/malloy/src/lang/test/parse-expects.ts
+++ b/packages/malloy/src/lang/test/parse-expects.ts
@@ -229,6 +229,17 @@ function eToStr(e: Expr, symbols: ESymbols): string {
       return `"${e.literal}"`;
     case 'timeLiteral':
       return `@${e.literal}`;
+    case 'recordLiteral': {
+      const parts: string[] = [];
+      for (const [name, val] of Object.entries(e.kids)) {
+        parts.push(`${name}:${subExpr(val)}`);
+      }
+      return `{${parts.join(', ')}}`;
+    }
+    case 'arrayLiteral': {
+      const parts = e.kids.values.map(k => subExpr(k));
+      return `[${parts.join(', ')}]`;
+    }
     case 'regexpLiteral':
       return `/${e.literal}/`;
     case 'trunc':


### PR DESCRIPTION
```
[
  {name is 'Michael', job is 'Golfing'},
  {'Lloyd', 'Cycling'},
  {'Chris', 'Climbing}
]
```