### PR TITLE
Snowflake fixes

### DIFF
--- a/packages/malloy-db-snowflake/src/snowflake_connection.ts
+++ b/packages/malloy-db-snowflake/src/snowflake_connection.ts
@@ -350,7 +350,7 @@ export class SnowflakeConnection
             case
               when typeof(value) = 'INTEGER' then 'decimal'
               when typeof(value) = 'DOUBLE' then 'decimal'
-              else lower(typeof(value)) end as type
+            else lower(typeof(value)) end as type
           from
             (select object_construct(*) o from ${tablePath} limit 100)
               ,table(flatten(input => o, recursive => true)) as meta

--- a/packages/malloy-db-snowflake/src/snowflake_connection.ts
+++ b/packages/malloy-db-snowflake/src/snowflake_connection.ts
@@ -350,7 +350,7 @@ export class SnowflakeConnection
             case
               when typeof(value) = 'INTEGER' then 'decimal'
               when typeof(value) = 'DOUBLE' then 'decimal'
-          else lower(typeof(value)) end as type
+              else lower(typeof(value)) end as type
           from
             (select object_construct(*) o from ${tablePath} limit 100)
               ,table(flatten(input => o, recursive => true)) as meta

--- a/packages/malloy-db-snowflake/src/snowflake_connection.ts
+++ b/packages/malloy-db-snowflake/src/snowflake_connection.ts
@@ -347,7 +347,10 @@ export class SnowflakeConnection
         from (
           select
             regexp_replace(path, '\\\\[[0-9]+\\\\]', '[*]') as path,
-            case when typeof(value) = 'INTEGER' then 'decimal' else lower(typeof(value)) end as type
+            case
+              when typeof(value) = 'INTEGER' then 'decimal'
+              when typeof(value) = 'DOUBLE' then 'decimal'
+          else lower(typeof(value)) end as type
           from
             (select object_construct(*) o from ${tablePath} limit 100)
               ,table(flatten(input => o, recursive => true)) as meta

--- a/packages/malloy/src/dialect/snowflake/snowflake.ts
+++ b/packages/malloy/src/dialect/snowflake/snowflake.ts
@@ -240,7 +240,7 @@ export class SnowflakeDialect extends Dialect {
   sqlSumDistinct(key: string, value: string, funcName: string): string {
     const hashKey = this.sqlSumDistinctHashedKey(key);
     const scale = 100000000.0;
-    const v = `(CAST (COALESCE(${value},0)*${scale}) as INT)`;
+    const v = `(CAST (COALESCE(${value},0)*${scale} as INT))`;
 
     const sqlSum = `(SUM(DISTINCT ${hashKey} + ${v}) - SUM(DISTINCT ${hashKey}))/${scale}`;
     if (funcName === 'SUM') {

--- a/packages/malloy/src/dialect/snowflake/snowflake.ts
+++ b/packages/malloy/src/dialect/snowflake/snowflake.ts
@@ -240,7 +240,7 @@ export class SnowflakeDialect extends Dialect {
   sqlSumDistinct(key: string, value: string, funcName: string): string {
     const hashKey = this.sqlSumDistinctHashedKey(key);
     const scale = 100000000.0;
-    const v = `(COALESCE(${value},0)*${scale})`;
+    const v = `(CAST (COALESCE(${value},0)*${scale}) as INT)`;
 
     const sqlSum = `(SUM(DISTINCT ${hashKey} + ${v}) - SUM(DISTINCT ${hashKey}))/${scale}`;
     if (funcName === 'SUM') {


### PR DESCRIPTION
* asymm aggregates: cast the field to int (to prevent float arithmetic from throwing off the computation)
* combine nested fields that are decimal, float, double etc. 