### PR TITLE
Fix issue where BQ refused to generate "complex SQL" for a select

### DIFF
--- a/packages/malloy/src/lang/test/expressions.spec.ts
+++ b/packages/malloy/src/lang/test/expressions.spec.ts
@@ -334,6 +334,18 @@ describe('expressions', () => {
       errorMessage('Filtered expression requires an aggregate computation')
     );
   });
+  test('can use calculate with partition by in select', () => {
+    expect(markSource`
+    ##! experimental { partition_by function_order_by }
+    run: a -> {
+      select: ai, astr
+      calculate: prev is lag(ai) {
+        partition_by: astr
+        order_by: ai asc
+      }
+      order_by: ai asc, astr asc
+    }`).toTranslate();
+  });
 
   describe('expr props', () => {
     test('aggregate order by not allowed without experiments enabled', () => {

--- a/packages/malloy/src/model/malloy_query.ts
+++ b/packages/malloy/src/model/malloy_query.ts
@@ -131,6 +131,7 @@ import {
   shouldMaterialize,
 } from './materialization/utils';
 import {EventStream} from '../runtime_types';
+import {Tag} from '../tags';
 
 interface TurtleDefPlus extends TurtleDef, Filtered {}
 
@@ -3411,6 +3412,13 @@ class QueryQuery extends QueryField {
     };
     this.generateStage0Fields(this.rootResult, f, stageWriter);
 
+    if (
+      this.firstSegment.type === 'project' &&
+      !this.parent.modelCompilerFlags().has('unsafe_complex_select_query')
+    ) {
+      throw new Error('PROJECT cannot be used on queries with turtles');
+    }
+
     const groupBy = 'GROUP BY ' + f.dimensionIndexes.join(',') + '\n';
 
     from += this.parent.dialect.sqlGroupSetTable(this.maxGroupSet) + '\n';
@@ -4307,6 +4315,16 @@ class QueryStruct {
 
     this.dialect = getDialect(this.findFirstDialect());
     this.addFieldsFromFieldList(structDef.fields);
+  }
+
+  private _modelTag: Tag | undefined = undefined;
+  modelCompilerFlags(): Tag {
+    if (this._modelTag === undefined) {
+      const annotation = this.structDef.modelAnnotation;
+      const {tag} = Tag.annotationToTag(annotation, {prefix: /^##!\s*/});
+      this._modelTag = tag;
+    }
+    return this._modelTag;
   }
 
   protected findFirstDialect(): string {

--- a/packages/malloy/src/model/malloy_query.ts
+++ b/packages/malloy/src/model/malloy_query.ts
@@ -3411,9 +3411,6 @@ class QueryQuery extends QueryField {
     };
     this.generateStage0Fields(this.rootResult, f, stageWriter);
 
-    if (this.firstSegment.type === 'project') {
-      throw new Error('PROJECT cannot be used on queries with turtles');
-    }
     const groupBy = 'GROUP BY ' + f.dimensionIndexes.join(',') + '\n';
 
     from += this.parent.dialect.sqlGroupSetTable(this.maxGroupSet) + '\n';

--- a/test/src/databases/all/functions.spec.ts
+++ b/test/src/databases/all/functions.spec.ts
@@ -1745,6 +1745,7 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
     it('can be used in a select', async () => {
       await expect(`
         ##! experimental { function_order_by partition_by }
+        ##! unsafe_complex_select_query
         run: state_facts -> {
           select: state, births, popular_name
           calculate: prev_births_by_name is lag(births) {
@@ -1752,7 +1753,7 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
             order_by: births desc
           }
           order_by: births desc
-          limit: 10
+          limit: 3
         }
       `).malloyResultMatches(expressionModel, [
         {
@@ -1772,48 +1773,6 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
           births: 21467359,
           popular_name: 'Isabella',
           prev_births_by_name: 23694136,
-        },
-        {
-          state: 'PA',
-          births: 16661910,
-          popular_name: 'Isabella',
-          prev_births_by_name: 21467359,
-        },
-        {
-          state: 'IL',
-          births: 15178876,
-          popular_name: 'Isabella',
-          prev_births_by_name: 16661910,
-        },
-        {
-          state: 'OH',
-          births: 14201526,
-          popular_name: 'Isabella',
-          prev_births_by_name: 15178876,
-        },
-        {
-          state: 'MI',
-          births: 11643455,
-          popular_name: 'Sophia',
-          prev_births_by_name: null,
-        },
-        {
-          state: 'FL',
-          births: 9277223,
-          popular_name: 'Isabella',
-          prev_births_by_name: 14201526,
-        },
-        {
-          state: 'NC',
-          births: 8440235,
-          popular_name: 'Emma',
-          prev_births_by_name: null,
-        },
-        {
-          state: 'NJ',
-          births: 8318769,
-          popular_name: 'Isabella',
-          prev_births_by_name: 9277223,
         },
       ]);
     });

--- a/test/src/databases/all/functions.spec.ts
+++ b/test/src/databases/all/functions.spec.ts
@@ -1741,6 +1741,82 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
         {name: 'UNITED AIR LINES INC', r: 1},
       ]);
     });
+
+    it('can be used in a select', async () => {
+      await expect(`
+        ##! experimental { function_order_by partition_by }
+        run: state_facts -> {
+          select: state, births, popular_name
+          calculate: prev_births_by_name is lag(births) {
+            partition_by: popular_name
+            order_by: births desc
+          }
+          order_by: births desc
+          limit: 10
+        }
+      `).malloyResultMatches(expressionModel, [
+        {
+          state: 'CA',
+          births: 28810563,
+          popular_name: 'Isabella',
+          prev_births_by_name: null,
+        },
+        {
+          state: 'NY',
+          births: 23694136,
+          popular_name: 'Isabella',
+          prev_births_by_name: 28810563,
+        },
+        {
+          state: 'TX',
+          births: 21467359,
+          popular_name: 'Isabella',
+          prev_births_by_name: 23694136,
+        },
+        {
+          state: 'PA',
+          births: 16661910,
+          popular_name: 'Isabella',
+          prev_births_by_name: 21467359,
+        },
+        {
+          state: 'IL',
+          births: 15178876,
+          popular_name: 'Isabella',
+          prev_births_by_name: 16661910,
+        },
+        {
+          state: 'OH',
+          births: 14201526,
+          popular_name: 'Isabella',
+          prev_births_by_name: 15178876,
+        },
+        {
+          state: 'MI',
+          births: 11643455,
+          popular_name: 'Sophia',
+          prev_births_by_name: null,
+        },
+        {
+          state: 'FL',
+          births: 9277223,
+          popular_name: 'Isabella',
+          prev_births_by_name: 14201526,
+        },
+        {
+          state: 'NC',
+          births: 8440235,
+          popular_name: 'Emma',
+          prev_births_by_name: null,
+        },
+        {
+          state: 'NJ',
+          births: 8318769,
+          popular_name: 'Isabella',
+          prev_births_by_name: 9277223,
+        },
+      ]);
+    });
   });
 });
 

--- a/test/src/databases/all/functions.spec.ts
+++ b/test/src/databases/all/functions.spec.ts
@@ -1742,6 +1742,7 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
       ]);
     });
 
+    // TODO remove the need for the `##! unsafe_complex_select_query` compiler flag
     it('can be used in a select', async () => {
       await expect(`
         ##! experimental { function_order_by partition_by }


### PR DESCRIPTION
This adds a (temporary!) compiler flag `##! unsafe_complex_select_query` which removes an error-checking condition in the compiler where if "complex SQL" was ever generated for a `select` it would throw an error. This was probably once reasonable when the only way you could generate complex SQL was when there were nests, but now it can also happen if you use window functions. This is locked behind a compiler flag because this error checking condition still does catch some incorrect cases, and to handle both properly, there is a more involved long-term fix. See https://github.com/malloydata/malloy/issues/1604.