### PR TITLE
Allow Presto and Trino to run at the same time

### DIFF
--- a/test/presto/presto_start.sh
+++ b/test/presto/presto_start.sh
@@ -1,17 +1,20 @@
 #! /bin/bash
+
+set -e
+
 rm -rf .tmp
 mkdir .tmp
 
 # generate config file
-> ./.tmp/bigquery.properties
-cat << EOF > ./.tmp/bigquery.properties
+> ./.tmp/bigquery-pesto.properties
+cat << EOF > ./.tmp/bigquery-pesto.properties
 connector.name=bigquery
 bigquery.project-id=advance-lacing-417917
 bigquery.credentials-key=$BQ_CREDENTIALS_KEY
 EOF
 
 # run docker
-docker run -p 8080:8080 -d -v ./.tmp/bigquery.properties:/opt/presto-server/etc/catalog/bigquery.properties --name presto-malloy prestodb/presto:0.287
+docker run -p ${PRESTO_PORT:-8080}:8080 -d -v ./.tmp/bigquery-pesto.properties:/opt/presto-server/etc/catalog/bigquery.properties --name presto-malloy prestodb/presto:0.287
 
 # wait for server to start
 counter=0

--- a/test/trino/trino_start.sh
+++ b/test/trino/trino_start.sh
@@ -1,4 +1,7 @@
 #! /bin/bash
+
+set -e
+
 rm -rf .tmp
 mkdir .tmp
 
@@ -8,8 +11,8 @@ if [ "x${BQ_CREDENTIALS_KEY}" = x ]; then
   exit 1
 fi
 # generate config file
-> ./.tmp/bigquery.properties
-cat << EOF > ./.tmp/bigquery.properties
+> ./.tmp/bigquery-trino.properties
+cat << EOF > ./.tmp/bigquery-trino.properties
 connector.name=bigquery
 bigquery.project-id=advance-lacing-417917
 bigquery.credentials-key=$BQ_CREDENTIALS_KEY
@@ -17,7 +20,7 @@ bigquery.arrow-serialization.enabled=false
 EOF
 
 # run docker
-docker run -p 8080:8080 -d -v ./.tmp/bigquery.properties:/etc/trino/catalog/bigquery.properties --name trino-malloy trinodb/trino
+docker run -p ${TRINO_PORT:-8080}:8080 -d -v ./.tmp/bigquery-trino.properties:/etc/trino/catalog/bigquery.properties --name trino-malloy trinodb/trino
 
 # wait for server to start
 counter=0


### PR DESCRIPTION
Allow setting of port and have different file names because docker won't mount the same host file in two running containers. Also fail fast if errors occur instead of polling out.