### PR TITLE
Update PR tests to use pull_request_target

### DIFF
--- a/.github/workflows/db-bigquery.yaml
+++ b/.github/workflows/db-bigquery.yaml
@@ -1,7 +1,6 @@
-name: "DB:BigQuery"
+name: 'DB:BigQuery'
 
 on:
-  pull_request:
   workflow_call:
     secrets:
       BIGQUERY_KEY:

--- a/.github/workflows/db-bigquery.yaml
+++ b/.github/workflows/db-bigquery.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Use Node.js 18.x
         uses: actions/setup-node@v4
         with:
-          node-version: Use Node.js 18.x
+          node-version: 18.x
       - name: GCloud auth
         uses: 'google-github-actions/auth@v2'
         with:

--- a/.github/workflows/db-bigquery.yaml
+++ b/.github/workflows/db-bigquery.yaml
@@ -10,18 +10,14 @@ jobs:
   test-bigquery:
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [18.x]
-
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: 'true'
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js 18.x
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: Use Node.js 18.x
       - name: GCloud auth
         uses: 'google-github-actions/auth@v2'
         with:

--- a/.github/workflows/db-duckdb-wasm.yaml
+++ b/.github/workflows/db-duckdb-wasm.yaml
@@ -6,18 +6,14 @@ jobs:
   test-duckdb-wasm:
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [18.x]
-
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: 'true'
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 18.x
       - name: npm install, build, and test
         run: |
           npm ci --loglevel error

--- a/.github/workflows/db-duckdb-wasm.yaml
+++ b/.github/workflows/db-duckdb-wasm.yaml
@@ -1,6 +1,6 @@
-name: "DB:DuckDB(WASM)"
+name: 'DB:DuckDB(WASM)'
 
-on: [pull_request, workflow_call]
+on: workflow_call
 
 jobs:
   test-duckdb-wasm:

--- a/.github/workflows/db-duckdb.yaml
+++ b/.github/workflows/db-duckdb.yaml
@@ -1,6 +1,6 @@
-name: "DB:DuckDB"
+name: 'DB:DuckDB'
 
-on: [pull_request, workflow_call]
+on: workflow_call
 
 jobs:
   test-duckdb:

--- a/.github/workflows/db-duckdb.yaml
+++ b/.github/workflows/db-duckdb.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Use Node.js 18.x
         uses: actions/setup-node@v4
         with:
-          node-version: Use Node.js 18.x
+          node-version: 18.x
       - name: npm install, build, and test
         run: |
           npm ci --loglevel error

--- a/.github/workflows/db-duckdb.yaml
+++ b/.github/workflows/db-duckdb.yaml
@@ -6,18 +6,14 @@ jobs:
   test-duckdb:
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [18.x]
-
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: 'true'
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js 18.x
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: Use Node.js 18.x
       - name: npm install, build, and test
         run: |
           npm ci --loglevel error

--- a/.github/workflows/db-motherduck.yaml
+++ b/.github/workflows/db-motherduck.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Use Node.js 18.x
         uses: actions/setup-node@v4
         with:
-          node-version: Use Node.js 18.x
+          node-version: 18.x
       - name: npm install, build, and test
         run: |
           npm ci --loglevel error

--- a/.github/workflows/db-motherduck.yaml
+++ b/.github/workflows/db-motherduck.yaml
@@ -1,7 +1,6 @@
-name: "DB:MotherDuck"
+name: 'DB:MotherDuck'
 
 on:
-  pull_request:
   workflow_call:
     secrets:
       MOTHERDUCK_TOKEN_10:

--- a/.github/workflows/db-motherduck.yaml
+++ b/.github/workflows/db-motherduck.yaml
@@ -10,18 +10,14 @@ jobs:
   test-motherduck:
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [18.x]
-
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: 'true'
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js 18.x
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: Use Node.js 18.x
       - name: npm install, build, and test
         run: |
           npm ci --loglevel error

--- a/.github/workflows/db-mysql.yaml
+++ b/.github/workflows/db-mysql.yaml
@@ -7,18 +7,14 @@ jobs:
   test-mysql:
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [18.x]
-
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: 'true'
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js 18.x
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: Use Node.js 18.x
       - name: npm install, build, and test
         run: |
           npm ci --loglevel error

--- a/.github/workflows/db-mysql.yaml
+++ b/.github/workflows/db-mysql.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Use Node.js 18.x
         uses: actions/setup-node@v4
         with:
