### PR TITLE
Add arg_[min/max] for DuckDB

### DIFF
--- a/packages/malloy/src/dialect/duckdb/dialect_functions.ts
+++ b/packages/malloy/src/dialect/duckdb/dialect_functions.ts
@@ -87,17 +87,53 @@ const arg_min: OverloadedDefinitionBlueprint = {
     supportsOrderBy: true,
     isSymmetric: true,
   },
+  generalize_for_n_vals: {
+    generic: {
+      'T': ['string', 'number', 'date', 'timestamp', 'boolean', 'json'],
+    },
+    takes: {
+      'arg': {dimension: {generic: 'T'}},
+      'val': {dimension: 'any'},
+      'n': 'number',
+    },
+    returns: {measure: {array: {generic: 'T'}}},
+    impl: {
+      sql: 'arg_min(${arg}, ${val}, ${n}${order_by:})',
+    },
+    supportsOrderBy: true,
+    isSymmetric: false,
+  },
 };
 
-const arg_max: DefinitionBlueprint = {
-  generic: {'T': ['string', 'number', 'date', 'timestamp', 'boolean', 'json']},
-  takes: {'arg': {dimension: {generic: 'T'}}, 'val': {dimension: 'any'}},
-  returns: {measure: {generic: 'T'}},
-  impl: {
-    sql: 'arg_max(${arg}, ${val}${order_by:})',
+const arg_max: OverloadedDefinitionBlueprint = {
+  default: {
+    generic: {
+      'T': ['string', 'number', 'date', 'timestamp', 'boolean', 'json'],
+    },
+    takes: {'arg': {dimension: {generic: 'T'}}, 'val': {dimension: 'any'}},
+    returns: {measure: {generic: 'T'}},
+    impl: {
+      sql: 'arg_max(${arg}, ${val}${order_by:})',
+    },
+    supportsOrderBy: true,
+    isSymmetric: true,
   },
-  supportsOrderBy: true,
-  isSymmetric: true,
+  generalize_for_n_vals: {
+    generic: {
+      'T': ['string', 'number', 'date', 'timestamp', 'boolean', 'json'],
+    },
+    takes: {
+      'arg': {dimension: {generic: 'T'}},
+      'val': {dimension: 'any'},
+      'n': 'number',
+    },
+    returns: {measure: {array: {generic: 'T'}}},
+    impl: {
+      sql: 'arg_max(${arg}, ${val}, ${n}${order_by:})',
+    },
+    supportsOrderBy: true,
+    isSymmetric: false,
+  },
 };
 
 const string_agg_distinct: OverloadedDefinitionBlueprint = {

--- a/packages/malloy/src/dialect/duckdb/dialect_functions.ts
+++ b/packages/malloy/src/dialect/duckdb/dialect_functions.ts
@@ -74,6 +74,32 @@ const string_agg: OverloadedDefinitionBlueprint = {
   },
 };
 
+const arg_min: OverloadedDefinitionBlueprint = {
+  default: {
+    generic: {
+      'T': ['string', 'number', 'date', 'timestamp', 'boolean', 'json'],
+    },
+    takes: {'arg': {dimension: {generic: 'T'}}, 'val': {dimension: 'any'}},
+    returns: {measure: {generic: 'T'}},
+    impl: {
+      sql: 'arg_min(${arg}, ${val}${order_by:})',
+    },
+    supportsOrderBy: true,
+    isSymmetric: true,
+  },
+};
+
+const arg_max: DefinitionBlueprint = {
+  generic: {'T': ['string', 'number', 'date', 'timestamp', 'boolean', 'json']},
+  takes: {'arg': {dimension: {generic: 'T'}}, 'val': {dimension: 'any'}},
+  returns: {measure: {generic: 'T'}},
+  impl: {
+    sql: 'arg_max(${arg}, ${val}${order_by:})',
+  },
+  supportsOrderBy: true,
+  isSymmetric: true,
+};
+
 const string_agg_distinct: OverloadedDefinitionBlueprint = {
   default_separator: {
     ...string_agg['default_separator'],
@@ -104,4 +130,6 @@ export const DUCKDB_DIALECT_FUNCTIONS: DefinitionBlueprintMap = {
   date_part,
   ...def('repeat', {'str': 'string', 'n': 'number'}, 'string'),
   ...def('reverse', {'str': 'string'}, 'string'),
+  arg_max,
+  arg_min,
 };

--- a/test/src/databases/duckdb/duckdb.spec.ts
+++ b/test/src/databases/duckdb/duckdb.spec.ts
@@ -145,8 +145,21 @@ describe.each(allDucks.runtimeList)('duckdb:%s', (dbName, runtime) => {
         m2 is arg_min(x, y)
         m3 is arg_max(y, x)
         m4 is arg_max(x, y)
+        m5 is arg_min(y, x, 2)
+        m6 is arg_min(x, y, 1)
+        m7 is arg_max(y, x, 3)
+        m8 is arg_max(x, y, 2)
     }`
-    ).malloyResultMatches(runtime, {m1: 100, m2: 55, m3: 1, m4: 1});
+    ).malloyResultMatches(runtime, {
+      m1: 100,
+      m2: 55,
+      m3: 1,
+      m4: 1,
+      m5: [100, 50],
+      m6: [55],
+      m7: [1, 50, 100],
+      m8: [1, 22],
+    });
   });
 
   describe('time oddities', () => {


### PR DESCRIPTION
Support for scalar result and 'n' generalized overload. 'n' overload is marked _not_ symmetric for now; subject to change based on future discussion. 