### PR TITLE
Add `defaultRowLimit` parameter when compiling queries

### DIFF
--- a/packages/malloy/src/malloy.ts
+++ b/packages/malloy/src/malloy.ts
@@ -117,6 +117,7 @@ interface CompileQueryOptions {
   replaceMaterializedReferences?: boolean;
   materializedTablePrefix?: string;
   eventStream?: EventStream;
+  defaultRowLimit?: number;
 }
 
 export class Malloy {
@@ -443,7 +444,10 @@ export class Malloy {
         }
         const compiledSql = queryModel.compileQuery(
           segment,
-          options,
+          {
+            ...options,
+            defaultRowLimit: undefined,
+          },
           false
         ).sql;
         selectStr += parenAlready ? compiledSql : `(${compiledSql})`;

--- a/packages/malloy/src/model/malloy_query.ts
+++ b/packages/malloy/src/model/malloy_query.ts
@@ -5004,12 +5004,33 @@ export class QueryModel {
     };
   }
 
+  addDefaultRowLimit(query: Query, defaultRowLimit?: number): Query {
+    if (defaultRowLimit === undefined) return query;
+    const lastSegment = query.pipeline[query.pipeline.length - 1];
+    if (lastSegment.type === 'raw') return query;
+    if (lastSegment.limit !== undefined) return query;
+    return {
+      ...query,
+      pipeline: [
+        ...query.pipeline.slice(0, -1),
+        {
+          ...lastSegment,
+          limit: defaultRowLimit,
+        },
+      ],
+    };
+  }
+
   compileQuery(
     query: Query,
     prepareResultOptions?: PrepareResultOptions,
     finalize = true
   ): CompiledQuery {
     let newModel: QueryModel | undefined;
+    query = this.addDefaultRowLimit(
+      query,
+      prepareResultOptions?.defaultRowLimit
+    );
     const m = newModel || this;
     const ret = m.loadQuery(
       query,

--- a/packages/malloy/src/model/malloy_types.ts
+++ b/packages/malloy/src/model/malloy_types.ts
@@ -1620,6 +1620,7 @@ export interface SearchValueMapResult {
 export interface PrepareResultOptions {
   replaceMaterializedReferences?: boolean;
   materializedTablePrefix?: string;
+  defaultRowLimit?: number;
 }
 
 type UTD =


### PR DESCRIPTION
When calling `getPreparedResult`, `loadPreparedResult`, or `run`, you can now pass in `defaultRowLimit` option. This will change the compiled SQL to have a row limit on the last stage if one is not already present.