-          node-version: Use Node.js 18.x
+          node-version: 18.x
       - name: npm install, build, and test
         run: |
           npm ci --loglevel error

--- a/.github/workflows/db-mysql.yaml
+++ b/.github/workflows/db-mysql.yaml
@@ -1,6 +1,6 @@
-name: "DB:MySQL"
+name: 'DB:MySQL'
 
-on: [pull_request, workflow_call]
+on: workflow_call
 
 jobs:
   # Label of the container job

--- a/.github/workflows/db-postgres.yaml
+++ b/.github/workflows/db-postgres.yaml
@@ -7,10 +7,6 @@ jobs:
   test-postgres:
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [18.x]
-
     services:
       postgres:
         image: postgres
@@ -29,10 +25,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: 'true'
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js 18.x
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: Use Node.js 18.x
       - name: npm install, build, and test
         run: |
           npm ci --loglevel error

--- a/.github/workflows/db-postgres.yaml
+++ b/.github/workflows/db-postgres.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Use Node.js 18.x
         uses: actions/setup-node@v4
         with:
-          node-version: Use Node.js 18.x
+          node-version: 18.x
       - name: npm install, build, and test
         run: |
           npm ci --loglevel error

--- a/.github/workflows/db-postgres.yaml
+++ b/.github/workflows/db-postgres.yaml
@@ -1,6 +1,6 @@
-name: "DB:Postgres"
+name: 'DB:Postgres'
 
-on: [pull_request, workflow_call]
+on: workflow_call
 
 jobs:
   # Label of the container job

--- a/.github/workflows/db-presto.yaml
+++ b/.github/workflows/db-presto.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Use Node.js 18.x
         uses: actions/setup-node@v4
         with:
-          node-version: Use Node.js 18.x
+          node-version: 18.x
       - name: npm install, build, and test
         run: |
           npm ci --loglevel error

--- a/.github/workflows/db-presto.yaml
+++ b/.github/workflows/db-presto.yaml
@@ -1,7 +1,6 @@
-name: "DB:Presto"
+name: 'DB:Presto'
 
 on:
-  pull_request:
   workflow_call:
     secrets:
       BQ_PRESTO_TRINO_KEY:

--- a/.github/workflows/db-presto.yaml
+++ b/.github/workflows/db-presto.yaml
@@ -11,18 +11,14 @@ jobs:
   test-presto:
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [18.x]
-
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: 'true'
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js 18.x
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: Use Node.js 18.x
       - name: npm install, build, and test
         run: |
           npm ci --loglevel error

--- a/.github/workflows/db-snowflake.yaml
+++ b/.github/workflows/db-snowflake.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Use Node.js 18.x
         uses: actions/setup-node@v4
         with:
-          node-version: Use Node.js 18.x
+          node-version: 18.x
       - name: npm install, build, and test
         run: |
           npm ci --loglevel error

--- a/.github/workflows/db-snowflake.yaml
+++ b/.github/workflows/db-snowflake.yaml
@@ -1,7 +1,6 @@
-name: "DB:Snowflake"
+name: 'DB:Snowflake'
 
 on:
-  pull_request:
   workflow_call:
     secrets:
       SNOWFLAKE_CONNECTION:

--- a/.github/workflows/db-snowflake.yaml
+++ b/.github/workflows/db-snowflake.yaml
@@ -10,18 +10,14 @@ jobs:
   test-snowflake:
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [18.x]
-
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: 'true'
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js 18.x
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: Use Node.js 18.x
       - name: npm install, build, and test
         run: |
           npm ci --loglevel error

--- a/.github/workflows/db-trino.yaml
+++ b/.github/workflows/db-trino.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Use Node.js 18.x
         uses: actions/setup-node@v4
         with:
-          node-version: Use Node.js 18.x
+          node-version: 18.x
       - name: npm install, build, and test
         run: |
           npm ci --loglevel error

--- a/.github/workflows/db-trino.yaml
+++ b/.github/workflows/db-trino.yaml
@@ -11,18 +11,14 @@ jobs:
   test-trino:
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [18.x]
-
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: 'true'
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js 18.x
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: Use Node.js 18.x
       - name: npm install, build, and test
         run: |
           npm ci --loglevel error

--- a/.github/workflows/db-trino.yaml
+++ b/.github/workflows/db-trino.yaml
@@ -1,7 +1,6 @@
-name: "DB:Trino"
+name: 'DB:Trino'
 
 on:
