### PR TITLE
Really switch to pull_request_target

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -1,6 +1,6 @@
 name: Malloy Tests
 
-on: [workflow_dispatch, pull_request]
+on: [workflow_dispatch, pull_request_target]
 
 jobs:
   check-permission:


### PR DESCRIPTION
After all the excitement of completely restructuring our test builds I didn't make the actual final cut over to pull_request_target