### PR TITLE
Improved handling of null or non-numeric values.

### DIFF
--- a/packages/malloy-render/src/component/render-numeric-field.ts
+++ b/packages/malloy-render/src/component/render-numeric-field.ts
@@ -54,13 +54,8 @@ export function renderNumericField(f: AtomicField, value: number): string {
   } else if (tag.has('number'))
     displayValue = format(tag.text('number') ?? '#', value);
   else {
-    const numericValue = Number(value ?? '');
-    if (!isNaN(numericValue)) {
-      displayValue = numericValue.toLocaleString();
-    } else {
-      // handle the case where value is not a number
-      displayValue = String(value ?? '');
-    }
+    const nonNullValue = value ?? '';
+    displayValue = (nonNullValue as number).toLocaleString();
   }
   return displayValue;
 }

--- a/packages/malloy-render/src/component/render-numeric-field.ts
+++ b/packages/malloy-render/src/component/render-numeric-field.ts
@@ -25,8 +25,12 @@ import {AtomicField} from '@malloydata/malloy';
 import {Currency, DurationUnit} from '../html/data_styles';
 import {format} from 'ssf';
 import {getText} from '../html/duration';
+import {NULL_SYMBOL} from './apply-renderer';
 
-export function renderNumericField(f: AtomicField, value: number): string {
+export function renderNumericField(f: AtomicField, value: number | null | undefined): string {
+  if (value === null || value === undefined) {
+    return NULL_SYMBOL;
+  }
   let displayValue: string | number = value;
   const {tag} = f.tagParse();
   if (tag.has('currency')) {
@@ -53,9 +57,6 @@ export function renderNumericField(f: AtomicField, value: number): string {
     );
   } else if (tag.has('number'))
     displayValue = format(tag.text('number') ?? '#', value);
-  else {
-    const nonNullValue = value ?? '';
-    displayValue = (nonNullValue as number).toLocaleString();
-  }
+  else displayValue = (value as number).toLocaleString();
   return displayValue;
 }

--- a/packages/malloy-render/src/component/render-numeric-field.ts
+++ b/packages/malloy-render/src/component/render-numeric-field.ts
@@ -27,8 +27,11 @@ import {format} from 'ssf';
 import {getText} from '../html/duration';
 import {NULL_SYMBOL} from './apply-renderer';
 
-export function renderNumericField(f: AtomicField, value: number | null | undefined): string {
-  if (value == null) {
+export function renderNumericField(
+  f: AtomicField,
+  value: number | null | undefined
+): string {
+  if (value === null || value === undefined) {
     return NULL_SYMBOL;
   }
   let displayValue: string | number = value;

--- a/packages/malloy-render/src/component/render-numeric-field.ts
+++ b/packages/malloy-render/src/component/render-numeric-field.ts
@@ -28,7 +28,7 @@ import {getText} from '../html/duration';
 import {NULL_SYMBOL} from './apply-renderer';
 
 export function renderNumericField(f: AtomicField, value: number | null | undefined): string {
-  if (value === null || value === undefined) {
+  if (value == null) {
     return NULL_SYMBOL;
   }
   let displayValue: string | number = value;

--- a/packages/malloy-render/src/component/render-numeric-field.ts
+++ b/packages/malloy-render/src/component/render-numeric-field.ts
@@ -53,6 +53,14 @@ export function renderNumericField(f: AtomicField, value: number): string {
     );
   } else if (tag.has('number'))
     displayValue = format(tag.text('number') ?? '#', value);
-  else displayValue = (value as number).toLocaleString();
+  else {
+    const numericValue = Number(value ?? '');
+    if (!isNaN(numericValue)) {
+      displayValue = numericValue.toLocaleString();
+    } else {
+      // handle the case where value is not a number
+      displayValue = String(value ?? '');
+    }
+  }
   return displayValue;
 }


### PR DESCRIPTION
This line was erroring when queries returned null numerics:
  Cannot read properties of undefined (reading 'toLocaleString')

See T214044108 for details