### PR TITLE
Allow escaping of % and _ in LIKE strings

### DIFF
--- a/packages/malloy/src/dialect/standardsql/standardsql.ts
+++ b/packages/malloy/src/dialect/standardsql/standardsql.ts
@@ -127,6 +127,7 @@ export class StandardSQLDialect extends Dialect {
   hasModOperator = false;
   nestedArrays = false; // Can't have an array of arrays for some reason
   supportsHyperLogLog = true;
+  likeEscape = false; // Uses \ instead of ESCAPE 'X' in like clauses
 
   quoteTablePath(tablePath: string): string {
     return `\`${tablePath}\``;

--- a/packages/malloy/src/lang/grammar/MalloyLexer.g4
+++ b/packages/malloy/src/lang/grammar/MalloyLexer.g4
@@ -138,22 +138,16 @@ fragment DQ: '"';
 fragment SQ3: SQ SQ SQ;
 fragment DQ3: DQ DQ DQ;
 fragment BQ3: BQ BQ BQ;
-fragment RAW_CHAR: ( '\\' . ) | (~ '\\');
+fragment RAW_CHAR: ('\\'  ~[\n]) | ~[\\\n];
 fragment FILTER: F SPACE_CHAR*;
 fragment RAWSTR: S SPACE_CHAR*;
 HACKY_REGEX: ('/' | R) SQ RAW_CHAR*? SQ;
 
-RAW_SQ: RAWSTR SQ RAW_CHAR*? SQ;
-RAW_DQ: RAWSTR DQ RAW_CHAR*? DQ;
-
-STRING_ESCAPE
-  : '\\' '\''
-  | '\\' '\\'
-  | '\\' .
-  ;
+RAW_SQ: RAWSTR SQ RAW_CHAR*? (SQ | '\n');
+RAW_DQ: RAWSTR DQ RAW_CHAR*? (DQ | '\n');
 
 fragment HEX: [0-9a-fA-F];
-fragment UNICODE: '\\u' HEX HEX HEX HEX;
+fragment UNICODE: '\\' U HEX HEX HEX HEX;
 fragment SAFE_NON_QUOTE: ~ ['"`\\\u0000-\u001F];
 fragment ESCAPED: '\\' ~ '\n';
 fragment STR_CHAR: UNICODE | ESCAPED | SAFE_NON_QUOTE | '\t';
@@ -202,7 +196,6 @@ QMARK: '?';
 fragment F_YEAR: DIGIT DIGIT DIGIT DIGIT;
 fragment F_DD: DIGIT DIGIT;
 fragment F_TZ: '[' (ID_CHAR | '/')* ']';
-fragment LX: '-' 'X' (ID_CHAR | DIGIT)+;
 // @YYYY-MM-DD HH:MM:SS.n
 LITERAL_TIMESTAMP
   : '@' F_YEAR '-' F_DD '-' F_DD

--- a/packages/malloy/src/lang/grammar/MalloyLexer.g4
+++ b/packages/malloy/src/lang/grammar/MalloyLexer.g4
@@ -132,12 +132,25 @@ WITH: W I T H ;
 YEAR: Y E A R S?;
 UNGROUPED: U N G R O U P E D;
 
+fragment SQ: '\'';
+fragment BQ: '`';
+fragment DQ: '"';
+fragment SQ3: SQ SQ SQ;
+fragment DQ3: DQ DQ DQ;
+fragment BQ3: BQ BQ BQ;
+fragment RAW_CHAR: ( '\\' . ) | (~ '\\');
+fragment FILTER: F SPACE_CHAR*;
+fragment RAWSTR: S SPACE_CHAR*;
+HACKY_REGEX: ('/' | R) SQ RAW_CHAR*? SQ;
+
+RAW_SQ: RAWSTR SQ RAW_CHAR*? SQ;
+RAW_DQ: RAWSTR DQ RAW_CHAR*? DQ;
+
 STRING_ESCAPE
   : '\\' '\''
   | '\\' '\\'
   | '\\' .
   ;
-HACKY_REGEX: ('/' | [rR]) '\'' (STRING_ESCAPE | ~('\\' | '\''))* '\'';
 
 fragment HEX: [0-9a-fA-F];
 fragment UNICODE: '\\u' HEX HEX HEX HEX;

--- a/packages/malloy/src/lang/grammar/MalloyParser.g4
+++ b/packages/malloy/src/lang/grammar/MalloyParser.g4
@@ -537,12 +537,18 @@ shortString
   : (SQ_STRING | DQ_STRING)
   ;
 
+rawString
+  : RAW_SQ
+  | RAW_DQ
+  ;
+
 numericLiteral
   : (NUMERIC_LITERAL | INTEGER_LITERAL)
   ;
 
 literal
   : string                                      # exprString
+  | rawString                                   # stub_rawString
   | numericLiteral                              # exprNumber
   | dateLiteral                                 # exprTime
   | NULL                                        # exprNULL

--- a/packages/malloy/src/lang/malloy-to-ast.ts
+++ b/packages/malloy/src/lang/malloy-to-ast.ts
@@ -1316,6 +1316,14 @@ export class MalloyToAST
 
   visitRawString(pcx: parse.RawStringContext): ast.ExprString {
     const str = pcx.text.slice(1).trimStart();
+    const lastChar = str[str.length - 1];
+    if (lastChar === '\n') {
+      this.contextError(
+        pcx,
+        'literal-string-newline',
+        'String cannot contain a new-line character'
+      );
+    }
     const astStr = new ast.ExprString(str.slice(1, -1));
     return this.astAt(astStr, pcx);
   }

--- a/packages/malloy/src/lang/malloy-to-ast.ts
+++ b/packages/malloy/src/lang/malloy-to-ast.ts
@@ -1314,6 +1314,12 @@ export class MalloyToAST
     return new ast.ExprString(str);
   }
 
+  visitRawString(pcx: parse.RawStringContext): ast.ExprString {
+    const str = pcx.text.slice(1).trimStart();
+    const astStr = new ast.ExprString(str.slice(1, -1));
+    return this.astAt(astStr, pcx);
+  }
+
   visitExprRegex(pcx: parse.ExprRegexContext): ast.ExprRegEx {
     const malloyRegex = pcx.HACKY_REGEX().text;
     return new ast.ExprRegEx(malloyRegex.slice(2, -1));

--- a/packages/malloy/src/lang/parse-log.ts
+++ b/packages/malloy/src/lang/parse-log.ts
@@ -402,6 +402,7 @@ type MessageParameterTypes = {
   'cannot-tag-include-except': string;
   'unsupported-path-in-include': string;
   'wildcard-include-rename': string;
+  'literal-string-newline': string;
 };
 
 export const MESSAGE_FORMATTERS: PartialErrorCodeMessageMap = {

--- a/packages/malloy/src/lang/test/expressions.spec.ts
+++ b/packages/malloy/src/lang/test/expressions.spec.ts
@@ -80,7 +80,7 @@ describe('expressions', () => {
   });
   test('raw function call codegen', () => {
     expect(expr`special_function!(aweird, 'foo')`).compilesTo(
-      'special_function({aweird},{"foo"})'
+      'special_function({aweird},{{"foo"}})'
     );
   });
 
@@ -135,27 +135,27 @@ describe('expressions', () => {
     });
     test('match', () => {
       expect("'forty-two' ~ 'fifty-four'").compilesTo(
-        '{"forty-two" like "fifty-four"}'
+        '{{"forty-two"} like {"fifty-four"}}'
       );
     });
     test('not match', () => {
       expect("'forty-two' !~ 'fifty-four'").compilesTo(
-        '{"forty-two" !like "fifty-four"}'
+        '{{"forty-two"} !like {"fifty-four"}}'
       );
     });
     test('regexp-match', () => {
       expect("'forty-two' ~ r'fifty-four'").compilesTo(
-        '{"forty-two" regex-match /fifty-four/}'
+        '{{"forty-two"} regex-match /fifty-four/}'
       );
     });
     test('not regexp-match', () => {
       expect("'forty-two' !~ r'fifty-four'").compilesTo(
-        '{not {"forty-two" regex-match /fifty-four/}}'
+        '{not {{"forty-two"} regex-match /fifty-four/}}'
       );
     });
     test('apply as equality', () => {
       expect("'forty-two' ? 'fifty-four'").compilesTo(
-        '{"forty-two" = "fifty-four"}'
+        '{{"forty-two"} = {"fifty-four"}}'
       );
     });
     test('not', () => {
@@ -277,7 +277,7 @@ describe('expressions', () => {
         expect(warnSrc).toLog(
           warningMessage("Use Malloy operator '~' instead of 'LIKE'")
         );
-        expect(warnSrc).compilesTo('{astr like "a"}');
+        expect(warnSrc).compilesTo('{astr like {"a"}}');
         const warning = warnSrc.translator.problems()[0];
         expect(warning.replacement).toEqual("astr ~ 'a'");
       });
@@ -286,7 +286,7 @@ describe('expressions', () => {
         expect(warnSrc).toLog(
           warningMessage("Use Malloy operator '!~' instead of 'NOT LIKE'")
         );
-        expect(warnSrc).compilesTo('{astr !like "a"}');
+        expect(warnSrc).compilesTo('{astr !like {"a"}}');
         const warning = warnSrc.translator.problems()[0];
         expect(warning.replacement).toEqual("astr !~ 'a'");
       });
@@ -1017,7 +1017,7 @@ describe('expressions', () => {
       `;
       expect(e).toLog(warning('sql-case'));
       expect(e).compilesTo(
-        '{case when {ai = 42} then "the answer" when {ai = 54} then "the questionable answer" else "random"}'
+        '{case when {ai = 42} then {"the answer"} when {ai = 54} then {"the questionable answer"} else {"random"}}'
       );
     });
     test('with value', () => {
@@ -1030,7 +1030,7 @@ describe('expressions', () => {
       `;
       expect(e).toLog(warning('sql-case'));
       expect(e).compilesTo(
-        '{case ai when 42 then "the answer" when 54 then "the questionable answer" else "random"}'
+        '{case ai when 42 then {"the answer"} when 54 then {"the questionable answer"} else {"random"}}'
       );
     });
     test('no else', () => {
@@ -1042,7 +1042,7 @@ describe('expressions', () => {
       `;
       expect(e).toLog(warning('sql-case'));
       expect(e).compilesTo(
-        '{case when {ai = 42} then "the answer" when {ai = 54} then "the questionable answer"}'
+        '{case when {ai = 42} then {"the answer"} when {ai = 54} then {"the questionable answer"}}'
       );
     });
     test('wrong then type', () => {

--- a/packages/malloy/src/lang/test/literals.spec.ts
+++ b/packages/malloy/src/lang/test/literals.spec.ts
@@ -290,6 +290,11 @@ describe('literals', () => {
       const x = new BetaExpression('"""x"""');
       expect(x).toParse();
     });
+    test('Error for missing close in raw string', () => {
+      expect(expr`s'hello\n`).toLog(
+        errorMessage('String cannot contain a new-line character')
+      );
+    });
     test('a string containing a tab', () => expect(expr`'\t'`).toParse());
   });
   describe('compound literals', () => {

--- a/packages/malloy/src/lang/test/literals.spec.ts
+++ b/packages/malloy/src/lang/test/literals.spec.ts
@@ -50,6 +50,15 @@ describe('literals', () => {
     const str = "'Is " + '\\' + '\\' + " nice'";
     expect(new BetaExpression(str)).toTranslate();
   });
+  test("raw s'string", () => {
+    expect("s'a'").compilesTo('{"a"}');
+  });
+  test('raw s"string', () => {
+    expect('s "a"').compilesTo('{"a"}');
+  });
+  test('raw string with quoted end char', () => {
+    expect("s'a\\'b'").compilesTo('{"a\\\'b"}');
+  });
   const literalTimes: [string, string, string | undefined, unknown][] = [
     ['@1960', 'date', 'year', {literal: '1960-01-01'}],
     ['@1960-Q2', 'date', 'quarter', {literal: '1960-04-01'}],
@@ -293,11 +302,11 @@ describe('literals', () => {
     test('array of records with same schema', () => {
       expect(
         '[{name is "one", val is 1},{name is "two", val is 2}]'
-      ).compilesTo('[{name:"one", val:1}, {name:"two", val:2}]');
+      ).compilesTo('[{name:{"one"}, val:1}, {name:{"two"}, val:2}]');
     });
     test('array of records with head schema', () => {
       expect('[{name is "one", val is 1},{"two", 2}]').compilesTo(
-        '[{name:"one", val:1}, {name:"two", val:2}]'
+        '[{name:{"one"}, val:1}, {name:{"two"}, val:2}]'
       );
     });
   });

--- a/packages/malloy/src/lang/test/parse-expects.ts
+++ b/packages/malloy/src/lang/test/parse-expects.ts
@@ -227,7 +227,7 @@ function eToStr(e: Expr, symbols: ESymbols): string {
     case 'numberLiteral':
       return `${e.literal}`;
     case 'stringLiteral':
-      return `"${e.literal}"`;
+      return `{"${e.literal}"}`;
     case 'timeLiteral':
       return `@${e.literal}`;
     case 'recordLiteral': {

--- a/packages/malloy/src/model/malloy_query.ts
+++ b/packages/malloy/src/model/malloy_query.ts
@@ -1308,15 +1308,15 @@ class QueryField extends QueryNode {
         return `${expr.kids.left.sql} ${expr.node} ${expr.kids.right.sql}`;
       case 'coalesce':
         return `COALESCE(${expr.kids.left.sql},${expr.kids.right.sql})`;
-      case 'like':
-        return `${expr.kids.left.sql} LIKE ${expr.kids.right.sql}`;
       case 'in': {
         const oneOf = expr.kids.oneOf.map(o => o.sql).join(',');
         return `${expr.kids.e.sql} ${expr.not ? 'NOT IN' : 'IN'} (${oneOf})`;
       }
+      case 'like':
+        return this.parent.dialect.likeExpr(expr);
       // Malloy inequality comparisons always return a boolean
       case '!like': {
-        const notLike = `${expr.kids.left.sql} NOT LIKE ${expr.kids.right.sql}`;
+        const notLike = this.parent.dialect.likeExpr(expr);
         return `COALESCE(${notLike},true)`;
       }
       case '()':

--- a/test/src/databases/all/expr.spec.ts
+++ b/test/src/databases/all/expr.spec.ts
@@ -754,6 +754,18 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
       dimension: satDay is 6
     }`,
   });
+  test('basic like', async () => {
+    const result = await sqlEq("'abz' ~ '%z'", true);
+    expect(result).isSqlEq();
+  });
+  test('basic like with string', async () => {
+    const result = await sqlEq("'%' ~ '\\\\%'", true);
+    expect(result).isSqlEq();
+  });
+  test('basic like with raw string', async () => {
+    const result = await sqlEq("'%' ~ s'\\%'", true);
+    expect(result).isSqlEq();
+  });
 
   describe.skip('alternations with not-eq', () => {
     /*


### PR DESCRIPTION
This implements [WN-0020](https://github.com/malloydata/whatsnext/blob/main/wns/WN-0020-like-escape/wn-0020.md)