### PR TITLE
Fix snowflake error : "Lateral cannot be on the left side of join"

### DIFF
--- a/test/src/databases/all/compound-atomic.spec.ts
+++ b/test/src/databases/all/compound-atomic.spec.ts
@@ -91,6 +91,13 @@ describe.each(runtimes.runtimeList)(
     """)`;
 
     describe('simple arrays', () => {
+      test('join on scalar array field', async () => {
+        const nestedArrayJoin = `
+           source: a is ${conName}.sql(""" SELECT 2 as "a_two" """) extend {}
+           source: b is ${evens} extend { join_one: a is a on a.a_two = evens.value}
+           run: b -> {select: a_two is a.a_two}`;
+        await expect(nestedArrayJoin).malloyResultMatches(runtime, {a_two: 2});
+      });
       test('array literal dialect function', async () => {
         await expect(`
           run: ${evens}`).malloyResultMatches(runtime, {


### PR DESCRIPTION
For nested fields we were using lateral flatten. The issue with it is that if the

nested field is used in a join, snowflake complains that lateral flatten can't be on left side of join (https://stackoverflow.com/questions/63397022/snowflake-lateral-cannot-be-on-the-left-side-of-join)

fix is to always convert lateral flatten to a left join

Also simplify the array[scalar] vs array[record] treatment. earlier, at the unnesting step we were creating a object for array[scalar] case to make it consistent with the array[record] case. Now at the reference time, based on the case, use the right expression
- array[record] : parent.value:sql_field
- array[scalar] : parent.value