### PR TITLE
Add two minimal .malloy test files for presto and trino

### DIFF
--- a/test/presto/example_presto.malloy
+++ b/test/presto/example_presto.malloy
@@ -1,0 +1,13 @@
+-- A simple malloy model representing a valid connection to the test presto container.
+source: presto_models is presto.table("malloytest.aircraft_models") extend {
+    measure: model_count is count()
+
+    view: biggest_airplanes is {
+        group_by:
+            model,
+            seats
+        aggregate: model_count
+        order_by: seats DESC
+        limit: 20
+    }
+}

--- a/test/trino/example_trino.malloy
+++ b/test/trino/example_trino.malloy
@@ -1,0 +1,13 @@
+-- A simple malloy model representing a valid connection to the test trino container.
+source: trino_models is trino.table("malloytest.aircraft_models") extend {
+    measure: model_count is count()
+
+    view: biggest_airplanes is {
+        group_by:
+            model,
+            seats
+        aggregate: model_count
+        order_by: seats DESC
+        limit: 20
+    }
+}


### PR DESCRIPTION
While testing the connection editors for trino and presto, I built small malloy files I could use for manual testing. I figured it would be useful to check in for future use cases, because I could not find any other `trino` or `presto` connections represented in our repos or documentation.