### PR TITLE
Fix issue with referencing field in doubly-nested join inside a nest

### DIFF
--- a/packages/malloy/src/lang/ast/field-space/query-spaces.ts
+++ b/packages/malloy/src/lang/ast/field-space/query-spaces.ts
@@ -50,6 +50,7 @@ import {
   emptyCompositeFieldUsage,
   emptyNarrowedCompositeFieldResolution,
   isEmptyCompositeFieldUsage,
+  joinedCompositeFieldUsage,
   mergeCompositeFieldUsage,
   narrowCompositeFieldResolution,
   NarrowedCompositeFieldResolution,
@@ -220,9 +221,10 @@ export abstract class QueryOperationSpace
     const lookup = this.exprSpace.lookup(reference);
     // Should always be found...
     if (lookup.found && lookup.found instanceof StructSpaceFieldBase) {
-      return (
+      return joinedCompositeFieldUsage(
+        joinPath.slice(0, -1),
         lookup.found.fieldDef().onCompositeFieldUsage ??
-        emptyCompositeFieldUsage()
+          emptyCompositeFieldUsage()
       );
     }
     throw new Error('Unexpected join lookup was not found or not a struct');

--- a/packages/malloy/src/lang/test/query.spec.ts
+++ b/packages/malloy/src/lang/test/query.spec.ts
@@ -777,6 +777,19 @@ describe('query:', () => {
         group_by: b.ai
       }`).toTranslate();
     });
+    test('reference field in double nested join inside nest', () => {
+      expect(`
+        source: a_2 is a extend { join_one: b is b extend {
+          join_one: c is b on 1 = c.ai
+        } with astr }
+
+        run: a_2 -> {
+          nest: x is {
+            group_by: ai is b.c.ai
+          }
+        }
+      `).toTranslate();
+    });
     test.skip('reference join as field', () => {
       expect(`run: a -> {
         extend: { join_one: b with astr }


### PR DESCRIPTION
In this kind of construction:

```
source: a_2 is a extend { join_one: b is b extend {
  join_one: c is b on 1 = c.ai
} with astr }

run: a_2 -> {
  nest: x is {
    group_by: ai is b.c.ai
  }
}
```
I was computing the wrong join usage (which is used for the composite sources feature). Specifically, it was making it out that `ai is b.c.ai` used joins `b.c` as well as `c` (unqualified). Then when the nest was evaluated in the outer query, it tried to figure out what `c` was (unqualified), and that doesn't exist.