### PR TITLE
Add model caching capability to Runtime

### DIFF
--- a/packages/malloy-db-bigquery/src/bigquery.spec.ts
+++ b/packages/malloy-db-bigquery/src/bigquery.spec.ts
@@ -40,10 +40,16 @@ describe('db:BigQuery', () => {
     const files = {
       readURL: async (url: URL) => {
         const filePath = fileURLToPath(url);
-        return await util.promisify(fs.readFile)(filePath, 'utf8');
+        const contents = await util.promisify(fs.readFile)(filePath, 'utf8');
+        // TODO do we ever care about invalidation keys here?
+        return {contents, invalidationKey: 1};
       },
+      getInvalidationKey: async (_url: URL) => 1,
     };
-    runtime = new malloy.Runtime(files, bq);
+    runtime = new malloy.Runtime({
+      urlReader: files,
+      connection: bq,
+    });
   });
 
   it('runs a SQL query', async () => {

--- a/packages/malloy-db-bigquery/src/bigquery.spec.ts
+++ b/packages/malloy-db-bigquery/src/bigquery.spec.ts
@@ -40,11 +40,8 @@ describe('db:BigQuery', () => {
     const files = {
       readURL: async (url: URL) => {
         const filePath = fileURLToPath(url);
-        const contents = await util.promisify(fs.readFile)(filePath, 'utf8');
-        // TODO do we ever care about invalidation keys here?
-        return {contents, invalidationKey: 1};
+        return await util.promisify(fs.readFile)(filePath, 'utf8');
       },
-      getInvalidationKey: async (_url: URL) => 1,
     };
     runtime = new malloy.Runtime({
       urlReader: files,

--- a/packages/malloy-db-snowflake/src/snowflake_connection.spec.ts
+++ b/packages/malloy-db-snowflake/src/snowflake_connection.spec.ts
@@ -46,11 +46,8 @@ describe('db:Snowflake', () => {
     const files = {
       readURL: async (url: URL) => {
         const filePath = fileURLToPath(url);
-        const contents = await util.promisify(fs.readFile)(filePath, 'utf8');
-        // TODO do we ever care about invalidation keys here?
-        return {contents, invalidationKey: 1};
+        return await util.promisify(fs.readFile)(filePath, 'utf8');
       },
-      getInvalidationKey: async (_url: URL) => 1,
     };
     runtime = new malloy.Runtime({
       urlReader: files,

--- a/packages/malloy-db-snowflake/src/snowflake_connection.spec.ts
+++ b/packages/malloy-db-snowflake/src/snowflake_connection.spec.ts
@@ -46,10 +46,16 @@ describe('db:Snowflake', () => {
     const files = {
       readURL: async (url: URL) => {
         const filePath = fileURLToPath(url);
-        return await util.promisify(fs.readFile)(filePath, 'utf8');
+        const contents = await util.promisify(fs.readFile)(filePath, 'utf8');
+        // TODO do we ever care about invalidation keys here?
+        return {contents, invalidationKey: 1};
       },
+      getInvalidationKey: async (_url: URL) => 1,
     };
-    runtime = new malloy.Runtime(files, conn);
+    runtime = new malloy.Runtime({
+      urlReader: files,
+      connection: conn,
+    });
   });
 
   afterAll(async () => {

--- a/packages/malloy-render/src/stories/util.ts
+++ b/packages/malloy-render/src/stories/util.ts
@@ -35,7 +35,7 @@ export async function loadModel({
   connection: Promise<DuckDBWASMConnection>;
 }) {
   const conn = await connection;
-  return new SingleConnectionRuntime(conn).loadModel(script);
+  return new SingleConnectionRuntime({connection: conn}).loadModel(script);
 }
 
 export async function runQuery({

--- a/packages/malloy/src/index.ts
+++ b/packages/malloy/src/index.ts
@@ -169,6 +169,7 @@ export {
   DataWriter,
   Explore,
   InMemoryModelCache,
+  CacheManager,
 } from './malloy';
 export type {
   PreparedQuery,
@@ -190,6 +191,7 @@ export type {
   ExploreMaterializer,
   WriteStream,
   SerializedExplore,
+  ModelCache,
   // Needed for renderer type narrowing
   DateField,
   TimestampField,

--- a/packages/malloy/src/index.ts
+++ b/packages/malloy/src/index.ts
@@ -192,6 +192,7 @@ export type {
   WriteStream,
   SerializedExplore,
   ModelCache,
+  CachedModel,
   // Needed for renderer type narrowing
   DateField,
   TimestampField,
@@ -204,6 +205,7 @@ export type {
   QueryString,
   QueryURL,
   URLReader,
+  InvalidationKey,
 } from './runtime_types';
 export type {
   Connection,

--- a/packages/malloy/src/index.ts
+++ b/packages/malloy/src/index.ts
@@ -168,6 +168,7 @@ export {
   Parse,
   DataWriter,
   Explore,
+  InMemoryModelCache,
 } from './malloy';
 export type {
   PreparedQuery,

--- a/packages/malloy/src/runtime_types.ts
+++ b/packages/malloy/src/runtime_types.ts
@@ -41,7 +41,8 @@ export type ModelURL = URL;
  */
 export type QueryURL = URL;
 
-export type InvalidationKey = string | number | Date;
+// An null InvalidationKey indicates to not cache...
+export type InvalidationKey = string | number | Date | null;
 
 /**
  * An object capable of reading the contents of a URL in some context.

--- a/packages/malloy/src/runtime_types.ts
+++ b/packages/malloy/src/runtime_types.ts
@@ -55,8 +55,8 @@ export interface URLReader {
    */
   readURL: (
     url: URL
-  ) => Promise<{contents: string; invalidationKey: InvalidationKey}>;
-  getInvalidationKey: (url: URL) => Promise<InvalidationKey>;
+  ) => Promise<string | {contents: string; invalidationKey?: InvalidationKey}>;
+  getInvalidationKey?: (url: URL) => Promise<InvalidationKey>;
 }
 
 export interface EventStream {

--- a/packages/malloy/src/runtime_types.ts
+++ b/packages/malloy/src/runtime_types.ts
@@ -41,6 +41,8 @@ export type ModelURL = URL;
  */
 export type QueryURL = URL;
 
+export type InvalidationKey = string | number | Date;
+
 /**
  * An object capable of reading the contents of a URL in some context.
  */
@@ -51,7 +53,10 @@ export interface URLReader {
    * @param url The URL to read.
    * @return A promise to the contents of the URL.
    */
-  readURL: (url: URL) => Promise<string>;
+  readURL: (
+    url: URL
+  ) => Promise<{contents: string; invalidationKey: InvalidationKey}>;
+  getInvalidationKey: (url: URL) => Promise<InvalidationKey>;
 }
 
 export interface EventStream {

--- a/test/src/core/multi_connection.spec.ts
+++ b/test/src/core/multi_connection.spec.ts
@@ -58,7 +58,7 @@ describe('Multi-connection', () => {
 
   const runtime = new malloy.Runtime({
     urlReader: files,
-    lookupConnection: connectionMap,
+    connections: connectionMap,
   });
 
   afterAll(async () => {

--- a/test/src/core/multi_connection.spec.ts
+++ b/test/src/core/multi_connection.spec.ts
@@ -56,7 +56,10 @@ describe('Multi-connection', () => {
     'duckdb'
   );
 
-  const runtime = new malloy.Runtime(files, connectionMap);
+  const runtime = new malloy.Runtime({
+    urlReader: files,
+    lookupConnection: connectionMap,
+  });
 
   afterAll(async () => {
     await postgresConnection.close();

--- a/test/src/databases/duckdb/model-caching.spec.ts
+++ b/test/src/databases/duckdb/model-caching.spec.ts
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files
+ * (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import {describeIfDatabaseAvailable} from '../../util';
+import {RuntimeList, TestURLReader} from '../../runtimes';
+
+const [_describe, databases] = describeIfDatabaseAvailable(['duckdb']);
+const runtimes = new RuntimeList(databases);
+
+describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
+  test('model caching works', async () => {
+    const modelCache = runtime.getModelCache();
+    const urlReader = runtime.urlReader;
+    expect(urlReader instanceof TestURLReader).toBe(true);
+    if (!(urlReader instanceof TestURLReader)) return;
+    expect(modelCache).toBeDefined();
+    if (modelCache === undefined) return;
+    const aURL = new URL('file://a.malloy');
+    const bURL = new URL('file://b.malloy');
+    urlReader.setFile(
+      aURL,
+      `
+        import 'file://b.malloy'
+
+        source: a is duckdb.sql("SELECT 1 as one")
+      `
+    );
+    urlReader.setFile(
+      bURL,
+      `
+        source: b is duckdb.sql("SELECT 1 as one")
+      `
+    );
+    const model1 = await runtime.getModel(aURL);
+    expect(model1.problems).toMatchObject([]);
+    const aCached = await modelCache.getModel(aURL);
+    expect(aCached).toBeDefined();
+    if (aCached === undefined) return;
+    expect(aCached.modelDef.contents['a']).toBeDefined();
+    expect(aCached.modelDef.dependencies).toMatchObject({
+      'file://b.malloy/': {},
+    });
+    expect(aCached.modelDef.contents['a']).toBeDefined();
+    urlReader.setFile(
+      bURL,
+      `
+        source: c is duckdb.sql("SELECT 1 as one")
+      `
+    );
+    const model2 = await runtime.getModel(aURL);
+    expect(model2._modelDef.contents['c']).toBeDefined();
+    expect(model2._modelDef.contents['a']).toBeDefined();
+    expect(model2._modelDef.contents['a2']).not.toBeDefined();
+    // We want to check that it's going to use the cached version of b...
+    // so we'll sneakily modify the cache in an evil way:
+    const existingModel = await modelCache.getModel(bURL);
+    expect(existingModel).toBeDefined();
+    if (existingModel === undefined) return;
+    await modelCache.setModel(
+      bURL,
+      {
+        ...existingModel.modelDef,
+        contents: {
+          ...existingModel.modelDef.contents,
+          'sneaky': existingModel.modelDef.contents['c'],
+        },
+        exports: ['sneaky'],
+      },
+      existingModel.invalidationKeys
+    );
+    urlReader.setFile(
+      aURL,
+      `
+        import 'file://b.malloy'
+
+        source: sneaky_copy is sneaky extend {}
+      `
+    );
+    const model3 = await runtime.getModel(aURL);
+    expect(model3._modelDef.contents['sneaky_copy']).toBeDefined();
+    expect(model3._modelDef.contents['a']).not.toBeDefined();
+  });
+});

--- a/test/src/databases/duckdb/model_caching.spec.ts
+++ b/test/src/databases/duckdb/model_caching.spec.ts
@@ -29,7 +29,7 @@ const runtimes = new RuntimeList(databases);
 
 describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
   test('model caching works', async () => {
-    const modelCache = runtime.getModelCache();
+    const modelCache = runtime.modelCache;
     const urlReader = runtime.urlReader;
     expect(urlReader instanceof TestURLReader).toBe(true);
     if (!(urlReader instanceof TestURLReader)) return;

--- a/test/src/databases/duckdb/model_caching.spec.ts
+++ b/test/src/databases/duckdb/model_caching.spec.ts
@@ -22,18 +22,20 @@
  */
 
 import {describeIfDatabaseAvailable} from '../../util';
-import {RuntimeList, TestURLReader} from '../../runtimes';
+import {RuntimeList, TestCacheManager, TestURLReader} from '../../runtimes';
 
 const [_describe, databases] = describeIfDatabaseAvailable(['duckdb']);
 const runtimes = new RuntimeList(databases);
 
 describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
   test('model caching works', async () => {
-    const modelCache = runtime.modelCache;
+    const cacheManager = runtime.cacheManager;
     const urlReader = runtime.urlReader;
     expect(urlReader instanceof TestURLReader).toBe(true);
     if (!(urlReader instanceof TestURLReader)) return;
-    expect(modelCache).toBeDefined();
+    expect(cacheManager instanceof TestCacheManager).toBe(true);
+    if (!(cacheManager instanceof TestCacheManager)) return;
+    const modelCache = cacheManager._modelCache;
     if (modelCache === undefined) return;
     const aURL = new URL('file://a.malloy');
     const bURL = new URL('file://b.malloy');

--- a/test/src/databases/duckdb/model_caching.spec.ts
+++ b/test/src/databases/duckdb/model_caching.spec.ts
@@ -78,9 +78,8 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
     const existingModel = await modelCache.getModel(bURL);
     expect(existingModel).toBeDefined();
     if (existingModel === undefined) return;
-    await modelCache.setModel(
-      bURL,
-      {
+    await modelCache.setModel(bURL, {
+      modelDef: {
         ...existingModel.modelDef,
         contents: {
           ...existingModel.modelDef.contents,
@@ -88,8 +87,8 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
         },
         exports: ['sneaky'],
       },
-      existingModel.invalidationKeys
-    );
+      invalidationKeys: existingModel.invalidationKeys,
+    });
     urlReader.setFile(
       aURL,
       `

--- a/test/src/runtimes.ts
+++ b/test/src/runtimes.ts
@@ -29,6 +29,7 @@ import {
   RunSQLOptions,
   SingleConnectionRuntime,
   InMemoryURLReader,
+  InMemoryModelCache,
 } from '@malloydata/malloy';
 import {BigQueryConnection} from '@malloydata/db-bigquery';
 import {DuckDBConnection} from '@malloydata/db-duckdb';
@@ -236,7 +237,12 @@ export function runtimeFor(dbName: string): SingleConnectionRuntime {
 }
 
 export function testRuntimeFor(connection: Connection) {
-  return new SingleConnectionRuntime(files, connection, new EventEmitter());
+  return new SingleConnectionRuntime({
+    urlReader: files,
+    connection,
+    eventStream: new EventEmitter(),
+    modelCache: new InMemoryModelCache(),
+  });
 }
 
 /**

--- a/test/src/runtimes.ts
+++ b/test/src/runtimes.ts
@@ -23,12 +23,12 @@
 
 import {
   Connection,
-  EmptyURLReader,
   MalloyQueryData,
   QueryDataRow,
   Result,
   RunSQLOptions,
   SingleConnectionRuntime,
+  InMemoryURLReader,
 } from '@malloydata/malloy';
 import {BigQueryConnection} from '@malloydata/db-bigquery';
 import {DuckDBConnection} from '@malloydata/db-duckdb';
@@ -144,7 +144,21 @@ export class DuckDBWASMTestConnection extends DuckDBWASMConnection {
   }
 }
 
-const files = new EmptyURLReader();
+export class TestURLReader extends InMemoryURLReader {
+  constructor() {
+    super(new Map());
+  }
+
+  setFile(url: URL, contents: string) {
+    this.files.set(url.toString(), contents);
+  }
+
+  deleteFile(url: URL) {
+    this.files.delete(url.toString());
+  }
+}
+
+const files = new TestURLReader();
 
 export function rows(qr: Result): QueryDataRow[] {
   return qr.data.value;

--- a/test/src/runtimes.ts
+++ b/test/src/runtimes.ts
@@ -30,6 +30,8 @@ import {
   SingleConnectionRuntime,
   InMemoryURLReader,
   InMemoryModelCache,
+  CacheManager,
+  ModelCache,
 } from '@malloydata/malloy';
 import {BigQueryConnection} from '@malloydata/db-bigquery';
 import {DuckDBConnection} from '@malloydata/db-duckdb';
@@ -145,6 +147,12 @@ export class DuckDBWASMTestConnection extends DuckDBWASMConnection {
   }
 }
 
+export class TestCacheManager extends CacheManager {
+  constructor(readonly _modelCache: ModelCache) {
+    super(_modelCache);
+  }
+}
+
 export class TestURLReader extends InMemoryURLReader {
   constructor() {
     super(new Map());
@@ -241,7 +249,7 @@ export function testRuntimeFor(connection: Connection) {
     urlReader: files,
     connection,
     eventStream: new EventEmitter(),
-    modelCache: new InMemoryModelCache(),
+    cacheManager: new TestCacheManager(new InMemoryModelCache()),
   });
 }
 


### PR DESCRIPTION
Changes:
* Changes constructor of `Runtime` (and related subclasses) to take an object with named things, rather than an arbitrary list of things: `new Runtime({ urlReader, connections })`
* Changes `Malloy.compile` to allow you to pass in a `url: URL` or `source: string` directly, rather than having to first call `Malloy.parse`. Therefore, you only need to use `Malloy.parse` if you only want to parse. If you always want to compile, you may as well use `Malloy.compile`.
* Adds a new thing you can give to a runtime, `CacheManager`, which maintains the information needed to interact with a `ModelCache` which is an async map from `URL` to `{modelDef: ModelDef; invalidationKeys: {[url: string]: InvalidationKey}}`, where `invalidationKeys` should be the set of invalidation keys for all the files (including the root file itself) that the cached model depends on.
```ts
export interface ModelCache {
  getModel(
    url: URL
  ): Promise<
    | {modelDef: ModelDef; invalidationKeys: {[url: string]: InvalidationKey}}
    | undefined
  >;
  setModel(
    url: URL,
    modelDef: ModelDef,
    invalidationKeys: {[url: string]: InvalidationKey}
  ): Promise<boolean>;
}
```
* Modifies `URLReader`'s interface to add knowledge of invalidation keys. It has been modified in such a way that if you don't change your url readers, they'll still work. If you aren't passing invalidation keys, we'll just hash the file contents for you.
```ts
export interface URLReader {
  readURL: (
    url: URL
  ) => Promise<string | {contents: string; invalidationKey?: InvalidationKey}>;
  getInvalidationKey?: (url: URL) => Promise<InvalidationKey>;
}
```