### PR TITLE
First pass at allowing translator to accept translated documents

### DIFF
--- a/packages/malloy/src/lang/ast/statements/import-statement.ts
+++ b/packages/malloy/src/lang/ast/statements/import-statement.ts
@@ -97,8 +97,9 @@ export class ImportStatement
         'Cannot import without translation context'
       );
     } else if (this.fullURL) {
+      const pretranslated = trans.root.pretranslateZone.getEntry(this.fullURL);
       const src = trans.root.importZone.getEntry(this.fullURL);
-      if (src.status === 'present') {
+      if (src.status === 'present' || pretranslated.status === 'present') {
         const importable = trans.getChildExports(this.fullURL);
         if (this.notEmpty()) {
           // just import the named objects

--- a/packages/malloy/src/lang/ast/types/document-compile-result.ts
+++ b/packages/malloy/src/lang/ast/types/document-compile-result.ts
@@ -21,13 +21,10 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import {ModelDef, Query, SQLSourceDef} from '../../../model/malloy_types';
+import {DocumentDef} from '../../../model/malloy_types';
 
 import {ModelDataRequest} from '../../translate-response';
 
-export interface DocumentCompileResult {
-  modelDef: ModelDef;
-  queryList: Query[];
-  sqlBlocks: SQLSourceDef[];
+export interface DocumentCompileResult extends DocumentDef {
   needs: ModelDataRequest;
 }

--- a/packages/malloy/src/lang/test/pretranslate.spec.ts
+++ b/packages/malloy/src/lang/test/pretranslate.spec.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import './parse-expects';
+import {TestTranslator} from './test-translator';
+
+describe('pretranslated models', () => {
+  test('import of pretranslated', () => {
+    const docParse = new TestTranslator('import "child"');
+    const xr = docParse.unresolved();
+    expect(docParse).toParse();
+    expect(xr).toEqual({urls: ['internal://test/langtests/child']});
+    docParse.update({
+      translations: {
+        'internal://test/langtests/child': {
+          modelDef: {
+            name: 'child',
+            exports: ['foo'],
+            contents: {
+              foo: {
+                type: 'table',
+                tablePath: 'foo',
+                connection: 'duckdb',
+                dialect: 'duckdb',
+                name: 'foo',
+                fields: [],
+              },
+            },
+          },
+          queryList: [],
+          sqlBlocks: [],
+        },
+      },
+    });
+    expect(docParse).toTranslate();
+    const foo = docParse.getSourceDef('foo');
+    expect(foo).toBeDefined();
+  });
+});

--- a/packages/malloy/src/lang/translate-response.ts
+++ b/packages/malloy/src/lang/translate-response.ts
@@ -23,10 +23,9 @@
 
 import {
   Annotation,
+  DocumentDef,
   ModelDef,
-  Query,
   SQLSentence,
-  SQLSourceDef,
 } from '../model/malloy_types';
 import {MalloyElement} from './ast';
 import {LogMessage} from './parse-log';
@@ -93,16 +92,13 @@ export type CompletionsResponse = Partial<Completions>;
 interface HelpContext extends NeededData, ProblemResponse, FinalResponse {
   helpContext: DocumentHelpContext | undefined;
 }
+
 export type HelpContextResponse = Partial<HelpContext>;
 interface TranslatedResponseData
   extends NeededData,
     ProblemResponse,
     FinalResponse {
-  translated: {
-    modelDef: ModelDef;
-    queryList: Query[];
-    sqlBlocks: SQLSourceDef[];
-  };
+  translated: DocumentDef;
   fromSources: string[];
 }
 

--- a/packages/malloy/src/model/malloy_types.ts
+++ b/packages/malloy/src/model/malloy_types.ts
@@ -1467,6 +1467,12 @@ export interface ModelDef {
   annotation?: ModelAnnotation;
 }
 
+export interface DocumentDef {
+  modelDef: ModelDef;
+  queryList: Query[];
+  sqlBlocks: SQLSourceDef[];
+}
+
 /** Very common record type */
 export type NamedSourceDefs = Record<string, SourceDef>;
 export type NamedModelObjects = Record<string, NamedModelObject>;


### PR DESCRIPTION
Adds a new way of interacting with the Malloy translator:
- If the translator asks for `{ urls: ['path'] }`, instead of updating with the contents of the file via: `{ urls: { 'path': 'contents' } }`, you can respond with `{ translations: { 'path': { modelDef: ... } } }`. This allows a user of the translator to cache translations.