-  pull_request:
   workflow_call:
     secrets:
       BQ_PRESTO_TRINO_KEY:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -11,7 +11,7 @@ on:
         required: true
 
 jobs:
-  test-all:
+  main:
     runs-on: ubuntu-latest
 
     services:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -5,7 +5,6 @@
 name: Core
 
 on:
-  pull_request:
   workflow_call:
     secrets:
       BIGQUERY_KEY:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -14,10 +14,6 @@ jobs:
   test-all:
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [18.x]
-
     services:
       postgres:
         image: postgres
@@ -36,10 +32,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: 'true'
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js 18.x
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: Use Node.js 18.x
       - name: GCloud auth
         uses: 'google-github-actions/auth@v2'
         with:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Use Node.js 18.x
         uses: actions/setup-node@v4
         with:
-          node-version: Use Node.js 18.x
+          node-version: 18.x
       - name: GCloud auth
         uses: 'google-github-actions/auth@v2'
         with:

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -3,31 +3,48 @@ name: Malloy Tests
 on: [workflow_dispatch, pull_request]
 
 jobs:
+  check-permission:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Permission Check
+        uses: malloydata/check-ci-permissions@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ github.triggering_actor }}
+          error_message: |
+            User does not have write access to this repository. Refer to CONTRIBUTING.md instructions on how to contribute to Malloy.
+
   main:
+    needs: check-permission
     uses: './.github/workflows/main.yaml'
     secrets:
       BIGQUERY_KEY: ${{ secrets.BIGQUERY_KEY }}
   db-trino:
+    needs: check-permission
     uses: './.github/workflows/db-trino.yaml'
     secrets:
       BQ_PRESTO_TRINO_KEY: ${{ secrets.BQ_PRESTO_TRINO_KEY }}
   db-presto:
+    needs: check-permission
     uses: './.github/workflows/db-presto.yaml'
     secrets:
       BQ_PRESTO_TRINO_KEY: ${{ secrets.BQ_PRESTO_TRINO_KEY }}
   db-duckdb:
     uses: './.github/workflows/db-duckdb.yaml'
   db-bigquery:
+    needs: check-permission
     uses: './.github/workflows/db-bigquery.yaml'
     secrets:
       BIGQUERY_KEY: ${{ secrets.BIGQUERY_KEY }}
   db-motherduck:
+    needs: check-permission
     uses: './.github/workflows/db-motherduck.yaml'
     secrets:
       MOTHERDUCK_TOKEN_10: ${{ secrets.MOTHERDUCK_TOKEN_10 }}
   db-postgres:
     uses: './.github/workflows/db-postgres.yaml'
   db-snowflake:
+    needs: check-permission
     uses: './.github/workflows/db-snowflake.yaml'
     secrets:
       SNOWFLAKE_CONNECTION: ${{ secrets.SNOWFLAKE_CONNECTION }}

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -14,6 +14,9 @@ jobs:
           error_message: |
             User does not have write access to this repository. Refer to CONTRIBUTING.md instructions on how to contribute to Malloy.
 
+  # *** IMPORTANT ***
+  # When modifying these, make sure that needs: check-permission
+  # is part of any job that requires secrets.
   main:
     needs: check-permission
     uses: './.github/workflows/main.yaml'

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -1,6 +1,6 @@
-name: Malloy Tests
+name: Run Malloy Tests
 
-on: [workflow_dispatch]
+on: [workflow_dispatch, pull_request]
 
 jobs:
   main:
@@ -37,7 +37,7 @@ jobs:
     uses: './.github/workflows/db-duckdb-wasm.yaml'
 
   # I think I have the sorted roughly longest to shortest
-  # so the longer running jobs get wrokers sooner, not sure
+  # so the longer running jobs get workers sooner, not sure
   # that is the right plan
   malloy-tests:
     needs:

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -3,37 +3,37 @@ name: Run Malloy Tests
 on: [workflow_dispatch, pull_request]
 
 jobs:
-  main:
+  test-all:
     uses: './.github/workflows/main.yaml'
     secrets:
       BIGQUERY_KEY: ${{ secrets.BIGQUERY_KEY }}
-  db-trino:
+  test-trino:
     uses: './.github/workflows/db-trino.yaml'
     secrets:
       BQ_PRESTO_TRINO_KEY: ${{ secrets.BQ_PRESTO_TRINO_KEY }}
