### PR TITLE
First Pass at Malloy Typescript API

### DIFF
--- a/jest.core.config.ts
+++ b/jest.core.config.ts
@@ -3,6 +3,7 @@ module.exports = {
   roots: [
     '<rootDir>/packages/malloy/',
     '<rootDir>/packages/malloy-filter/',
+    '<rootDir>/packages/malloy-interfaces/',
     '<rootDir>/packages/malloy-malloy-sql/',
     '<rootDir>/packages/malloy-syntax-highlight/',
     '<rootDir>/packages/malloy-tag/',

--- a/packages/malloy-db-bigquery/src/bigquery.spec.ts
+++ b/packages/malloy-db-bigquery/src/bigquery.spec.ts
@@ -274,12 +274,8 @@ describe('db:BigQuery', () => {
   });
 });
 
-const SQL_BLOCK_1: malloy.SQLSourceDef = {
-  type: 'sql_select',
-  name: 'block1',
-  dialect: 'standardsql',
+const SQL_BLOCK_1: malloy.SQLSourceRequest = {
   connection: 'bigquery',
-  fields: [],
   selectStr: `
 SELECT
 created_at,
@@ -295,12 +291,8 @@ FROM "inventory_items.parquet"
 `,
 };
 
-const SQL_BLOCK_2: malloy.SQLSourceDef = {
-  type: 'sql_select',
-  name: 'block2',
-  dialect: 'standardsql',
+const SQL_BLOCK_2: malloy.SQLSourceRequest = {
   connection: 'bigquery',
-  fields: [],
   selectStr: `
 SELECT
 created_at,

--- a/packages/malloy-db-bigquery/src/bigquery_connection.ts
+++ b/packages/malloy-db-bigquery/src/bigquery_connection.ts
@@ -52,6 +52,8 @@ import {
   toAsyncGenerator,
   StructDef,
   SQLSourceDef,
+  SQLSourceRequest,
+  sqlKey,
 } from '@malloydata/malloy';
 import {BaseConnection, TableMetadata} from '@malloydata/malloy/connection';
 // eslint-disable-next-line no-restricted-imports
@@ -549,12 +551,17 @@ export class BigQueryConnection
   }
 
   async fetchSelectSchema(
-    sqlSource: SQLSourceDef
+    sqlSource: SQLSourceRequest
   ): Promise<SQLSourceDef | string> {
     try {
-      const ret: SQLSourceDef = {...sqlSource};
-      ret.fields = [];
-      this.addFieldsToStructDef(ret, await this.getSQLBlockSchema(sqlSource));
+      const ret: SQLSourceDef = {
+        type: 'sql_select',
+        ...sqlSource,
+        dialect: this.dialectName,
+        fields: [],
+        name: sqlKey(sqlSource.connection, sqlSource.selectStr),
+      };
+      this.addFieldsToStructDef(ret, await this.getSQLBlockSchema(ret));
       return ret;
     } catch (error) {
       return error.message;

--- a/packages/malloy-db-duckdb/src/duckdb.spec.ts
+++ b/packages/malloy-db-duckdb/src/duckdb.spec.ts
@@ -23,7 +23,7 @@
 
 import {DuckDBCommon} from './duckdb_common';
 import {DuckDBConnection} from './duckdb_connection';
-import {SQLSourceDef, StructDef, mkArrayDef} from '@malloydata/malloy';
+import {SQLSourceRequest, StructDef, mkArrayDef} from '@malloydata/malloy';
 import {describeIfDatabaseAvailable} from '@malloydata/malloy/test';
 
 const [describe] = describeIfDatabaseAvailable(['duckdb']);
@@ -228,12 +228,8 @@ const makeStructDef = (): StructDef => {
 //
 
 // Uses string value for table
-const SQL_BLOCK_1: SQLSourceDef = {
-  type: 'sql_select',
-  name: 'block1',
-  dialect: 'duckdb',
+const SQL_BLOCK_1: SQLSourceRequest = {
   connection: 'duckdb',
-  fields: [],
   selectStr: `
 SELECT
 created_at,
@@ -250,12 +246,8 @@ FROM "inventory_items.parquet"
 };
 
 // Uses read_parquet() for table
-const SQL_BLOCK_2: SQLSourceDef = {
-  type: 'sql_select',
-  name: 'block2',
-  dialect: 'duckdb',
+const SQL_BLOCK_2: SQLSourceRequest = {
   connection: 'duckdb',
-  fields: [],
   selectStr: `
 SELECT
 created_at,

--- a/packages/malloy-db-duckdb/src/duckdb_common.ts
+++ b/packages/malloy-db-duckdb/src/duckdb_common.ts
@@ -36,6 +36,8 @@ import {
   SQLSourceDef,
   TableSourceDef,
   mkFieldDef,
+  SQLSourceRequest,
+  sqlKey,
 } from '@malloydata/malloy';
 import {BaseConnection} from '@malloydata/malloy/connection';
 
@@ -135,9 +137,15 @@ export abstract class DuckDBCommon
   ): AsyncIterableIterator<QueryDataRow>;
 
   async fetchSelectSchema(
-    sqlRef: SQLSourceDef
+    sqlRef: SQLSourceRequest
   ): Promise<SQLSourceDef | string> {
-    const sqlDef = {...sqlRef};
+    const sqlDef: SQLSourceDef = {
+      type: 'sql_select',
+      ...sqlRef,
+      dialect: this.dialectName,
+      fields: [],
+      name: sqlKey(sqlRef.connection, sqlRef.selectStr),
+    };
     await this.schemaFromQuery(
       `DESCRIBE SELECT * FROM (${sqlRef.selectStr})`,
       sqlDef

--- a/packages/malloy-db-duckdb/src/duckdb_wasm_connection.ts
+++ b/packages/malloy-db-duckdb/src/duckdb_wasm_connection.ts
@@ -31,6 +31,7 @@ import {
   SQLSourceDef,
   ConnectionConfig,
   TableSourceDef,
+  SQLSourceRequest,
 } from '@malloydata/malloy';
 import {StructRow, Table} from 'apache-arrow';
 import {DuckDBCommon} from './duckdb_common';
@@ -371,7 +372,7 @@ export abstract class DuckDBWASMConnection extends DuckDBCommon {
   }
 
   public async fetchSchemaForSQLStruct(
-    sqlRef: SQLSourceDef,
+    sqlRef: SQLSourceRequest,
     options: FetchSchemaOptions
   ): Promise<
     | {structDef: SQLSourceDef; error?: undefined}

--- a/packages/malloy-db-mysql/src/mysql.s_p_e_c_dont_run.ts
+++ b/packages/malloy-db-mysql/src/mysql.s_p_e_c_dont_run.ts
@@ -41,12 +41,8 @@ describe('MySQL Connection', () => {
   it('fetches schema for SQL block', async () => {
     const res = await connection.fetchSchemaForSQLStruct(
       {
-        name: 'foo',
-        type: 'sql_select',
         selectStr: 'SELECT 1 as one',
         connection: 'mysql',
-        fields: [],
-        dialect: 'mysql',
       },
       {}
     );

--- a/packages/malloy-db-mysql/src/mysql_connection.ts
+++ b/packages/malloy-db-mysql/src/mysql_connection.ts
@@ -19,6 +19,8 @@ import {
   QueryData,
   SQLSourceDef,
   TableSourceDef,
+  SQLSourceRequest,
+  sqlKey,
 } from '@malloydata/malloy';
 import {BaseConnection} from '@malloydata/malloy/connection';
 import {randomUUID, createHash} from 'crypto';
@@ -171,10 +173,13 @@ export class MySQLConnection
     return structDef;
   }
 
-  async fetchSelectSchema(sqlRef: SQLSourceDef): Promise<SQLSourceDef> {
-    const structDef: StructDef = {
+  async fetchSelectSchema(sqlRef: SQLSourceRequest): Promise<SQLSourceDef> {
+    const structDef: SQLSourceDef = {
+      type: 'sql_select',
       ...sqlRef,
-      name: sqlRef.name,
+      dialect: this.dialectName,
+      fields: [],
+      name: sqlKey(sqlRef.connection, sqlRef.selectStr),
     };
 
     const tempTableName = `tmp${randomUUID()}`.replace(/-/g, '');

--- a/packages/malloy-db-snowflake/src/snowflake_connection.ts
+++ b/packages/malloy-db-snowflake/src/snowflake_connection.ts
@@ -42,6 +42,8 @@ import {
   mkArrayDef,
   AtomicFieldDef,
   ArrayDef,
+  SQLSourceRequest,
+  sqlKey,
 } from '@malloydata/malloy';
 import {BaseConnection} from '@malloydata/malloy/connection';
 
@@ -400,8 +402,14 @@ export class SnowflakeConnection
     return structDef;
   }
 
-  async fetchSelectSchema(sqlRef: SQLSourceDef): Promise<SQLSourceDef> {
-    const structDef = {...sqlRef, fields: []};
+  async fetchSelectSchema(sqlRef: SQLSourceRequest): Promise<SQLSourceDef> {
+    const structDef: SQLSourceDef = {
+      type: 'sql_select',
+      ...sqlRef,
+      dialect: this.dialectName,
+      fields: [],
+      name: sqlKey(sqlRef.connection, sqlRef.selectStr),
+    };
     // create temp table with same schema as the query
     const tempTableName = this.getTempViewName(sqlRef.selectStr);
     this.runSQL(

--- a/packages/malloy-db-trino/src/trino_connection.ts
+++ b/packages/malloy-db-trino/src/trino_connection.ts
@@ -44,6 +44,8 @@ import {
   TinyParser,
   isRepeatedRecord,
   TestableConnection,
+  SQLSourceRequest,
+  sqlKey,
 } from '@malloydata/malloy';
 
 import {BaseConnection} from '@malloydata/malloy/connection';
@@ -355,8 +357,14 @@ export abstract class TrinoPrestoConnection
     return structDef;
   }
 
-  async fetchSelectSchema(sqlRef: SQLSourceDef): Promise<SQLSourceDef> {
-    const structDef: SQLSourceDef = {...sqlRef, fields: []};
+  async fetchSelectSchema(sqlRef: SQLSourceRequest): Promise<SQLSourceDef> {
+    const structDef: SQLSourceDef = {
+      type: 'sql_select',
+      ...sqlRef,
+      dialect: this.dialectName,
+      fields: [],
+      name: sqlKey(sqlRef.connection, sqlRef.selectStr),
+    };
     await this.fillStructDefForSqlBlockSchema(sqlRef.selectStr, structDef);
     return structDef;
   }

--- a/packages/malloy-interfaces/src/index.ts
+++ b/packages/malloy-interfaces/src/index.ts
@@ -133,6 +133,7 @@ export const test: Malloy.ModelInfo = {
 };
 
 export const res: Malloy.Result = {
+  connection_name: 'foo',
   data: {
     kind: 'table',
     rows: [

--- a/packages/malloy-interfaces/src/index.ts
+++ b/packages/malloy-interfaces/src/index.ts
@@ -8,6 +8,7 @@
 import * as Malloy from './types';
 export * from './types';
 export {queryToMalloy} from './to_malloy';
+export {nestUnions} from './nest_unions';
 
 export const test: Malloy.ModelInfo = {
   entries: [

--- a/packages/malloy-interfaces/src/nest_unions.spec.ts
+++ b/packages/malloy-interfaces/src/nest_unions.spec.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {nestUnions} from './nest_unions';
+import * as Malloy from './types';
+
+describe('unnest unions', () => {
+  test('works', () => {
+    const query: Malloy.Query = {
+      definition: {
+        kind: 'arrow',
+        source_reference: {
+          name: 'flights',
+        },
+        view: {
+          kind: 'segment',
+          operations: [
+            {
+              kind: 'group_by',
+              field: {
+                expression: {
+                  kind: 'field_reference',
+                  name: 'carrier',
+                },
+              },
+            },
+            {
+              kind: 'limit',
+              limit: 10,
+            },
+          ],
+        },
+      },
+    };
+    expect(nestUnions(query)).toMatchObject({
+      definition: {
+        arrow: {
+          source_reference: {
+            name: 'flights',
+          },
+          view: {
+            segment: {
+              operations: [
+                {
+                  group_by: {
+                    field: {
+                      expression: {
+                        field_reference: {name: 'carrier'},
+                      },
+                    },
+                  },
+                },
+                {
+                  limit: {limit: 10},
+                },
+              ],
+            },
+          },
+        },
+      },
+    });
+  });
+});

--- a/packages/malloy-interfaces/src/nest_unions.ts
+++ b/packages/malloy-interfaces/src/nest_unions.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export function nestUnions(obj: unknown): unknown {
+  if (obj === null) {
+    return obj;
+  } else if (typeof obj === 'string' || typeof obj === 'number') {
+    return obj;
+  } else if (Array.isArray(obj)) {
+    return obj.map(nestUnions);
+  } else {
+    const result = {};
+    let kind: string | undefined = undefined;
+    for (const key in obj) {
+      if (key === 'kind') {
+        kind = obj[key];
+      } else {
+        result[key] = nestUnions(obj[key]);
+      }
+    }
+    if (kind === undefined) {
+      return result;
+    } else {
+      return {[kind]: result};
+    }
+  }
+}

--- a/packages/malloy-interfaces/src/types.ts
+++ b/packages/malloy-interfaces/src/types.ts
@@ -99,6 +99,7 @@ export type CellWithArrayCell = {kind: 'array_cell'} & ArrayCell;
 export type CellWithTableCell = {kind: 'table_cell'} & TableCell;
 export type CompileModelRequest = {
   model_url: string;
+  extend_model_url?: string;
   compiler_needs?: CompilerNeeds;
 };
 export type CompileModelResponse = {
@@ -117,6 +118,7 @@ export type CompileQueryResponse = {
 export type CompileSourceRequest = {
   model_url: string;
   name: string;
+  extend_model_url?: string;
   compiler_needs?: CompilerNeeds;
 };
 export type CompileSourceResponse = {

--- a/packages/malloy-interfaces/src/types.ts
+++ b/packages/malloy-interfaces/src/types.ts
@@ -97,6 +97,38 @@ export type CellWithJSONCell = {kind: 'json_cell'} & JSONCell;
 export type CellWithRecordCell = {kind: 'record_cell'} & RecordCell;
 export type CellWithArrayCell = {kind: 'array_cell'} & ArrayCell;
 export type CellWithTableCell = {kind: 'table_cell'} & TableCell;
+export type CompileModelRequest = {
+  model_url: string;
+  compiler_needs?: CompilerNeeds;
+};
+export type CompileModelResponse = {
+  model?: ModelInfo;
+  compiler_needs?: CompilerNeeds;
+};
+export type CompileQueryRequest = {
+  model_url: string;
+  query: Query;
+  compiler_needs?: CompilerNeeds;
+};
+export type CompileQueryResponse = {
+  result?: Result;
+  compiler_needs?: CompilerNeeds;
+};
+export type CompileSourceRequest = {
+  model_url: string;
+  name: string;
+  compiler_needs?: CompilerNeeds;
+};
+export type CompileSourceResponse = {
+  source?: SourceInfo;
+  compiler_needs?: CompilerNeeds;
+};
+export type CompilerNeeds = {
+  table_schemas?: Array<SQLTable>;
+  sql_schemas?: Array<SQLQuery>;
+  files?: Array<File>;
+  translations?: Array<Translation>;
+};
 export type DataType = 'record' | 'table';
 export type Data = DataWithRecord | DataWithTable;
 export type DataWithRecord = {kind: 'record'} & RecordCell;
@@ -148,6 +180,11 @@ export type FieldInfoWithDimension = {kind: 'dimension'} & DimensionInfo;
 export type FieldInfoWithMeasure = {kind: 'measure'} & MeasureInfo;
 export type FieldInfoWithJoin = {kind: 'join'} & JoinInfo;
 export type FieldInfoWithView = {kind: 'view'} & ViewInfo;
+export type File = {
+  url: string;
+  contents?: string;
+  invalidation_key?: string;
+};
 export type FilterType = 'filter_string';
 export type Filter = FilterWithFilterString;
 export type FilterWithFilterString = {
@@ -224,7 +261,7 @@ export type ModelEntryValueWithQuery = {kind: 'query'} & QueryInfo;
 export type ModelInfo = {
   entries: Array<ModelEntryValue>;
   annotations?: Array<Annotation>;
-  anonymous_queries: Array<QueryInfo>;
+  anonymous_queries: Array<AnonymousQueryInfo>;
 };
 export type Nest = {
   name?: string;
@@ -315,8 +352,40 @@ export type Result = {
 export type Row = {
   cells: Array<Cell>;
 };
+export type RunIndexQueryRequest = {
+  model_url: string;
+  source_name: string;
+  compiler_needs?: CompilerNeeds;
+};
+export type RunIndexQueryResponse = {
+  result?: Result;
+  compiler_needs?: CompilerNeeds;
+};
+export type RunQueryRequest = {
+  model_url: string;
+  query: Query;
+  compiler_needs?: CompilerNeeds;
+};
+export type RunQueryResponse = {
+  result?: Result;
+  compiler_needs?: CompilerNeeds;
+};
 export type SQLNativeType = {
   sql_type?: string;
+};
+export type SQLQuery = {
+  sql: string;
+  schema?: Schema;
+  connection_name: string;
+  dialect?: string;
+  key: string;
+};
+export type SQLTable = {
+  name: string;
+  schema?: Schema;
+  connection_name: string;
+  dialect?: string;
+  key: string;
 };
 export type Schema = {
   fields: Array<FieldInfo>;
@@ -362,6 +431,10 @@ export type TimestampTimeframe =
   | 'second';
 export type TimestampType = {
   timeframe?: TimestampTimeframe;
+};
+export type Translation = {
+  url: string;
+  compiled_model_json?: string;
 };
 export type View = {
   definition: ViewDefinition;

--- a/packages/malloy-interfaces/src/types.ts
+++ b/packages/malloy-interfaces/src/types.ts
@@ -373,6 +373,7 @@ export type Result = {
   data?: Data;
   schema: Schema;
   sql?: string;
+  connection_name: string;
 };
 export type Row = {
   cells: Array<Cell>;

--- a/packages/malloy-interfaces/src/types.ts
+++ b/packages/malloy-interfaces/src/types.ts
@@ -104,6 +104,7 @@ export type CompileModelRequest = {
 };
 export type CompileModelResponse = {
   model?: ModelInfo;
+  logs?: Array<LogMessage>;
   compiler_needs?: CompilerNeeds;
 };
 export type CompileQueryRequest = {
@@ -113,6 +114,7 @@ export type CompileQueryRequest = {
 };
 export type CompileQueryResponse = {
   result?: Result;
+  logs?: Array<LogMessage>;
   compiler_needs?: CompilerNeeds;
 };
 export type CompileSourceRequest = {
@@ -123,6 +125,7 @@ export type CompileSourceRequest = {
 };
 export type CompileSourceResponse = {
   source?: SourceInfo;
+  logs?: Array<LogMessage>;
   compiler_needs?: CompilerNeeds;
 };
 export type CompilerNeeds = {
@@ -155,6 +158,14 @@ export type DimensionInfo = {
   name: string;
   type: AtomicType;
   annotations?: Array<Annotation>;
+};
+export type DocumentPosition = {
+  line: number;
+  character: number;
+};
+export type DocumentRange = {
+  start: DocumentPosition;
+  end: DocumentPosition;
 };
 export type ExpressionType =
   | 'field_reference'
@@ -254,6 +265,13 @@ export type Location = {
   url: string;
   range: Range;
 };
+export type LogMessage = {
+  url: string;
+  range: DocumentRange;
+  severity: LogSeverity;
+  message: string;
+};
+export type LogSeverity = 'debug' | 'info' | 'warn' | 'error';
 export type MeasureInfo = {
   name: string;
   type: AtomicType;
@@ -375,6 +393,7 @@ export type RunQueryRequest = {
 };
 export type RunQueryResponse = {
   result?: Result;
+  logs?: Array<LogMessage>;
   compiler_needs?: CompilerNeeds;
 };
 export type SQLNativeType = {

--- a/packages/malloy-interfaces/src/types.ts
+++ b/packages/malloy-interfaces/src/types.ts
@@ -127,7 +127,12 @@ export type CompilerNeeds = {
   table_schemas?: Array<SQLTable>;
   sql_schemas?: Array<SQLQuery>;
   files?: Array<File>;
+  connections?: Array<Connection>;
   translations?: Array<Translation>;
+};
+export type Connection = {
+  name: string;
+  dialect?: string;
 };
 export type DataType = 'record' | 'table';
 export type Data = DataWithRecord | DataWithTable;
@@ -377,15 +382,11 @@ export type SQLQuery = {
   sql: string;
   schema?: Schema;
   connection_name: string;
-  dialect?: string;
-  key: string;
 };
 export type SQLTable = {
   name: string;
   schema?: Schema;
   connection_name: string;
-  dialect?: string;
-  key: string;
 };
 export type Schema = {
   fields: Array<FieldInfo>;

--- a/packages/malloy-interfaces/thrift/malloy.thrift
+++ b/packages/malloy-interfaces/thrift/malloy.thrift
@@ -8,7 +8,7 @@
 struct ModelInfo {
   1: required list<ModelEntryValue> entries,
   2: optional list<Annotation> annotations,
-  3: required list<QueryInfo> anonymous_queries,
+  3: required list<AnonymousQueryInfo> anonymous_queries,
 }
 
 union ModelEntryValue {
@@ -523,3 +523,118 @@ TODO
 
 // concern: shape of FieldInfo and GroupBy (no object for "Field") are funadmentally pretty different,
 // but it might be nice for them to be more similar.
+
+struct SQLTable {
+  1: required string name,
+  2: optional Schema schema,
+  3: required string connection_name,
+  4: optional string dialect,
+  5: required string key,
+}
+
+struct SQLQuery {
+  1: required string sql,
+  2: optional Schema schema,
+  3: required string connection_name,
+  // TODO should dialect be retrieved separately in a 'connections' need?
+  4: optional string dialect,
+  5: required string key,
+}
+
+struct File {
+  1: required string url,
+  2: optional string contents,
+  3: optional string invalidation_key,
+}
+
+// struct Connection {
+//   1: required string name,
+//   2: optional string dialect,
+// }
+
+struct Translation {
+  1: required string url,
+  2: optional string compiled_model_json,
+}
+
+struct CompilerNeeds {
+  1: optional list<SQLTable> table_schemas,
+  2: optional list<SQLQuery> sql_schemas,
+  3: optional list<File> files,
+  // 4: optional list<Connection> connections,
+  5: optional list<Translation> translations,
+}
+
+// Given the URL to a model, return the StableModelDef for that model
+
+struct CompileModelRequest {
+  1: required string model_url,
+
+  9: optional CompilerNeeds compiler_needs,
+}
+
+struct CompileModelResponse {
+  1: optional ModelInfo model,
+
+  9: optional CompilerNeeds compiler_needs,
+}
+
+// Given the URL to a model and a name of a queryable thing, get a StableSourceDef
+
+struct CompileSourceRequest {
+  1: required string model_url,
+  2: required string name,
+
+  9: optional CompilerNeeds compiler_needs,
+}
+
+struct CompileSourceResponse {
+  1: optional SourceInfo source,
+
+  9: optional CompilerNeeds compiler_needs,
+}
+
+// Given a StableQueryDef and the URL to a model, run it and return a StableResult
+
+struct RunQueryRequest {
+  1: required string model_url,
+  2: required Query query,
+
+  9: optional CompilerNeeds compiler_needs,
+}
+
+struct RunQueryResponse {
+  1: optional Result result,
+
+  9: optional CompilerNeeds compiler_needs,
+}
+
+// Given a StableQueryDef and the URL to a model, compile it and return a StableResultDef
+
+struct CompileQueryRequest {
+  1: required string model_url,
+  2: required Query query,
+
+  9: optional CompilerNeeds compiler_needs,
+}
+
+struct CompileQueryResponse {
+  1: optional Result result,
+
+  9: optional CompilerNeeds compiler_needs,
+}
+
+// Given a URL to a model and the name of a source, run the indexing query
+
+struct RunIndexQueryRequest {
+  1: required string model_url,
+  2: required string source_name,
+
+  9: optional CompilerNeeds compiler_needs,
+}
+
+struct RunIndexQueryResponse {
+  1: optional Result result,
+
+  9: optional CompilerNeeds compiler_needs,
+}

--- a/packages/malloy-interfaces/thrift/malloy.thrift
+++ b/packages/malloy-interfaces/thrift/malloy.thrift
@@ -564,6 +564,7 @@ struct CompilerNeeds {
 
 struct CompileModelRequest {
   1: required string model_url,
+  2: optional string extend_model_url,
 
   9: optional CompilerNeeds compiler_needs,
 }
@@ -579,6 +580,7 @@ struct CompileModelResponse {
 struct CompileSourceRequest {
   1: required string model_url,
   2: required string name,
+  3: optional string extend_model_url,
 
   9: optional CompilerNeeds compiler_needs,
 }

--- a/packages/malloy-interfaces/thrift/malloy.thrift
+++ b/packages/malloy-interfaces/thrift/malloy.thrift
@@ -528,17 +528,12 @@ struct SQLTable {
   1: required string name,
   2: optional Schema schema,
   3: required string connection_name,
-  4: optional string dialect,
-  5: required string key,
 }
 
 struct SQLQuery {
   1: required string sql,
   2: optional Schema schema,
   3: required string connection_name,
-  // TODO should dialect be retrieved separately in a 'connections' need?
-  4: optional string dialect,
-  5: required string key,
 }
 
 struct File {
@@ -547,10 +542,10 @@ struct File {
   3: optional string invalidation_key,
 }
 
-// struct Connection {
-//   1: required string name,
-//   2: optional string dialect,
-// }
+struct Connection {
+  1: required string name,
+  2: optional string dialect,
+}
 
 struct Translation {
   1: required string url,
@@ -561,7 +556,7 @@ struct CompilerNeeds {
   1: optional list<SQLTable> table_schemas,
   2: optional list<SQLQuery> sql_schemas,
   3: optional list<File> files,
-  // 4: optional list<Connection> connections,
+  4: optional list<Connection> connections,
   5: optional list<Translation> translations,
 }
 

--- a/packages/malloy-interfaces/thrift/malloy.thrift
+++ b/packages/malloy-interfaces/thrift/malloy.thrift
@@ -479,6 +479,7 @@ struct Result {
   1: optional Data data,
   2: required Schema schema,
   3: optional string sql,
+  4: required string connection_name,
 }
 
 /*

--- a/packages/malloy-interfaces/thrift/malloy.thrift
+++ b/packages/malloy-interfaces/thrift/malloy.thrift
@@ -560,6 +560,30 @@ struct CompilerNeeds {
   5: optional list<Translation> translations,
 }
 
+struct DocumentPosition {
+  1: required i32 line;
+  2: required i32 character;
+}
+
+struct DocumentRange {
+  1: required DocumentPosition start;
+  2: required DocumentPosition end;
+}
+
+enum LogSeverity {
+  DEBUG = 1,
+  INFO = 2,
+  WARN = 3,
+  ERROR = 4
+}
+
+struct LogMessage {
+  1: required string url;
+  2: required DocumentRange range;
+  3: required LogSeverity severity;
+  4: required string message;
+}
+
 // Given the URL to a model, return the StableModelDef for that model
 
 struct CompileModelRequest {
@@ -572,6 +596,7 @@ struct CompileModelRequest {
 struct CompileModelResponse {
   1: optional ModelInfo model,
 
+  8: optional list<LogMessage> logs,
   9: optional CompilerNeeds compiler_needs,
 }
 
@@ -588,6 +613,7 @@ struct CompileSourceRequest {
 struct CompileSourceResponse {
   1: optional SourceInfo source,
 
+  8: optional list<LogMessage> logs,
   9: optional CompilerNeeds compiler_needs,
 }
 
@@ -603,6 +629,7 @@ struct RunQueryRequest {
 struct RunQueryResponse {
   1: optional Result result,
 
+  8: optional list<LogMessage> logs,
   9: optional CompilerNeeds compiler_needs,
 }
 
@@ -618,6 +645,7 @@ struct CompileQueryRequest {
 struct CompileQueryResponse {
   1: optional Result result,
 
+  8: optional list<LogMessage> logs,
   9: optional CompilerNeeds compiler_needs,
 }
 

--- a/packages/malloy/src/api/api.spec.ts
+++ b/packages/malloy/src/api/api.spec.ts
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {compileModel, compileQuery} from './api';
+import * as Malloy from '@malloydata/malloy-interfaces';
+
+describe('api', () => {
+  describe('compile model', () => {
+    test('compile model with table dependency', () => {
+      const result = compileModel({
+        model_url: 'file://test.malloy',
+        compiler_needs: {
+          table_schemas: [
+            {
+              key: 'connection:flights',
+              connection_name: 'connection',
+              name: 'flights',
+              dialect: 'duckdb',
+              schema: {
+                fields: [
+                  {
+                    kind: 'dimension',
+                    name: 'carrier',
+                    type: {kind: 'string_type'},
+                  },
+                ],
+              },
+            },
+          ],
+          files: [
+            {
+              url: 'file://test.malloy',
+              contents: "source: flights is connection.table('flights')",
+            },
+          ],
+        },
+      });
+      const expected: Malloy.CompileModelResponse = {
+        model: {
+          entries: [
+            {
+              kind: 'source',
+              name: 'flights',
+              schema: {
+                fields: [
+                  {
+                    kind: 'dimension',
+                    name: 'carrier',
+                    type: {kind: 'string_type'},
+                  },
+                ],
+              },
+            },
+          ],
+          anonymous_queries: [],
+        },
+      };
+      expect(result).toMatchObject(expected);
+    });
+  });
+  describe('compile query', () => {
+    test('compile query with table dependency', () => {
+      const result = compileQuery({
+        model_url: 'file://test.malloy',
+        query: {
+          definition: {
+            kind: 'arrow',
+            source_reference: {name: 'flights'},
+            view: {
+              kind: 'segment',
+              operations: [
+                {
+                  kind: 'group_by',
+                  field: {
+                    expression: {kind: 'field_reference', name: 'carrier'},
+                  },
+                },
+              ],
+            },
+          },
+        },
+        compiler_needs: {
+          table_schemas: [
+            {
+              key: 'connection:flights',
+              connection_name: 'connection',
+              name: 'flights',
+              dialect: 'duckdb',
+              schema: {
+                fields: [
+                  {
+                    kind: 'dimension',
+                    name: 'carrier',
+                    type: {kind: 'string_type'},
+                  },
+                ],
+              },
+            },
+          ],
+          files: [
+            {
+              url: 'file://test.malloy',
+              contents: "source: flights is connection.table('flights')",
+            },
+          ],
+        },
+      });
+      const expected: Malloy.CompileQueryResponse = {
+        result: {
+          sql: `SELECT \n\
+   base."carrier" as "carrier"
+FROM flights as base
+GROUP BY 1
+ORDER BY 1 asc NULLS LAST
+`,
+          schema: {
+            fields: [
+              {
+                kind: 'dimension',
+                name: 'carrier',
+                type: {kind: 'string_type'},
+              },
+            ],
+          },
+        },
+      };
+      expect(result).toMatchObject(expected);
+    });
+  });
+});

--- a/packages/malloy/src/api/api.ts
+++ b/packages/malloy/src/api/api.ts
@@ -20,6 +20,7 @@ import {
 } from '../model';
 import {modelDefToModelInfo} from '../to_stable';
 import {sqlKey} from '../model/sql_block';
+import {SQLSourceRequest} from '../lang/translate-response';
 
 // TODO find where this should go...
 function tableKey(connectionName: string, tablePath: string): string {
@@ -162,7 +163,7 @@ function compilerNeedsToUpdate(
 }
 
 function convertCompilerNeeds(
-  compileSQL: SQLSourceDef | undefined,
+  compileSQL: SQLSourceRequest | undefined,
   urls: string[] | undefined,
   tables:
     | Record<

--- a/packages/malloy/src/api/api.ts
+++ b/packages/malloy/src/api/api.ts
@@ -1,0 +1,364 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import * as Malloy from '@malloydata/malloy-interfaces';
+import {MalloyTranslator} from '../lang';
+import {ParseUpdate} from '../lang/parse-malloy';
+import {
+  AtomicFieldDef,
+  AtomicTypeDef,
+  FieldDef,
+  isSegmentSQL,
+  mkFieldDef,
+  ModelDef,
+  QueryModel,
+  SQLSentence,
+  SQLSourceDef,
+  TableSourceDef,
+} from '../model';
+import {modelDefToModelInfo} from '../to_stable';
+
+function makeSQLSourceDef(sql: Malloy.SQLQuery): SQLSourceDef {
+  return {
+    type: 'sql_select',
+    selectStr: sql.sql,
+    connection: sql.connection_name,
+    dialect: sql.dialect ?? '__missing_dialect__', // TODO make this an error
+    fields: sql.schema ? getSchemaFields(sql.schema) : [],
+    name: '', // TODO
+  };
+}
+
+function makeTableSourceDef(table: Malloy.SQLTable): TableSourceDef {
+  return {
+    type: 'table',
+    tablePath: table.name,
+    connection: table.connection_name,
+    dialect: table.dialect ?? '__missing_dialect__', // TODO make this an error
+    fields: table.schema ? getSchemaFields(table.schema) : [],
+    name: `${table.connection_name}:${table.name}`,
+  };
+}
+
+function convertNumberSubtype(
+  subtype?: Malloy.NumberSubtype
+): 'float' | 'integer' | undefined {
+  if (subtype === undefined) return undefined;
+  if (subtype === 'decimal') return 'float';
+  return 'integer';
+}
+
+function typeDefFromField(type: Malloy.AtomicType): AtomicTypeDef {
+  switch (type.kind) {
+    case 'string_type':
+      return {type: 'string'};
+    case 'number_type':
+      return {type: 'number', numberType: convertNumberSubtype(type.subtype)};
+    case 'boolean_type':
+      return {type: 'boolean'};
+    case 'timestamp_type':
+      return {type: 'timestamp', timeframe: type.timeframe};
+    case 'date_type':
+      return {type: 'date', timeframe: type.timeframe};
+    case 'sql_native_type':
+      return {type: 'sql native', rawType: type.sql_type};
+    case 'json_type':
+      return {type: 'json'};
+    case 'array_type': {
+      if (type.element_type.kind === 'record_type') {
+        return {
+          type: 'array',
+          elementTypeDef: {type: 'record_element'},
+          fields: type.element_type.fields.map(convertDimension),
+        };
+      } else {
+        const elementTypeDef = typeDefFromField(type.element_type);
+        if (elementTypeDef.type === 'record') {
+          throw new Error('Arrays of records should be a repeated record type');
+        }
+        return {
+          type: 'array',
+          elementTypeDef,
+        };
+      }
+    }
+    case 'record_type':
+      return {type: 'record', fields: type.fields.map(convertDimension)};
+  }
+}
+
+function convertDimension(field: Malloy.DimensionInfo): AtomicFieldDef {
+  const typeDef = typeDefFromField(field.type);
+  return mkFieldDef(typeDef, field.name);
+}
+
+function convertTableField(field: Malloy.FieldInfo): AtomicFieldDef {
+  if (field.kind !== 'dimension') {
+    throw new Error('Table schemas must only have dimension fields');
+  }
+  return convertDimension(field);
+}
+
+function getSchemaFields(schema: Malloy.Schema): FieldDef[] {
+  const fields: FieldDef[] = [];
+  for (const field of schema.fields) {
+    fields.push(convertTableField(field));
+  }
+  return fields;
+}
+
+function compilerNeedsToUpdate(
+  compilerNeeds?: Malloy.CompilerNeeds
+): ParseUpdate {
+  const update: ParseUpdate = {
+    urls: {},
+    tables: {},
+    compileSQL: {},
+    translations: {},
+  };
+  if (compilerNeeds) {
+    for (const file of compilerNeeds.files ?? []) {
+      if (file.contents !== undefined) {
+        update.urls![file.url] = file.contents;
+      }
+    }
+    for (const table of compilerNeeds.table_schemas ?? []) {
+      update.tables![table.key] = makeTableSourceDef(table);
+    }
+    for (const sql of compilerNeeds.sql_schemas ?? []) {
+      if (sql !== undefined) {
+        update.compileSQL![sql.key] = makeSQLSourceDef(sql);
+      }
+    }
+    for (const translation of compilerNeeds.translations ?? []) {
+      if (translation.compiled_model_json) {
+        const modelDef = JSON.parse(translation.compiled_model_json);
+        update.translations![translation.url] = modelDef;
+      }
+    }
+  }
+  return update;
+}
+
+function convertCompilerNeeds(
+  compileSQL: {partialModel: ModelDef; sqlSentence: SQLSentence} | undefined,
+  urls: string[] | undefined,
+  tables:
+    | Record<
+        string,
+        {
+          connectionName: string | undefined;
+          tablePath: string;
+        }
+      >
+    | undefined
+): Malloy.CompilerNeeds {
+  const compilerNeeds: Malloy.CompilerNeeds = {
+    files: [],
+    table_schemas: [],
+  };
+  if (compileSQL !== undefined) {
+    const block = compileSQLBlock(
+      compileSQL.partialModel,
+      compileSQL.sqlSentence
+    );
+    compilerNeeds.sql_schemas = [
+      {
+        sql: block.selectStr,
+        connection_name: block.connection,
+        key: block.name,
+      },
+    ];
+  }
+  if (urls !== undefined) {
+    for (const url of urls) {
+      compilerNeeds.files!.push({url});
+    }
+  }
+  if (tables !== undefined) {
+    for (const key in tables) {
+      const table = tables[key];
+      compilerNeeds.table_schemas!.push({
+        name: table.tablePath,
+        connection_name: table.connectionName ?? '__default__', // TODO do we even support default connections any more?,
+        key,
+      });
+    }
+  }
+  return compilerNeeds;
+}
+
+function compile(
+  modelURL: string,
+  compilerNeeds?: Malloy.CompilerNeeds,
+  extendURL?: string
+):
+  | {
+      model: Malloy.ModelInfo;
+      modelDef: ModelDef;
+      compilerNeeds?: undefined;
+    }
+  | {
+      model?: undefined;
+      modelDef?: undefined;
+      compilerNeeds: Malloy.CompilerNeeds;
+    } {
+  let extendingModel: ModelDef | undefined;
+  if (extendURL) {
+    const extendResult = compile(extendURL, compilerNeeds);
+    if (extendResult.modelDef) {
+      extendingModel = extendResult.modelDef;
+    } else {
+      return extendResult;
+    }
+  }
+  const translator = new MalloyTranslator(
+    modelURL,
+    null,
+    compilerNeedsToUpdate(compilerNeeds)
+  );
+  const result = translator.translate(extendingModel);
+  if (result.final) {
+    if (result.modelDef) {
+      return {
+        model: modelDefToModelInfo(result.modelDef),
+        modelDef: result.modelDef,
+      };
+    } else {
+      if (result.problems === undefined || result.problems.length === 0) {
+        throw new Error('No problems found, but no model either');
+      }
+      // TODO return an error...
+      throw new Error(result.problems[0].message);
+    }
+  } else {
+    const compileSQL =
+      result.compileSQL && result.partialModel
+        ? {partialModel: result.partialModel, sqlSentence: result.compileSQL}
+        : undefined;
+    const compilerNeeds = convertCompilerNeeds(
+      compileSQL,
+      result.urls,
+      result.tables
+    );
+    return {compilerNeeds};
+  }
+}
+
+// Given the URL to a model, return the StableModelDef for that model
+
+export function compileModel(
+  request: Malloy.CompileModelRequest
+): Malloy.CompileModelResponse {
+  return compile(request.model_url, request.compiler_needs);
+}
+
+// Given the URL to a model and a name of a queryable thing, get a StableSourceDef
+
+export function compileSource(
+  request: Malloy.CompileSourceRequest
+): Malloy.CompileSourceResponse {
+  const result = compile(request.model_url, request.compiler_needs);
+  if (result.model) {
+    const source = result.model.entries.find(e => e.name === request.name);
+    if (source === undefined) {
+      // TODO decide how to actually respond with an error?
+      throw new Error('Source not found');
+    }
+    return {source};
+  } else {
+    return {compiler_needs: result.compilerNeeds};
+  }
+}
+
+// Given a StableQueryDef and the URL to a model, run it and return a StableResult
+
+// Given a StableQueryDef and the URL to a model, compile it and return a StableResultDef
+
+export function compileQuery(
+  request: Malloy.CompileQueryRequest
+): Malloy.CompileQueryResponse {
+  const queryMalloy = Malloy.queryToMalloy(request.query);
+  const needs = {
+    ...request.compiler_needs,
+  };
+  const queryURL = 'internal://query.malloy';
+  needs.files = [
+    {
+      url: queryURL,
+      contents: queryMalloy,
+    },
+    ...(needs.files ?? []),
+  ];
+  const result = compile(queryURL, needs, request.model_url);
+  if (result.model) {
+    const queries = result.modelDef.queryList;
+    if (queries.length === 0) {
+      throw new Error('No queries found');
+    }
+    const index = queries.length - 1;
+    const query = result.modelDef.queryList[index];
+    const schema = result.model.anonymous_queries[index].schema;
+    const queryModel = new QueryModel(result.modelDef);
+    const translatedQuery = queryModel.compileQuery(query);
+    return {
+      result: {
+        sql: translatedQuery.sql,
+        schema,
+      },
+    };
+  } else {
+    return {compiler_needs: result.compilerNeeds};
+  }
+}
+
+// Given a StableQueryDef and the URL to a model, validate it and return a list of StableErrors
+
+// Given a URL to a model and the name of a source, run the indexing query
+
+function compileSQLBlock(
+  partialModel: ModelDef | undefined,
+  toCompile: SQLSentence
+): SQLSourceDef {
+  let queryModel: QueryModel | undefined = undefined;
+  let selectStr = '';
+  let parenAlready = false;
+  for (const segment of toCompile.select) {
+    if (isSegmentSQL(segment)) {
+      selectStr += segment.sql;
+      parenAlready = segment.sql.match(/\(\s*$/) !== null;
+    } else {
+      // TODO catch exceptions and throw errors ...
+      if (!queryModel) {
+        if (!partialModel) {
+          throw new Error(
+            'Internal error: Partial model missing when compiling SQL block'
+          );
+        }
+        queryModel = new QueryModel(partialModel);
+      }
+      const compiledSql = queryModel.compileQuery(
+        segment,
+        {
+          defaultRowLimit: undefined,
+        },
+        false
+      ).sql;
+      selectStr += parenAlready ? compiledSql : `(${compiledSql})`;
+      parenAlready = false;
+    }
+  }
+  const {name, connection} = toCompile;
+  return {
+    type: 'sql_select',
+    name,
+    connection,
+    dialect: '~no_dialect~',
+    selectStr,
+    fields: [],
+  };
+}

--- a/packages/malloy/src/api/asynchronous.spec.ts
+++ b/packages/malloy/src/api/asynchronous.spec.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {compileModel} from './asynchronous';
+import * as Malloy from '@malloydata/malloy-interfaces';
+import {InfoConnection, LookupConnection} from './connection';
+import {URLReader} from '../runtime_types';
+
+describe('api', () => {
+  describe('compile model', () => {
+    test('compile model with table dependency', async () => {
+      const connection: InfoConnection = {
+        dialectName: 'duckdb',
+        fetchSchemaForTable: async (_name: string) => {
+          return {
+            fields: [
+              {
+                kind: 'dimension',
+                name: 'carrier',
+                type: {kind: 'string_type'},
+              },
+            ],
+          };
+        },
+        fetchSchemaForSQLQuery: async (_sql: string) => {
+          throw new Error('not implemented');
+        },
+      };
+      const urls: URLReader = {
+        readURL: async (_url: URL) => {
+          return "source: flights is connection.table('flights')";
+        },
+      };
+      const connections: LookupConnection<InfoConnection> = {
+        lookupConnection: async (_name: string) => {
+          return connection;
+        },
+      };
+      const fetchers = {
+        urls,
+        connections,
+      };
+      const result = await compileModel(
+        {
+          model_url: 'file://test.malloy',
+        },
+        fetchers
+      );
+      const expected: Malloy.CompileModelResponse = {
+        model: {
+          entries: [
+            {
+              kind: 'source',
+              name: 'flights',
+              schema: {
+                fields: [
+                  {
+                    kind: 'dimension',
+                    name: 'carrier',
+                    type: {kind: 'string_type'},
+                  },
+                ],
+              },
+            },
+          ],
+          anonymous_queries: [],
+        },
+      };
+      expect(result).toMatchObject(expected);
+    });
+  });
+});

--- a/packages/malloy/src/api/asynchronous.spec.ts
+++ b/packages/malloy/src/api/asynchronous.spec.ts
@@ -5,9 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {compileModel} from './asynchronous';
+import {compileModel, compileQuery, runQuery} from './asynchronous';
 import * as Malloy from '@malloydata/malloy-interfaces';
-import {InfoConnection, LookupConnection} from './connection';
+import {Connection, InfoConnection, LookupConnection} from './connection';
 import {URLReader} from '../runtime_types';
 
 describe('api', () => {
@@ -68,6 +68,179 @@ describe('api', () => {
             },
           ],
           anonymous_queries: [],
+        },
+      };
+      expect(result).toMatchObject(expected);
+    });
+  });
+  describe('compile query', () => {
+    test('compile query with table dependency', async () => {
+      const connection: InfoConnection = {
+        dialectName: 'duckdb',
+        fetchSchemaForTable: async (_name: string) => {
+          return {
+            fields: [
+              {
+                kind: 'dimension',
+                name: 'carrier',
+                type: {kind: 'string_type'},
+              },
+            ],
+          };
+        },
+        fetchSchemaForSQLQuery: async (_sql: string) => {
+          throw new Error('not implemented');
+        },
+      };
+      const urls: URLReader = {
+        readURL: async (_url: URL) => {
+          return "source: flights is connection.table('flights')";
+        },
+      };
+      const connections: LookupConnection<InfoConnection> = {
+        lookupConnection: async (_name: string) => {
+          return connection;
+        },
+      };
+      const fetchers = {
+        urls,
+        connections,
+      };
+      const result = await compileQuery(
+        {
+          model_url: 'file://test.malloy',
+          query: {
+            definition: {
+              kind: 'arrow',
+              source_reference: {name: 'flights'},
+              view: {
+                kind: 'segment',
+                operations: [
+                  {
+                    kind: 'group_by',
+                    field: {
+                      expression: {kind: 'field_reference', name: 'carrier'},
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        },
+        fetchers
+      );
+      const expected: Malloy.CompileQueryResponse = {
+        result: {
+          connection_name: 'connection',
+          sql: `SELECT \n\
+   base."carrier" as "carrier"
+FROM flights as base
+GROUP BY 1
+ORDER BY 1 asc NULLS LAST
+`,
+          schema: {
+            fields: [
+              {
+                kind: 'dimension',
+                name: 'carrier',
+                type: {kind: 'string_type'},
+              },
+            ],
+          },
+        },
+      };
+      expect(result).toMatchObject(expected);
+    });
+  });
+  describe('run query', () => {
+    test('run query with table dependency', async () => {
+      const data: Malloy.Data = {
+        kind: 'table',
+        rows: [
+          {
+            cells: [{kind: 'string_cell', string_value: 'WN'}],
+          },
+          {
+            cells: [{kind: 'string_cell', string_value: 'AA'}],
+          },
+        ],
+      };
+      const connection: Connection = {
+        dialectName: 'duckdb',
+        fetchSchemaForTable: async (_name: string) => {
+          return {
+            fields: [
+              {
+                kind: 'dimension',
+                name: 'carrier',
+                type: {kind: 'string_type'},
+              },
+            ],
+          };
+        },
+        fetchSchemaForSQLQuery: async (_sql: string) => {
+          throw new Error('not implemented');
+        },
+        runSQL: async (_sql: string) => {
+          return data;
+        },
+      };
+      const urls: URLReader = {
+        readURL: async (_url: URL) => {
+          return "source: flights is connection.table('flights')";
+        },
+      };
+      const connections: LookupConnection<Connection> = {
+        lookupConnection: async (_name: string) => {
+          return connection;
+        },
+      };
+      const fetchers = {
+        urls,
+        connections,
+      };
+      const result = await runQuery(
+        {
+          model_url: 'file://test.malloy',
+          query: {
+            definition: {
+              kind: 'arrow',
+              source_reference: {name: 'flights'},
+              view: {
+                kind: 'segment',
+                operations: [
+                  {
+                    kind: 'group_by',
+                    field: {
+                      expression: {kind: 'field_reference', name: 'carrier'},
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        },
+        fetchers
+      );
+      const expected: Malloy.CompileQueryResponse = {
+        result: {
+          connection_name: 'connection',
+          sql: `SELECT \n\
+   base."carrier" as "carrier"
+FROM flights as base
+GROUP BY 1
+ORDER BY 1 asc NULLS LAST
+`,
+          schema: {
+            fields: [
+              {
+                kind: 'dimension',
+                name: 'carrier',
+                type: {kind: 'string_type'},
+              },
+            ],
+          },
+          data,
         },
       };
       expect(result).toMatchObject(expected);

--- a/packages/malloy/src/api/asynchronous.ts
+++ b/packages/malloy/src/api/asynchronous.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import * as Malloy from '@malloydata/malloy-interfaces';
+import * as Core from './core';
+
+export async function compileModel(
+  request: Malloy.CompileModelRequest
+): Promise<Malloy.CompileModelResponse> {
+  return Core.compileModel(request);
+}
+
+export async function compileSource(
+  request: Malloy.CompileSourceRequest
+): Promise<Malloy.CompileSourceResponse> {
+  return Core.compileSource(request);
+}
+
+export async function compileQuery(
+  request: Malloy.CompileQueryRequest
+): Promise<Malloy.CompileQueryResponse> {
+  return Core.compileQuery(request);
+}

--- a/packages/malloy/src/api/asynchronous.ts
+++ b/packages/malloy/src/api/asynchronous.ts
@@ -7,11 +7,132 @@
 
 import * as Malloy from '@malloydata/malloy-interfaces';
 import * as Core from './core';
+import {InfoConnection, LookupConnection} from './connection';
+import {URLReader} from '../runtime_types';
+import {CacheManager} from '../malloy';
+
+async function fetchNeeds(
+  needs: Malloy.CompilerNeeds | undefined,
+  fetchers: CompilerNeedFetch
+): Promise<Malloy.CompilerNeeds> {
+  if (needs === undefined) {
+    throw new Error(
+      "Expected compiler to have needs because it didn't return a result"
+    );
+  }
+  const result: Malloy.CompilerNeeds = {};
+  if (needs.connections) {
+    for (const connection of needs.connections) {
+      const info = await fetchers.connections.lookupConnection(connection.name);
+      result.connections ??= [];
+      result.connections.push({
+        ...connection,
+        dialect: info.dialectName,
+      });
+    }
+  }
+  if (needs.files) {
+    for (const file of needs.files) {
+      // TODO handle checking if the cache has the file...
+      const info = await fetchers.urls.readURL(new URL(file.url));
+      result.files ??= [];
+      if (typeof info === 'string') {
+        result.files.push({
+          ...file,
+          contents: info,
+        });
+      } else {
+        result.files.push({
+          ...file,
+          contents: info.contents,
+          invalidation_key: info.invalidationKey?.toString(),
+        });
+      }
+    }
+  }
+  if (needs.table_schemas) {
+    const tableSchemasByConnection: {
+      [connectionName: string]: Malloy.SQLTable[];
+    } = {};
+    for (const tableSchema of needs.table_schemas) {
+      tableSchemasByConnection[tableSchema.connection_name] ??= [];
+      tableSchemasByConnection[tableSchema.connection_name].push(tableSchema);
+    }
+    for (const connectionName in tableSchemasByConnection) {
+      const connection =
+        await fetchers.connections.lookupConnection(connectionName);
+      const tableNames = tableSchemasByConnection[connectionName].map(
+        t => t.name
+      );
+      const schemas = await Promise.all(
+        tableNames.map(async tableName => ({
+          name: tableName,
+          schema: await connection.fetchSchemaForTable(tableName),
+        }))
+      );
+      result.table_schemas ??= [];
+      for (const schema of schemas) {
+        result.table_schemas.push({
+          connection_name: connectionName,
+          name: schema.name,
+          schema: schema.schema,
+        });
+      }
+    }
+  }
+  if (needs.sql_schemas) {
+    const sqlSchemasByConnectionName: {
+      [connectionName: string]: Malloy.SQLQuery[];
+    } = {};
+    for (const sqlSchema of needs.sql_schemas) {
+      sqlSchemasByConnectionName[sqlSchema.connection_name] ??= [];
+      sqlSchemasByConnectionName[sqlSchema.connection_name].push(sqlSchema);
+    }
+    for (const connectionName in sqlSchemasByConnectionName) {
+      const connection =
+        await fetchers.connections.lookupConnection(connectionName);
+      const sqlQueries = sqlSchemasByConnectionName[connectionName].map(
+        t => t.sql
+      );
+      const schemas = await Promise.all(
+        sqlQueries.map(async sql => ({
+          sql,
+          schema: await connection.fetchSchemaForSQLQuery(sql),
+        }))
+      );
+      result.sql_schemas ??= [];
+      for (const schema of schemas) {
+        result.sql_schemas.push({
+          connection_name: connectionName,
+          sql: schema.sql,
+          schema: schema.schema,
+        });
+      }
+    }
+  }
+  return result;
+}
+
+export interface CompilerNeedFetch {
+  connections: LookupConnection<InfoConnection>;
+  urls: URLReader;
+  cacheManager?: CacheManager;
+}
 
 export async function compileModel(
-  request: Malloy.CompileModelRequest
+  request: Malloy.CompileModelRequest,
+  fetchers: CompilerNeedFetch
 ): Promise<Malloy.CompileModelResponse> {
-  return Core.compileModel(request);
+  const state = Core.newCompileModelState(request);
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const result = Core.statedCompileModel(state);
+    if (result.model) {
+      return result;
+    }
+    const needs = await fetchNeeds(result.compiler_needs, fetchers);
+    Core.updateCompileModelState(state, needs);
+  }
 }
 
 export async function compileSource(

--- a/packages/malloy/src/api/connection.ts
+++ b/packages/malloy/src/api/connection.ts
@@ -14,7 +14,7 @@ export interface InfoConnection {
 }
 
 export interface Connection extends InfoConnection {
-  runSQL(sql: string): Promise<Malloy.Result>;
+  runSQL(sql: string): Promise<Malloy.Data>;
 }
 
 export interface LookupConnection<T extends InfoConnection> {

--- a/packages/malloy/src/api/connection.ts
+++ b/packages/malloy/src/api/connection.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import * as Malloy from '@malloydata/malloy-interfaces';
+
+export interface InfoConnection {
+  fetchSchemaForTable(name: string): Promise<Malloy.Schema>;
+  fetchSchemaForSQLQuery(sqlQuery: string): Promise<Malloy.Schema>;
+  get dialectName(): string;
+}
+
+export interface Connection extends InfoConnection {
+  runSQL(sql: string): Promise<Malloy.Result>;
+}
+
+export interface LookupConnection<T extends InfoConnection> {
+  lookupConnection(connectionName?: string): Promise<T>;
+}

--- a/packages/malloy/src/api/core.ts
+++ b/packages/malloy/src/api/core.ts
@@ -386,7 +386,7 @@ export function _statedCompileModel(state: CompileModelState): CompileResponse {
   }
 }
 
-const DEFAULT_LOG_RANGE: Malloy.DocumentRange = {
+export const DEFAULT_LOG_RANGE: Malloy.DocumentRange = {
   start: {
     line: 0,
     character: 0,
@@ -530,6 +530,7 @@ export function statedCompileQuery(
         result: {
           sql: translatedQuery.sql,
           schema,
+          connection_name: translatedQuery.connectionName,
         },
       };
     } catch (error) {

--- a/packages/malloy/src/api/index.ts
+++ b/packages/malloy/src/api/index.ts
@@ -4,4 +4,5 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-export * from './api';
+export * as sessioned from './sessioned';
+export * as stateless from './stateless';

--- a/packages/malloy/src/api/index.ts
+++ b/packages/malloy/src/api/index.ts
@@ -6,3 +6,4 @@
  */
 export * as sessioned from './sessioned';
 export * as stateless from './stateless';
+export * as asynchronous from './asynchronous';

--- a/packages/malloy/src/api/index.ts
+++ b/packages/malloy/src/api/index.ts
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+export * from './api';

--- a/packages/malloy/src/api/sessioned.spec.ts
+++ b/packages/malloy/src/api/sessioned.spec.ts
@@ -23,6 +23,7 @@ describe('api', () => {
           ],
         },
       };
+      expect(result).toMatchObject(expected);
       result = compileModel({
         model_url: 'file://test.malloy',
         compiler_needs: {

--- a/packages/malloy/src/api/sessioned.spec.ts
+++ b/packages/malloy/src/api/sessioned.spec.ts
@@ -235,6 +235,7 @@ describe('api', () => {
       });
       expected = {
         result: {
+          connection_name: 'connection',
           sql: `SELECT \n\
    base."carrier" as "carrier"
 FROM flights as base

--- a/packages/malloy/src/api/sessioned.spec.ts
+++ b/packages/malloy/src/api/sessioned.spec.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {compileModel} from './sessioned';
+import * as Malloy from '@malloydata/malloy-interfaces';
+
+describe('api', () => {
+  describe('compile model', () => {
+    test('compile model with table dependency', () => {
+      let result = compileModel({
+        model_url: 'file://test.malloy',
+      });
+      let expected: Malloy.CompileModelResponse = {
+        compiler_needs: {
+          files: [
+            {
+              url: 'file://test.malloy',
+            },
+          ],
+        },
+      };
+      result = compileModel({
+        model_url: 'file://test.malloy',
+        compiler_needs: {
+          files: [
+            {
+              url: 'file://test.malloy',
+              contents: "source: flights is connection.table('flights')",
+            },
+          ],
+        },
+      });
+      expected = {
+        compiler_needs: {
+          table_schemas: [
+            {
+              connection_name: 'connection',
+              name: 'flights',
+            },
+          ],
+          connections: [{name: 'connection'}],
+        },
+      };
+      expect(result).toMatchObject(expected);
+      result = compileModel({
+        model_url: 'file://test.malloy',
+        compiler_needs: {
+          table_schemas: [
+            {
+              connection_name: 'connection',
+              name: 'flights',
+              schema: {
+                fields: [
+                  {
+                    kind: 'dimension',
+                    name: 'carrier',
+                    type: {kind: 'string_type'},
+                  },
+                ],
+              },
+            },
+          ],
+          connections: [{name: 'connection', dialect: 'duckdb'}],
+        },
+      });
+      expected = {
+        model: {
+          entries: [
+            {
+              kind: 'source',
+              name: 'flights',
+              schema: {
+                fields: [
+                  {
+                    kind: 'dimension',
+                    name: 'carrier',
+                    type: {kind: 'string_type'},
+                  },
+                ],
+              },
+            },
+          ],
+          anonymous_queries: [],
+        },
+      };
+      expect(result).toMatchObject(expected);
+    });
+  });
+});

--- a/packages/malloy/src/api/sessioned.ts
+++ b/packages/malloy/src/api/sessioned.ts
@@ -167,6 +167,10 @@ class SessionManager {
     );
   }
 
+  public hasErrors(log: Malloy.LogMessage[] | undefined) {
+    return log?.some(m => m.severity === 'error') ?? false;
+  }
+
   public compileModel(
     request: Malloy.CompileModelRequest,
     options?: OptionsBase
@@ -184,7 +188,7 @@ class SessionManager {
       this.sessions.push(session);
     }
     const result = Core.statedCompileModel(session.state);
-    if (result.model) {
+    if (result.model || this.hasErrors(result.logs)) {
       this.killSession(sessionInfo);
     }
     return result;
@@ -217,7 +221,7 @@ class SessionManager {
       this.sessions.push(session);
     }
     const result = Core.statedCompileSource(session.state, request.name);
-    if (result.source) {
+    if (result.source || this.hasErrors(result.logs)) {
       this.killSession(sessionInfo);
     }
     return result;
@@ -251,7 +255,7 @@ class SessionManager {
       this.sessions.push(session);
     }
     const result = Core.statedCompileQuery(session.state);
-    if (result.result) {
+    if (result.result || this.hasErrors(result.logs)) {
       this.killSession(sessionInfo);
     }
     return result;

--- a/packages/malloy/src/api/sessioned.ts
+++ b/packages/malloy/src/api/sessioned.ts
@@ -173,6 +173,12 @@ class SessionManager {
     }
   }
 
+  private killSession(sessionInfo: SessionInfo) {
+    this.sessions = this.sessions.filter(
+      s => !sessionInfosMatch(s.sessionInfo, sessionInfo)
+    );
+  }
+
   public compileModel(
     request: Malloy.CompileModelRequest,
     options?: OptionsBase
@@ -193,7 +199,11 @@ class SessionManager {
       );
       this.sessions.push(session);
     }
-    return Core.statedCompileModel(session.state);
+    const result = Core.statedCompileModel(session.state);
+    if (result.model) {
+      this.killSession(sessionInfo);
+    }
+    return result;
   }
 
   private findCompileSourceSession(
@@ -226,7 +236,11 @@ class SessionManager {
       );
       this.sessions.push(session);
     }
-    return Core.statedCompileSource(session.state, request.name);
+    const result = Core.statedCompileSource(session.state, request.name);
+    if (result.source) {
+      this.killSession(sessionInfo);
+    }
+    return result;
   }
 
   private findCompileQuerySession(
@@ -260,7 +274,11 @@ class SessionManager {
       );
       this.sessions.push(session);
     }
-    return Core.statedCompileQuery(session.state);
+    const result = Core.statedCompileQuery(session.state);
+    if (result.result) {
+      this.killSession(sessionInfo);
+    }
+    return result;
   }
 }
 

--- a/packages/malloy/src/api/sessioned.ts
+++ b/packages/malloy/src/api/sessioned.ts
@@ -108,16 +108,12 @@ class SessionManager {
   }
 
   private newCompileModelSession(
+    request: Malloy.CompileModelRequest,
     sessionInfo: SessionInfoForCompileModel,
-    compilerNeeds?: Malloy.CompilerNeeds,
     options?: OptionsBase
   ): SessionStateForCompileModel {
     const expires = options?.ttl ? this.getExpires(options.ttl) : undefined;
-    const state = Core.newCompileModelState(
-      sessionInfo.modelURL,
-      compilerNeeds,
-      undefined
-    );
+    const state = Core.newCompileModelState(request);
     return {
       type: 'compile_model',
       sessionInfo,
@@ -127,16 +123,12 @@ class SessionManager {
   }
 
   private newCompileSourceSession(
+    request: Malloy.CompileSourceRequest,
     sessionInfo: SessionInfoForCompileSource,
-    compilerNeeds?: Malloy.CompilerNeeds,
     options?: OptionsBase
   ): SessionStateForCompileSource {
     const expires = options?.ttl ? this.getExpires(options.ttl) : undefined;
-    const state = Core.newCompileModelState(
-      sessionInfo.modelURL,
-      compilerNeeds,
-      undefined
-    );
+    const state = Core.newCompileSourceState(request);
     return {
       type: 'compile_source',
       sessionInfo,
@@ -146,16 +138,12 @@ class SessionManager {
   }
 
   private newCompileQuerySession(
+    request: Malloy.CompileQueryRequest,
     sessionInfo: SessionInfoForCompileQuery,
-    compilerNeeds?: Malloy.CompilerNeeds,
     options?: OptionsBase
   ): SessionStateForCompileQuery {
     const expires = options?.ttl ? this.getExpires(options.ttl) : undefined;
-    const state = Core.newCompileQueryState(
-      sessionInfo.query,
-      sessionInfo.modelURL,
-      compilerNeeds
-    );
+    const state = Core.newCompileQueryState(request);
     return {
       type: 'compile_query',
       sessionInfo,
@@ -192,11 +180,7 @@ class SessionManager {
     if (session) {
       Core.updateCompileModelState(session.state, request.compiler_needs);
     } else {
-      session = this.newCompileModelSession(
-        sessionInfo,
-        request.compiler_needs,
-        options
-      );
+      session = this.newCompileModelSession(request, sessionInfo, options);
       this.sessions.push(session);
     }
     const result = Core.statedCompileModel(session.state);
@@ -229,11 +213,7 @@ class SessionManager {
     if (session) {
       Core.updateCompileModelState(session.state, request.compiler_needs);
     } else {
-      session = this.newCompileSourceSession(
-        sessionInfo,
-        request.compiler_needs,
-        options
-      );
+      session = this.newCompileSourceSession(request, sessionInfo, options);
       this.sessions.push(session);
     }
     const result = Core.statedCompileSource(session.state, request.name);
@@ -267,11 +247,7 @@ class SessionManager {
     if (session) {
       Core.updateCompileModelState(session.state, request.compiler_needs);
     } else {
-      session = this.newCompileQuerySession(
-        sessionInfo,
-        request.compiler_needs,
-        options
-      );
+      session = this.newCompileQuerySession(request, sessionInfo, options);
       this.sessions.push(session);
     }
     const result = Core.statedCompileQuery(session.state);

--- a/packages/malloy/src/api/sessioned.ts
+++ b/packages/malloy/src/api/sessioned.ts
@@ -1,0 +1,216 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import * as Malloy from '@malloydata/malloy-interfaces';
+import * as Core from './core';
+
+interface SessionInfoForCompileModel {
+  type: 'compile_model';
+  modelURL: string;
+}
+
+interface SessionInfoForCompileSource {
+  type: 'compile_source';
+  modelURL: string;
+  name: string;
+}
+
+interface SessionInfoForCompileQuery {
+  type: 'compile_query';
+  modelURL: string;
+  query: string;
+}
+
+type SessionInfo =
+  | SessionInfoForCompileModel
+  | SessionInfoForCompileSource
+  | SessionInfoForCompileQuery;
+
+type SessionState =
+  | SessionStateForCompileModel
+  | SessionStateForCompileSource
+  | SessionStateForCompileQuery;
+
+interface SessionStateBase {
+  expires?: Date;
+}
+
+interface SessionStateForCompileModel extends SessionStateBase {
+  type: 'compile_model';
+  sessionInfo: SessionInfoForCompileModel;
+  state: Core.CompileModelState;
+}
+
+interface SessionStateForCompileSource extends SessionStateBase {
+  type: 'compile_source';
+  sessionInfo: SessionInfoForCompileSource;
+}
+
+interface SessionStateForCompileQuery extends SessionStateBase {
+  type: 'compile_query';
+  sessionInfo: SessionInfoForCompileQuery;
+}
+
+function sessionInfosMatch(a: SessionInfo, b: SessionInfo) {
+  if (a.type === 'compile_model') {
+    if (b.type !== 'compile_model') return false;
+    return a.modelURL === b.modelURL;
+  } else if (a.type === 'compile_source') {
+    if (b.type !== 'compile_source') return false;
+    return a.modelURL === b.modelURL && a.name === b.name;
+  } else {
+    if (b.type !== 'compile_query') return false;
+    return a.modelURL === b.modelURL && a.query === b.query;
+  }
+}
+
+class SessionManager {
+  private sessions: SessionState[] = [];
+
+  private purgeExpired(except?: SessionInfo) {
+    const now = new Date();
+    this.sessions = this.sessions.filter(
+      s =>
+        (except && sessionInfosMatch(s.sessionInfo, except)) ||
+        s.expires === undefined ||
+        s.expires > now
+    );
+  }
+
+  findSession(sessionInfo: SessionInfo) {
+    const session = this.sessions.find(s =>
+      sessionInfosMatch(s.sessionInfo, sessionInfo)
+    );
+    this.purgeExpired(sessionInfo);
+    return session;
+  }
+
+  private getExpires(ttl: TTL): Date {
+    if (ttl instanceof Date) {
+      return ttl;
+    } else {
+      // TODO is this how you do this?
+      return new Date(Date.now() + ttl.seconds * 1000);
+    }
+  }
+
+  newCompileModelSession(
+    sessionInfo: SessionInfoForCompileModel,
+    compilerNeeds?: Malloy.CompilerNeeds,
+    options?: OptionsBase
+  ): SessionStateForCompileModel {
+    const expires = options?.ttl ? this.getExpires(options.ttl) : undefined;
+    const state = Core.newCompileModelState(
+      sessionInfo.modelURL,
+      compilerNeeds,
+      undefined
+    );
+    return {
+      type: 'compile_model',
+      sessionInfo,
+      state,
+      expires,
+    };
+  }
+
+  newCompileSourceSession(
+    _sessionInfo: SessionInfoForCompileSource
+  ): SessionStateForCompileSource {
+    throw new Error('Method not implemented.');
+  }
+
+  newCompileQuerySession(
+    _sessionInfo: SessionInfoForCompileQuery
+  ): SessionStateForCompileQuery {
+    throw new Error('Method not implemented.');
+  }
+
+  private findCompileModelSession(
+    sessionInfo: SessionInfoForCompileModel
+  ): SessionStateForCompileModel | undefined {
+    const session = this.findSession(sessionInfo);
+    if (session?.type === 'compile_model') {
+      return session;
+    }
+  }
+
+  compileModel(
+    request: Malloy.CompileModelRequest,
+    options?: OptionsBase
+  ): Malloy.CompileModelResponse {
+    const sessionInfo: SessionInfoForCompileModel = {
+      type: 'compile_model',
+      modelURL: request.model_url,
+    };
+    let session = this.findCompileModelSession(sessionInfo);
+    if (session) {
+      Core.updateCompileModelState(session.state, request.compiler_needs);
+    } else {
+      session = this.newCompileModelSession(
+        sessionInfo,
+        request.compiler_needs,
+        options
+      );
+      this.sessions.push(session);
+    }
+    return Core.statedCompileModel(session.state);
+  }
+
+  compileSource(
+    request: Malloy.CompileSourceRequest,
+    _options?: OptionsBase
+  ): Malloy.CompileSourceResponse {
+    const _sessionInfo = {
+      type: 'compile_source',
+      modelURL: request.model_url,
+      name: request.name,
+    };
+    throw new Error('Method not implemented.');
+  }
+
+  compileQuery(
+    request: Malloy.CompileQueryRequest,
+    _options?: OptionsBase
+  ): Malloy.CompileQueryResponse {
+    const query = Malloy.queryToMalloy(request.query);
+    const _sessionInfo = {
+      type: 'compile_query',
+      modelURL: request.model_url,
+      query,
+    };
+    throw new Error('Method not implemented.');
+  }
+}
+
+const SESSION_MANAGER = new SessionManager();
+
+export type TTL = {'seconds': number} | Date;
+
+export interface OptionsBase {
+  ttl?: TTL;
+}
+
+export function compileModel(
+  request: Malloy.CompileModelRequest,
+  options?: OptionsBase
+): Malloy.CompileModelResponse {
+  return SESSION_MANAGER.compileModel(request, options);
+}
+
+export function compileSource(
+  request: Malloy.CompileSourceRequest,
+  options?: OptionsBase
+): Malloy.CompileSourceResponse {
+  return SESSION_MANAGER.compileSource(request, options);
+}
+
+export function compileQuery(
+  request: Malloy.CompileQueryRequest,
+  options?: OptionsBase
+): Malloy.CompileQueryResponse {
+  return SESSION_MANAGER.compileQuery(request, options);
+}

--- a/packages/malloy/src/api/stateless.spec.ts
+++ b/packages/malloy/src/api/stateless.spec.ts
@@ -314,6 +314,7 @@ describe('api', () => {
       });
       const expected: Malloy.CompileQueryResponse = {
         result: {
+          connection_name: 'connection',
           sql: `SELECT \n\
    base."carrier" as "carrier"
 FROM flights as base

--- a/packages/malloy/src/api/stateless.spec.ts
+++ b/packages/malloy/src/api/stateless.spec.ts
@@ -60,6 +60,74 @@ describe('api', () => {
       };
       expect(result).toMatchObject(expected);
     });
+    test('compile model with model extension', () => {
+      const result = compileModel({
+        model_url: 'file://test.malloy',
+        extend_model_url: 'file://base.malloy',
+        compiler_needs: {
+          table_schemas: [
+            {
+              connection_name: 'connection',
+              name: 'flights',
+              schema: {
+                fields: [
+                  {
+                    kind: 'dimension',
+                    name: 'carrier',
+                    type: {kind: 'string_type'},
+                  },
+                ],
+              },
+            },
+          ],
+          files: [
+            {
+              url: 'file://base.malloy',
+              contents: "source: flights_base is connection.table('flights')",
+            },
+            {
+              url: 'file://test.malloy',
+              contents: 'source: flights is flights_base',
+            },
+          ],
+          connections: [{name: 'connection', dialect: 'duckdb'}],
+        },
+      });
+      const expected: Malloy.CompileModelResponse = {
+        model: {
+          entries: [
+            {
+              kind: 'source',
+              name: 'flights_base',
+              schema: {
+                fields: [
+                  {
+                    kind: 'dimension',
+                    name: 'carrier',
+                    type: {kind: 'string_type'},
+                  },
+                ],
+              },
+            },
+            {
+              kind: 'source',
+              name: 'flights',
+              schema: {
+                fields: [
+                  {
+                    kind: 'dimension',
+                    name: 'carrier',
+                    type: {kind: 'string_type'},
+                  },
+                ],
+              },
+            },
+          ],
+          anonymous_queries: [],
+        },
+      };
+      expect(result).toMatchObject(expected);
+    });
     test('compile model with sql dependency', () => {
       const result = compileModel({
         model_url: 'file://test.malloy',

--- a/packages/malloy/src/api/stateless.spec.ts
+++ b/packages/malloy/src/api/stateless.spec.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {compileModel, compileQuery} from './api';
+import {compileModel, compileQuery} from './stateless';
 import * as Malloy from '@malloydata/malloy-interfaces';
 
 describe('api', () => {

--- a/packages/malloy/src/api/stateless.ts
+++ b/packages/malloy/src/api/stateless.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import * as Malloy from '@malloydata/malloy-interfaces';
+import * as Core from './core';
+
+export function compileModel(
+  request: Malloy.CompileModelRequest
+): Malloy.CompileModelResponse {
+  return Core.compileModel(request);
+}
+
+export function compileSource(
+  request: Malloy.CompileSourceRequest
+): Malloy.CompileSourceResponse {
+  return Core.compileSource(request);
+}
+
+export function compileQuery(
+  request: Malloy.CompileQueryRequest
+): Malloy.CompileQueryResponse {
+  return Core.compileQuery(request);
+}

--- a/packages/malloy/src/connection/base_connection.ts
+++ b/packages/malloy/src/connection/base_connection.ts
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import {SQLSourceRequest} from '../lang/translate-response';
 import {
   MalloyQueryData,
   QueryRunStats,
@@ -12,6 +13,7 @@ import {
   StructDef,
   TableSourceDef,
 } from '../model/malloy_types';
+import {sqlKey} from '../model/sql_block';
 import {RunSQLOptions} from '../run_sql_options';
 import {
   Connection,
@@ -54,7 +56,7 @@ export abstract class BaseConnection implements Connection {
   ): Promise<TableSourceDef | string>;
 
   abstract fetchSelectSchema(
-    sqlSource: SQLSourceDef
+    sqlSource: SQLSourceRequest
   ): Promise<SQLSourceDef | string>;
 
   protected schemaCache: Record<string, CachedSchema<StructDef>> = {};
@@ -121,14 +123,15 @@ export abstract class BaseConnection implements Connection {
   }
 
   public async fetchSchemaForSQLStruct(
-    sqlRef: SQLSourceDef,
+    sqlRef: SQLSourceRequest,
     {refreshTimestamp}: FetchSchemaOptions
   ): Promise<
     | {structDef: SQLSourceDef; error?: undefined}
     | {error: string; structDef?: undefined}
   > {
+    const key = sqlKey(sqlRef.connection, sqlRef.selectStr);
     const inCache = await this.checkSchemaCache<SQLSourceDef>(
-      sqlRef.name,
+      key,
       'sql_select',
       async () => await this.fetchSelectSchema(sqlRef),
       refreshTimestamp

--- a/packages/malloy/src/connection/types.ts
+++ b/packages/malloy/src/connection/types.ts
@@ -8,6 +8,7 @@ import {
   TableSourceDef,
 } from '../model/malloy_types';
 import {Dialect} from '../dialect';
+import {SQLSourceRequest} from '../lang/translate-response';
 
 /**
  * Options passed to fetchSchema methods.
@@ -48,7 +49,7 @@ export interface InfoConnection {
    */
 
   fetchSchemaForSQLStruct(
-    sentence: SQLSourceDef,
+    sentence: SQLSourceRequest,
     options: FetchSchemaOptions
   ): Promise<
     | {structDef: SQLSourceDef; error?: undefined}

--- a/packages/malloy/src/index.ts
+++ b/packages/malloy/src/index.ts
@@ -225,3 +225,5 @@ export {toAsyncGenerator} from './connection_utils';
 export {modelDefToModelInfo} from './to_stable';
 export {annotationToTag} from './annotation';
 export * from './api';
+export type {SQLSourceRequest} from './lang/translate-response';
+export {sqlKey} from './model/sql_block';

--- a/packages/malloy/src/index.ts
+++ b/packages/malloy/src/index.ts
@@ -224,6 +224,6 @@ export type {
 export {toAsyncGenerator} from './connection_utils';
 export {modelDefToModelInfo} from './to_stable';
 export {annotationToTag} from './annotation';
-export * from './api';
+export * as API from './api';
 export type {SQLSourceRequest} from './lang/translate-response';
 export {sqlKey} from './model/sql_block';

--- a/packages/malloy/src/index.ts
+++ b/packages/malloy/src/index.ts
@@ -225,3 +225,4 @@ export type {
 export {toAsyncGenerator} from './connection_utils';
 export {modelDefToModelInfo} from './to_stable';
 export {annotationToTag} from './annotation';
+export * from './api';

--- a/packages/malloy/src/index.ts
+++ b/packages/malloy/src/index.ts
@@ -74,7 +74,6 @@ export type {
   Expr,
   // Needed for drills in render
   FilterCondition,
-  SQLSentence,
   // Used in Composer
   Argument,
   Parameter,

--- a/packages/malloy/src/lang/ast/source-elements/sql-source.ts
+++ b/packages/malloy/src/lang/ast/source-elements/sql-source.ts
@@ -27,7 +27,7 @@ import {
   SourceDef,
   SQLSourceDef,
 } from '../../../model/malloy_types';
-import {compileSQLSentence} from '../../../model/sql_block';
+import {compileSQLInterpolation} from '../../../model/sql_block';
 import {NeedCompileSQL} from '../../translate-response';
 import {Source} from './source';
 import {ErrorFactory} from '../error-factory';
@@ -45,11 +45,11 @@ export class SQLSource extends Source {
     super({connectionName, select});
   }
 
-  sqlSentence(doc: Document): SQLSourceDef {
+  sqlSource(doc: Document): SQLSourceDef {
     const partialModel = this.select.containsQueries
       ? doc.modelDef()
       : undefined;
-    return compileSQLSentence(
+    return compileSQLInterpolation(
       this.select.sqlPhrases(),
       this.connectionName.refString,
       partialModel
@@ -90,7 +90,7 @@ export class SQLSource extends Source {
     const childNeeds = super.needs(doc);
     if (childNeeds) return childNeeds;
     if (this.requestBlock === undefined) {
-      this.requestBlock = this.sqlSentence(doc);
+      this.requestBlock = this.sqlSource(doc);
     }
     const sql = this.requestBlock;
     const sqlDefEntry = this.translator()?.root.sqlQueryZone;

--- a/packages/malloy/src/lang/parse-malloy.ts
+++ b/packages/malloy/src/lang/parse-malloy.ts
@@ -904,7 +904,6 @@ export abstract class MalloyTranslation {
     if (ret?.compileSQL) {
       return {
         compileSQL: ret.compileSQL,
-        partialModel: ret.partialModel,
       };
     }
   }

--- a/packages/malloy/src/lang/test/locations.spec.ts
+++ b/packages/malloy/src/lang/test/locations.spec.ts
@@ -36,6 +36,7 @@ import {
 } from './test-translator';
 import './parse-expects';
 import {DocumentLocation, DocumentPosition} from '../../model/malloy_types';
+import {sqlKey} from '../../model/sql_block';
 
 describe('source locations', () => {
   test('renamed source location', () => {
@@ -144,7 +145,7 @@ describe('source locations', () => {
     expect(compileSql).toBeDefined();
     if (compileSql) {
       m.update({
-        compileSQL: {[compileSql.name]: getSelectOneStruct(compileSql)},
+        compileSQL: getSelectOneStruct(compileSql),
       });
       expect(m).toTranslate();
       const na = getExplore(m.modelDef, 'na');

--- a/packages/malloy/src/lang/test/locations.spec.ts
+++ b/packages/malloy/src/lang/test/locations.spec.ts
@@ -36,7 +36,6 @@ import {
 } from './test-translator';
 import './parse-expects';
 import {DocumentLocation, DocumentPosition} from '../../model/malloy_types';
-import {sqlKey} from '../../model/sql_block';
 
 describe('source locations', () => {
   test('renamed source location', () => {

--- a/packages/malloy/src/lang/test/parse-expects.ts
+++ b/packages/malloy/src/lang/test/parse-expects.ts
@@ -124,7 +124,7 @@ function prettyNeeds(response: TranslateResponse) {
     }
   }
   if (response.compileSQL) {
-    needString += `Compile SQL: ${response.compileSQL.name}`;
+    needString += `Compile SQL: ${response.compileSQL.selectStr}`;
   }
   if (response.urls) {
     needString += 'URLs:\n';

--- a/packages/malloy/src/lang/test/parse.spec.ts
+++ b/packages/malloy/src/lang/test/parse.spec.ts
@@ -32,6 +32,7 @@ import {
   warningMessage,
 } from './test-translator';
 import './parse-expects';
+import {sqlKey} from '../../model/sql_block';
 
 describe('model statements', () => {
   describe('table method', () => {
@@ -251,10 +252,14 @@ describe('error handling', () => {
     const needSchema = badTrans.translate();
     expect(needSchema.compileSQL).toBeDefined();
     if (needSchema.compileSQL) {
+      const key = sqlKey(
+        needSchema.compileSQL.connection,
+        needSchema.compileSQL.selectStr
+      );
       badTrans.update({
         errors: {
           compileSQL: {
-            [needSchema.compileSQL.name]: 'Nobody ZZZZ',
+            [key]: 'Nobody ZZZZ',
           },
         },
       });
@@ -304,7 +309,8 @@ describe('translation need error locations', () => {
     const req = m.translate().compileSQL;
     expect(req).toBeDefined();
     if (req) {
-      m.update({errors: {compileSQL: {[req.name]: 'Bad SQL!'}}});
+      const key = sqlKey(req.connection, req.selectStr);
+      m.update({errors: {compileSQL: {[key]: 'Bad SQL!'}}});
     }
     expect(m).not.toTranslate();
     const errList = m.problems();
@@ -568,7 +574,7 @@ describe('sql expressions', () => {
     expect(compileSql).toBeDefined();
     if (compileSql) {
       m.translator.update({
-        compileSQL: {[compileSql.name]: getSelectOneStruct(compileSql)},
+        compileSQL: getSelectOneStruct(compileSql),
       });
       expect(m).toTranslate();
     }
@@ -583,7 +589,7 @@ describe('sql expressions', () => {
     expect(compileSql).toBeDefined();
     if (compileSql) {
       m.translator.update({
-        compileSQL: {[compileSql.name]: getSelectOneStruct(compileSql)},
+        compileSQL: getSelectOneStruct(compileSql),
       });
       expect(m).toTranslate();
     }
@@ -598,7 +604,7 @@ describe('sql expressions', () => {
     expect(compileSql).toBeDefined();
     if (compileSql) {
       m.translator.update({
-        compileSQL: {[compileSql.name]: getSelectOneStruct(compileSql)},
+        compileSQL: getSelectOneStruct(compileSql),
       });
       expect(m).toTranslate();
     }
@@ -614,7 +620,7 @@ describe('sql expressions', () => {
     expect(compileSql).toBeDefined();
     if (compileSql) {
       m.translator.update({
-        compileSQL: {[compileSql.name]: getSelectOneStruct(compileSql)},
+        compileSQL: getSelectOneStruct(compileSql),
       });
       expect(m).toTranslate();
     }
@@ -629,7 +635,7 @@ describe('sql expressions', () => {
     expect(compileSql).toBeDefined();
     if (compileSql) {
       m.update({
-        compileSQL: {[compileSql.name]: getSelectOneStruct(compileSql)},
+        compileSQL: getSelectOneStruct(compileSql),
       });
       expect(m).toTranslate();
     }
@@ -644,7 +650,7 @@ describe('sql expressions', () => {
     expect(compileSql).toBeDefined();
     if (compileSql) {
       m.update({
-        compileSQL: {[compileSql.name]: getSelectOneStruct(compileSql)},
+        compileSQL: getSelectOneStruct(compileSql),
       });
       expect(m).toTranslate();
     }
@@ -659,7 +665,7 @@ describe('sql expressions', () => {
     expect(compileSql).toBeDefined();
     if (compileSql) {
       m.update({
-        compileSQL: {[compileSql.name]: getSelectOneStruct(compileSql)},
+        compileSQL: getSelectOneStruct(compileSql),
       });
       expect(m).toLog(errorMessage('Cannot add view refinements to a source'));
     }
@@ -677,7 +683,7 @@ describe('sql expressions', () => {
     expect(compileSql).toBeDefined();
     if (compileSql) {
       m.translator.update({
-        compileSQL: {[compileSql.name]: getSelectOneStruct(compileSql)},
+        compileSQL: getSelectOneStruct(compileSql),
       });
       expect(m).toTranslate();
     }
@@ -692,7 +698,7 @@ describe('sql expressions', () => {
     expect(compileSql).toBeDefined();
     if (compileSql) {
       m.update({
-        compileSQL: {[compileSql.name]: getSelectOneStruct(compileSql)},
+        compileSQL: getSelectOneStruct(compileSql),
       });
       expect(m).toTranslate();
     }
@@ -707,7 +713,7 @@ describe('sql expressions', () => {
     expect(compileSql).toBeDefined();
     if (compileSql) {
       m.update({
-        compileSQL: {[compileSql.name]: getSelectOneStruct(compileSql)},
+        compileSQL: getSelectOneStruct(compileSql),
       });
       expect(m).toTranslate();
     }
@@ -722,7 +728,7 @@ describe('sql expressions', () => {
     expect(compileSql).toBeDefined();
     if (compileSql) {
       m.update({
-        compileSQL: {[compileSql.name]: getSelectOneStruct(compileSql)},
+        compileSQL: getSelectOneStruct(compileSql),
       });
       expect(m).toTranslate();
     }
@@ -738,7 +744,7 @@ describe('sql expressions', () => {
     expect(compileSql).toBeDefined();
     if (compileSql) {
       m.update({
-        compileSQL: {[compileSql.name]: getSelectOneStruct(compileSql)},
+        compileSQL: getSelectOneStruct(compileSql),
       });
       expect(m).toLog(errorMessage('A raw query cannot be refined'));
     }
@@ -753,7 +759,7 @@ describe('sql expressions', () => {
     expect(compileSql).toBeDefined();
     if (compileSql) {
       m.update({
-        compileSQL: {[compileSql.name]: getSelectOneStruct(compileSql)},
+        compileSQL: getSelectOneStruct(compileSql),
       });
       expect(m).toLog(errorMessage('Cannot add view refinements to a source'));
     }

--- a/packages/malloy/src/lang/test/test-translator.ts
+++ b/packages/malloy/src/lang/test/test-translator.ts
@@ -46,12 +46,17 @@ import {ExpressionDef, MalloyElement} from '../ast';
 import {NameSpace} from '../ast/types/name-space';
 import {ModelEntry} from '../ast/types/model-entry';
 import {MalloyChildTranslator, MalloyTranslator} from '../parse-malloy';
-import {DataRequestResponse, TranslateResponse} from '../translate-response';
+import {
+  DataRequestResponse,
+  SQLSourceRequest,
+  TranslateResponse,
+} from '../translate-response';
 import {StaticSourceSpace} from '../ast/field-space/static-space';
 import {ExprValue} from '../ast/types/expr-value';
 import {GlobalNameSpace} from '../ast/types/global-name-space';
 import {LogSeverity, MessageCode, MessageParameterType} from '../parse-log';
 import {EventStream} from '../../runtime_types';
+import {sqlKey} from '../../model/sql_block';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any,@typescript-eslint/explicit-module-boundary-types
 export function pretty(thing: any): string {
@@ -628,14 +633,19 @@ export function markSource(
   return {code, locations};
 }
 
-export function getSelectOneStruct(sqlBlock: SQLSourceDef): SQLSourceDef {
+export function getSelectOneStruct(sqlBlock: SQLSourceRequest): {
+  [key: string]: SQLSourceDef;
+} {
+  const key = sqlKey(sqlBlock.connection, sqlBlock.selectStr);
   return {
-    type: 'sql_select',
-    name: sqlBlock.name,
-    dialect: 'standardsql',
-    connection: 'bigquery',
-    selectStr: sqlBlock.selectStr,
-    fields: [{type: 'number', name: 'one'}],
+    [key]: {
+      type: 'sql_select',
+      name: key,
+      dialect: 'standardsql',
+      connection: 'bigquery',
+      selectStr: sqlBlock.selectStr,
+      fields: [{type: 'number', name: 'one'}],
+    },
   };
 }
 

--- a/packages/malloy/src/lang/test/test-translator.ts
+++ b/packages/malloy/src/lang/test/test-translator.ts
@@ -630,17 +630,13 @@ export function markSource(
   return {code, locations};
 }
 
-export function getSelectOneStruct(sqlBlock: SQLSentence): SQLSourceDef {
-  const selectThis = sqlBlock.select[0];
-  if (!isSegmentSQL(selectThis)) {
-    throw new Error('weird test support error sorry');
-  }
+export function getSelectOneStruct(sqlBlock: SQLSourceDef): SQLSourceDef {
   return {
     type: 'sql_select',
     name: sqlBlock.name,
     dialect: 'standardsql',
     connection: 'bigquery',
-    selectStr: selectThis.sql,
+    selectStr: sqlBlock.selectStr,
     fields: [{type: 'number', name: 'one'}],
   };
 }

--- a/packages/malloy/src/lang/test/test-translator.ts
+++ b/packages/malloy/src/lang/test/test-translator.ts
@@ -34,13 +34,11 @@ import {
   StructDef,
   TurtleDef,
   isQuerySegment,
-  isSegmentSQL,
   isSourceDef,
   SourceDef,
   JoinBase,
   TableSourceDef,
   SQLSourceDef,
-  SQLSentence,
   NumberTypeDef,
   mkArrayDef,
 } from '../../model/malloy_types';

--- a/packages/malloy/src/lang/translate-response.ts
+++ b/packages/malloy/src/lang/translate-response.ts
@@ -21,7 +21,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import {Annotation, ModelDef, SQLSentence} from '../model/malloy_types';
+import {Annotation, ModelDef, SQLSourceDef} from '../model/malloy_types';
 import {MalloyElement} from './ast';
 import {LogMessage} from './parse-log';
 import {DocumentSymbol} from './parse-tree-walkers/document-symbol-walker';
@@ -56,8 +56,7 @@ export interface NeedURLData {
 }
 
 export interface NeedCompileSQL {
-  compileSQL: SQLSentence;
-  partialModel: ModelDef | undefined;
+  compileSQL: SQLSourceDef;
 }
 interface NeededData extends NeedURLData, NeedSchemaData, NeedCompileSQL {}
 export type DataRequestResponse = Partial<NeededData> | null;

--- a/packages/malloy/src/lang/translate-response.ts
+++ b/packages/malloy/src/lang/translate-response.ts
@@ -21,7 +21,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import {Annotation, ModelDef, SQLSourceDef} from '../model/malloy_types';
+import {Annotation, ModelDef} from '../model/malloy_types';
 import {MalloyElement} from './ast';
 import {LogMessage} from './parse-log';
 import {DocumentSymbol} from './parse-tree-walkers/document-symbol-walker';
@@ -55,8 +55,13 @@ export interface NeedURLData {
   urls: string[];
 }
 
+export interface SQLSourceRequest {
+  connection: string;
+  selectStr: string;
+}
+
 export interface NeedCompileSQL {
-  compileSQL: SQLSourceDef;
+  compileSQL: SQLSourceRequest;
 }
 interface NeededData extends NeedURLData, NeedSchemaData, NeedCompileSQL {}
 export type DataRequestResponse = Partial<NeededData> | null;

--- a/packages/malloy/src/malloy.ts
+++ b/packages/malloy/src/malloy.ts
@@ -277,15 +277,12 @@ export class Malloy {
     refreshSchemaCache,
     noThrowOnError,
     eventStream,
-    replaceMaterializedReferences,
-    materializedTablePrefix,
     importBaseURL,
     cacheManager,
   }: {
     urlReader: URLReader;
     connections: LookupConnection<InfoConnection>;
     model?: Model;
-    replaceMaterializedReferences?: boolean;
     cacheManager?: CacheManager;
   } & Compilable &
     CompileOptions &
@@ -496,28 +493,18 @@ export class Malloy {
           const connectionName = toCompile.connection;
           try {
             const conn = await connections.lookupConnection(connectionName);
-            const expanded = Malloy.compileSQLBlock(
-              conn.dialectName,
-              result.partialModel,
-              toCompile,
-              {
-                replaceMaterializedReferences,
-                materializedTablePrefix,
-                eventStream,
-              }
-            );
-            const resolved = await conn.fetchSchemaForSQLStruct(expanded, {
+            const resolved = await conn.fetchSchemaForSQLStruct(toCompile, {
               refreshTimestamp,
               modelAnnotation,
             });
             if (resolved.error) {
               translator.update({
-                errors: {compileSQL: {[expanded.name]: resolved.error}},
+                errors: {compileSQL: {[toCompile.name]: resolved.error}},
               });
             }
             if (resolved.structDef) {
               translator.update({
-                compileSQL: {[expanded.name]: resolved.structDef},
+                compileSQL: {[toCompile.name]: resolved.structDef},
               });
             }
           } catch (error) {

--- a/packages/malloy/src/malloy.ts
+++ b/packages/malloy/src/malloy.ts
@@ -52,14 +52,12 @@ import {
   StructDef,
   TurtleDef,
   expressionIsCalculation,
-  isSegmentSQL,
   NativeUnsupportedFieldDef,
   QueryRunStats,
   ImportLocation,
   Annotation,
   NamedModelObject,
   QueryValue,
-  SQLSentence,
   SQLSourceDef,
   AtomicFieldDef,
   DateFieldDef,
@@ -536,52 +534,6 @@ export class Malloy {
       }
     }
     return ret;
-  }
-
-  static compileSQLBlock(
-    dialect: string,
-    partialModel: ModelDef | undefined,
-    toCompile: SQLSentence,
-    options?: CompileQueryOptions
-  ): SQLSourceDef {
-    let queryModel: QueryModel | undefined = undefined;
-    let selectStr = '';
-    let parenAlready = false;
-    for (const segment of toCompile.select) {
-      if (isSegmentSQL(segment)) {
-        selectStr += segment.sql;
-        parenAlready = segment.sql.match(/\(\s*$/) !== null;
-      } else {
-        // TODO catch exceptions and throw errors ...
-        if (!queryModel) {
-          if (!partialModel) {
-            throw new Error(
-              'Internal error: Partial model missing when compiling SQL block'
-            );
-          }
-          queryModel = new QueryModel(partialModel, options?.eventStream);
-        }
-        const compiledSql = queryModel.compileQuery(
-          segment,
-          {
-            ...options,
-            defaultRowLimit: undefined,
-          },
-          false
-        ).sql;
-        selectStr += parenAlready ? compiledSql : `(${compiledSql})`;
-        parenAlready = false;
-      }
-    }
-    const {name, connection} = toCompile;
-    return {
-      type: 'sql_select',
-      name,
-      connection,
-      dialect,
-      selectStr,
-      fields: [],
-    };
   }
 
   /**

--- a/packages/malloy/src/model/malloy_types.ts
+++ b/packages/malloy/src/model/malloy_types.ts
@@ -1120,11 +1120,6 @@ export interface CompositeSourceDef extends SourceDefBase {
  * Malloy has a kind of "strings" which is a list of segments. Each segment
  * is either a string, or a query, which is meant to be replaced
  * by the text of the query when the query is compiled to SQL.
- *
- * The data types for this are:
- *  SQLPhrase -- A phrase, used to make a sentence
- *  SQLSentence -- Used to request a schema from the connection
- *  SQLSelectSource -- Returned from a query, contains the scehma
  */
 export interface SQLStringSegment {
   sql: string;
@@ -1132,12 +1127,6 @@ export interface SQLStringSegment {
 export type SQLPhraseSegment = Query | SQLStringSegment;
 export function isSegmentSQL(f: SQLPhraseSegment): f is SQLStringSegment {
   return 'sql' in f;
-}
-
-export interface SQLSentence {
-  name: string;
-  connection: string;
-  select: SQLPhraseSegment[];
 }
 
 export interface SQLSourceDef extends SourceDefBase {

--- a/packages/malloy/src/model/sql_block.ts
+++ b/packages/malloy/src/model/sql_block.ts
@@ -21,20 +21,16 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+import {SQLSourceRequest} from '../lang/translate-response';
 import {QueryModel} from './malloy_query';
-import {
-  SQLPhraseSegment,
-  isSegmentSQL,
-  ModelDef,
-  SQLSourceDef,
-} from './malloy_types';
+import {SQLPhraseSegment, isSegmentSQL, ModelDef} from './malloy_types';
 import {generateHash} from './utils';
 
 export function compileSQLInterpolation(
   select: SQLPhraseSegment[],
   connection: string,
   partialModel: ModelDef | undefined
-): SQLSourceDef {
+): SQLSourceRequest {
   let queryModel: QueryModel | undefined = undefined;
   let selectStr = '';
   let parenAlready = false;
@@ -64,12 +60,8 @@ export function compileSQLInterpolation(
     }
   }
   return {
-    type: 'sql_select',
-    name: sqlKey(connection, selectStr),
     connection,
-    dialect: '~connection_failed_to_set_dialect~',
     selectStr,
-    fields: [],
   };
 }
 

--- a/packages/malloy/src/model/sql_block.ts
+++ b/packages/malloy/src/model/sql_block.ts
@@ -23,7 +23,6 @@
 
 import {QueryModel} from './malloy_query';
 import {
-  SQLSentence,
   SQLPhraseSegment,
   isSegmentSQL,
   ModelDef,
@@ -31,7 +30,7 @@ import {
 } from './malloy_types';
 import {generateHash} from './utils';
 
-export function compileSQLSentence(
+export function compileSQLInterpolation(
   select: SQLPhraseSegment[],
   connection: string,
   partialModel: ModelDef | undefined

--- a/packages/malloy/src/model/sql_block.ts
+++ b/packages/malloy/src/model/sql_block.ts
@@ -21,36 +21,59 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import {SQLSentence, SQLPhraseSegment, isSegmentSQL} from './malloy_types';
+import {QueryModel} from './malloy_query';
+import {
+  SQLSentence,
+  SQLPhraseSegment,
+  isSegmentSQL,
+  ModelDef,
+  SQLSourceDef,
+} from './malloy_types';
 import {generateHash} from './utils';
 
-/**
- * The factory for SQLSentences. Exists because the name is computed
- * from the components of the block and that name needs to be
- * unique, but predictable so that it can be used to cache schema fetches.
- */
-export function makeSQLSentence(
+export function compileSQLSentence(
   select: SQLPhraseSegment[],
-  connection: string
-): SQLSentence {
+  connection: string,
+  partialModel: ModelDef | undefined
+): SQLSourceDef {
+  let queryModel: QueryModel | undefined = undefined;
+  let selectStr = '';
+  let parenAlready = false;
+  for (const segment of select) {
+    if (isSegmentSQL(segment)) {
+      selectStr += segment.sql;
+      parenAlready = segment.sql.match(/\(\s*$/) !== null;
+    } else {
+      // TODO catch exceptions and throw errors ...
+      if (!queryModel) {
+        if (!partialModel) {
+          throw new Error(
+            'Internal error: Partial model missing when compiling SQL block'
+          );
+        }
+        queryModel = new QueryModel(partialModel);
+      }
+      const compiledSql = queryModel.compileQuery(
+        segment,
+        {
+          defaultRowLimit: undefined,
+        },
+        false
+      ).sql;
+      selectStr += parenAlready ? compiledSql : `(${compiledSql})`;
+      parenAlready = false;
+    }
+  }
   return {
-    name: `sql://${connection}/${nameFor(select)}`,
+    type: 'sql_select',
+    name: sqlKey(connection, selectStr),
     connection,
-    select,
+    dialect: '~no_dialect~',
+    selectStr,
+    fields: [],
   };
 }
 
-// This feels like wrongness on toast, before SQL contained a query we
-// could compute a stable hash from the select property to use to
-// indentify this piece of SQL. Now the actual SQL isn't known until
-// runtime and I am not certain what the right thing to do is, and
-// at this moment when I am still trying to imagine how this is all
-// going to work, I am using stringify(), but I suspect I will be back
-// here for later, and that the whole "how to determine the name of a query"
-// algorithm needs to change
-function nameFor(select: SQLPhraseSegment[]): string {
-  const phrases = select.map(el =>
-    isSegmentSQL(el) ? el.sql : JSON.stringify(el)
-  );
-  return generateHash(phrases.join(';'));
+export function sqlKey(connectionName: string, sql: string): string {
+  return `sql://${connectionName}/${generateHash(sql)}`;
 }

--- a/packages/malloy/src/model/sql_block.ts
+++ b/packages/malloy/src/model/sql_block.ts
@@ -67,7 +67,7 @@ export function compileSQLInterpolation(
     type: 'sql_select',
     name: sqlKey(connection, selectStr),
     connection,
-    dialect: '~no_dialect~',
+    dialect: '~connection_failed_to_set_dialect~',
     selectStr,
     fields: [],
   };

--- a/packages/malloy/src/to_stable.ts
+++ b/packages/malloy/src/to_stable.ts
@@ -51,6 +51,15 @@ export function modelDefToModelInfo(modelDef: ModelDef): Malloy.ModelInfo {
       modelInfo.entries.push(queryInfo);
     }
   }
+  for (const query of modelDef.queryList) {
+    const outputStruct = getResultStructDefForQuery(modelDef, query);
+    const queryInfo: Malloy.AnonymousQueryInfo = {
+      schema: {
+        fields: convertFieldInfos(outputStruct, outputStruct.fields),
+      },
+    };
+    modelInfo.anonymous_queries.push(queryInfo);
+  }
   return modelInfo;
 }
 

--- a/test/src/databases/all/compound-atomic.spec.ts
+++ b/test/src/databases/all/compound-atomic.spec.ts
@@ -14,7 +14,7 @@ import {
   ArrayTypeDef,
   FieldDef,
   Expr,
-  SQLSourceDef,
+  SQLSourceRequest,
 } from '@malloydata/malloy';
 
 const runtimes = new RuntimeList(databasesFromEnvironmentOr(allDatabases));
@@ -220,13 +220,9 @@ describe.each(runtimes.runtimeList)(
             kids: {values: [aOne, aTwo]},
           };
           const sql_aoa = runtime.dialect.sqlLiteralArray(aoa);
-          const asStruct: SQLSourceDef = {
-            name: 'select_with_aoa',
-            type: 'sql_select',
+          const asStruct: SQLSourceRequest = {
             connection: conName,
-            dialect: runtime.dialect.name,
             selectStr: `SELECT ${sql_aoa} AS aoa`,
-            fields: [],
           };
           const ret = await runtime.connection.fetchSchemaForSQLStruct(
             asStruct,

--- a/test/src/databases/all/sql_expressions.spec.ts
+++ b/test/src/databases/all/sql_expressions.spec.ts
@@ -29,8 +29,7 @@ import {databasesFromEnvironmentOr} from '../../util';
 import '../../util/db-jest-matchers';
 // No prebuilt shared model, each test is complete.  Makes debugging easier.
 
-const runtimes = new RuntimeList(databasesFromEnvironmentOr(['duckdb']));
-// const runtimes = new RuntimeList(databasesFromEnvironmentOr(allDatabases));
+const runtimes = new RuntimeList(databasesFromEnvironmentOr(allDatabases));
 
 afterAll(async () => {
   await runtimes.closeAll();

--- a/test/src/databases/all/sql_expressions.spec.ts
+++ b/test/src/databases/all/sql_expressions.spec.ts
@@ -29,7 +29,8 @@ import {databasesFromEnvironmentOr} from '../../util';
 import '../../util/db-jest-matchers';
 // No prebuilt shared model, each test is complete.  Makes debugging easier.
 
-const runtimes = new RuntimeList(databasesFromEnvironmentOr(allDatabases));
+const runtimes = new RuntimeList(databasesFromEnvironmentOr(['duckdb']));
+// const runtimes = new RuntimeList(databasesFromEnvironmentOr(allDatabases));
 
 afterAll(async () => {
   await runtimes.closeAll();


### PR DESCRIPTION
Adds the new official (though still not stable) API for interacting with Malloy.

There are three ways of using the API:
* Stateless
* Sessioned
* Asynchronous

The basic interface for all three is the same, but each has slightly different behavior.

Supported operations:

* `compileModel`: given a model URL and optionally the URL of a model to extend, compile the model into a `ModelInfo`
* `compileSource`: given a model URL, the name of a source in the model, and optionally the URL of a model to extend, compile the model and extract the `SourceInfo` for the given source name
* `compileQuery`: given a model URL and a `Query`, compile the query and return the SQL for the query, the name of the connection against which the query should be run, and the schema for the output of the query
* Asynchronous only
  * `runQuery`: same as `compileQuery`, but also runs the query and returns `Data`

## Stateless

Any file contents, table schemas, SQL schemas, and pre-compiled (cached) models must be passed in; no state is preserved. Will return `compiler_needs` that need to be filled in and passed in a subsequent request, if any information was missing in the initial request.

```ts
import { API } from "@malloydata/malloy"
const result = API.stateless.compileModel({
  model_url: 'file://test.malloy',
  compiler_needs: {
    table_schemas: [
      {
        connection_name: 'connection',
        name: 'flights',
        schema: {
          fields: [
            {
              kind: 'dimension',
              name: 'carrier',
              type: {kind: 'string_type'},
            },
          ],
        },
      },
    ],
    files: [
      {
        url: 'file://test.malloy',
        contents: "source: flights is connection.table('flights')",
      },
    ],
    connections: [{name: 'connection', dialect: 'duckdb'}],
  },
});
```

## Sessioned

Calling an API method creates a session for that call (if one does not exist). Subsequent calls will reuse the same session, allowing the underlying translation object to be preserved, allowing you to avoid having to pass back and forth the same objects as the compiler progressively learns what it needs from you.

A TTL (either a number of seconds or a date) may be provided on the call that starts a session. Sessions are killed a) when a final result (error or success) is returned for that session, or b) the TTL has expired and a different session is accessed.

```ts
import { API } from "@malloydata/malloy"
API.sessioned.compileModel({
  model_url: 'file://test.malloy',
}, {
  ttl: { seconds: 300 }
});
API.sessioned.compileModel({
  model_url: 'file://test.malloy',
  compiler_needs: {
    files: [
      {
        url: 'file://test.malloy',
        contents: "source: flights is connection.table('flights')",
      },
    ],
  },
});
const result = API.sessioned.compileModel({
  model_url: 'file://test.malloy',
  compiler_needs: {
    table_schemas: [
      {
        connection_name: 'connection',
        name: 'flights',
        schema: {
          fields: [
            {
              kind: 'dimension',
              name: 'carrier',
              type: {kind: 'string_type'},
            },
          ],
        },
      },
    ],
    connections: [{name: 'connection', dialect: 'duckdb'}],
  },
});
```

## Asynchronous

Any file contents, table schemas, SQL schemas, and pre-compiled (cached) models are retrieved from asynchronous fetchers which are passed in to the various functions.

```ts
import { API } from "@malloydata/malloy"
const connection: Connection = {
  dialectName: 'duckdb',
  fetchSchemaForTable: async (_name: string) => {
    return {
      fields: [
        {
          kind: 'dimension',
          name: 'carrier',
          type: {kind: 'string_type'},
        },
      ],
    };
  },
  fetchSchemaForSQLQuery: async (_sql: string) => {
    throw new Error('not implemented');
  },
  runSQL: async (_sql: string) => {
    return {
      kind: 'table',
      rows: [
        {
          cells: [{kind: 'string_cell', string_value: 'WN'}],
        },
        {
          cells: [{kind: 'string_cell', string_value: 'AA'}],
        },
      ],
    };
  },
};
const urls: URLReader = {
  readURL: async (_url: URL) => {
    return "source: flights is connection.table('flights')";
  },
};
const connections: LookupConnection<Connection> = {
  lookupConnection: async (_name: string) => {
    return connection;
  },
};
const fetchers = {
  urls,
  connections,
};
const result = await API.asynchronous.runQuery(
  {
    model_url: 'file://test.malloy',
    query: {
      definition: {
        kind: 'arrow',
        source_reference: {name: 'flights'},
        view: {
          kind: 'segment',
          operations: [
            {
              kind: 'group_by',
              field: {
                expression: {kind: 'field_reference', name: 'carrier'},
              },
            },
          ],
        },
      },
    },
  },
  fetchers
);
```

