### PR TITLE
fix case where the nested field can have multiple types

### DIFF
--- a/packages/malloy-db-snowflake/src/snowflake_connection.ts
+++ b/packages/malloy-db-snowflake/src/snowflake_connection.ts
@@ -332,10 +332,12 @@ export class SnowflakeConnection
       // * decimal and integer should be treated as the same type.
       // * remove null values
       // * remove fields for which we have multiple types
+      // * make sure that the regexp path is properly escaped. we want
+      // something like \\[[0-9]+\\] in the final query.
       const sampleQuery = `
       SELECT PATH, min(type) as type
       FROM (
-        SELECT regexp_replace(PATH, '\\[[0-9]+\\]', '[*]') as PATH,
+        SELECT regexp_replace(PATH, '\\\\[[0-9]+\\\\]', '[*]') as PATH,
         CASE WHEN lower(TYPEOF(value)) = 'integer' THEN 'decimal' ELSE lower(TYPEOF(value)) END as type
       FROM (select object_construct(*) o from  ${tablePath} limit 100)
             ,table(flatten(input => o, recursive => true)) as meta

--- a/packages/malloy-db-snowflake/src/snowflake_connection.ts
+++ b/packages/malloy-db-snowflake/src/snowflake_connection.ts
@@ -133,7 +133,7 @@ class SnowObject extends SnowField {
         );
       } else {
         // If we get multiple type for a field, ignore them. The exception
-        // is if there is field with integer and decimal types. In that case
+        // is if there is field with integer and decimal types. In that case,
         // we overwrite the field type with decimal. This can happen if
         // the field is an array and sometimes the value is a float and
         // sometimes it is a integer. In that case we don't want to fail


### PR DESCRIPTION
fix case where the nested field can have multiple types (based on the 100 sample).

In most cases, we should fail but in cases where the field types are integer and decimal we should not fail and make the field decimal. this can happen when there is a nested field and sometimes has a float value and sometimes an integer value