### PR TITLE
Add a custom error message for a missing alias after 'aggregate:'

### DIFF
--- a/packages/malloy/src/lang/syntax-errors/custom-error-messages.ts
+++ b/packages/malloy/src/lang/syntax-errors/custom-error-messages.ts
@@ -29,6 +29,15 @@ export interface ErrorCase {
   // The error message to show to the user, instead of whatever was default
   // Supports tokenization: ${currentToken}
   errorMessage: string;
+
+  // By default, the error checker does lookahead and lookback based on the curentToken
+  // (the parser's position in the inputStream). However, for many error cases it is
+  // better to check from the offending token and not from the current token, since the
+  // error may have been hit while the ATN was looking ahead for alternatives.
+  // Note: In most cases, if this option is enabled, the 'ruleContext' may be a parser rule
+  // much higher in the tree than you would expect, and may be better to leave off entirely.
+  // Note: You can use this option without actually specifying the offendingSymbol match.
+  lookbackFromOffendingSymbol?: boolean;
 }
 
 export const checkCustomErrorMessage = (
@@ -53,7 +62,15 @@ export const checkCustomErrorMessage = (
       // If so, try to check the preceding tokens.
       if (errorCase.precedingTokenOptions) {
         const hasPrecedingTokenMatch = errorCase.precedingTokenOptions.some(
-          sequence => checkTokenSequenceMatch(parser, sequence, 'lookback')
+          sequence =>
+            checkTokenSequenceMatch(
+              parser,
+              sequence,
+              'lookback',
+              errorCase.lookbackFromOffendingSymbol
+                ? offendingSymbol?.tokenIndex
+                : undefined
+            )
         );
         if (!hasPrecedingTokenMatch) {
           continue; // Continue to check a different error case
@@ -61,7 +78,15 @@ export const checkCustomErrorMessage = (
       }
       if (errorCase.lookAheadOptions) {
         const hasLookaheadTokenMatch = errorCase.lookAheadOptions.some(
-          sequence => checkTokenSequenceMatch(parser, sequence, 'lookahead')
+          sequence =>
+            checkTokenSequenceMatch(
+              parser,
+              sequence,
+              'lookahead',
+              errorCase.lookbackFromOffendingSymbol
+                ? offendingSymbol?.tokenIndex
+                : undefined
+            )
         );
         if (!hasLookaheadTokenMatch) {
           continue; // Continue to check a different error case
@@ -83,13 +108,23 @@ export const checkCustomErrorMessage = (
 const checkTokenSequenceMatch = (
   parser: Parser,
   sequence: number[],
-  direction: 'lookahead' | 'lookback'
+  direction: 'lookahead' | 'lookback',
+  anchorTokenPosition: number | undefined
 ): boolean => {
   try {
     for (let i = 0; i < sequence.length; i++) {
+      let streamToken: number | undefined = undefined;
+      if (typeof anchorTokenPosition === 'number') {
+        const tokenOffset = direction === 'lookahead' ? i + 1 : -1 * (i + 1);
+        streamToken = parser.inputStream.get(
+          anchorTokenPosition + tokenOffset
+        ).type;
+      } else {
+        const tokenOffset = direction === 'lookahead' ? i + 2 : -1 * (i + 1);
+        streamToken = parser.inputStream.LA(tokenOffset);
+      }
       // Note: positive lookahead starts at '2' because '1' is the current token.
-      const tokenIndex = direction === 'lookahead' ? i + 2 : -1 * (i + 1);
-      const streamToken = parser.inputStream.LA(tokenIndex);
+
 
       // Note: negative checking is < -1 becuase Token.EOF is -1, but below
       // that we use negatives to indicate "does-not-match" rules.

--- a/packages/malloy/src/lang/syntax-errors/malloy-parser-error-listener.ts
+++ b/packages/malloy/src/lang/syntax-errors/malloy-parser-error-listener.ts
@@ -46,9 +46,10 @@ export const commonErrorCases: ErrorCase[] = [
   {
     errorMessage:
       "'aggregate:' entries must include a name (ex: `some_name is count()`)",
-    ruleContextOptions: ['queryFieldEntry'],
+    // ruleContextOptions: ['queryFieldEntry'],
     precedingTokenOptions: [[MalloyParser.AGGREGATE]],
     lookAheadOptions: [[-MalloyParser.IS]],
+    lookbackFromOffendingSymbol: true,
   },
 ];
 

--- a/packages/malloy/src/lang/syntax-errors/malloy-parser-error-listener.ts
+++ b/packages/malloy/src/lang/syntax-errors/malloy-parser-error-listener.ts
@@ -43,6 +43,13 @@ export const commonErrorCases: ErrorCase[] = [
       [MalloyParser.SOURCE],
     ],
   },
+  {
+    errorMessage:
+      "'aggregate:' entries must include a name (ex: `some_name is count()`)",
+    ruleContextOptions: ['queryFieldEntry'],
+    precedingTokenOptions: [[MalloyParser.AGGREGATE]],
+    lookAheadOptions: [[-MalloyParser.IS]],
+  },
 ];
 
 export class MalloyParserErrorListener implements ANTLRErrorListener<Token> {

--- a/packages/malloy/src/lang/test/syntax-errors.spec.ts
+++ b/packages/malloy/src/lang/test/syntax-errors.spec.ts
@@ -68,4 +68,16 @@ describe('errors', () => {
         primary_key: id
     `).toLogAtLeast(errorMessage("Missing '{' after 'extend'"));
   });
+
+  test('missing alias for aggregate entry', () => {
+    expect(`
+        run: x -> {
+          aggregate: count()
+        }
+      `).toLogAtLeast(
+      errorMessage(
+        "'aggregate:' entries must include a name (ex: `some_name is count()`)"
+      )
+    );
+  });
 });

--- a/packages/malloy/src/lang/test/syntax-errors.spec.ts
+++ b/packages/malloy/src/lang/test/syntax-errors.spec.ts
@@ -80,4 +80,21 @@ describe('errors', () => {
       )
     );
   });
+
+  test('missing alias for aggregate inside source>view', () => {
+    expect(`
+      source: x is aa extend {
+        measure: airport_count is count()
+
+        view: by_state is {
+          where: state is not null
+          aggregate: count()
+        }
+      }
+      `).toLogAtLeast(
+      errorMessage(
+        "'aggregate:' entries must include a name (ex: `some_name is count()`)"
+      )
+    );
+  });
 });


### PR DESCRIPTION
Fixes https://github.com/malloydata/malloy/issues/34

I added a helpful error message: "'aggregate:' entries must include a name (ex: `some_name is count()`)"

Add an error message rewriter for the case:

```
run: x -> {
  aggregate: count()
}
```


**Was:**

<img width="300" alt="image" src="https://github.com/user-attachments/assets/019e31bc-a5d3-47a2-b4c5-ed1b44534ff1" />

**Now:**

<img width="400" alt="image" src="https://github.com/user-attachments/assets/09c2d3b5-67bf-4c80-972d-dc945dbb0299" />



I also wanted to make sure we could support the aggregate error even when it is nested inside of a view. To do so, we couldn't rely on the same logic because the parser fails to parse the entire `view:` clause. Instead, I added a new error rewriter option `lookbackFromOffendingSymbol` that lets us do relative sequence comparisons from the token associated with the error, rather than the token associated with the parser's current position. The Malloy grammar has a lot of ambiguity that is resolved by lookahead logic in the ATN and so we cannot rely on the `currentToken` to be up-to-date when an error is hit.

```
source: airports is duckdb.table('../data/airports.parquet') extend {
  measure: airport_count is count()

  view: by_state is {
    where: state is not null
    aggregate: count()
  }
}
```

**Was:**

<img width="400" alt="image" src="https://github.com/user-attachments/assets/f6223801-e45b-4a48-ace5-6836286f5e39" />


**Now:**

<img width="400" alt="image" src="https://github.com/user-attachments/assets/80bdcafd-2583-402a-9743-d01589fc82b7" />

