### PR TITLE
More cleanup of array functions

### DIFF
--- a/packages/malloy/src/dialect/duckdb/dialect_functions.ts
+++ b/packages/malloy/src/dialect/duckdb/dialect_functions.ts
@@ -9,13 +9,8 @@ import {
   DefinitionBlueprint,
   DefinitionBlueprintMap,
   OverloadedDefinitionBlueprint,
+  wrapDef,
 } from '../functions/util';
-
-const repeat: DefinitionBlueprint = {
-  takes: {'str': 'string', 'n': 'number'},
-  returns: 'string',
-  impl: {function: 'REPEAT'},
-};
 
 const list_extract: DefinitionBlueprint = {
   takes: {'value': {array: {generic: 'T'}}, 'index': 'number'},
@@ -103,9 +98,10 @@ export const DUCKDB_DIALECT_FUNCTIONS: DefinitionBlueprintMap = {
   count_approx,
   dayname,
   to_timestamp,
-  repeat,
   string_agg,
   string_agg_distinct,
   to_seconds,
   date_part,
+  ...wrapDef('repeat', {'str': 'string', 'n': 'number'}, 'string'),
+  ...wrapDef('reverse', {'str': 'string'}, 'string'),
 };

--- a/packages/malloy/src/dialect/duckdb/dialect_functions.ts
+++ b/packages/malloy/src/dialect/duckdb/dialect_functions.ts
@@ -9,7 +9,7 @@ import {
   DefinitionBlueprint,
   DefinitionBlueprintMap,
   OverloadedDefinitionBlueprint,
-  wrapDef,
+  def,
 } from '../functions/util';
 
 const list_extract: DefinitionBlueprint = {
@@ -102,6 +102,6 @@ export const DUCKDB_DIALECT_FUNCTIONS: DefinitionBlueprintMap = {
   string_agg_distinct,
   to_seconds,
   date_part,
-  ...wrapDef('repeat', {'str': 'string', 'n': 'number'}, 'string'),
-  ...wrapDef('reverse', {'str': 'string'}, 'string'),
+  ...def('repeat', {'str': 'string', 'n': 'number'}, 'string'),
+  ...def('reverse', {'str': 'string'}, 'string'),
 };

--- a/packages/malloy/src/dialect/functions/malloy_standard_functions.ts
+++ b/packages/malloy/src/dialect/functions/malloy_standard_functions.ts
@@ -60,7 +60,6 @@ type Standard = {
   regexp_extract: D;
   string_repeat: D;
   replace: {string: D; regular_expression: D};
-  reverse: D;
   round: {to_integer: D; to_precision: D};
   rtrim: {whitespace: D; characters: D};
   sign: D;
@@ -337,12 +336,6 @@ const replace: DefinitionFor<Standard['replace']> = {
     returns: 'string',
     impl: {function: 'REGEXP_REPLACE'},
   },
-};
-
-const reverse: DefinitionFor<Standard['reverse']> = {
-  takes: {'value': 'string'},
-  returns: 'string',
-  impl: {function: 'REVERSE'},
 };
 
 const round: DefinitionFor<Standard['round']> = {
@@ -718,7 +711,6 @@ export const MALLOY_STANDARD_FUNCTIONS: MalloyStandardFunctionDefinitions = {
   rand,
   regexp_extract,
   replace,
-  reverse,
   round,
   rtrim,
   sign,

--- a/packages/malloy/src/dialect/functions/util.ts
+++ b/packages/malloy/src/dialect/functions/util.ts
@@ -743,11 +743,13 @@ export function wrapDef(
   takes: Record<string, TypeDescBlueprint>,
   returns: TypeDescBlueprint
 ): DefinitionBlueprintMap {
+  let anyGenerics = false;
   const generic: {[name: string]: TypeDescElementBlueprintOrNamedGeneric[]} =
     {};
   for (const argType of Object.values(takes)) {
     for (const genericRef of findGenerics(argType)) {
       generic[genericRef.generic] = ['any'];
+      anyGenerics = true;
     }
   }
   const newDef: DefinitionBlueprint = {
@@ -755,10 +757,8 @@ export function wrapDef(
     returns,
     impl: {function: name.toUpperCase()},
   };
-  // avoids constructing an array just to test the length
-  for (const _atLeastOneGeneric in generic) {
+  if (anyGenerics) {
     newDef.generic = generic;
-    break;
   }
   return {[name]: newDef};
 }

--- a/packages/malloy/src/dialect/functions/util.ts
+++ b/packages/malloy/src/dialect/functions/util.ts
@@ -772,9 +772,8 @@ function* findGenerics(
 ): IterableIterator<NamedGeneric> {
   if (typeof tdbp !== 'string') {
     if ('generic' in tdbp) {
-      return tdbp;
-    }
-    if ('array' in tdbp) {
+      yield tdbp;
+    } else if ('array' in tdbp) {
       yield* findGenerics(tdbp.array);
     } else if ('record' in tdbp) {
       for (const recType of Object.values(tdbp.record)) {

--- a/packages/malloy/src/dialect/functions/util.ts
+++ b/packages/malloy/src/dialect/functions/util.ts
@@ -773,22 +773,25 @@ function* findGenerics(
   if (typeof tdbp !== 'string') {
     if ('generic' in tdbp) {
       yield tdbp;
-    } else if ('array' in tdbp) {
-      yield* findGenerics(tdbp.array);
     } else if ('record' in tdbp) {
       for (const recType of Object.values(tdbp.record)) {
         yield* findGenerics(recType);
       }
-    } else if ('literal' in tdbp) {
-      yield* findGenerics(tdbp.literal);
-    } else if ('measure' in tdbp) {
-      yield* findGenerics(tdbp.measure);
-    } else if ('dimension' in tdbp) {
-      yield* findGenerics(tdbp.dimension);
-    } else if ('constant' in tdbp) {
-      yield* findGenerics(tdbp.constant);
-    } else if ('calculation' in tdbp) {
-      yield* findGenerics(tdbp.calculation);
+    } else {
+      for (const leaflet of [
+        'array',
+        'literal',
+        'measure',
+        'dimension',
+        'measure',
+        'constant',
+        'cacluation',
+      ]) {
+        if (leaflet in tdbp) {
+          yield* findGenerics(tdbp[leaflet]);
+          return;
+        }
+      }
     }
   }
 }

--- a/packages/malloy/src/dialect/functions/util.ts
+++ b/packages/malloy/src/dialect/functions/util.ts
@@ -745,8 +745,8 @@ export function wrapDef(
 ): DefinitionBlueprintMap {
   const generic: {[name: string]: TypeDescElementBlueprintOrNamedGeneric[]} =
     {};
-  for (const argVal of Object.values(takes)) {
-    for (const genericRef of findGenerics(argVal)) {
+  for (const argType of Object.values(takes)) {
+    for (const genericRef of findGenerics(argType)) {
       generic[genericRef.generic] = ['any'];
     }
   }

--- a/packages/malloy/src/dialect/functions/util.ts
+++ b/packages/malloy/src/dialect/functions/util.ts
@@ -729,6 +729,10 @@ export function expandOverrideMapFromBase(
  *   0) Not an overloaded definition
  *   1) The function has the same name in malloy and in the dialect
  *   2) Every generic in args or return generics is type ['any']
+ * USAGE:
+ *
+ *     ...wrapDef('func_name', {'arg0': 'type0', 'arg1': 'type1'}, 'return-type')
+ *
  * @param name name of function
  * @param takes Record<Argument blueprint>
  * @param returns Return Blueprint
@@ -742,12 +746,12 @@ export function wrapDef(
   const generic: {[name: string]: TypeDescElementBlueprintOrNamedGeneric[]} =
     {};
   for (const argVal of Object.values(takes)) {
-    const anyGeneric = Array.from(tdLeafTypes(argVal)).filter(
+    const genericRefs = Array.from(tdLeafTypes(argVal)).filter(
       (t: TypeDescBlueprint): t is NamedGeneric => {
         return typeof t !== 'string' && 'generic' in t;
       }
     );
-    for (const genericRef of anyGeneric) {
+    for (const genericRef of genericRefs) {
       generic[genericRef.generic] = ['any'];
     }
   }
@@ -756,8 +760,10 @@ export function wrapDef(
     returns,
     impl: {function: name.toUpperCase()},
   };
-  if (Object.entries(generic).length > 0) {
+  // avoids constructing an erray just to test the length
+  for (const _atLeastOneGeneric in generic) {
     newDef.generic = generic;
+    break;
   }
   return {[name]: newDef};
 }

--- a/packages/malloy/src/dialect/functions/util.ts
+++ b/packages/malloy/src/dialect/functions/util.ts
@@ -746,13 +746,10 @@ export function wrapDef(
   const generic: {[name: string]: TypeDescElementBlueprintOrNamedGeneric[]} =
     {};
   for (const argVal of Object.values(takes)) {
-    const genericRefs = Array.from(tdLeafTypes(argVal)).filter(
-      (t: TypeDescBlueprint): t is NamedGeneric => {
-        return typeof t !== 'string' && 'generic' in t;
+    for (const leafType of tdLeafTypes(argVal)) {
+      if (typeof leafType !== 'string' && 'generic' in leafType) {
+        generic[leafType.generic] = ['any'];
       }
-    );
-    for (const genericRef of genericRefs) {
-      generic[genericRef.generic] = ['any'];
     }
   }
   const newDef: DefinitionBlueprint = {
@@ -760,7 +757,7 @@ export function wrapDef(
     returns,
     impl: {function: name.toUpperCase()},
   };
-  // avoids constructing an erray just to test the length
+  // avoids constructing an array just to test the length
   for (const _atLeastOneGeneric in generic) {
     newDef.generic = generic;
     break;

--- a/packages/malloy/src/dialect/mysql/dialect_functions.ts
+++ b/packages/malloy/src/dialect/mysql/dialect_functions.ts
@@ -6,16 +6,10 @@
  */
 
 import {
-  DefinitionBlueprint,
   DefinitionBlueprintMap,
   OverloadedDefinitionBlueprint,
+  wrapDef,
 } from '../functions/util';
-
-const repeat: DefinitionBlueprint = {
-  takes: {'str': 'string', 'n': 'number'},
-  returns: 'string',
-  impl: {function: 'REPEAT'},
-};
 
 const string_agg: OverloadedDefinitionBlueprint = {
   default_separator: {
@@ -59,5 +53,6 @@ const string_agg_distinct: OverloadedDefinitionBlueprint = {
 export const MYSQL_DIALECT_FUNCTIONS: DefinitionBlueprintMap = {
   string_agg,
   string_agg_distinct,
-  repeat,
+  ...wrapDef('repeat', {'str': 'string', 'n': 'number'}, 'string'),
+  ...wrapDef('reverse', {'str': 'string'}, 'string'),
 };

--- a/packages/malloy/src/dialect/mysql/dialect_functions.ts
+++ b/packages/malloy/src/dialect/mysql/dialect_functions.ts
@@ -8,7 +8,7 @@
 import {
   DefinitionBlueprintMap,
   OverloadedDefinitionBlueprint,
-  wrapDef,
+  def,
 } from '../functions/util';
 
 const string_agg: OverloadedDefinitionBlueprint = {
@@ -53,6 +53,6 @@ const string_agg_distinct: OverloadedDefinitionBlueprint = {
 export const MYSQL_DIALECT_FUNCTIONS: DefinitionBlueprintMap = {
   string_agg,
   string_agg_distinct,
-  ...wrapDef('repeat', {'str': 'string', 'n': 'number'}, 'string'),
-  ...wrapDef('reverse', {'str': 'string'}, 'string'),
+  ...def('repeat', {'str': 'string', 'n': 'number'}, 'string'),
+  ...def('reverse', {'str': 'string'}, 'string'),
 };

--- a/packages/malloy/src/dialect/postgres/dialect_functions.ts
+++ b/packages/malloy/src/dialect/postgres/dialect_functions.ts
@@ -6,16 +6,10 @@
  */
 
 import {
-  DefinitionBlueprint,
   DefinitionBlueprintMap,
   OverloadedDefinitionBlueprint,
+  wrapDef,
 } from '../functions/util';
-
-const repeat: DefinitionBlueprint = {
-  takes: {'str': 'string', 'n': 'number'},
-  returns: 'string',
-  impl: {function: 'REPEAT'},
-};
 
 const string_agg: OverloadedDefinitionBlueprint = {
   default_separator: {
@@ -59,5 +53,6 @@ const string_agg_distinct: OverloadedDefinitionBlueprint = {
 export const POSTGRES_DIALECT_FUNCTIONS: DefinitionBlueprintMap = {
   string_agg,
   string_agg_distinct,
-  repeat,
+  ...wrapDef('repeat', {'str': 'string', 'n': 'number'}, 'string'),
+  ...wrapDef('reverse', {'str': 'string'}, 'string'),
 };

--- a/packages/malloy/src/dialect/postgres/dialect_functions.ts
+++ b/packages/malloy/src/dialect/postgres/dialect_functions.ts
@@ -8,7 +8,7 @@
 import {
   DefinitionBlueprintMap,
   OverloadedDefinitionBlueprint,
-  wrapDef,
+  def,
 } from '../functions/util';
 
 const string_agg: OverloadedDefinitionBlueprint = {
@@ -53,6 +53,6 @@ const string_agg_distinct: OverloadedDefinitionBlueprint = {
 export const POSTGRES_DIALECT_FUNCTIONS: DefinitionBlueprintMap = {
   string_agg,
   string_agg_distinct,
-  ...wrapDef('repeat', {'str': 'string', 'n': 'number'}, 'string'),
-  ...wrapDef('reverse', {'str': 'string'}, 'string'),
+  ...def('repeat', {'str': 'string', 'n': 'number'}, 'string'),
+  ...def('reverse', {'str': 'string'}, 'string'),
 };

--- a/packages/malloy/src/dialect/snowflake/dialect_functions.ts
+++ b/packages/malloy/src/dialect/snowflake/dialect_functions.ts
@@ -7,7 +7,7 @@
 
 import {AggregateOrderByNode} from '../../model';
 import {
-  wrapDef,
+  def,
   DefinitionBlueprintMap,
   OverloadedDefinitionBlueprint,
   arg as a,
@@ -62,6 +62,6 @@ const string_agg_distinct: OverloadedDefinitionBlueprint = {
 export const SNOWFLAKE_DIALECT_FUNCTIONS: DefinitionBlueprintMap = {
   string_agg,
   string_agg_distinct,
-  ...wrapDef('repeat', {'str': 'string', 'n': 'number'}, 'string'),
-  ...wrapDef('reverse', {'str': 'string'}, 'string'),
+  ...def('repeat', {'str': 'string', 'n': 'number'}, 'string'),
+  ...def('reverse', {'str': 'string'}, 'string'),
 };

--- a/packages/malloy/src/dialect/snowflake/dialect_functions.ts
+++ b/packages/malloy/src/dialect/snowflake/dialect_functions.ts
@@ -7,18 +7,12 @@
 
 import {AggregateOrderByNode} from '../../model';
 import {
-  DefinitionBlueprint,
+  wrapDef,
   DefinitionBlueprintMap,
   OverloadedDefinitionBlueprint,
   arg as a,
   sql,
 } from '../functions/util';
-
-const repeat: DefinitionBlueprint = {
-  takes: {'str': 'string', 'n': 'number'},
-  returns: 'string',
-  impl: {function: 'REPEAT'},
-};
 
 const order_by: AggregateOrderByNode = {
   node: 'aggregate_order_by',
@@ -68,5 +62,6 @@ const string_agg_distinct: OverloadedDefinitionBlueprint = {
 export const SNOWFLAKE_DIALECT_FUNCTIONS: DefinitionBlueprintMap = {
   string_agg,
   string_agg_distinct,
-  repeat,
+  ...wrapDef('repeat', {'str': 'string', 'n': 'number'}, 'string'),
+  ...wrapDef('reverse', {'str': 'string'}, 'string'),
 };

--- a/packages/malloy/src/dialect/standardsql/dialect_functions.ts
+++ b/packages/malloy/src/dialect/standardsql/dialect_functions.ts
@@ -6,7 +6,7 @@
  */
 
 import {
-  wrapDef,
+  def,
   DefinitionBlueprint,
   DefinitionBlueprintMap,
   OverloadedDefinitionBlueprint,
@@ -69,6 +69,6 @@ export const STANDARDSQL_DIALECT_FUNCTIONS: DefinitionBlueprintMap = {
   date_from_unix_date,
   string_agg,
   string_agg_distinct,
-  ...wrapDef('repeat', {'str': 'string', 'n': 'number'}, 'string'),
-  ...wrapDef('reverse', {'str': 'string'}, 'string'),
+  ...def('repeat', {'str': 'string', 'n': 'number'}, 'string'),
+  ...def('reverse', {'str': 'string'}, 'string'),
 };

--- a/packages/malloy/src/dialect/standardsql/dialect_functions.ts
+++ b/packages/malloy/src/dialect/standardsql/dialect_functions.ts
@@ -6,16 +6,11 @@
  */
 
 import {
+  wrapDef,
   DefinitionBlueprint,
   DefinitionBlueprintMap,
   OverloadedDefinitionBlueprint,
 } from '../functions/util';
-
-const repeat: DefinitionBlueprint = {
-  takes: {'str': 'string', 'n': 'number'},
-  returns: 'string',
-  impl: {function: 'REPEAT'},
-};
 
 const date_from_unix_date: DefinitionBlueprint = {
   takes: {'unix_date': 'number'},
@@ -74,5 +69,6 @@ export const STANDARDSQL_DIALECT_FUNCTIONS: DefinitionBlueprintMap = {
   date_from_unix_date,
   string_agg,
   string_agg_distinct,
-  repeat,
+  ...wrapDef('repeat', {'str': 'string', 'n': 'number'}, 'string'),
+  ...wrapDef('reverse', {'str': 'string'}, 'string'),
 };

--- a/packages/malloy/src/dialect/trino/dialect_functions.ts
+++ b/packages/malloy/src/dialect/trino/dialect_functions.ts
@@ -389,7 +389,7 @@ const sequence: OverloadedDefinitionBlueprint = {
 const trino_reverse: DefinitionBlueprint = {
   takes: {'str': 'string'},
   returns: 'string',
-  impl: {sql: 'REVERSE(CAST ${str} AS VARCHAR)'},
+  impl: {sql: 'REVERSE(CAST(${str} AS VARCHAR))'},
 };
 
 export const TRINO_DIALECT_FUNCTIONS: DefinitionBlueprintMap = {
@@ -540,7 +540,8 @@ const reverse: OverloadedDefinitionBlueprint = {
     impl: {function: 'REVERSE'},
   },
   ngirts: {
-    takes: {'str_v': 'string'},
+    takes: {'str_v': T},
+    generic: {'T': ['string', 'null']},
     returns: 'string',
     impl: {function: 'REVERSE'},
   },

--- a/packages/malloy/src/dialect/trino/dialect_functions.ts
+++ b/packages/malloy/src/dialect/trino/dialect_functions.ts
@@ -475,13 +475,13 @@ export const TRINO_DIALECT_FUNCTIONS: DefinitionBlueprintMap = {
 
 const array_position: OverloadedDefinitionBlueprint = {
   first_instance: {
-    takes: {x: {array: T}, el: T},
+    takes: {'array_v': {array: T}, 'el': T},
     generic: {T: ['any']},
     returns: 'number',
     impl: {function: 'ARRAY_POSITION'},
   },
   nth_instance: {
-    takes: {x: {array: T}, el: T, instance: 'number'},
+    takes: {'array_v': {array: T}, 'el': T, 'instance': 'number'},
     generic: {T: ['any']},
     returns: 'number',
     impl: {function: 'ARRAY_POSITION'},
@@ -491,15 +491,15 @@ const array_position: OverloadedDefinitionBlueprint = {
 const array_intersect: OverloadedDefinitionBlueprint = {
   two_arrays: {
     takes: {
-      'a': {array: T},
-      'b': {array: T},
+      'array_v1': {array: T},
+      'array_v2': {array: T},
     },
     generic: {'T': ['any']},
     returns: {array: T},
     impl: {function: 'ARRAY_INTERSECT'},
   },
   nested_array: {
-    takes: {'a': {array: {array: T}}},
+    takes: {'array_v': {array: {array: T}}},
     generic: {'T': ['any']},
     returns: {array: T},
     impl: {function: 'ARRAY_INTERSECT'},
@@ -544,12 +544,12 @@ export const PRESTO_DIALECT_FUNCTIONS: DefinitionBlueprintMap = {
   array_least_frequent,
   array_position,
   reverse,
-  ...wrapDef('array_average', {x: {array: T}}, 'number'),
-  ...wrapDef('array_has_duplicates', {x: {array: T}}, 'boolean'),
+  ...wrapDef('array_average', {'array_v': {array: T}}, 'number'),
+  ...wrapDef('array_has_duplicates', {'array_v': {array: T}}, 'boolean'),
   ...wrapDef('array_cum_sum', {numeric_array: {array: T}}, {array: 'number'}),
-  ...wrapDef('array_duplicates', {x: {array: T}}, {array: T}),
-  ...wrapDef('array_sum', {x: {array: T}}, 'number'),
-  ...wrapDef('array_sort_desc', {x: {array: T}}, {array: T}),
-  ...wrapDef('remove_nulls', {x: {array: T}}, {array: T}),
-  ...wrapDef('array_top_n', {x: {array: T}, n: 'number'}, {array: T}),
+  ...wrapDef('array_duplicates', {'array_v': {array: T}}, {array: T}),
+  ...wrapDef('array_sum', {'array_v': {array: T}}, 'number'),
+  ...wrapDef('array_sort_desc', {'array_v': {array: T}}, {array: T}),
+  ...wrapDef('remove_nulls', {'array_v': {array: T}}, {array: T}),
+  ...wrapDef('array_top_n', {'array_v': {array: T}, 'n': 'number'}, {array: T}),
 };

--- a/packages/malloy/src/dialect/trino/dialect_functions.ts
+++ b/packages/malloy/src/dialect/trino/dialect_functions.ts
@@ -473,7 +473,7 @@ export const TRINO_DIALECT_FUNCTIONS: DefinitionBlueprintMap = {
 
 /******** Presto Only *********/
 
-const array_vosition: OverloadedDefinitionBlueprint = {
+const array_position: OverloadedDefinitionBlueprint = {
   first_instance: {
     takes: {x: {array: T}, el: T},
     generic: {T: ['any']},
@@ -542,7 +542,7 @@ export const PRESTO_DIALECT_FUNCTIONS: DefinitionBlueprintMap = {
   ...TRINO_DIALECT_FUNCTIONS,
   array_intersect,
   array_least_frequent,
-  array_vosition,
+  array_position,
   reverse,
   ...wrapDef('array_average', {x: {array: T}}, 'number'),
   ...wrapDef('array_has_duplicates', {x: {array: T}}, 'boolean'),

--- a/packages/malloy/src/dialect/trino/dialect_functions.ts
+++ b/packages/malloy/src/dialect/trino/dialect_functions.ts
@@ -10,7 +10,7 @@ import {
   DefinitionBlueprintMap,
   OverloadedDefinitionBlueprint,
   TypeDescBlueprint,
-  wrapDef,
+  def,
 } from '../functions/util';
 
 /*
@@ -22,97 +22,19 @@ import {
  * OverloadedDefinitionBlueprint, naming it with the name of the function
  * you want to add, and then to add that name to the dialcect function list.
  *
- * Experimentally, there is also a function wrapDef which creates
- * a DefinitionBlueprint for you. If the function name in malloy source
- * is the same as the function name in sql, and any generic argument or return
- * types are type 'any'( like array<any> ), then you can use the wrapper
- * definition generator wrapDef, and there are examples in this file
- * of how to do that. Let us know if you like wrapDef a lot, and we
- * can extend it to also allow overloads and generics and other impl: geatures.
+ * Experimentally, there is also a function def which creates a
+ * DefinitionBlueprint for you. For simple blueprints, you can use the wrapper
+ * definition generator def(), and there are examples in this file
+ * of how to do that, and def() has some hover-documentation.
  *
- * Also let us know if you prefer editing the Blueprint data structures.
+ * It is an experiment so please let us know if you like def(),
+ * or if you prefer editing the Blueprint data structures.
  */
 
 // Cute shortcut So you can write things like: {array: T} and {dimension: T}
 const T: TypeDescBlueprint = {generic: 'T'};
 
 // Aggregate functions:
-
-const arbitrary: DefinitionBlueprint = {
-  generic: {'T': ['string', 'number', 'date', 'timestamp', 'boolean', 'json']},
-  takes: {'value': {dimension: T}},
-  returns: {measure: T},
-  impl: {function: 'ARBITRARY'},
-};
-
-const count_approx: DefinitionBlueprint = {
-  takes: {'value': {dimension: 'any'}},
-  returns: {measure: 'number'},
-  impl: {function: 'APPROX_DISTINCT'},
-  isSymmetric: true,
-};
-
-const hll_accumulate: OverloadedDefinitionBlueprint = {
-  default: {
-    generic: {
-      'T': ['string', 'number', 'date', 'timestamp', 'boolean', 'json'],
-    },
-    takes: {'value': {dimension: T}},
-    returns: {measure: {sql_native: 'hyperloglog'}},
-    isSymmetric: true,
-    impl: {
-      function: 'APPROX_SET',
-    },
-  },
-  with_percent: {
-    generic: {
-      'T': ['string', 'number', 'date', 'timestamp', 'boolean', 'json'],
-    },
-    takes: {'value': {dimension: T}, 'accuracy': 'number'},
-    returns: {measure: {sql_native: 'hyperloglog'}},
-    isSymmetric: true,
-    impl: {
-      function: 'APPROX_SET',
-    },
-  },
-};
-
-const hll_combine: DefinitionBlueprint = {
-  takes: {
-    'value': {sql_native: 'hyperloglog'},
-  },
-  returns: {measure: {sql_native: 'hyperloglog'}},
-  impl: {function: 'MERGE'},
-  isSymmetric: true,
-};
-
-const hll_estimate: DefinitionBlueprint = {
-  takes: {
-    'value': {sql_native: 'hyperloglog'},
-  },
-  returns: {dimension: 'number'},
-  impl: {function: 'CARDINALITY'},
-};
-
-const hll_export: DefinitionBlueprint = {
-  takes: {
-    'value': {sql_native: 'hyperloglog'},
-  },
-  returns: {dimension: {sql_native: 'varbinary'}},
-  impl: {
-    sql: 'CAST(${value} AS VARBINARY)',
-  },
-};
-
-const hll_import: DefinitionBlueprint = {
-  takes: {
-    'value': {sql_native: 'varbinary'},
-  },
-  returns: {dimension: {sql_native: 'hyperloglog'}},
-  impl: {
-    sql: 'CAST(${value} AS HyperLogLog)',
-  },
-};
 
 const max_by: DefinitionBlueprint = {
   generic: {'T': ['string', 'number', 'date', 'timestamp', 'boolean', 'json']},
@@ -255,19 +177,16 @@ const array_join: OverloadedDefinitionBlueprint = {
 const sequence: OverloadedDefinitionBlueprint = {
   num_to_num: {
     takes: {'start': 'number', 'stop': 'number'},
-    generic: {'T': ['any']},
     returns: {array: 'number'},
     impl: {function: 'SEQUENCE'},
   },
   num_to_num_step: {
     takes: {'start': 'number', 'stop': 'number', 'step': 'number'},
-    generic: {'T': ['any']},
     returns: {array: 'number'},
     impl: {function: 'SEQUENCE'},
   },
   date_to_date: {
     takes: {'start': 'date', 'stop': 'date'},
-    generic: {'T': ['any']},
     returns: {array: 'date'},
     impl: {function: 'SEQUENCE'},
   },
@@ -296,79 +215,123 @@ export const TRINO_DIALECT_FUNCTIONS: DefinitionBlueprintMap = {
   // want to implement that at some point
   // In Presto, this is an "error" parameter between 0 and 1
   // In Trino, this is a "weight" parameter between 1 and 99
-  ...wrapDef(
+  ...def(
     'approx_percentile',
     {'value': 'number', 'percentage': 'number'},
     {measure: 'number'}
   ),
-  arbitrary,
-  ...wrapDef(
+  ...def(
+    'arbitrary',
+    {'value': {dimension: T}},
+    {measure: T},
+    {
+      generic: {
+        'T': ['string', 'number', 'date', 'timestamp', 'boolean', 'json'],
+      },
+    }
+  ),
+  ...def(
     'bitwise_and_agg',
     {'value': {dimension: 'number'}},
-    {measure: 'number'}
+    {measure: 'number'},
+    {isSymmetric: true}
   ),
-  ...wrapDef(
+  ...def(
     'bitwise_or_agg',
     {'value': {dimension: 'number'}},
-    {measure: 'number'}
+    {measure: 'number'},
+    {isSymmetric: true}
   ),
-  ...wrapDef(
+  ...def(
     'bitwise_xor_agg',
     {'value': {dimension: 'number'}},
-    {measure: 'number'}
+    {measure: 'number'},
+    {isSymmetric: true}
   ),
-  ...wrapDef(
-    'bool_and',
-    {'value': {dimension: 'boolean'}},
-    {measure: 'boolean'}
-  ),
-  ...wrapDef(
-    'bool_or',
-    {'value': {dimension: 'boolean'}},
-    {measure: 'boolean'}
-  ),
-  ...wrapDef(
+  ...def('bool_and', {'value': {dimension: 'boolean'}}, {measure: 'boolean'}),
+  ...def('bool_or', {'value': {dimension: 'boolean'}}, {measure: 'boolean'}),
+  ...def(
     'corr',
     {'y': {dimension: 'number'}, 'x': {dimension: 'number'}},
     {measure: 'number'}
   ),
-  count_approx,
-  hll_accumulate,
-  hll_combine,
+  ...def(
+    'count_approx',
+    {'value': {dimension: 'any'}},
+    {measure: 'number'},
+    {
+      impl: {function: 'APPROX_DISTINCT'},
+      isSymmetric: true,
+    }
+  ),
+  hll_accumulate: {
+    default: {
+      takes: {'value': {dimension: T}},
+      returns: {measure: {sql_native: 'hyperloglog'}},
+      generic: {
+        'T': ['string', 'number', 'date', 'timestamp', 'boolean', 'json'],
+      },
+      isSymmetric: true,
+      impl: {function: 'APPROX_SET'},
+    },
+    with_percent: {
+      takes: {'value': {dimension: T}, 'accuracy': 'number'},
+      returns: {measure: {sql_native: 'hyperloglog'}},
+      generic: {
+        'T': ['string', 'number', 'date', 'timestamp', 'boolean', 'json'],
+      },
+      isSymmetric: true,
+      impl: {function: 'APPROX_SET'},
+    },
+  },
+  hll_combine: {
+    takes: {'value': {sql_native: 'hyperloglog'}},
+    returns: {measure: {sql_native: 'hyperloglog'}},
+    impl: {function: 'MERGE'},
+    isSymmetric: true,
+  },
+  hll_estimate: {
+    takes: {'value': {sql_native: 'hyperloglog'}},
+    returns: {dimension: 'number'},
+    impl: {function: 'CARDINALITY'},
+  },
+  hll_export: {
+    takes: {'value': {sql_native: 'hyperloglog'}},
+    returns: {dimension: {sql_native: 'varbinary'}},
+    impl: {sql: 'CAST(${value} AS VARBINARY)'},
+  },
+  hll_import: {
+    takes: {'value': {sql_native: 'varbinary'}},
+    returns: {dimension: {sql_native: 'hyperloglog'}},
+    impl: {sql: 'CAST(${value} AS HyperLogLog)'},
+  },
   max_by,
   min_by,
   string_agg,
   string_agg_distinct,
-  ...wrapDef('variance', {'n': 'number'}, {measure: 'number'}),
+  ...def('variance', {'n': 'number'}, {measure: 'number'}),
 
   // scalar functions
-  ...wrapDef('bitwise_and', {'val1': 'number', 'val2': 'number'}, 'number'),
-  ...wrapDef('bitwise_or', {'val1': 'number', 'val2': 'number'}, 'number'),
-  ...wrapDef(
-    'date_format',
-    {'ts_val': 'timestamp', 'format': 'string'},
-    'string'
-  ),
+  ...def('bitwise_and', {'val1': 'number', 'val2': 'number'}, 'number'),
+  ...def('bitwise_or', {'val1': 'number', 'val2': 'number'}, 'number'),
+  ...def('date_format', {'ts_val': 'timestamp', 'format': 'string'}, 'string'),
   date_parse,
-  ...wrapDef('from_unixtime', {'unixtime': 'number'}, 'timestamp'),
-  hll_estimate,
-  hll_export,
-  hll_import,
+  ...def('from_unixtime', {'unixtime': 'number'}, 'timestamp'),
   json_extract_scalar,
   regexp_like,
   regexp_replace,
-  ...wrapDef('to_unixtime', {'ts_val': 'timestamp'}, 'number'),
-  ...wrapDef('url_extract_fragment', {'url': 'string'}, 'string'),
-  ...wrapDef('url_extract_host', {'url': 'string'}, 'string'),
-  ...wrapDef(
+  ...def('to_unixtime', {'ts_val': 'timestamp'}, 'number'),
+  ...def('url_extract_fragment', {'url': 'string'}, 'string'),
+  ...def('url_extract_host', {'url': 'string'}, 'string'),
+  ...def(
     'url_extract_parameter',
     {'url': 'string', 'parameter': 'string'},
     'string'
   ),
-  ...wrapDef('url_extract_path', {'url': 'string'}, 'string'),
-  ...wrapDef('url_extract_port', {'url': 'string'}, 'number'),
-  ...wrapDef('url_extract_protocol', {'url': 'string'}, 'string'),
-  ...wrapDef('url_extract_query', {'url': 'string'}, 'string'),
+  ...def('url_extract_path', {'url': 'string'}, 'string'),
+  ...def('url_extract_port', {'url': 'string'}, 'number'),
+  ...def('url_extract_protocol', {'url': 'string'}, 'string'),
+  ...def('url_extract_query', {'url': 'string'}, 'string'),
 
   // window functions
   percent_rank,
@@ -376,40 +339,32 @@ export const TRINO_DIALECT_FUNCTIONS: DefinitionBlueprintMap = {
   // array function
   array_join,
   sequence,
-  ...wrapDef('array_distinct', {'x': {array: T}}, {array: T}),
-  ...wrapDef('array_except', {'x': {array: T}, 'y': {array: T}}, {array: T}),
-  ...wrapDef('array_intersect', {'x': {array: T}, 'y': {array: T}}, {array: T}),
-  ...wrapDef('array_max', {'x': {array: T}}, T),
-  ...wrapDef('array_min', {'x': {array: T}}, T),
-  ...wrapDef('array_normalize', {'x': {array: T}, 'p': 'number'}, {array: T}),
-  ...wrapDef('array_remove', {'x': {array: T}, 'element': T}, {array: T}),
-  ...wrapDef('array_sort', {'x': {array: T}}, {array: T}),
-  ...wrapDef('arrays_overlap', {'x': {array: T}, 'y': {array: T}}, 'boolean'),
-  ...wrapDef('array_union', {'x': {array: T}, 'y': {array: T}}, {array: T}),
-  ...wrapDef('cardinality', {'x': {array: T}}, 'number'),
-  ...wrapDef('shuffle', {'x': {array: T}}, {array: T}),
-  ...wrapDef(
-    'combinations',
-    {'x': {array: T}, 'n': 'number'},
-    {array: {array: T}}
-  ),
-  ...wrapDef('contains', {'x': {array: T}, 'element': T}, 'boolean'),
-  ...wrapDef('element_at', {'x': {array: T}, 'oridnal': 'number'}, T),
-  ...wrapDef('flatten', {'x': {array: {array: T}}}, {array: T}),
-  ...wrapDef('ngrams', {'x': {array: T}, 'n': 'number'}, {array: {array: T}}),
-  ...wrapDef('repeat', {'x': T, 'n': 'number'}, {array: T}),
-  ...wrapDef(
+  ...def('array_distinct', {'x': {array: T}}, {array: T}),
+  ...def('array_except', {'x': {array: T}, 'y': {array: T}}, {array: T}),
+  ...def('array_intersect', {'x': {array: T}, 'y': {array: T}}, {array: T}),
+  ...def('array_max', {'x': {array: T}}, T),
+  ...def('array_min', {'x': {array: T}}, T),
+  ...def('array_normalize', {'x': {array: T}, 'p': 'number'}, {array: T}),
+  ...def('array_remove', {'x': {array: T}, 'element': T}, {array: T}),
+  ...def('array_sort', {'x': {array: T}}, {array: T}),
+  ...def('arrays_overlap', {'x': {array: T}, 'y': {array: T}}, 'boolean'),
+  ...def('array_union', {'x': {array: T}, 'y': {array: T}}, {array: T}),
+  ...def('cardinality', {'x': {array: T}}, 'number'),
+  ...def('shuffle', {'x': {array: T}}, {array: T}),
+  ...def('combinations', {'x': {array: T}, 'n': 'number'}, {array: {array: T}}),
+  ...def('contains', {'x': {array: T}, 'element': T}, 'boolean'),
+  ...def('element_at', {'x': {array: T}, 'oridnal': 'number'}, T),
+  ...def('flatten', {'x': {array: {array: T}}}, {array: T}),
+  ...def('ngrams', {'x': {array: T}, 'n': 'number'}, {array: {array: T}}),
+  ...def('repeat', {'x': T, 'n': 'number'}, {array: T}),
+  ...def(
     'slice',
     {'x': {array: T}, 'start': 'number', 'len': 'number'},
     {array: T}
   ),
-  ...wrapDef(
-    'split',
-    {to_split: 'string', seperator: 'string'},
-    {array: 'string'}
-  ),
-  ...wrapDef('trim_array', {'x': {array: T}, 'n': 'number'}, {array: T}),
-  ...wrapDef(
+  ...def('split', {to_split: 'string', seperator: 'string'}, {array: 'string'}),
+  ...def('trim_array', {'x': {array: T}, 'n': 'number'}, {array: T}),
+  ...def(
     'array_split_into_chunks',
     {'x': {array: T}, 'n': 'number'},
     {array: {array: T}}
@@ -418,79 +373,45 @@ export const TRINO_DIALECT_FUNCTIONS: DefinitionBlueprintMap = {
 
 /******** Presto Only *********/
 
-const array_position: OverloadedDefinitionBlueprint = {
-  first_instance: {
-    takes: {'x': {array: T}, 'el': T},
-    generic: {T: ['any']},
-    returns: 'number',
-    impl: {function: 'ARRAY_POSITION'},
-  },
-  nth_instance: {
-    takes: {'x': {array: T}, 'el': T, 'instance': 'number'},
-    generic: {T: ['any']},
-    returns: 'number',
-    impl: {function: 'ARRAY_POSITION'},
-  },
-};
-
-const array_intersect: OverloadedDefinitionBlueprint = {
-  two_arrays: {
-    takes: {
-      'array_v1': {array: T},
-      'array_v2': {array: T},
-    },
-    generic: {'T': ['any']},
-    returns: {array: T},
-    impl: {function: 'ARRAY_INTERSECT'},
-  },
-  nested_array: {
-    takes: {'x': {array: {array: T}}},
-    generic: {'T': ['any']},
-    returns: {array: T},
-    impl: {function: 'ARRAY_INTERSECT'},
-  },
-};
-
-const array_least_frequent: OverloadedDefinitionBlueprint = {
-  array_only: {
-    takes: {'x': {array: T}},
-    generic: {'T': ['any']},
-    returns: {array: T},
-    impl: {function: 'ARRAY_LEAST_FREQUENT'},
-  },
-  bottom: {
-    takes: {
-      'array_v': {array: T},
-      'count': 'number',
-    },
-    generic: {'T': ['any']},
-    returns: {array: T},
-    impl: {function: 'ARRAY_LEAST_FREQUENT'},
-  },
-};
-
-const reverse: OverloadedDefinitionBlueprint = {
-  ngirts: {...string_reverse},
-  yarra: {
-    takes: {'x': {array: T}},
-    returns: {array: T},
-    generic: {'T': ['any']},
-    impl: {function: 'REVERSE'},
-  },
-};
-
 export const PRESTO_DIALECT_FUNCTIONS: DefinitionBlueprintMap = {
   ...TRINO_DIALECT_FUNCTIONS,
-  array_intersect,
-  array_least_frequent,
-  array_position,
-  reverse,
-  ...wrapDef('array_average', {'x': {array: T}}, 'number'),
-  ...wrapDef('array_has_duplicates', {'x': {array: T}}, 'boolean'),
-  ...wrapDef('array_cum_sum', {numeric_array: {array: T}}, {array: 'number'}),
-  ...wrapDef('array_duplicates', {'x': {array: T}}, {array: T}),
-  ...wrapDef('array_sum', {'x': {array: T}}, 'number'),
-  ...wrapDef('array_sort_desc', {'x': {array: T}}, {array: T}),
-  ...wrapDef('remove_nulls', {'x': {array: T}}, {array: T}),
-  ...wrapDef('array_top_n', {'x': {array: T}, 'n': 'number'}, {array: T}),
+  array_intersect: {
+    ...def('array_intersect', {'x': {array: T}, 'y': {array: T}}, {array: T}),
+    nested_array: {
+      takes: {'x': {array: {array: T}}},
+      generic: {'T': ['any']},
+      returns: {array: T},
+      impl: {function: 'ARRAY_INTERSECT'},
+    },
+  },
+  array_least_frequent: {
+    ...def('array_least_frequent', {'x': {array: T}}, {array: T}),
+    bottom_n: {
+      takes: {'array_v': {array: T}, 'n': 'number'},
+      returns: {array: T},
+      generic: {'T': ['any']},
+      impl: {function: 'ARRAY_LEAST_FREQUENT'},
+    },
+  },
+  array_position: {
+    ...def('array_position', {'x': {array: T}, 'el': T}, 'number'),
+    nth_instance: {
+      takes: {'x': {array: T}, 'el': T, 'instance': 'number'},
+      generic: {'T': ['any']},
+      returns: 'number',
+      impl: {function: 'ARRAY_POSITION'},
+    },
+  },
+  reverse: {
+    string_reverse,
+    ...def('reverse', {'x': {array: T}}, {array: T}),
+  },
+  ...def('array_average', {'x': {array: T}}, 'number'),
+  ...def('array_has_duplicates', {'x': {array: T}}, 'boolean'),
+  ...def('array_cum_sum', {numeric_array: {array: T}}, {array: 'number'}),
+  ...def('array_duplicates', {'x': {array: T}}, {array: T}),
+  ...def('array_sum', {'x': {array: T}}, 'number'),
+  ...def('array_sort_desc', {'x': {array: T}}, {array: T}),
+  ...def('remove_nulls', {'x': {array: T}}, {array: T}),
+  ...def('array_top_n', {'x': {array: T}, 'n': 'number'}, {array: T}),
 };

--- a/packages/malloy/src/dialect/trino/dialect_functions.ts
+++ b/packages/malloy/src/dialect/trino/dialect_functions.ts
@@ -33,7 +33,8 @@ import {
  * Also let us know if you prefer editing the Blueprint data structures.
  */
 
-const T: TypeDescBlueprint = {generic: 'T'}; // So you can write things like: {array: T}
+// Cute shortcut So you can write things like: {array: T} and {dimension: T}
+const T: TypeDescBlueprint = {generic: 'T'};
 
 // Aggregate functions:
 
@@ -56,7 +57,7 @@ const hll_accumulate: OverloadedDefinitionBlueprint = {
     generic: {
       'T': ['string', 'number', 'date', 'timestamp', 'boolean', 'json'],
     },
-    takes: {'value': {dimension: {generic: 'T'}}},
+    takes: {'value': {dimension: T}},
     returns: {measure: {sql_native: 'hyperloglog'}},
     isSymmetric: true,
     impl: {
@@ -67,7 +68,7 @@ const hll_accumulate: OverloadedDefinitionBlueprint = {
     generic: {
       'T': ['string', 'number', 'date', 'timestamp', 'boolean', 'json'],
     },
-    takes: {'value': {dimension: {generic: 'T'}}, 'accuracy': 'number'},
+    takes: {'value': {dimension: T}, 'accuracy': 'number'},
     returns: {measure: {sql_native: 'hyperloglog'}},
     isSymmetric: true,
     impl: {

--- a/packages/malloy/src/dialect/trino/dialect_functions.ts
+++ b/packages/malloy/src/dialect/trino/dialect_functions.ts
@@ -386,7 +386,14 @@ const sequence: OverloadedDefinitionBlueprint = {
   },
 };
 
+const trino_reverse: DefinitionBlueprint = {
+  takes: {'str': 'string'},
+  returns: 'string',
+  impl: {sql: 'REVERSE(CAST ${str} AS VARCHAR)'},
+};
+
 export const TRINO_DIALECT_FUNCTIONS: DefinitionBlueprintMap = {
+  reverse: trino_reverse,
   // aggregate functions
   approx_percentile,
   arbitrary,
@@ -443,7 +450,6 @@ export const TRINO_DIALECT_FUNCTIONS: DefinitionBlueprintMap = {
   ...wrapDef('arrays_overlap', {'x': {array: T}, 'y': {array: T}}, 'boolean'),
   ...wrapDef('array_union', {'x': {array: T}, 'y': {array: T}}, {array: T}),
   ...wrapDef('cardinality', {'x': {array: T}}, 'number'),
-  ...wrapDef('reverse', {'x': 'string'}, 'string'),
   ...wrapDef('shuffle', {'x': {array: T}}, {array: T}),
   ...wrapDef(
     'combinations',

--- a/packages/malloy/src/dialect/trino/dialect_functions.ts
+++ b/packages/malloy/src/dialect/trino/dialect_functions.ts
@@ -20,16 +20,17 @@ import {
  * So in this file we are experimenting with various ways to define things.
  * The most general and powerful is to write a DefinitionBlueprint or
  * OverloadedDefinitionBlueprint, naming it with the name of the function
- * you want to add, and then to add that name to the dialcect funciton list.
+ * you want to add, and then to add that name to the dialcect function list.
  *
- * Experimentally, currently there is also a function wrapDef which creates
+ * Experimentally, there is also a function wrapDef which creates
  * a DefinitionBlueprint for you. If the function name in malloy source
- * is the same as the function name in sql, any generic argument or return
+ * is the same as the function name in sql, and any generic argument or return
  * types are type 'any'( like array<any> ), then you can use the wrapper
  * definition generator wrapDef, and there are examples in this file
  * of how to do that. Let us know if you like wrapDef a lot, and we
- * can extend it to also allow overloads. Also let us know
- * if you prefer editing Blueprint data structures.
+ * can extend it to also allow overloads and generics and other impl: geatures.
+ *
+ * Also let us know if you prefer editing the Blueprint data structures.
  */
 
 const T: TypeDescBlueprint = {generic: 'T'}; // So you can write things like: {array: T}

--- a/packages/malloy/src/dialect/trino/dialect_functions.ts
+++ b/packages/malloy/src/dialect/trino/dialect_functions.ts
@@ -532,7 +532,7 @@ const reverse: OverloadedDefinitionBlueprint = {
     impl: {function: 'REVERSE'},
   },
   ngirts: {
-    takes: {'array_v': 'string'},
+    takes: {'str_v': 'string'},
     returns: 'string',
     impl: {function: 'REVERSE'},
   },

--- a/packages/malloy/src/dialect/trino/dialect_functions.ts
+++ b/packages/malloy/src/dialect/trino/dialect_functions.ts
@@ -384,7 +384,6 @@ const sequence: OverloadedDefinitionBlueprint = {
     returns: {array: 'date'},
     impl: {function: 'SEQUENCE'},
   },
-  // mtoy todo document missing sequence
 };
 
 export const TRINO_DIALECT_FUNCTIONS: DefinitionBlueprintMap = {
@@ -440,7 +439,6 @@ export const TRINO_DIALECT_FUNCTIONS: DefinitionBlueprintMap = {
   ...wrapDef('array_min', {'x': {array: T}}, T),
   ...wrapDef('array_normalize', {'x': {array: T}, 'p': 'number'}, {array: T}),
   ...wrapDef('array_remove', {'x': {array: T}, 'element': T}, {array: T}),
-  // mtoy todo document mising lambda sort
   ...wrapDef('array_sort', {'x': {array: T}}, {array: T}),
   ...wrapDef('arrays_overlap', {'x': {array: T}, 'y': {array: T}}, 'boolean'),
   ...wrapDef('array_union', {'x': {array: T}, 'y': {array: T}}, {array: T}),

--- a/packages/malloy/src/dialect/trino/dialect_functions.ts
+++ b/packages/malloy/src/dialect/trino/dialect_functions.ts
@@ -278,6 +278,14 @@ const string_reverse: DefinitionBlueprint = {
   impl: {sql: 'REVERSE(CAST(${str} AS VARCHAR))'},
 };
 
+/**
+ * This map is for functions which exist in both Presto and Trino.
+ * If you are adding functions which only exist in Presto, put them in
+ * to PRESTO_DIALECT_FUNCTIONS.
+ *
+ * If you have a function which works differently in each, add them to
+ * both.
+ */
 export const TRINO_DIALECT_FUNCTIONS: DefinitionBlueprintMap = {
   // string functions
   reverse: string_reverse,

--- a/packages/malloy/src/dialect/trino/dialect_functions.ts
+++ b/packages/malloy/src/dialect/trino/dialect_functions.ts
@@ -346,7 +346,7 @@ const url_extract_query: DefinitionBlueprint = {
 const array_join: OverloadedDefinitionBlueprint = {
   skip_nulls: {
     takes: {
-      'theArray': {array: T},
+      'array_v': {array: T},
       'sep': 'string',
     },
     generic: {T: ['any']},
@@ -355,7 +355,7 @@ const array_join: OverloadedDefinitionBlueprint = {
   },
   null_aware: {
     takes: {
-      'theArray': T,
+      'array_v': T,
       'sep': 'string',
       'nullStr': 'string',
     },
@@ -473,7 +473,7 @@ export const TRINO_DIALECT_FUNCTIONS: DefinitionBlueprintMap = {
 
 /******** Presto Only *********/
 
-const array_position: OverloadedDefinitionBlueprint = {
+const array_vosition: OverloadedDefinitionBlueprint = {
   first_instance: {
     takes: {x: {array: T}, el: T},
     generic: {T: ['any']},
@@ -508,14 +508,14 @@ const array_intersect: OverloadedDefinitionBlueprint = {
 
 const array_least_frequent: OverloadedDefinitionBlueprint = {
   array_only: {
-    takes: {'theArray': {array: T}},
+    takes: {'array_v': {array: T}},
     generic: {'T': ['any']},
     returns: {array: T},
     impl: {function: 'ARRAY_LEAST_FREQUENT'},
   },
   bottom: {
     takes: {
-      'theArray': {array: T},
+      'array_v': {array: T},
       'count': 'number',
     },
     generic: {'T': ['any']},
@@ -524,11 +524,26 @@ const array_least_frequent: OverloadedDefinitionBlueprint = {
   },
 };
 
+const reverse: OverloadedDefinitionBlueprint = {
+  yarra: {
+    takes: {'array_v': {array: T}},
+    returns: {array: T},
+    generic: {'T': ['any']},
+    impl: {function: 'REVERSE'},
+  },
+  ngirts: {
+    takes: {'array_v': 'string'},
+    returns: 'string',
+    impl: {function: 'REVERSE'},
+  },
+};
+
 export const PRESTO_DIALECT_FUNCTIONS: DefinitionBlueprintMap = {
   ...TRINO_DIALECT_FUNCTIONS,
   array_intersect,
   array_least_frequent,
-  array_position,
+  array_vosition,
+  reverse,
   ...wrapDef('array_average', {x: {array: T}}, 'number'),
   ...wrapDef('array_has_duplicates', {x: {array: T}}, 'boolean'),
   ...wrapDef('array_cum_sum', {numeric_array: {array: T}}, {array: 'number'}),

--- a/packages/malloy/src/dialect/trino/dialect_functions.ts
+++ b/packages/malloy/src/dialect/trino/dialect_functions.ts
@@ -17,61 +17,11 @@ const T: TypeDescBlueprint = {generic: 'T'};
 
 // Aggregate functions:
 
-// TODO: Approx percentile can be called with a third argument; we probably
-// want to implement that at some point
-// In Presto, this is an "error" parameter between 0 and 1
-// In Trino, this is a "weight" parameter between 1 and 99
-const approx_percentile: DefinitionBlueprint = {
-  takes: {'value': 'number', 'percentage': 'number'},
-  returns: {measure: 'number'},
-  impl: {
-    function: 'APPROX_PERCENTILE',
-  },
-};
-
 const arbitrary: DefinitionBlueprint = {
   generic: {'T': ['string', 'number', 'date', 'timestamp', 'boolean', 'json']},
   takes: {'value': {dimension: T}},
   returns: {measure: T},
   impl: {function: 'ARBITRARY'},
-};
-
-const bitwise_and_agg: DefinitionBlueprint = {
-  takes: {'value': {dimension: 'number'}},
-  returns: {measure: 'number'},
-  impl: {function: 'BITWISE_OR_AGG'},
-};
-
-const bitwise_or_agg: DefinitionBlueprint = {
-  takes: {'value': {dimension: 'number'}},
-  returns: {measure: 'number'},
-  impl: {function: 'BITWISE_AND_AGG'},
-};
-
-const bitwise_xor_agg: DefinitionBlueprint = {
-  takes: {'value': {dimension: 'number'}},
-  returns: {measure: 'number'},
-  impl: {function: 'BITWISE_XOR_AGG'},
-};
-
-const bool_and: DefinitionBlueprint = {
-  takes: {'value': {dimension: 'boolean'}},
-  returns: {measure: 'boolean'},
-  impl: {function: 'BOOL_AND'},
-};
-
-const bool_or: DefinitionBlueprint = {
-  takes: {'value': {dimension: 'boolean'}},
-  returns: {measure: 'boolean'},
-  impl: {function: 'BOOL_OR'},
-};
-
-const corr: DefinitionBlueprint = {
-  takes: {'y': {dimension: 'number'}, 'x': {dimension: 'number'}},
-  returns: {measure: 'number'},
-  impl: {
-    sql: 'CORR(${y}, ${x})',
-  },
 };
 
 const count_approx: DefinitionBlueprint = {
@@ -204,37 +154,7 @@ const string_agg_distinct: OverloadedDefinitionBlueprint = {
   },
 };
 
-const variance: DefinitionBlueprint = {
-  takes: {'value': {dimension: 'number'}},
-  returns: {measure: 'number'},
-  impl: {function: 'VARIANCE'},
-};
-
 // Scalar functions
-
-const bitwise_and: DefinitionBlueprint = {
-  takes: {'val1': 'number', 'val2': 'number'},
-  returns: 'number',
-  impl: {
-    function: 'BITWISE_AND',
-  },
-};
-
-const bitwise_or: DefinitionBlueprint = {
-  takes: {'val1': 'number', 'val2': 'number'},
-  returns: 'number',
-  impl: {
-    function: 'BITWISE_OR',
-  },
-};
-
-const date_format: DefinitionBlueprint = {
-  takes: {'ts_val': 'timestamp', 'format': 'string'},
-  returns: 'string',
-  impl: {
-    function: 'DATE_FORMAT',
-  },
-};
 
 const date_parse: DefinitionBlueprint = {
   takes: {'ts_string': 'string', 'format': 'string'},
@@ -242,12 +162,6 @@ const date_parse: DefinitionBlueprint = {
   impl: {
     sql: 'DATE_PARSE(${ts_string}, ${format})',
   },
-};
-
-const from_unixtime: DefinitionBlueprint = {
-  takes: {'unixtime': 'number'},
-  returns: 'timestamp',
-  impl: {function: 'FROM_UNIXTIME'},
 };
 
 // TODO: support Presto JSON types
@@ -289,58 +203,10 @@ const regexp_replace: OverloadedDefinitionBlueprint = {
   },
 };
 
-const to_unixtime: DefinitionBlueprint = {
-  takes: {'ts_val': 'timestamp'},
-  returns: 'number',
-  impl: {function: 'TO_UNIXTIME'},
-};
-
 const percent_rank: DefinitionBlueprint = {
   takes: {},
   returns: {calculation: 'number'},
   impl: {function: 'PERCENT_RANK', needsWindowOrderBy: true},
-};
-
-const url_extract_fragment: DefinitionBlueprint = {
-  takes: {'url': 'string'},
-  returns: 'string',
-  impl: {function: 'URL_EXTRACT_FRAGMENT'},
-};
-
-const url_extract_host: DefinitionBlueprint = {
-  takes: {'url': 'string'},
-  returns: 'string',
-  impl: {function: 'URL_EXTRACT_HOST'},
-};
-
-const url_extract_parameter: DefinitionBlueprint = {
-  takes: {'url': 'string', 'parameter': 'string'},
-  returns: 'string',
-  impl: {function: 'URL_EXTRACT_PARAMETER'},
-};
-
-const url_extract_path: DefinitionBlueprint = {
-  takes: {'url': 'string'},
-  returns: 'string',
-  impl: {function: 'URL_EXTRACT_PATH'},
-};
-
-const url_extract_port: DefinitionBlueprint = {
-  takes: {'url': 'string'},
-  returns: 'number',
-  impl: {function: 'URL_EXTRACT_PORT'},
-};
-
-const url_extract_protocol: DefinitionBlueprint = {
-  takes: {'url': 'string'},
-  returns: 'string',
-  impl: {function: 'URL_EXTRACT_PROTOCOL'},
-};
-
-const url_extract_query: DefinitionBlueprint = {
-  takes: {'url': 'string'},
-  returns: 'string',
-  impl: {function: 'URL_EXTRACT_QUERY'},
 };
 
 const array_join: OverloadedDefinitionBlueprint = {
@@ -393,16 +259,50 @@ const string_reverse: DefinitionBlueprint = {
 };
 
 export const TRINO_DIALECT_FUNCTIONS: DefinitionBlueprintMap = {
+  // string functions
   reverse: string_reverse,
+
   // aggregate functions
-  approx_percentile,
+  // TODO: Approx percentile can be called with a third argument; we probably
+  // want to implement that at some point
+  // In Presto, this is an "error" parameter between 0 and 1
+  // In Trino, this is a "weight" parameter between 1 and 99
+  ...wrapDef(
+    'approx_percentile',
+    {'value': 'number', 'percentage': 'number'},
+    {measure: 'number'}
+  ),
   arbitrary,
-  bitwise_and_agg,
-  bitwise_or_agg,
-  bitwise_xor_agg,
-  bool_and,
-  bool_or,
-  corr,
+  ...wrapDef(
+    'bitwise_and_agg',
+    {'value': {dimension: 'number'}},
+    {measure: 'number'}
+  ),
+  ...wrapDef(
+    'bitwise_or_agg',
+    {'value': {dimension: 'number'}},
+    {measure: 'number'}
+  ),
+  ...wrapDef(
+    'bitwise_xor_agg',
+    {'value': {dimension: 'number'}},
+    {measure: 'number'}
+  ),
+  ...wrapDef(
+    'bool_and',
+    {'value': {dimension: 'boolean'}},
+    {measure: 'boolean'}
+  ),
+  ...wrapDef(
+    'bool_or',
+    {'value': {dimension: 'boolean'}},
+    {measure: 'boolean'}
+  ),
+  ...wrapDef(
+    'corr',
+    {'y': {dimension: 'number'}, 'x': {dimension: 'number'}},
+    {measure: 'number'}
+  ),
   count_approx,
   hll_accumulate,
   hll_combine,
@@ -410,33 +310,41 @@ export const TRINO_DIALECT_FUNCTIONS: DefinitionBlueprintMap = {
   min_by,
   string_agg,
   string_agg_distinct,
-  variance,
+  ...wrapDef('variance', {'n': 'number'}, {measure: 'number'}),
 
   // scalar functions
-  bitwise_and,
-  bitwise_or,
-  date_format,
+  ...wrapDef('bitwise_and', {'val1': 'number', 'val2': 'number'}, 'number'),
+  ...wrapDef('bitwise_or', {'val1': 'number', 'val2': 'number'}, 'number'),
+  ...wrapDef(
+    'date_format',
+    {'ts_val': 'timestamp', 'format': 'string'},
+    'string'
+  ),
   date_parse,
-  from_unixtime,
+  ...wrapDef('from_unixtime', {'unixtime': 'number'}, 'timestamp'),
   hll_estimate,
   hll_export,
   hll_import,
   json_extract_scalar,
   regexp_like,
   regexp_replace,
-  to_unixtime,
-  url_extract_fragment,
-  url_extract_host,
-  url_extract_parameter,
-  url_extract_path,
-  url_extract_port,
-  url_extract_protocol,
-  url_extract_query,
+  ...wrapDef('to_unixtime', {'ts_val': 'timestamp'}, 'number'),
+  ...wrapDef('url_extract_fragment', {'url': 'string'}, 'string'),
+  ...wrapDef('url_extract_host', {'url': 'string'}, 'string'),
+  ...wrapDef(
+    'url_extract_parameter',
+    {'url': 'string', 'parameter': 'string'},
+    'string'
+  ),
+  ...wrapDef('url_extract_path', {'url': 'string'}, 'string'),
+  ...wrapDef('url_extract_port', {'url': 'string'}, 'number'),
+  ...wrapDef('url_extract_protocol', {'url': 'string'}, 'string'),
+  ...wrapDef('url_extract_query', {'url': 'string'}, 'string'),
 
   // window functions
   percent_rank,
 
-  // array functions except those below
+  // array function
   array_join,
   sequence,
   ...wrapDef('array_distinct', {'x': {array: T}}, {array: T}),

--- a/packages/malloy/src/dialect/trino/dialect_functions.ts
+++ b/packages/malloy/src/dialect/trino/dialect_functions.ts
@@ -386,14 +386,14 @@ const sequence: OverloadedDefinitionBlueprint = {
   },
 };
 
-const trino_reverse: DefinitionBlueprint = {
+const string_reverse: DefinitionBlueprint = {
   takes: {'str': 'string'},
   returns: 'string',
   impl: {sql: 'REVERSE(CAST(${str} AS VARCHAR))'},
 };
 
 export const TRINO_DIALECT_FUNCTIONS: DefinitionBlueprintMap = {
-  reverse: trino_reverse,
+  reverse: string_reverse,
   // aggregate functions
   approx_percentile,
   arbitrary,
@@ -533,16 +533,11 @@ const array_least_frequent: OverloadedDefinitionBlueprint = {
 };
 
 const reverse: OverloadedDefinitionBlueprint = {
+  ngirts: {...string_reverse},
   yarra: {
     takes: {'x': {array: T}},
     returns: {array: T},
     generic: {'T': ['any']},
-    impl: {function: 'REVERSE'},
-  },
-  ngirts: {
-    takes: {'str_v': T},
-    generic: {'T': ['string', 'null']},
-    returns: 'string',
     impl: {function: 'REVERSE'},
   },
 };

--- a/packages/malloy/src/dialect/trino/dialect_functions.ts
+++ b/packages/malloy/src/dialect/trino/dialect_functions.ts
@@ -13,7 +13,26 @@ import {
   wrapDef,
 } from '../functions/util';
 
-const T: TypeDescBlueprint = {generic: 'T'};
+/*
+ * We are experimenting with the best way to make this file easy for someone
+ * to step in and modify, AND to make it easy to create a new dialect.
+ *
+ * So in this file we are experimenting with various ways to define things.
+ * The most general and powerful is to write a DefinitionBlueprint or
+ * OverloadedDefinitionBlueprint, naming it with the name of the function
+ * you want to add, and then to add that name to the dialcect funciton list.
+ *
+ * Experimentally, currently there is also a function wrapDef which creates
+ * a DefinitionBlueprint for you. If the function name in malloy source
+ * is the same as the function name in sql, any generic argument or return
+ * types are type 'any'( like array<any> ), then you can use the wrapper
+ * definition generator wrapDef, and there are examples in this file
+ * of how to do that. Let us know if you like wrapDef a lot, and we
+ * can extend it to also allow overloads. Also let us know
+ * if you prefer editing Blueprint data structures.
+ */
+
+const T: TypeDescBlueprint = {generic: 'T'}; // So you can write things like: {array: T}
 
 // Aggregate functions:
 

--- a/packages/malloy/src/dialect/trino/dialect_functions.ts
+++ b/packages/malloy/src/dialect/trino/dialect_functions.ts
@@ -433,29 +433,33 @@ export const TRINO_DIALECT_FUNCTIONS: DefinitionBlueprintMap = {
   // array functions except those below
   array_join,
   sequence,
-  ...wrapDef('array_distinct', {x: {array: T}}, {array: T}),
-  ...wrapDef('array_except', {x: {array: T}, y: {array: T}}, {array: T}),
-  ...wrapDef('array_intersect', {x: {array: T}, y: {array: T}}, {array: T}),
-  ...wrapDef('array_max', {x: {array: T}}, T),
-  ...wrapDef('array_min', {x: {array: T}}, T),
-  ...wrapDef('array_normalize', {x: {array: T}, p: 'number'}, {array: T}),
-  ...wrapDef('array_remove', {x: {array: T}, element: T}, {array: T}),
+  ...wrapDef('array_distinct', {'x': {array: T}}, {array: T}),
+  ...wrapDef('array_except', {'x': {array: T}, 'y': {array: T}}, {array: T}),
+  ...wrapDef('array_intersect', {'x': {array: T}, 'y': {array: T}}, {array: T}),
+  ...wrapDef('array_max', {'x': {array: T}}, T),
+  ...wrapDef('array_min', {'x': {array: T}}, T),
+  ...wrapDef('array_normalize', {'x': {array: T}, 'p': 'number'}, {array: T}),
+  ...wrapDef('array_remove', {'x': {array: T}, 'element': T}, {array: T}),
   // mtoy todo document mising lambda sort
-  ...wrapDef('array_sort', {x: {array: T}}, {array: T}),
-  ...wrapDef('arrays_overlap', {x: {array: T}, y: {array: T}}, 'boolean'),
-  ...wrapDef('array_union', {x: {array: T}, y: {array: T}}, {array: T}),
-  ...wrapDef('cardinality', {x: {array: T}}, 'number'),
-  ...wrapDef('reverse', {x: {array: T}}, {array: T}),
-  ...wrapDef('shuffle', {x: {array: T}}, {array: T}),
-  ...wrapDef('combinations', {x: {array: T}, n: 'number'}, {array: {array: T}}),
-  ...wrapDef('contains', {x: {array: T}, element: T}, 'boolean'),
-  ...wrapDef('element_at', {x: {array: T}, oridnal: 'number'}, T),
-  ...wrapDef('flatten', {x: {array: {array: T}}}, {array: T}),
-  ...wrapDef('ngrams', {x: {array: T}, n: 'number'}, {array: {array: T}}),
-  ...wrapDef('repeat', {x: T, n: 'number'}, {array: T}),
+  ...wrapDef('array_sort', {'x': {array: T}}, {array: T}),
+  ...wrapDef('arrays_overlap', {'x': {array: T}, 'y': {array: T}}, 'boolean'),
+  ...wrapDef('array_union', {'x': {array: T}, 'y': {array: T}}, {array: T}),
+  ...wrapDef('cardinality', {'x': {array: T}}, 'number'),
+  ...wrapDef('reverse', {'x': 'string'}, 'string'),
+  ...wrapDef('shuffle', {'x': {array: T}}, {array: T}),
+  ...wrapDef(
+    'combinations',
+    {'x': {array: T}, 'n': 'number'},
+    {array: {array: T}}
+  ),
+  ...wrapDef('contains', {'x': {array: T}, 'element': T}, 'boolean'),
+  ...wrapDef('element_at', {'x': {array: T}, 'oridnal': 'number'}, T),
+  ...wrapDef('flatten', {'x': {array: {array: T}}}, {array: T}),
+  ...wrapDef('ngrams', {'x': {array: T}, 'n': 'number'}, {array: {array: T}}),
+  ...wrapDef('repeat', {'x': T, 'n': 'number'}, {array: T}),
   ...wrapDef(
     'slice',
-    {x: {array: T}, start: 'number', len: 'number'},
+    {'x': {array: T}, 'start': 'number', 'len': 'number'},
     {array: T}
   ),
   ...wrapDef(
@@ -463,10 +467,10 @@ export const TRINO_DIALECT_FUNCTIONS: DefinitionBlueprintMap = {
     {to_split: 'string', seperator: 'string'},
     {array: 'string'}
   ),
-  ...wrapDef('trim_array', {x: {array: T}, n: 'number'}, {array: T}),
+  ...wrapDef('trim_array', {'x': {array: T}, 'n': 'number'}, {array: T}),
   ...wrapDef(
     'array_split_into_chunks',
-    {x: {array: T}, n: 'number'},
+    {'x': {array: T}, 'n': 'number'},
     {array: {array: T}}
   ),
 };
@@ -475,13 +479,13 @@ export const TRINO_DIALECT_FUNCTIONS: DefinitionBlueprintMap = {
 
 const array_position: OverloadedDefinitionBlueprint = {
   first_instance: {
-    takes: {'array_v': {array: T}, 'el': T},
+    takes: {'x': {array: T}, 'el': T},
     generic: {T: ['any']},
     returns: 'number',
     impl: {function: 'ARRAY_POSITION'},
   },
   nth_instance: {
-    takes: {'array_v': {array: T}, 'el': T, 'instance': 'number'},
+    takes: {'x': {array: T}, 'el': T, 'instance': 'number'},
     generic: {T: ['any']},
     returns: 'number',
     impl: {function: 'ARRAY_POSITION'},
@@ -499,7 +503,7 @@ const array_intersect: OverloadedDefinitionBlueprint = {
     impl: {function: 'ARRAY_INTERSECT'},
   },
   nested_array: {
-    takes: {'array_v': {array: {array: T}}},
+    takes: {'x': {array: {array: T}}},
     generic: {'T': ['any']},
     returns: {array: T},
     impl: {function: 'ARRAY_INTERSECT'},
@@ -508,7 +512,7 @@ const array_intersect: OverloadedDefinitionBlueprint = {
 
 const array_least_frequent: OverloadedDefinitionBlueprint = {
   array_only: {
-    takes: {'array_v': {array: T}},
+    takes: {'x': {array: T}},
     generic: {'T': ['any']},
     returns: {array: T},
     impl: {function: 'ARRAY_LEAST_FREQUENT'},
@@ -526,7 +530,7 @@ const array_least_frequent: OverloadedDefinitionBlueprint = {
 
 const reverse: OverloadedDefinitionBlueprint = {
   yarra: {
-    takes: {'array_v': {array: T}},
+    takes: {'x': {array: T}},
     returns: {array: T},
     generic: {'T': ['any']},
     impl: {function: 'REVERSE'},
@@ -544,12 +548,12 @@ export const PRESTO_DIALECT_FUNCTIONS: DefinitionBlueprintMap = {
   array_least_frequent,
   array_position,
   reverse,
-  ...wrapDef('array_average', {'array_v': {array: T}}, 'number'),
-  ...wrapDef('array_has_duplicates', {'array_v': {array: T}}, 'boolean'),
+  ...wrapDef('array_average', {'x': {array: T}}, 'number'),
+  ...wrapDef('array_has_duplicates', {'x': {array: T}}, 'boolean'),
   ...wrapDef('array_cum_sum', {numeric_array: {array: T}}, {array: 'number'}),
-  ...wrapDef('array_duplicates', {'array_v': {array: T}}, {array: T}),
-  ...wrapDef('array_sum', {'array_v': {array: T}}, 'number'),
-  ...wrapDef('array_sort_desc', {'array_v': {array: T}}, {array: T}),
-  ...wrapDef('remove_nulls', {'array_v': {array: T}}, {array: T}),
-  ...wrapDef('array_top_n', {'array_v': {array: T}, 'n': 'number'}, {array: T}),
+  ...wrapDef('array_duplicates', {'x': {array: T}}, {array: T}),
+  ...wrapDef('array_sum', {'x': {array: T}}, 'number'),
+  ...wrapDef('array_sort_desc', {'x': {array: T}}, {array: T}),
+  ...wrapDef('remove_nulls', {'x': {array: T}}, {array: T}),
+  ...wrapDef('array_top_n', {'x': {array: T}, 'n': 'number'}, {array: T}),
 };

--- a/packages/malloy/src/dialect/trino/function_overrides.ts
+++ b/packages/malloy/src/dialect/trino/function_overrides.ts
@@ -28,9 +28,6 @@ export const TRINO_MALLOY_STANDARD_OVERLOADS: OverrideMap = {
   string_repeat: {
     sql: "ARRAY_JOIN(REPEAT(${value}, CASE WHEN ${value} IS NOT NULL THEN ${count} END),'')",
   },
-  reverse: {
-    sql: 'REVERSE(CAST(${value} AS VARCHAR))',
-  },
   starts_with: {sql: 'COALESCE(STARTS_WITH(${value}, ${prefix}), false)'},
   ends_with: {
     sql: 'COALESCE(STARTS_WITH(REVERSE(CAST(${value} AS VARCHAR)), REVERSE(CAST(${suffix} AS VARCHAR))), false)',

--- a/test/src/databases/all/expr.spec.ts
+++ b/test/src/databases/all/expr.spec.ts
@@ -357,16 +357,6 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
     }
   );
 
-  it('uses the correct symbol for modulus, either % or MOD', async () => {
-    await expect(`
-      run: aircraft_models->{
-        group_by: mod_example is 10 % 4
-      }
-    `).malloyResultMatches(expressionModel, {
-      mod_example: 2,
-    });
-  });
-
   it('named query metadata undefined', async () => {
     const result = await expressionModel
       .loadQuery(

--- a/test/src/databases/presto-trino/presto-trino.spec.ts
+++ b/test/src/databases/presto-trino/presto-trino.spec.ts
@@ -439,7 +439,11 @@ describe.each(runtimes.runtimeList)(
           `run: ${nums}->{select: t is remove_nulls([null, 2])}`
         ).malloyResultMatches(runtime, {t: [2]});
       });
-      /// mtoy todo figure out overload
+      it('runs reverse(null)', async () => {
+        await expect(
+          `run: ${nums}->{select: t is reverse(null)}`
+        ).malloyResultMatches(runtime, {t: null});
+      });
       it.when(presto)('runs reverse(array)', async () => {
         await expect(
           `run: ${nums}->{select: t is reverse(nums)}`

--- a/test/src/databases/presto-trino/presto-trino.spec.ts
+++ b/test/src/databases/presto-trino/presto-trino.spec.ts
@@ -219,8 +219,8 @@ describe.each(runtimes.runtimeList)(
         or_agg is bitwise_or_agg(n1)
         xor_agg is bitwise_xor_agg(n1)
       }`).malloyResultMatches(runtime, {
-        and_agg: 33552351,
-        or_agg: 4166,
+        and_agg: 4166,
+        or_agg: 33552351,
         xor_agg: 28922591,
       });
     });

--- a/test/src/databases/presto-trino/presto-trino.spec.ts
+++ b/test/src/databases/presto-trino/presto-trino.spec.ts
@@ -440,7 +440,7 @@ describe.each(runtimes.runtimeList)(
         ).malloyResultMatches(runtime, {t: [2]});
       });
       /// mtoy todo figure out overload
-      it.skip('runs reverse', async () => {
+      it.when(presto)('runs reverse(array)', async () => {
         await expect(
           `run: ${nums}->{select: t is reverse(nums)}`
         ).malloyResultMatches(runtime, {t: [1, 1, 4]});


### PR DESCRIPTION
I pushed #2051 early to catch a release train so there would be an alpha available. Finishing up here.

* repeat and reverse are no longer in the standard library
* string_reverse is added to the standard library
* repeat and reverse are now in each dialects dialect library, with dialect specific semantics

In general, because some dialects have few or no functions supporting arrays, at this time, there will not be any further array functions in the standard library. We need a re-think of the standard library before that happens.

- [x] Update function docs to explain `def()`
- [x] [Update language docs](https://github.com/malloydata/malloydata.github.io/issues/203)

