### PR TITLE
Export annotationToTaglines

### DIFF
--- a/packages/malloy/src/index.ts
+++ b/packages/malloy/src/index.ts
@@ -224,4 +224,4 @@ export type {
 } from './connection/types';
 export {toAsyncGenerator} from './connection_utils';
 export {modelDefToModelInfo} from './to_stable';
-export {annotationToTag} from './annotation';
+export {annotationToTag, annotationToTaglines} from './annotation';


### PR DESCRIPTION
Used by the composer and extension for now.