### PR TITLE
Query builder bug fixes

### DIFF
--- a/packages/malloy-query-builder/README.md
+++ b/packages/malloy-query-builder/README.md
@@ -328,7 +328,7 @@ run: flights -> { aggregate: flight_count { where: carrier ~ f`WN, AA`} }
 {@link ASTSourceReference.setParameter}
 
 ```ts
-query.source.setParameter("param", 1);
+query.definition.asArrowQueryDefinition().sourceReference.parameters.setParameter("param", 1)
 ```
 ```
 run: flights(param is 1) ->
@@ -339,7 +339,7 @@ run: flights(param is 1) ->
 {@link ASTSourceReference.getSourceParameters}
 
 ```ts
-query.definition.asArrowQueryDefinition().source.getSourceParameters();
+query.definition.asArrowQueryDefinition().sourceReference.getSourceParameters();
 ```
 
 ## To a particular field in the query (including nests), add/edit/delete annotation


### PR DESCRIPTION
- Field references in `ASTOrderByViewOperation`s were resolving themselves in the segment input schema, when they should resolve themselves in the output schema
- Getting the output schema of an `ASTView` resulted in an infinite loop if it contained an `ASTRefinementViewDefinition`.
- Adds `ASTQuery.fieldWasCalculation(fieldInfo)` to determine whether an output field was a calculation (measure)