### PR TITLE
Stop using regex based schema parser for table schema on tresto

### DIFF
--- a/packages/malloy-db-trino/src/index.ts
+++ b/packages/malloy-db-trino/src/index.ts
@@ -24,7 +24,6 @@
 export type {BaseRunner} from './trino_connection';
 export {
   PrestoConnection,
-  PrestoExplainParser,
   TrinoConnection,
   TrinoPrestoConnection,
 } from './trino_connection';

--- a/packages/malloy-db-trino/src/trino_connection.spec.ts
+++ b/packages/malloy-db-trino/src/trino_connection.spec.ts
@@ -114,17 +114,4 @@ describe('Trino connection', () => {
       });
     });
   });
-
-  describe('splitColumns', () => {
-    it('handles internal rows', () => {
-      const nested =
-        'popular_name varchar, airport_count double, by_state array(row(state varchar, airport_count double))';
-
-      expect(connection.splitColumns(nested)).toEqual([
-        'popular_name varchar',
-        'airport_count double',
-        'by_state array(row(state varchar, airport_count double))',
-      ]);
-    });
-  });
 });


### PR DESCRIPTION
I didn't touch the table schema parser when I added the Query Plan schema parser because it seemed to be working and I was afraid to break things. Then we discovered the regex based table schema parser fails to parse the 70K schema for a facebook post. I switched to using the new parser and it works much better.