### PR TITLE
API: Handle race condition with multiple sessions compiling the same source/model/query

### DIFF
--- a/packages/malloy/src/api/sessioned.spec.ts
+++ b/packages/malloy/src/api/sessioned.spec.ts
@@ -14,7 +14,7 @@ describe('api', () => {
       let result = compileModel({
         model_url: 'file://test.malloy',
       });
-      let expected: Malloy.CompileModelResponse = {
+      let expected: Malloy.CompileModelResponse & {session_id?: string} = {
         compiler_needs: {
           files: [
             {
@@ -24,17 +24,20 @@ describe('api', () => {
         },
       };
       expect(result).toMatchObject(expected);
-      result = compileModel({
-        model_url: 'file://test.malloy',
-        compiler_needs: {
-          files: [
-            {
-              url: 'file://test.malloy',
-              contents: "source: flights is connection.table('flights')",
-            },
-          ],
+      result = compileModel(
+        {
+          model_url: 'file://test.malloy',
+          compiler_needs: {
+            files: [
+              {
+                url: 'file://test.malloy',
+                contents: "source: flights is connection.table('flights')",
+              },
+            ],
+          },
         },
-      });
+        {session_id: result.session_id}
+      );
       expected = {
         compiler_needs: {
           table_schemas: [
@@ -45,29 +48,33 @@ describe('api', () => {
           ],
           connections: [{name: 'connection'}],
         },
+        session_id: result.session_id,
       };
       expect(result).toMatchObject(expected);
-      result = compileModel({
-        model_url: 'file://test.malloy',
-        compiler_needs: {
-          table_schemas: [
-            {
-              connection_name: 'connection',
-              name: 'flights',
-              schema: {
-                fields: [
-                  {
-                    kind: 'dimension',
-                    name: 'carrier',
-                    type: {kind: 'string_type'},
-                  },
-                ],
+      result = compileModel(
+        {
+          model_url: 'file://test.malloy',
+          compiler_needs: {
+            table_schemas: [
+              {
+                connection_name: 'connection',
+                name: 'flights',
+                schema: {
+                  fields: [
+                    {
+                      kind: 'dimension',
+                      name: 'carrier',
+                      type: {kind: 'string_type'},
+                    },
+                  ],
+                },
               },
-            },
-          ],
-          connections: [{name: 'connection', dialect: 'duckdb'}],
+            ],
+            connections: [{name: 'connection', dialect: 'duckdb'}],
+          },
         },
-      });
+        {session_id: result.session_id}
+      );
       expected = {
         model: {
           entries: [
@@ -87,6 +94,7 @@ describe('api', () => {
           ],
           anonymous_queries: [],
         },
+        session_id: result.session_id,
       };
       expect(result).toMatchObject(expected);
     });
@@ -103,7 +111,7 @@ describe('api', () => {
           ],
         },
       });
-      let expected: Malloy.CompileSourceResponse = {
+      let expected: Malloy.CompileSourceResponse & {session_id?: string} = {
         compiler_needs: {
           table_schemas: [
             {
@@ -115,28 +123,31 @@ describe('api', () => {
         },
       };
       expect(result).toMatchObject(expected);
-      result = compileSource({
-        model_url: 'file://test.malloy',
-        name: 'flights',
-        compiler_needs: {
-          table_schemas: [
-            {
-              connection_name: 'connection',
-              name: 'flights',
-              schema: {
-                fields: [
-                  {
-                    kind: 'dimension',
-                    name: 'carrier',
-                    type: {kind: 'string_type'},
-                  },
-                ],
+      result = compileSource(
+        {
+          model_url: 'file://test.malloy',
+          name: 'flights',
+          compiler_needs: {
+            table_schemas: [
+              {
+                connection_name: 'connection',
+                name: 'flights',
+                schema: {
+                  fields: [
+                    {
+                      kind: 'dimension',
+                      name: 'carrier',
+                      type: {kind: 'string_type'},
+                    },
+                  ],
+                },
               },
-            },
-          ],
-          connections: [{name: 'connection', dialect: 'duckdb'}],
+            ],
+            connections: [{name: 'connection', dialect: 'duckdb'}],
+          },
         },
-      });
+        {session_id: result.session_id}
+      );
       expected = {
         source: {
           name: 'flights',
@@ -150,6 +161,7 @@ describe('api', () => {
             ],
           },
         },
+        session_id: result.session_id,
       };
       expect(result).toMatchObject(expected);
     });
@@ -177,7 +189,7 @@ describe('api', () => {
         model_url: 'file://test.malloy',
         query,
       });
-      let expected: Malloy.CompileQueryResponse = {
+      let expected: Malloy.CompileQueryResponse & {session_id?: string} = {
         compiler_needs: {
           files: [
             {
@@ -187,18 +199,21 @@ describe('api', () => {
         },
       };
       expect(result).toMatchObject(expected);
-      result = compileQuery({
-        model_url: 'file://test.malloy',
-        query,
-        compiler_needs: {
-          files: [
-            {
-              url: 'file://test.malloy',
-              contents: "source: flights is connection.table('flights')",
-            },
-          ],
+      result = compileQuery(
+        {
+          model_url: 'file://test.malloy',
+          query,
+          compiler_needs: {
+            files: [
+              {
+                url: 'file://test.malloy',
+                contents: "source: flights is connection.table('flights')",
+              },
+            ],
+          },
         },
-      });
+        {session_id: result.session_id}
+      );
       expected = {
         compiler_needs: {
           table_schemas: [
@@ -211,28 +226,31 @@ describe('api', () => {
         },
       };
       expect(result).toMatchObject(expected);
-      result = compileQuery({
-        model_url: 'file://test.malloy',
-        query,
-        compiler_needs: {
-          table_schemas: [
-            {
-              connection_name: 'connection',
-              name: 'flights',
-              schema: {
-                fields: [
-                  {
-                    kind: 'dimension',
-                    name: 'carrier',
-                    type: {kind: 'string_type'},
-                  },
-                ],
+      result = compileQuery(
+        {
+          model_url: 'file://test.malloy',
+          query,
+          compiler_needs: {
+            table_schemas: [
+              {
+                connection_name: 'connection',
+                name: 'flights',
+                schema: {
+                  fields: [
+                    {
+                      kind: 'dimension',
+                      name: 'carrier',
+                      type: {kind: 'string_type'},
+                    },
+                  ],
+                },
               },
-            },
-          ],
-          connections: [{name: 'connection', dialect: 'duckdb'}],
+            ],
+            connections: [{name: 'connection', dialect: 'duckdb'}],
+          },
         },
-      });
+        {session_id: result.session_id}
+      );
       expected = {
         result: {
           connection_name: 'connection',
@@ -252,6 +270,7 @@ ORDER BY 1 asc NULLS LAST
             ],
           },
         },
+        session_id: result.session_id,
       };
       expect(result).toMatchObject(expected);
     });
@@ -268,6 +287,7 @@ ORDER BY 1 asc NULLS LAST
             ttl: new Date(Date.now() - 1000),
           }
         );
+        const session_id = result.session_id;
         let expected: Malloy.CompileModelResponse = {
           compiler_needs: {
             files: [
@@ -281,9 +301,7 @@ ORDER BY 1 asc NULLS LAST
         compileModel({
           model_url: 'file://some_other_model.malloy',
         });
-        result = compileModel({
-          model_url: 'file://test.malloy',
-        });
+        result = compileModel({model_url: 'file://test.malloy'}, {session_id});
         expected = {
           compiler_needs: {
             files: [
@@ -294,6 +312,8 @@ ORDER BY 1 asc NULLS LAST
           },
         };
         expect(result).toMatchObject(expected);
+        // New session
+        expect(result.session_id).not.toBe(session_id);
       });
     });
     test('getting an error should kill session', () => {
@@ -338,10 +358,9 @@ ORDER BY 1 asc NULLS LAST
           },
         ],
       };
+      const session_id = result.session_id;
       expect(result).toMatchObject(expected);
-      result = compileModel({
-        model_url: 'file://test.malloy',
-      });
+      result = compileModel({model_url: 'file://test.malloy'}, {session_id});
       expected = {
         compiler_needs: {
           files: [
@@ -352,6 +371,8 @@ ORDER BY 1 asc NULLS LAST
         },
       };
       expect(result).toMatchObject(expected);
+      // Should be a new session
+      expect(result.session_id).not.toBe(session_id);
     });
     test('sessions should be cleared when they successfully return a result', () => {
       let result = compileModel({
@@ -401,10 +422,9 @@ ORDER BY 1 asc NULLS LAST
           anonymous_queries: [],
         },
       };
+      const session_id = result.session_id;
       expect(result).toMatchObject(expected);
-      result = compileModel({
-        model_url: 'file://test.malloy',
-      });
+      result = compileModel({model_url: 'file://test.malloy'}, {session_id});
       // Compiler should not know the contents of this file anymore because the session was cleared
       expected = {
         compiler_needs: {
@@ -416,6 +436,7 @@ ORDER BY 1 asc NULLS LAST
         },
       };
       expect(result).toMatchObject(expected);
+      expect(result.session_id).not.toBe(session_id);
     });
   });
 });

--- a/packages/malloy/src/api/sessioned.ts
+++ b/packages/malloy/src/api/sessioned.ts
@@ -196,6 +196,9 @@ class SessionManager {
       this.findCompileModelSession(options.session_id, sessionInfo);
     this.purgeExpired({except: options?.session_id});
     if (session) {
+      if (options?.ttl) {
+        session.expires = this.getExpires(options.ttl);
+      }
       Core.updateCompileModelState(session.state, request.compiler_needs);
     } else {
       session = this.newCompileModelSession(request, sessionInfo, options);
@@ -233,6 +236,9 @@ class SessionManager {
       this.findCompileSourceSession(options.session_id, sessionInfo);
     this.purgeExpired({except: options?.session_id});
     if (session) {
+      if (options?.ttl) {
+        session.expires = this.getExpires(options.ttl);
+      }
       Core.updateCompileModelState(session.state, request.compiler_needs);
     } else {
       session = this.newCompileSourceSession(request, sessionInfo, options);
@@ -271,6 +277,9 @@ class SessionManager {
       this.findCompileQuerySession(options.session_id, sessionInfo);
     this.purgeExpired({except: options?.session_id});
     if (session) {
+      if (options?.ttl) {
+        session.expires = this.getExpires(options.ttl);
+      }
       Core.updateCompileModelState(session.state, request.compiler_needs);
     } else {
       session = this.newCompileQuerySession(request, sessionInfo, options);


### PR DESCRIPTION
I feel pretty silly for overlooking this... 

If two clients tried to compile the same model, they would share the same session and stomp on each other.

So now the methods all accept a `session_id` parameter. This is required to reuse a session. In the first call, don't pass a `session_id` (or if you do and it doesn't correspond to a session, it will be ignored). The first response (and all subsequent responses) will have a `session_id` that you can use to keep the session state.

---

Also changed: `ttl` in subsequent requests is no longer ignored, and will cause the expiry date to update. This allows TTL to be used like a "maximum allowed time between requests" feature by always passing e.g. `{ seconds: 5 }`.