### PR TITLE
Added the windows equivalent command to the unix storybook script. 

### DIFF
--- a/packages/malloy-render/package.json
+++ b/packages/malloy-render/package.json
@@ -24,6 +24,7 @@
     "clean": "tsc --build --clean",
     "prepublishOnly": "npm run build",
     "storybook": "rm -rf ./node_modules/.cache && storybook dev -p 6006",
+    "storybook-windows": "del /s /q .\\node_modules\\.cache && storybook dev -p 6006",
     "build-storybook": "storybook build",
     "build-source": "vite build --outDir 'dist/module' --config vite.config.ts",
     "build-webcomponent": "vite build --outDir 'dist/webcomponent' --config vite.config.webcomponent.ts && vite build --outDir 'dist/register' --config vite.config.webcomponent-register.ts",


### PR DESCRIPTION
Eg "npm run storybook-windows".  The unix version fails on a windows machine.