-  db-presto:
+  test-presto:
     uses: './.github/workflows/db-presto.yaml'
     secrets:
       BQ_PRESTO_TRINO_KEY: ${{ secrets.BQ_PRESTO_TRINO_KEY }}
-  db-duckdb:
+  test-duckdb:
     uses: './.github/workflows/db-duckdb.yaml'
-  db-bigquery:
+  test-bigquery:
     uses: './.github/workflows/db-bigquery.yaml'
     secrets:
       BIGQUERY_KEY: ${{ secrets.BIGQUERY_KEY }}
-  db-motherduck:
+  test-motherduck:
     uses: './.github/workflows/db-motherduck.yaml'
     secrets:
       MOTHERDUCK_TOKEN_10: ${{ secrets.MOTHERDUCK_TOKEN_10 }}
-  db-postgres:
+  test-postgres:
     uses: './.github/workflows/db-postgres.yaml'
-  db-snowflake:
+  test-snowflake:
     uses: './.github/workflows/db-snowflake.yaml'
     secrets:
       SNOWFLAKE_CONNECTION: ${{ secrets.SNOWFLAKE_CONNECTION }}
-  db-mysql:
+  test-mysql:
     uses: './.github/workflows/db-mysql.yaml'
-  db-duckdb-wasm:
+  test-duckdb-wasm:
     uses: './.github/workflows/db-duckdb-wasm.yaml'
 
   # I think I have the sorted roughly longest to shortest
@@ -41,16 +41,16 @@ jobs:
   # that is the right plan
   malloy-tests:
     needs:
-      - main
-      - db-snowflake
-      - db-bigquery
-      - db-duckdb
-      - db-presto
-      - db-duckdb-wasm
-      - db-trino
-      - db-postgres
-      - db-motherduck
-      - db-mysql
+      - test-all
+      - test-snowflake
+      - test-bigquery
+      - test-duckdb
+      - test-presto
+      - test-duckdb-wasm
+      - test-trino
+      - test-postgres
+      - test-motherduck
+      - test-mysql
     runs-on: ubuntu-latest
     steps:
       - name: Success

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -1,49 +1,39 @@
-name: Run Malloy Tests
+name: Malloy Tests
 
 on: [workflow_dispatch, pull_request]
 
 jobs:
-  test-all:
-    name: test-all
+  main:
     uses: './.github/workflows/main.yaml'
     secrets:
       BIGQUERY_KEY: ${{ secrets.BIGQUERY_KEY }}
-  test-trino:
-    name: test-trino
+  db-trino:
     uses: './.github/workflows/db-trino.yaml'
     secrets:
       BQ_PRESTO_TRINO_KEY: ${{ secrets.BQ_PRESTO_TRINO_KEY }}
-  test-presto:
-    name: test-presto
+  db-presto:
     uses: './.github/workflows/db-presto.yaml'
     secrets:
       BQ_PRESTO_TRINO_KEY: ${{ secrets.BQ_PRESTO_TRINO_KEY }}
-  test-duckdb:
-    name: test-presto
+  db-duckdb:
     uses: './.github/workflows/db-duckdb.yaml'
-  test-bigquery:
-    name: test-bigquery
+  db-bigquery:
     uses: './.github/workflows/db-bigquery.yaml'
     secrets:
       BIGQUERY_KEY: ${{ secrets.BIGQUERY_KEY }}
-  test-motherduck:
-    name: test-motherduck
+  db-motherduck:
     uses: './.github/workflows/db-motherduck.yaml'
     secrets:
       MOTHERDUCK_TOKEN_10: ${{ secrets.MOTHERDUCK_TOKEN_10 }}
-  test-postgres:
-    name: test-postgres
+  db-postgres:
     uses: './.github/workflows/db-postgres.yaml'
-  test-snowflake:
-    name: test-snowflake
+  db-snowflake:
     uses: './.github/workflows/db-snowflake.yaml'
     secrets:
       SNOWFLAKE_CONNECTION: ${{ secrets.SNOWFLAKE_CONNECTION }}
-  test-mysql:
-    name: test-mysql
+  db-mysql:
     uses: './.github/workflows/db-mysql.yaml'
-  test-duckdb-wasm:
-    name: test-duckdb-wasm
+  db-duckdb-wasm:
     uses: './.github/workflows/db-duckdb-wasm.yaml'
 
   # I think I have the sorted roughly longest to shortest
@@ -51,16 +41,16 @@ jobs:
   # that is the right plan
   malloy-tests:
     needs:
