### PR TITLE
added some basic hyperloglog functions

### DIFF
--- a/packages/malloy/src/dialect/dialect.ts
+++ b/packages/malloy/src/dialect/dialect.ts
@@ -168,6 +168,8 @@ export abstract class Dialect {
 
   supportsCountApprox = false;
 
+  supportsHyperLogLog = false;
+
   // MYSQL doesn't have full join, maybe others.
   supportsFullJoin = true;
 

--- a/packages/malloy/src/dialect/trino/dialect_functions.ts
+++ b/packages/malloy/src/dialect/trino/dialect_functions.ts
@@ -79,10 +79,9 @@ const count_approx: DefinitionBlueprint = {
 
 const hll_accumulate: OverloadedDefinitionBlueprint = {
   default: {
-    generic: [
-      'T',
-      ['string', 'number', 'date', 'timestamp', 'boolean', 'json'],
-    ],
+    generic: {
+      'T': ['string', 'number', 'date', 'timestamp', 'boolean', 'json'],
+    },
     takes: {'value': {dimension: {generic: 'T'}}},
     returns: {measure: 'string'},
     isSymmetric: true,
@@ -91,10 +90,9 @@ const hll_accumulate: OverloadedDefinitionBlueprint = {
     },
   },
   with_percent: {
-    generic: [
-      'T',
-      ['string', 'number', 'date', 'timestamp', 'boolean', 'json'],
-    ],
+    generic: {
+      'T': ['string', 'number', 'date', 'timestamp', 'boolean', 'json'],
+    },
     takes: {'value': {dimension: {generic: 'T'}}, 'accuracy': 'number'},
     returns: {measure: 'string'},
     isSymmetric: true,

--- a/packages/malloy/src/dialect/trino/dialect_functions.ts
+++ b/packages/malloy/src/dialect/trino/dialect_functions.ts
@@ -77,6 +77,70 @@ const count_approx: DefinitionBlueprint = {
   isSymmetric: true,
 };
 
+const hll_accumulate: OverloadedDefinitionBlueprint = {
+  default: {
+    generic: [
+      'T',
+      ['string', 'number', 'date', 'timestamp', 'boolean', 'json'],
+    ],
+    takes: {'value': {dimension: {generic: 'T'}}},
+    returns: {measure: 'string'},
+    isSymmetric: true,
+    impl: {
+      function: 'APPROX_SET',
+    },
+  },
+  with_percent: {
+    generic: [
+      'T',
+      ['string', 'number', 'date', 'timestamp', 'boolean', 'json'],
+    ],
+    takes: {'value': {dimension: {generic: 'T'}}, 'accuracy': 'number'},
+    returns: {measure: 'string'},
+    isSymmetric: true,
+    impl: {
+      function: 'APPROX_SET',
+    },
+  },
+};
+
+const hll_combine: DefinitionBlueprint = {
+  takes: {
+    'value': 'string',
+  },
+  returns: {measure: 'string'},
+  impl: {function: 'MERGE'},
+  isSymmetric: true,
+};
+
+const hll_estimate: DefinitionBlueprint = {
+  takes: {
+    'value': 'string',
+  },
+  returns: {dimension: 'number'},
+  impl: {function: 'CARDINALITY'},
+};
+
+const hll_export: DefinitionBlueprint = {
+  takes: {
+    'value': 'string',
+  },
+  returns: {dimension: 'string'},
+  impl: {
+    sql: 'CAST(${value} AS VARBINARY)',
+  },
+};
+
+const hll_import: DefinitionBlueprint = {
+  takes: {
+    'value': 'string',
+  },
+  returns: {dimension: 'string'},
+  impl: {
+    sql: 'CAST(${value} AS HyperLogLog)',
+  },
+};
+
 const max_by: DefinitionBlueprint = {
   generic: ['T', ['string', 'number', 'date', 'timestamp', 'boolean', 'json']],
   takes: {
@@ -294,6 +358,8 @@ export const TRINO_DIALECT_FUNCTIONS: DefinitionBlueprintMap = {
   bool_or,
   corr,
   count_approx,
+  hll_accumulate,
+  hll_combine,
   max_by,
   min_by,
   string_agg,
@@ -306,6 +372,9 @@ export const TRINO_DIALECT_FUNCTIONS: DefinitionBlueprintMap = {
   date_format,
   date_parse,
   from_unixtime,
+  hll_estimate,
+  hll_export,
+  hll_import,
   json_extract_scalar,
   regexp_like,
   regexp_replace,

--- a/packages/malloy/src/dialect/trino/trino.ts
+++ b/packages/malloy/src/dialect/trino/trino.ts
@@ -142,6 +142,7 @@ export class TrinoDialect extends PostgresBase {
   supportsComplexFilteredSources = false;
   supportsTempTables = false;
   supportsCountApprox = true;
+  supportsHyperLogLog = true;
 
   quoteTablePath(tablePath: string): string {
     // TODO: look into escaping.

--- a/test/src/databases/all/functions.spec.ts
+++ b/test/src/databases/all/functions.spec.ts
@@ -1310,6 +1310,39 @@ expressionModels.forEach((x, databaseName) => {
     });
   });
 
+  describe('hll_functions', () => {
+    const supported = runtime.dialect.supportsHyperLogLog;
+    it.when(supported)(`hyperloglog basic - ${databaseName}`, async () => {
+      await expect(`run: ${databaseName}.table('malloytest.state_facts') -> {
+        aggregate:
+          m1 is floor(hll_estimate(hll_accumulate(state))/10)
+      }`).malloyResultMatches(runtime, {m1: 5});
+    });
+
+    it.when(supported)(`hyperloglog combine - ${databaseName}`, async () => {
+      await expect(`run: ${databaseName}.table('malloytest.state_facts') -> {
+          group_by: state
+          aggregate: names_hll is hll_accumulate(popular_name)
+      } -> {
+          aggregate: name_count is hll_estimate(hll_combine(names_hll))
+      }
+      `).malloyResultMatches(runtime, {name_count: 6});
+    });
+
+    it.when(supported)(
+      `hyperloglog import/export - ${databaseName}`,
+      async () => {
+        await expect(`run: ${databaseName}.table('malloytest.state_facts') -> {
+          group_by: state
+          aggregate: names_hll is hll_export(hll_accumulate(popular_name))
+      } -> {
+          aggregate: name_count is hll_estimate(hll_combine(hll_import(names_hll)))
+      }
+      `).malloyResultMatches(runtime, {name_count: 6});
+      }
+    );
+  });
+
   describe('dialect functions', () => {
     describe('duckdb', () => {
       const isDuckdb = databaseName === 'duckdb';

--- a/test/src/databases/presto-trino/presto-trino.spec.ts
+++ b/test/src/databases/presto-trino/presto-trino.spec.ts
@@ -285,33 +285,6 @@ describe.each(runtimes.runtimeList)(
       ]);
     });
 
-    it(`hyperloglog basic - ${databaseName}`, async () => {
-      await expect(`run: ${databaseName}.table('malloytest.state_facts') -> {
-        aggregate:
-          m1 is floor(hll_estimate(hll_accumulate(state))/10)
-      }`).malloyResultMatches(runtime, {m1: 5});
-    });
-
-    it(`hyperloglog combine - ${databaseName}`, async () => {
-      await expect(`run: ${databaseName}.table('malloytest.state_facts') -> {
-          group_by: state
-          aggregate: names_hll is hll_accumulate(popular_name)
-      } -> {
-          aggregate: name_count is hll_estimate(hll_combine(names_hll))
-      }
-      `).malloyResultMatches(runtime, {name_count: 6});
-    });
-
-    it(`hyperloglog import/export - ${databaseName}`, async () => {
-      await expect(`run: ${databaseName}.table('malloytest.state_facts') -> {
-          group_by: state
-          aggregate: names_hll is hll_export(hll_accumulate(popular_name))
-      } -> {
-          aggregate: name_count is hll_estimate(hll_combine(hll_import(names_hll)))
-      }
-      `).malloyResultMatches(runtime, {name_count: 6});
-    });
-
     it(`runs the url_extract functions - ${databaseName}`, async () => {
       await expect(`
         run: ${databaseName}.sql(

--- a/test/src/databases/presto-trino/presto-trino.spec.ts
+++ b/test/src/databases/presto-trino/presto-trino.spec.ts
@@ -285,6 +285,33 @@ describe.each(runtimes.runtimeList)(
       ]);
     });
 
+    it(`hyperloglog basic - ${databaseName}`, async () => {
+      await expect(`run: ${databaseName}.table('malloytest.state_facts') -> {
+        aggregate:
+          m1 is floor(hll_estimate(hll_accumulate(state))/10)
+      }`).malloyResultMatches(runtime, {m1: 5});
+    });
+
+    it(`hyperloglog combine - ${databaseName}`, async () => {
+      await expect(`run: ${databaseName}.table('malloytest.state_facts') -> {
+          group_by: state
+          aggregate: names_hll is hll_accumulate(popular_name)
+      } -> {
+          aggregate: name_count is hll_estimate(hll_combine(names_hll))
+      }
+      `).malloyResultMatches(runtime, {name_count: 6});
+    });
+
+    it(`hyperloglog import/export - ${databaseName}`, async () => {
+      await expect(`run: ${databaseName}.table('malloytest.state_facts') -> {
+          group_by: state
+          aggregate: names_hll is hll_export(hll_accumulate(popular_name))
+      } -> {
+          aggregate: name_count is hll_estimate(hll_combine(hll_import(names_hll)))
+      }
+      `).malloyResultMatches(runtime, {name_count: 6});
+    });
+
     it(`runs the url_extract functions - ${databaseName}`, async () => {
       await expect(`
         run: ${databaseName}.sql(


### PR DESCRIPTION
Added functions

* hll_accumulate(scalar) - aggregate function, build an hll counter
* hll_combine(hll_counter) - aggregate function, combine HLL counters
* hll_estimate(hll_counter) - convert a HLL counter to a number
* hll_export(hll_counter) - export a HLL counter into BINARY (for storage)
* hll_import(binary) - import (from storage) an HLL counter.

## Basic aggregation:
```
run: presto.table('malloytest.state_facts') -> {
        aggregate:
         state_count is hll_estimate(hll_accumulate(state))
```

## Multi stage aggregation.
```
run: presto.table('malloytest.state_facts') -> {
          group_by: state
          aggregate: names_hll is hll_accumulate(popular_name)
      } -> {
          aggregate: name_count is hll_estimate(hll_combine(names_hll))
      }
```

## write a counter to disk

```
CREATE TABLE foo as %{
  x -> {group_by: state, aggregate: name_hll is hll_export(hll_accumulate(popular_name)) 
}%
```

## Read a counter from disk
```
presto.table('foo')-> {
   aggregate: name_count is hll_estimate(hll_combine(hll_import(name_hll)))
}
```