### PR TITLE
fix for STRUCT() with unknown fields in duckdb

### DIFF
--- a/packages/malloy-db-duckdb/src/duckdb.spec.ts
+++ b/packages/malloy-db-duckdb/src/duckdb.spec.ts
@@ -167,7 +167,7 @@ describe('DuckDBConnection', () => {
         ],
       });
     });
-    it('parses schema with sql native field', () => {
+    it('parses struct with sql native field', () => {
       const structDef = makeStructDef();
       connection.fillStructDefFromTypeMap(structDef, {test: PROFESSOR_SCHEMA});
       expect(structDef.fields[0]).toEqual({

--- a/packages/malloy-db-duckdb/src/duckdb.spec.ts
+++ b/packages/malloy-db-duckdb/src/duckdb.spec.ts
@@ -167,6 +167,22 @@ describe('DuckDBConnection', () => {
         ],
       });
     });
+    it('parses schema with sql native field', () => {
+      const structDef = makeStructDef();
+      connection.fillStructDefFromTypeMap(structDef, {test: PROFESSOR_SCHEMA});
+      expect(structDef.fields[0]).toEqual({
+        'name': 'test',
+        'type': 'array',
+        'elementTypeDef': {type: 'record_element'},
+        'join': 'many',
+        'fields': [
+          {'name': 'professor_id', 'type': 'sql native', 'rawType': 'UUID'},
+          {'name': 'name', 'type': 'string'},
+          {'name': 'age', 'numberType': 'integer', 'type': 'number'},
+          {'name': 'total_sections', 'numberType': 'integer', 'type': 'number'},
+        ],
+      });
+    });
 
     it('parses a simple type', () => {
       const structDef = makeStructDef();
@@ -174,6 +190,16 @@ describe('DuckDBConnection', () => {
       expect(structDef.fields[0]).toEqual({
         'name': 'test',
         'type': 'string',
+      });
+    });
+
+    it('parses unknown type', () => {
+      const structDef = makeStructDef();
+      connection.fillStructDefFromTypeMap(structDef, {test: 'UUID'});
+      expect(structDef.fields[0]).toEqual({
+        'name': 'test',
+        'type': 'sql native',
+        'rawType': 'UUID',
       });
     });
   });
@@ -261,3 +287,6 @@ const NESTED_SCHEMA = 'STRUCT(a double, b integer, c varchar(60))[]';
 const intTyp = {type: 'number', numberType: 'integer'};
 const strTyp = {type: 'string'};
 const dblType = {type: 'number', numberType: 'float'};
+
+const PROFESSOR_SCHEMA =
+  'STRUCT(professor_id UUID, "name" VARCHAR, age BIGINT, total_sections BIGINT)[]';

--- a/packages/malloy/src/dialect/duckdb/duckdb.ts
+++ b/packages/malloy/src/dialect/duckdb/duckdb.ts
@@ -537,13 +537,16 @@ class DuckDBTypeParser extends TinyParser {
       if (wantID.type === 'id') {
         // unknown field type, strip all type decorations, there was a regex for this
         // in the pre-parser code, but no tests, so this is also untested
+        let idEnd = wantID.cursor + wantID.text.length;
         if (this.peek().type === 'precision') {
           this.next();
         }
-
+        if (this.peek().type === 'eof') {
+          idEnd = this.input.length;
+        }
         baseType = {
           type: 'sql native',
-          rawType: this.input.slice(wantID.cursor, this.parseCursor - 1),
+          rawType: this.input.slice(wantID.cursor, idEnd),
         };
       } else {
         throw this.parseError('Could not understand type');

--- a/packages/malloy/src/dialect/duckdb/duckdb.ts
+++ b/packages/malloy/src/dialect/duckdb/duckdb.ts
@@ -537,8 +537,7 @@ class DuckDBTypeParser extends TinyParser {
       if (wantID.type === 'id') {
         // unknown field type, strip all type decorations, there was a regex for this
         // in the pre-parser code, but no tests, so this is also untested
-        const next = this.peek();
-        if (next.type === 'precision') {
+        if (this.peek().type === 'precision') {
           this.next();
         }
 

--- a/packages/malloy/src/dialect/duckdb/duckdb.ts
+++ b/packages/malloy/src/dialect/duckdb/duckdb.ts
@@ -535,12 +535,13 @@ class DuckDBTypeParser extends TinyParser {
       }
     } else {
       if (wantID.type === 'id') {
-        // unknown field type strip all type decorations, we ha
-        // guess what a regex whic nobody tested used to do
+        // unknown field type, strip all type decorations, there was a regex for this
+        // in the pre-parser code, but no tests, so this is also untested
         const next = this.peek();
         if (next.type === 'precision') {
           this.next();
         }
+
         baseType = {
           type: 'sql native',
           rawType: this.input.slice(wantID.cursor, this.parseCursor - 1),

--- a/packages/malloy/src/dialect/tiny_parser.ts
+++ b/packages/malloy/src/dialect/tiny_parser.ts
@@ -6,6 +6,7 @@
  */
 
 export interface TinyToken {
+  cursor: number;
   type: string;
   text: string;
 }
@@ -139,12 +140,14 @@ export class TinyParser {
         if (foundToken) {
           notFound = false;
           let tokenText = foundToken[0];
+          const cursor = this.parseCursor;
           this.parseCursor += tokenText.length;
           if (tokenType !== 'space') {
             if (tokenType[0] === 'q') {
               tokenText = tokenText.slice(1, -1); // strip quotes
             }
             yield {
+              cursor,
               type: tokenType === 'char' ? tokenText : tokenType,
               text: tokenText,
             };
@@ -153,7 +156,7 @@ export class TinyParser {
         }
       }
       if (notFound) {
-        yield {type: 'unexpected token', text: src};
+        yield {cursor: this.parseCursor, type: 'unexpected token', text: src};
         return;
       }
     }


### PR DESCRIPTION
There's a blog post with an example where a STRUCT(x UUID) field exists and the type parser for duckdb did not properly handle that.

Fixed the bug and added the missing test that should have existed.