-      - test-all
-      - test-snowflake
-      - test-bigquery
-      - test-duckdb
-      - test-presto
-      - test-duckdb-wasm
-      - test-trino
-      - test-postgres
-      - test-motherduck
-      - test-mysql
+      - main
+      - db-snowflake
+      - db-bigquery
+      - db-duckdb
+      - db-presto
+      - db-duckdb-wasm
+      - db-trino
+      - db-postgres
+      - db-motherduck
+      - db-mysql
     runs-on: ubuntu-latest
     steps:
       - name: Success

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -4,36 +4,46 @@ on: [workflow_dispatch, pull_request]
 
 jobs:
   test-all:
+    name: test-all
     uses: './.github/workflows/main.yaml'
     secrets:
       BIGQUERY_KEY: ${{ secrets.BIGQUERY_KEY }}
   test-trino:
+    name: test-trino
     uses: './.github/workflows/db-trino.yaml'
     secrets:
       BQ_PRESTO_TRINO_KEY: ${{ secrets.BQ_PRESTO_TRINO_KEY }}
   test-presto:
+    name: test-presto
     uses: './.github/workflows/db-presto.yaml'
     secrets:
       BQ_PRESTO_TRINO_KEY: ${{ secrets.BQ_PRESTO_TRINO_KEY }}
   test-duckdb:
+    name: test-presto
     uses: './.github/workflows/db-duckdb.yaml'
   test-bigquery:
+    name: test-bigquery
     uses: './.github/workflows/db-bigquery.yaml'
     secrets:
       BIGQUERY_KEY: ${{ secrets.BIGQUERY_KEY }}
   test-motherduck:
+    name: test-motherduck
     uses: './.github/workflows/db-motherduck.yaml'
     secrets:
       MOTHERDUCK_TOKEN_10: ${{ secrets.MOTHERDUCK_TOKEN_10 }}
   test-postgres:
+    name: test-postgres
     uses: './.github/workflows/db-postgres.yaml'
   test-snowflake:
+    name: test-snowflake
     uses: './.github/workflows/db-snowflake.yaml'
     secrets:
       SNOWFLAKE_CONNECTION: ${{ secrets.SNOWFLAKE_CONNECTION }}
   test-mysql:
+    name: test-mysql
     uses: './.github/workflows/db-mysql.yaml'
   test-duckdb-wasm:
+    name: test-duckdb-wasm
     uses: './.github/workflows/db-duckdb-wasm.yaml'
 
   # I think I have the sorted roughly longest to shortest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,5 @@
 ## Project Committers
+
 Our committers are the following GitHub accounts:
 
 lloydtabb
@@ -11,13 +12,13 @@ whscullin
 
 ## Developer Certificate of Origin
 
-All new inbound code contributions must also be accompanied by a Developer 
-Certificate of Origin (http://developercertificate.org) sign-off in the source 
-code system that is submitted through a TSC-approved contribution process which 
-will bind the authorized contributor and, if not self-employed, their employer 
+All new inbound code contributions must also be accompanied by a Developer
+Certificate of Origin (http://developercertificate.org) sign-off in the source
+code system that is submitted through a TSC-approved contribution process which
+will bind the authorized contributor and, if not self-employed, their employer
 to the applicable license.
 
-Contributors sign-off that they adhere to these requirements by adding a 
+Contributors sign-off that they adhere to these requirements by adding a
 Signed-off-by line to commit messages.
 
 Git has a -s command line option to append this automatically to your commit
@@ -25,7 +26,7 @@ message, for example:
 
 ```
 $ git commit -s -m 'This is my commit message'
-``` 
+```
 
 ## Code Reviews
 
@@ -33,6 +34,9 @@ All submissions, including submissions by project members, require review. We
 use GitHub pull requests for this purpose. Consult
 [GitHub Help](https://help.github.com/articles/about-pull-requests/) for more
 information on using pull requests.
+
+All pull requests must pass tests. Outside contributors should contact the Malloy
+team via the`#developing` channel on the [Malloy Slack](https://malloydata.github.io/slack).
 
 ## Code of Conduct
 


### PR DESCRIPTION
This grants external PRs access to secrets in order to be able to run database tests. For security purposes external PRs will not automatically run tests, tests must be triggered by someone with write permissions to the repo (the core Malloy team).

This changes the names of the tests that are run, so older PRs will need to be updated to include these changes in order to pass the required test checks.