### PR TITLE
Finalize NULL related decisions

### DIFF
--- a/demo/malloy-duckdb-wasm/README.md
+++ b/demo/malloy-duckdb-wasm/README.md
@@ -73,7 +73,7 @@ source: airports is duckdb,table('airports.parquet') extend {
     heliport_count is airport_count {where: fac_type = 'HELIPORT'}
 
   view: by_state is {
-    where: state != null
+    where: state is not null
     group_by: state
     aggregate: airport_count
   }

--- a/packages/malloy-db-snowflake/src/snowflake_connection.spec.ts
+++ b/packages/malloy-db-snowflake/src/snowflake_connection.spec.ts
@@ -66,7 +66,7 @@ describe('db:Snowflake', () => {
       .loadModel("source: aircraft is snowflake.table('malloytest.aircraft')")
       .loadQuery(
         `run:  aircraft -> {
-        where: state != null
+        where: state is not null
         aggregate: cnt is count()
         group_by:  state}`
       )

--- a/packages/malloy/src/dialect/dialect.ts
+++ b/packages/malloy/src/dialect/dialect.ts
@@ -173,12 +173,13 @@ export abstract class Dialect {
   // MYSQL doesn't have full join, maybe others.
   supportsFullJoin = true;
 
-  nativeBoolean = true;
-
   // Can have arrays of arrays
   nestedArrays = true;
   // An array or record will reveal type of contents on schema read
   compoundObjectInSchema = true;
+
+  // No true boolean type, e.g. true=1 and false=0, set this to true
+  booleanAsNumbers = false;
 
   abstract getDialectFunctionOverrides(): {
     [name: string]: DialectFunctionOverloadDef[];

--- a/packages/malloy/src/dialect/mysql/mysql.ts
+++ b/packages/malloy/src/dialect/mysql/mysql.ts
@@ -107,7 +107,7 @@ export class MySQLDialect extends Dialect {
   defaultDecimalType = 'DECIMAL';
   udfPrefix = 'ms_temp.__udf';
   hasFinalStage = false;
-  // TODO: this may not be enough for lager casts.
+  // TODO: this may not be enough for larger casts.
   stringTypeName = 'VARCHAR(255)';
   divisionIsInteger = true;
   supportsSumDistinctFunction = true;
@@ -121,13 +121,13 @@ export class MySQLDialect extends Dialect {
   supportsQualify = false;
   supportsNesting = true;
   experimental = false;
-  nativeBoolean = false;
   supportsFullJoin = false;
   supportsPipelinesInViews = false;
   readsNestedData = false;
   supportsComplexFilteredSources = false;
   supportsArraysInData = false;
   compoundObjectInSchema = false;
+  booleanAsNumbers = true;
 
   malloyTypeToSQLType(malloyType: AtomicTypeDef): string {
     switch (malloyType.type) {

--- a/packages/malloy/src/lang/ast/expressions/expr-compare.ts
+++ b/packages/malloy/src/lang/ast/expressions/expr-compare.ts
@@ -43,6 +43,24 @@ const compareTypes = {
   '>': [TDU.numberT, TDU.stringT, TDU.dateT, TDU.timestampT],
 };
 
+export class ExprIsNull extends ExpressionDef {
+  elementType = 'is null';
+  constructor(
+    readonly expr: ExpressionDef,
+    readonly eq: boolean
+  ) {
+    super();
+    this.has({expr});
+  }
+
+  getExpression(fs: FieldSpace): ExprValue {
+    const expr = this.expr.getExpression(fs);
+    expr.type = 'boolean';
+    expr.value = {node: this.eq ? 'is-null' : 'is-not-null', e: expr.value};
+    return expr;
+  }
+}
+
 export class ExprCompare extends BinaryBoolean<CompareMalloyOperator> {
   elementType = 'a<=>b';
   constructor(

--- a/packages/malloy/src/lang/ast/expressions/expr-compare.ts
+++ b/packages/malloy/src/lang/ast/expressions/expr-compare.ts
@@ -93,6 +93,10 @@ export class ExprEquality extends ExprCompare {
     super(left, op, right);
   }
 
+  getExpression(fs: FieldSpace): ExprValue {
+    return this.right.apply(fs, this.op, this.left, true);
+  }
+
   apply(
     fs: FieldSpace,
     op: BinaryMalloyOperator,

--- a/packages/malloy/src/lang/ast/expressions/expr-compare.ts
+++ b/packages/malloy/src/lang/ast/expressions/expr-compare.ts
@@ -43,24 +43,6 @@ const compareTypes = {
   '>': [TDU.numberT, TDU.stringT, TDU.dateT, TDU.timestampT],
 };
 
-export class ExprIsNull extends ExpressionDef {
-  elementType = 'is null';
-  constructor(
-    readonly expr: ExpressionDef,
-    readonly eq: boolean
-  ) {
-    super();
-    this.has({expr});
-  }
-
-  getExpression(fs: FieldSpace): ExprValue {
-    const expr = this.expr.getExpression(fs);
-    expr.type = 'boolean';
-    expr.value = {node: this.eq ? 'is-null' : 'is-not-null', e: expr.value};
-    return expr;
-  }
-}
-
 export class ExprCompare extends BinaryBoolean<CompareMalloyOperator> {
   elementType = 'a<=>b';
   constructor(

--- a/packages/malloy/src/lang/ast/expressions/expr-compare.ts
+++ b/packages/malloy/src/lang/ast/expressions/expr-compare.ts
@@ -93,10 +93,6 @@ export class ExprEquality extends ExprCompare {
     super(left, op, right);
   }
 
-  getExpression(fs: FieldSpace): ExprValue {
-    return this.right.apply(fs, this.op, this.left, true);
-  }
-
   apply(
     fs: FieldSpace,
     op: BinaryMalloyOperator,

--- a/packages/malloy/src/lang/ast/expressions/expr-not.ts
+++ b/packages/malloy/src/lang/ast/expressions/expr-not.ts
@@ -36,6 +36,11 @@ export class ExprNot extends Unary {
 
   getExpression(fs: FieldSpace): ExprValue {
     const notThis = this.expr.getExpression(fs);
+    if (fs.dialectObj()?.booleanAsNumbers) {
+      if (this.legalChildTypes.find(t => t.type === 'number') === undefined) {
+        this.legalChildTypes.push(TDU.numberT);
+      }
+    }
     const doNot = this.typeCheck(this.expr, notThis);
     return {
       ...notThis,

--- a/packages/malloy/src/lang/ast/expressions/expr-null.ts
+++ b/packages/malloy/src/lang/ast/expressions/expr-null.ts
@@ -21,15 +21,34 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+import {BinaryMalloyOperator, FieldSpace} from '..';
 import {ExprValue, literalExprValue} from '../types/expr-value';
 import {ExpressionDef} from '../types/expression-def';
 
 export class ExprNULL extends ExpressionDef {
   elementType = 'NULL';
+
   getExpression(): ExprValue {
     return literalExprValue({
       dataType: {type: 'null'},
       value: {node: 'null'},
     });
+  }
+
+  apply(
+    fs: FieldSpace,
+    op: BinaryMalloyOperator,
+    left: ExpressionDef
+  ): ExprValue {
+    if (op === '!=' || op === '=') {
+      const expr = left.getExpression(fs);
+      expr.type = 'boolean';
+      expr.value = {
+        node: op === '=' ? 'is-null' : 'is-not-null',
+        e: expr.value,
+      };
+      return expr;
+    }
+    return super.apply(fs, op, left, true);
   }
 }

--- a/packages/malloy/src/lang/ast/expressions/expr-null.ts
+++ b/packages/malloy/src/lang/ast/expressions/expr-null.ts
@@ -23,7 +23,17 @@
 
 import {BinaryMalloyOperator, FieldSpace} from '..';
 import {ExprValue, literalExprValue} from '../types/expr-value';
-import {ExpressionDef} from '../types/expression-def';
+import {ATNodeType, ExpressionDef} from '../types/expression-def';
+
+function doIsNull(fs: FieldSpace, op: string, expr: ExpressionDef): ExprValue {
+  const nullCmp = expr.getExpression(fs);
+  nullCmp.type = 'boolean';
+  nullCmp.value = {
+    node: op === '=' ? 'is-null' : 'is-not-null',
+    e: nullCmp.value,
+  };
+  return nullCmp;
+}
 
 export class ExprNULL extends ExpressionDef {
   elementType = 'NULL';
@@ -41,14 +51,49 @@ export class ExprNULL extends ExpressionDef {
     left: ExpressionDef
   ): ExprValue {
     if (op === '!=' || op === '=') {
-      const expr = left.getExpression(fs);
-      expr.type = 'boolean';
-      expr.value = {
-        node: op === '=' ? 'is-null' : 'is-not-null',
-        e: expr.value,
-      };
-      return expr;
+      return doIsNull(fs, op, left);
     }
     return super.apply(fs, op, left, true);
+  }
+}
+
+export class PartialIsNull extends ExpressionDef {
+  elementType = '<=> NULL';
+  constructor(readonly op: '=' | '!=') {
+    super();
+  }
+
+  apply(fs: FieldSpace, op: string, expr: ExpressionDef): ExprValue {
+    return doIsNull(fs, op, expr);
+  }
+
+  requestExpression(_fs: FieldSpace): ExprValue | undefined {
+    return undefined;
+  }
+
+  getExpression(_fs: FieldSpace): ExprValue {
+    return this.loggedErrorExpr(
+      'partial-as-value',
+      'Partial null check does not have a value'
+    );
+  }
+
+  atNodeType(): ATNodeType {
+    return ATNodeType.Partial;
+  }
+}
+
+export class ExprIsNull extends ExpressionDef {
+  elementType = 'is null';
+  constructor(
+    readonly expr: ExpressionDef,
+    readonly op: '=' | '!='
+  ) {
+    super();
+    this.has({expr});
+  }
+
+  getExpression(fs: FieldSpace): ExprValue {
+    return doIsNull(fs, this.op, this.expr);
   }
 }

--- a/packages/malloy/src/lang/ast/expressions/expr-null.ts
+++ b/packages/malloy/src/lang/ast/expressions/expr-null.ts
@@ -64,7 +64,7 @@ export class PartialIsNull extends ExpressionDef {
   }
 
   apply(fs: FieldSpace, op: string, expr: ExpressionDef): ExprValue {
-    return doIsNull(fs, op, expr);
+    return doIsNull(fs, this.op, expr);
   }
 
   requestExpression(_fs: FieldSpace): ExprValue | undefined {

--- a/packages/malloy/src/lang/grammar/MalloyParser.g4
+++ b/packages/malloy/src/lang/grammar/MalloyParser.g4
@@ -624,9 +624,19 @@ fieldExpr
   | ungroup OPAREN fieldExpr (COMMA fieldName)* CPAREN     # exprUngroup
   ;
 
+partialCompare
+  : compareOp fieldExpr
+  ;
+
+partialTest
+  : partialCompare
+  | IS NOT? NULL
+  ;
+
 partialAllowedFieldExpr
-  : OPAREN compareOp? fieldExpr CPAREN
-  | compareOp? fieldExpr
+  : partialTest
+  | OPAREN partialTest CPAREN
+  | fieldExpr
   ;
 
 fieldExprList

--- a/packages/malloy/src/lang/grammar/MalloyParser.g4
+++ b/packages/malloy/src/lang/grammar/MalloyParser.g4
@@ -602,7 +602,7 @@ fieldExpr
   | fieldExpr BAR partialAllowedFieldExpr                  # exprOrTree
   | fieldExpr compareOp fieldExpr                          # exprCompare
   | fieldExpr NOT? LIKE fieldExpr                          # exprWarnLike
-  | fieldExpr IS NOT? NULL                                 # exprWarnNullCmp
+  | fieldExpr IS NOT? NULL                                 # exprNullCheck
   | fieldExpr NOT? IN OPAREN fieldExprList CPAREN          # exprWarnIn
   | fieldExpr QMARK partialAllowedFieldExpr                # exprApply
   | NOT fieldExpr                                          # exprNot

--- a/packages/malloy/src/lang/malloy-to-ast.ts
+++ b/packages/malloy/src/lang/malloy-to-ast.ts
@@ -1372,14 +1372,14 @@ export class MalloyToAST
         if (op === '=') {
           this.warnWithReplacement(
             'sql-is-null',
-            "Use IS NULL instead of '= null'",
+            "Use 'is null' to check for NULL instead of '= null'",
             wholeRange,
             `${this.getSourceCode(pcx.fieldExpr(0))} is null`
           );
         } else if (op === '!=') {
           this.warnWithReplacement(
             'sql-is-not-null',
-            "Use IS NOT NULL instead of '!= null'",
+            "Use 'is not null' to check for NULL instead of '!= null'",
             wholeRange,
             `${this.getSourceCode(pcx.fieldExpr(0))} is not null`
           );

--- a/packages/malloy/src/lang/malloy-to-ast.ts
+++ b/packages/malloy/src/lang/malloy-to-ast.ts
@@ -2124,29 +2124,10 @@ export class MalloyToAST
     );
   }
 
-  visitExprWarnNullCmp(pcx: parse.ExprWarnNullCmpContext): ast.ExprCompare {
-    let op: ast.CompareMalloyOperator = '=';
+  visitExprNullCheck(pcx: parse.ExprNullCheckContext): ast.ExprIsNull {
     const expr = pcx.fieldExpr();
-    const wholeRange = this.parseInfo.rangeFromContext(pcx);
-    if (pcx.NOT()) {
-      op = '!=';
-      this.warnWithReplacement(
-        'sql-is-not-null',
-        "Use '!= NULL' to check for NULL instead of 'IS NOT NULL'",
-        wholeRange,
-        `${this.getSourceCode(expr)} != null`
-      );
-    } else {
-      this.warnWithReplacement(
-        'sql-is-null',
-        "Use '= NULL' to check for NULL instead of 'IS NULL'",
-        wholeRange,
-        `${this.getSourceCode(expr)} = null`
-      );
-    }
-    const nullExpr = new ast.ExprNULL();
     return this.astAt(
-      new ast.ExprCompare(this.getFieldExpr(expr), op, nullExpr),
+      new ast.ExprIsNull(this.getFieldExpr(expr), pcx.NOT() === undefined),
       pcx
     );
   }

--- a/packages/malloy/src/lang/malloy-to-ast.ts
+++ b/packages/malloy/src/lang/malloy-to-ast.ts
@@ -1348,6 +1348,24 @@ export class MalloyToAST
     const left = this.getFieldExpr(pcx.fieldExpr(0));
     const right = this.getFieldExpr(pcx.fieldExpr(1));
     if (ast.isEquality(op)) {
+      const wholeRange = this.parseInfo.rangeFromContext(pcx);
+      if (right instanceof ast.ExprNULL) {
+        if (op === '=') {
+          this.warnWithReplacement(
+            'sql-is-null',
+            "Use IS NULL instead of '= null'",
+            wholeRange,
+            `${this.getSourceCode(pcx.fieldExpr(0))} is null`
+          );
+        } else if (op === '!=') {
+          this.warnWithReplacement(
+            'sql-is-not-null',
+            "Use IS NOT NULL instead of '!= null'",
+            wholeRange,
+            `${this.getSourceCode(pcx.fieldExpr(0))} is not null`
+          );
+        }
+      }
       return this.astAt(new ast.ExprEquality(left, op, right), pcx);
     } else if (ast.isComparison(op)) {
       return this.astAt(new ast.ExprCompare(left, op, right), pcx);

--- a/packages/malloy/src/lang/test/expressions.spec.ts
+++ b/packages/malloy/src/lang/test/expressions.spec.ts
@@ -170,6 +170,12 @@ describe('expressions', () => {
     test('null-check (??)', () => {
       expect('ai ?? 7').compilesTo('{ai coalesce 7}');
     });
+    test('is-null', () => {
+      expect('ai is null').compilesTo('{is-null ai}');
+    });
+    test('is-not-null', () => {
+      expect('ai is not null').compilesTo('{is-not-null ai}');
+    });
     test('coalesce type mismatch', () => {
       expect(new BetaExpression('ai ?? @2003')).toLog(
         errorMessage('Mismatched types for coalesce (number, date)')
@@ -230,26 +236,6 @@ describe('expressions', () => {
       expect(expr`ai ? (> 1 & < 100)`).toTranslate();
     });
     describe('sql friendly warnings', () => {
-      test('is null with warning', () => {
-        const warnSrc = expr`ai is null`;
-        expect(warnSrc).toLog(
-          warningMessage("Use '= NULL' to check for NULL instead of 'IS NULL'")
-        );
-        expect(warnSrc).compilesTo('{is-null ai}');
-        const warning = warnSrc.translator.problems()[0];
-        expect(warning.replacement).toEqual('ai = null');
-      });
-      test('is not null with warning', () => {
-        const warnSrc = expr`ai is not null`;
-        expect(warnSrc).toLog(
-          warningMessage(
-            "Use '!= NULL' to check for NULL instead of 'IS NOT NULL'"
-          )
-        );
-        expect(warnSrc).compilesTo('{is-not-null ai}');
-        const warning = warnSrc.translator.problems()[0];
-        expect(warning.replacement).toEqual('ai != null');
-      });
       test('like with warning', () => {
         const warnSrc = expr`astr like 'a'`;
         expect(warnSrc).toLog(
@@ -267,24 +253,6 @@ describe('expressions', () => {
         expect(warnSrc).compilesTo('{astr !like "a"}');
         const warning = warnSrc.translator.problems()[0];
         expect(warning.replacement).toEqual("astr !~ 'a'");
-      });
-      test('is is-null in a model', () => {
-        const isNullSrc = model`source: xa is a extend { dimension: x1 is astr is null }`;
-        expect(isNullSrc).toLog(
-          warningMessage("Use '= NULL' to check for NULL instead of 'IS NULL'")
-        );
-      });
-      test('is not-null in a model', () => {
-        const isNullSrc = model`source: xa is a extend { dimension: x1 is not null }`;
-        expect(isNullSrc).toTranslate();
-      });
-      test('is not-null is in a model', () => {
-        const isNullSrc = model`source: xa is a extend { dimension: x1 is not null is null }`;
-        expect(isNullSrc).toLog(
-          warningMessage("Use '= NULL' to check for NULL instead of 'IS NULL'")
-        );
-        const warning = isNullSrc.translator.problems()[0];
-        expect(warning.replacement).toEqual('null = null');
       });
       test('x is expr y is not null', () => {
         const isNullSrc = model`source: xa is a extend { dimension: x is 1 y is not null }`;

--- a/packages/malloy/src/lang/test/expressions.spec.ts
+++ b/packages/malloy/src/lang/test/expressions.spec.ts
@@ -170,11 +170,17 @@ describe('expressions', () => {
     test('null-check (??)', () => {
       expect('ai ?? 7').compilesTo('{ai coalesce 7}');
     });
-    test('is-null', () => {
+    test('normal is-null', () => {
       expect('ai is null').compilesTo('{is-null ai}');
     });
-    test('is-not-null', () => {
+    test('normal is-not-null', () => {
       expect('ai is not null').compilesTo('{is-not-null ai}');
+    });
+    test('apply is-null', () => {
+      expect('ai ? is null').compilesTo('{is-null ai}');
+    });
+    test('apply is-not-null', () => {
+      expect('ai ? is not null').compilesTo('{is-not-null ai}');
     });
     test('coalesce type mismatch', () => {
       expect(new BetaExpression('ai ?? @2003')).toLog(

--- a/packages/malloy/src/lang/test/expressions.spec.ts
+++ b/packages/malloy/src/lang/test/expressions.spec.ts
@@ -1292,7 +1292,7 @@ describe('expressions', () => {
     ['astr', 'string'],
     ['abool', 'boolean'],
   ])('Can compare field %s (type %s) to NULL', (name, _datatype) => {
-    expect(expr`${name} = NULL`).toTranslate();
+    expect(expr`${name} IS NULL`).toTranslate();
   });
 });
 describe('alternations as in', () => {
@@ -1353,7 +1353,7 @@ describe('sql native fields in schema', () => {
   });
   test('sql native reference can be compared to NULL', () => {
     const uModel = new TestTranslator(
-      'run: a->{ where: aun != NULL; select: * }'
+      'run: a->{ where: aun !IS NULL; select: * }'
     );
     expect(uModel).toTranslate();
   });

--- a/packages/malloy/src/lang/test/expressions.spec.ts
+++ b/packages/malloy/src/lang/test/expressions.spec.ts
@@ -242,6 +242,26 @@ describe('expressions', () => {
       expect(expr`ai ? (> 1 & < 100)`).toTranslate();
     });
     describe('sql friendly warnings', () => {
+      test('= null with warning', () => {
+        const warnSrc = expr`${'ai = null'}`;
+        expect(warnSrc).toLog(
+          warningMessage("Use 'is null' to check for NULL instead of '= null'")
+        );
+        expect(warnSrc).compilesTo('{is-null ai}');
+        const warning = warnSrc.translator.problems()[0];
+        expect(warning.replacement).toEqual('ai is null');
+      });
+      test('is not null with warning', () => {
+        const warnSrc = expr`${'ai != null'}`;
+        expect(warnSrc).toLog(
+          warningMessage(
+            "Use 'is not null' to check for NULL instead of '!= null'"
+          )
+        );
+        expect(warnSrc).compilesTo('{is-not-null ai}');
+        const warning = warnSrc.translator.problems()[0];
+        expect(warning.replacement).toEqual('ai is not null');
+      });
       test('like with warning', () => {
         const warnSrc = expr`astr like 'a'`;
         expect(warnSrc).toLog(

--- a/packages/malloy/src/lang/test/expressions.spec.ts
+++ b/packages/malloy/src/lang/test/expressions.spec.ts
@@ -1353,7 +1353,7 @@ describe('sql native fields in schema', () => {
   });
   test('sql native reference can be compared to NULL', () => {
     const uModel = new TestTranslator(
-      'run: a->{ where: aun !IS NULL; select: * }'
+      'run: a->{ where: aun is not null; select: * }'
     );
     expect(uModel).toTranslate();
   });

--- a/packages/malloy/src/lang/test/parameters.spec.ts
+++ b/packages/malloy/src/lang/test/parameters.spec.ts
@@ -71,7 +71,7 @@ describe('parameters', () => {
     expect(`
       ##! experimental.parameters
       source: ab_new(param is null::string) is ab extend {
-        where: param = null
+        where: param is null
       }
         run: ab_new(param is "foo") -> { select: * } -> { select: * }
     `).toTranslate();

--- a/test/src/databases/all/composite_sources.spec.ts
+++ b/test/src/databases/all/composite_sources.spec.ts
@@ -397,7 +397,7 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
         run: compose(
           state_facts extend { dimension: bar is 1 },
           state_facts
-        ) -> { index: bar } -> { group_by: fieldName; where: fieldName != null }
+        ) -> { index: bar } -> { group_by: fieldName; where: fieldName is not null }
       `).malloyResultMatches(runtime, {fieldName: 'bar'});
     });
   });

--- a/test/src/databases/all/expr.spec.ts
+++ b/test/src/databases/all/expr.spec.ts
@@ -839,14 +839,14 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
   describe('null safe booleans', () => {
     const nulls = `${databaseName}.sql("""
       SELECT
-        0 as nulls,
+        0 as null_cnt,
         1 as ${q`x`}, 2 as ${q`y`},
         'a' as ${q`a`}, 'b' as ${q`b`},
         (1 = 1) as ${q`tf`}
       UNION ALL SELECT
-        1,
+        5,
         null, null, null, null, null
-    """) extend { where: nulls > 0 }`;
+    """) extend { where: null_cnt > 0 }`;
 
     it('select boolean', async () => {
       await expect(`run: ${nulls} -> {

--- a/test/src/databases/all/expr.spec.ts
+++ b/test/src/databases/all/expr.spec.ts
@@ -234,7 +234,7 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
       run: aircraft->{
         top: 10
         order_by: 1
-        where: region != NULL
+        where: region is not null
         group_by: region
         nest: by_state is {
           top: 10
@@ -823,7 +823,7 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
           SELECT '' as ${q`null_value`}, '' as ${q`string_value`}
           UNION ALL SELECT null, 'correct'
       """) -> {
-        where: null_value = null
+        where: null_value is null
         select:
           found_null is  null_value ?? 'correct',
           else_pass is string_value ?? 'incorrect'

--- a/test/src/databases/all/expr.spec.ts
+++ b/test/src/databases/all/expr.spec.ts
@@ -839,14 +839,15 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
   describe('null safe booleans', () => {
     const nulls = `${databaseName}.sql("""
       SELECT
-        0 as null_cnt,
+        0 as ${q`n`},
         1 as ${q`x`}, 2 as ${q`y`},
         'a' as ${q`a`}, 'b' as ${q`b`},
         (1 = 1) as ${q`tf`}
       UNION ALL SELECT
         5,
         null, null, null, null, null
-    """) extend { where: null_cnt > 0 }`;
+    """) extend { where: n > 0 }`;
+    const is_true = databaseName === 'mysql' ? 1 : true;
 
     it('select boolean', async () => {
       await expect(`run: ${nulls} -> {
@@ -858,32 +859,32 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
       await expect(`run: ${nulls} -> {
         select:
           not_null_boolean is not tf
-      }`).malloyResultMatches(runtime, {not_null_boolean: true});
+      }`).malloyResultMatches(runtime, {not_null_boolean: is_true});
     });
     it('numeric != non-null to null', async () => {
       await expect(
         `run: ${nulls} -> { select: val_ne_null is x != 9 }`
-      ).malloyResultMatches(runtime, {val_ne_null: true});
+      ).malloyResultMatches(runtime, {val_ne_null: is_true});
     });
     it('string !~ non-null to null', async () => {
       await expect(
         `run: ${nulls} -> { select: val_ne_null is a !~ 'z' }`
-      ).malloyResultMatches(runtime, {val_ne_null: true});
+      ).malloyResultMatches(runtime, {val_ne_null: is_true});
     });
     it('regex !~ non-null to null', async () => {
       await expect(
         `run: ${nulls} -> { select: val_ne_null is a !~ r'z' }`
-      ).malloyResultMatches(runtime, {val_ne_null: true});
+      ).malloyResultMatches(runtime, {val_ne_null: is_true});
     });
     it('numeric != null-to-null', async () => {
       await expect(
         `run: ${nulls} -> { select: null_ne_null is x != y }`
-      ).malloyResultMatches(runtime, {null_ne_null: true});
+      ).malloyResultMatches(runtime, {null_ne_null: is_true});
     });
     it('string !~ null-to-null', async () => {
       await expect(
         `run: ${nulls} -> { select: null_ne_null is a !~ b }`
-      ).malloyResultMatches(runtime, {null_ne_null: true});
+      ).malloyResultMatches(runtime, {null_ne_null: is_true});
     });
   });
 

--- a/test/src/databases/all/functions.spec.ts
+++ b/test/src/databases/all/functions.spec.ts
@@ -642,7 +642,7 @@ expressionModels.forEach((x, databaseName) => {
           `
           run: aircraft -> {
             group_by: state
-            where: state != null
+            where: state is not null
             nest: by_county is {
               limit: 2
               group_by: county
@@ -680,7 +680,7 @@ expressionModels.forEach((x, databaseName) => {
           `
           run: airports extend { measure: airport_count is count() } -> {
             group_by: state
-            where: state != null
+            where: state is not null
             calculate: prev_airport_count is lag(airport_count)
           }`
         )

--- a/test/src/databases/all/nomodel.spec.ts
+++ b/test/src/databases/all/nomodel.spec.ts
@@ -63,23 +63,6 @@ afterAll(async () => {
 
 runtimes.runtimeMap.forEach((runtime, databaseName) => {
   const q = runtime.getQuoter();
-  // Issue #1824
-  it.when(runtime.dialect.nativeBoolean)(
-    `not boolean field with null - ${databaseName}`,
-    async () => {
-      await expect(`
-      run: ${databaseName}.sql("""
-          SELECT
-            CASE WHEN 1=1 THEN NULL ELSE false END as ${q`n`}
-      """) -> {
-        select:
-          is_true is not n
-      }
-    `).malloyResultMatches(runtime, {
-        is_true: true,
-      });
-    }
-  );
 
   // Issue: #1284
   it(`parenthesize output field values - ${databaseName}`, async () => {

--- a/test/src/databases/all/nomodel.spec.ts
+++ b/test/src/databases/all/nomodel.spec.ts
@@ -82,7 +82,7 @@ runtimes.runtimeMap.forEach((runtime, databaseName) => {
   it(`bug 151 which used to throw unknown dialect is still fixed- ${databaseName}`, async () => {
     await expect(`
       query: q is ${databaseName}.table('malloytest.aircraft')->{
-        where: state != null
+        where: state is not null
         group_by: state
       }
       run: q extend {
@@ -1035,7 +1035,7 @@ SELECT row_to_json(finalStage) as row FROM __stage0 AS finalStage`);
           ${splitFN!(q`city`, ' ')} as ${q`words`}
         FROM ${rootDbPath(databaseName)}malloytest.aircraft
       """) -> {
-        where: words.value != null
+        where: words.value is not null
         group_by: words.value
         aggregate: c is count()
       }
@@ -1089,7 +1089,7 @@ SELECT row_to_json(finalStage) as row FROM __stage0 AS finalStage`);
     await expect(`
         source: ga_sample is ${databaseName}.table('malloytest.ga_sample')
         run: ga_sample -> {
-          where: hits.product.productBrand != null
+          where: hits.product.productBrand is not null
           group_by:
             hits.product.productBrand
             hits.product.productSKU
@@ -1124,16 +1124,16 @@ SELECT row_to_json(finalStage) as row FROM __stage0 AS finalStage`);
         .loadQuery(
           `
         run: ${databaseName}.table('malloytest.airports') -> {
-          where: faa_region = null
+          where: faa_region is null
           group_by: faa_region
           aggregate: airport_count is count()
           nest: by_state is {
-            where: state != null
+            where: state is not null
             group_by: state
             aggregate: airport_count is count()
           }
           nest: by_state1 is {
-            where: state != null
+            where: state is not null
             group_by: state
             aggregate: airport_count is count()
             limit: 1

--- a/test/src/databases/all/parameters.spec.ts
+++ b/test/src/databases/all/parameters.spec.ts
@@ -320,7 +320,7 @@ runtimes.runtimeMap.forEach((runtime, databaseName) => {
         param::string is null,
         state_filter::string is "CA"
       ) is ${databaseName}.table('malloytest.state_facts') extend {
-        where: param = null and state = state_filter
+        where: param is null and state = state_filter
       }
       run: state_facts -> { group_by: state }
     `).malloyResultMatches(runtime, {state: 'CA'});

--- a/test/src/databases/bigquery/malloy_query.spec.ts
+++ b/test/src/databases/bigquery/malloy_query.spec.ts
@@ -486,7 +486,7 @@ describe('BigQuery expression tests', () => {
         }
       }
       -> {
-        where: state.code.code != null
+        where: state.code.code is not null
         group_by: state.code.code
       }
     `
@@ -639,7 +639,7 @@ describe('airport_tests', () => {
       `
       run: airports-> {
         nest: zero is {
-          nest: by_faa_region_i is { where: county ~'I%' and  state != NULL
+          nest: by_faa_region_i is { where: county ~'I%' and  state is not null
             group_by: faa_region
             aggregate: airport_count
             nest: by_state is {

--- a/test/src/databases/bigquery/nested_source_table.spec.ts
+++ b/test/src/databases/bigquery/nested_source_table.spec.ts
@@ -154,7 +154,7 @@ describe.each(runtimes.runtimeList)(
     test(`search_index - ${databaseName}`, async () => {
       await expect(`
         run: ga_sessions->search_index -> {
-          where: fieldName != null
+          where: fieldName is not null
           select: *
           order_by: fieldName, weight desc
           limit: 10

--- a/test/src/databases/duckdb/nested_source_table.spec.ts
+++ b/test/src/databases/duckdb/nested_source_table.spec.ts
@@ -154,7 +154,7 @@ describe.each(runtimes.runtimeList)(
     test(`search_index - ${databaseName}`, async () => {
       await expect(`
         run: ga_sessions->search_index -> {
-          where: fieldName != null
+          where: fieldName is not null
           select: *
           order_by: fieldName, weight desc
           limit: 10

--- a/test/src/databases/duckdb/streaming.spec.ts
+++ b/test/src/databases/duckdb/streaming.spec.ts
@@ -56,7 +56,7 @@ function modelText(databaseName: string) {
   }
 
   view: by_county is {
-    where: county != null
+    where: county is not null
     group_by: county
     aggregate: airport_count
     limit: 2
@@ -64,7 +64,7 @@ function modelText(databaseName: string) {
   }
 
   view: by_state is {
-    where: state != null
+    where: state is not null
     group_by: state
     aggregate: airport_count
     limit: 2


### PR DESCRIPTION
1) `= NULL` and `!= NULL` are deprecated
2) `IS NULL` and `IS NOT NULL` are official
3) `!=` and `!~` return true if either argument `is null`
4) `not x` returns true if `x is null`
5) Added partials for `is null` and `is not null` for the sake of pick statements

- [ ] Fix docs for `= NULL` and `IS NULL` ( https://github.com/malloydata/malloydata.github.io/pull/211 )
- [ ] Write a page about why we do this in the docs tree
- [x] `is null` and `is not null` as legal partials ?
