### PR TITLE
Added an initial fix for broken line charts when the x dimension is boolean

### DIFF
--- a/packages/malloy-render/DEVELOPING.md
+++ b/packages/malloy-render/DEVELOPING.md
@@ -8,11 +8,16 @@ The legacy renderer is deprecated but is still available and in use for features
 
 ## Viewing the renderer locally
 
-Storybook is used to view the renderer locally. To launch the storybook:
+Storybook is used to view the renderer locally. To launch the storybook, run the storybook script in `packages/malloy-render/package.json`:
 
 ```bash
 $ npm run storybook
 ```
+Or, on a Windows machine, and from the Malloy repo directory:
+```bash
+$ npm run --prefix packages/malloy-render storybook-windows
+```
+
 
 Then navigate to the URL provided. In this storybook, you can navigate between different stories that render Malloy queries from the Malloy source code.
 

--- a/packages/malloy-render/src/component/line-chart/generate-line_chart-vega-spec.ts
+++ b/packages/malloy-render/src/component/line-chart/generate-line_chart-vega-spec.ts
@@ -578,8 +578,8 @@ export function generateLineChartVegaSpec(
           ? xIsDateorTime
             ? [xMeta.min, xMeta.max]
             : xIsBoolean
-              ? [true, false]
-              : [...xMeta.values]
+            ? [true, false]
+            : [...xMeta.values]
           : {data: 'values', field: 'x'},
         range: 'width',
         paddingOuter: 0.05,

--- a/packages/malloy-render/src/component/line-chart/generate-line_chart-vega-spec.ts
+++ b/packages/malloy-render/src/component/line-chart/generate-line_chart-vega-spec.ts
@@ -80,6 +80,8 @@ export function generateLineChartVegaSpec(
   const xField = getFieldFromRootPath(explore, xFieldPath);
   const xIsDateorTime =
     xField.isAtomicField() && (xField.isDate() || xField.isTimestamp());
+  const xIsBoolean =
+    xField.isAtomicField() && xField.isBoolean();
   const yField = getFieldFromRootPath(explore, yFieldPath);
   const seriesField = seriesFieldPath
     ? getFieldFromRootPath(explore, seriesFieldPath)
@@ -576,7 +578,7 @@ export function generateLineChartVegaSpec(
         domain: shouldShareXDomain
           ? xIsDateorTime
             ? [xMeta.min, xMeta.max]
-            : [...xMeta.values]
+            : xIsBoolean ? [true, false] : [...xMeta.values]
           : {data: 'values', field: 'x'},
         range: 'width',
         paddingOuter: 0.05,

--- a/packages/malloy-render/src/component/line-chart/generate-line_chart-vega-spec.ts
+++ b/packages/malloy-render/src/component/line-chart/generate-line_chart-vega-spec.ts
@@ -577,7 +577,9 @@ export function generateLineChartVegaSpec(
         domain: shouldShareXDomain
           ? xIsDateorTime
             ? [xMeta.min, xMeta.max]
-            : xIsBoolean ? [true, false] : [...xMeta.values]
+            : xIsBoolean
+              ? [true, false]
+              : [...xMeta.values]
           : {data: 'values', field: 'x'},
         range: 'width',
         paddingOuter: 0.05,

--- a/packages/malloy-render/src/component/line-chart/generate-line_chart-vega-spec.ts
+++ b/packages/malloy-render/src/component/line-chart/generate-line_chart-vega-spec.ts
@@ -80,8 +80,7 @@ export function generateLineChartVegaSpec(
   const xField = getFieldFromRootPath(explore, xFieldPath);
   const xIsDateorTime =
     xField.isAtomicField() && (xField.isDate() || xField.isTimestamp());
-  const xIsBoolean =
-    xField.isAtomicField() && xField.isBoolean();
+  const xIsBoolean = xField.isAtomicField() && xField.isBoolean();
   const yField = getFieldFromRootPath(explore, yFieldPath);
   const seriesField = seriesFieldPath
     ? getFieldFromRootPath(explore, seriesFieldPath)

--- a/packages/malloy-render/src/stories/line_charts.stories.malloy
+++ b/packages/malloy-render/src/stories/line_charts.stories.malloy
@@ -236,6 +236,18 @@ source: products is duckdb.table("static/data/products.parquet") extend {
     }
   }
 
+  dimension:
+    is_woman is pick true when department = 'Women' else false
+  measure:
+    product_count_by_gender is count(id)
+  #(story)
+  # line_chart
+  view: boolean_line_chart is {
+    group_by: is_woman
+    aggregate: product_count_by_gender
+    limit: 10
+  }
+
 }
 
 run: products -> { group_by: distribution_center_id}

--- a/packages/malloy-render/src/stories/line_charts.stories.malloy
+++ b/packages/malloy-render/src/stories/line_charts.stories.malloy
@@ -237,17 +237,22 @@ source: products is duckdb.table("static/data/products.parquet") extend {
   }
 
   dimension:
-    is_woman is pick true when department = 'Women' else false
+    is_female is pick true when department = 'Women' else false
   measure:
     product_count_by_gender is count(id)
-  #(story)
-  # line_chart
-  view: boolean_line_chart is {
-    group_by: is_woman
-    aggregate: product_count_by_gender
-    limit: 10
-  }
 
+  #(story)
+  view: line_chart_with_boolean is {
+    view: table_by_gender is {
+      group_by: is_female
+      aggregate: product_count_by_gender
+    }
+    # line_chart
+    view: chart_by_gender is {
+      group_by: is_female
+      aggregate: product_count_by_gender
+    }
+  }
 }
 
 run: products -> { group_by: distribution_center_id}

--- a/packages/malloy-render/src/stories/line_charts.stories.malloy
+++ b/packages/malloy-render/src/stories/line_charts.stories.malloy
@@ -243,12 +243,12 @@ source: products is duckdb.table("static/data/products.parquet") extend {
 
   #(story)
   view: line_chart_with_boolean is {
-    view: table_by_gender is {
+    nest: product_sales_by_gender is {
       group_by: is_female
       aggregate: product_count_by_gender
     }
     # line_chart
-    view: chart_by_gender is {
+    nest: product_sales_chart is {
       group_by: is_female
       aggregate: product_count_by_gender
     }


### PR DESCRIPTION
This PR adds support for boolean (x-axis) for line charts.  See:
https://www.internalfb.com/tasks/?t=211025161  (for the Malloy team)
https://github.com/malloydata/malloy/issues/104  (an older, but related issue)

Still to do:
 - null values are still missing from the legend.  That will be a separate fix.
 - bar charts seem to have the same issue with booleans.  
  