### PR TITLE
add extra fields to the trino connector

### DIFF
--- a/packages/malloy-db-trino/src/trino_connection.ts
+++ b/packages/malloy-db-trino/src/trino_connection.ts
@@ -56,7 +56,7 @@ import {
   PrestoQuery,
 } from '@prestodb/presto-js-client';
 import {randomUUID} from 'crypto';
-import {Trino, type ConnectionOptions, BasicAuth} from 'trino-client';
+import {Trino, ConnectionOptions, BasicAuth} from 'trino-client';
 
 export interface TrinoManagerOptions {
   credentials?: {
@@ -75,7 +75,9 @@ export interface TrinoConnectionConfiguration {
   schema?: string;
   user?: string;
   password?: string;
-  extraConfig?: Partial<Omit<ConnectionOptions, keyof TrinoConnectionConfiguration>>;
+  extraConfig?: Partial<
+    Omit<ConnectionOptions, keyof TrinoConnectionConfiguration>
+  >;
 }
 
 export type TrinoConnectionOptions = ConnectionConfig;

--- a/packages/malloy-db-trino/src/trino_connection.ts
+++ b/packages/malloy-db-trino/src/trino_connection.ts
@@ -56,7 +56,7 @@ import {
   PrestoQuery,
 } from '@prestodb/presto-js-client';
 import {randomUUID} from 'crypto';
-import {Trino, BasicAuth} from 'trino-client';
+import {Trino, type ConnectionOptions, BasicAuth} from 'trino-client';
 
 export interface TrinoManagerOptions {
   credentials?: {
@@ -75,7 +75,7 @@ export interface TrinoConnectionConfiguration {
   schema?: string;
   user?: string;
   password?: string;
-  extraConfig?: any;
+  extraConfig?: Omit<ConnectionOptions, keyof TrinoConnectionConfiguration>;
 }
 
 export type TrinoConnectionOptions = ConnectionConfig;
@@ -143,11 +143,11 @@ class TrinoRunner implements BaseRunner {
   client: Trino;
   constructor(config: TrinoConnectionConfiguration) {
     this.client = Trino.create({
+      ...config.extraConfig,
       catalog: config.catalog,
       server: config.server,
       schema: config.schema,
       auth: new BasicAuth(config.user!, config.password || ''),
-      ...config.extraConfig,
     });
   }
   async runSQL(

--- a/packages/malloy-db-trino/src/trino_connection.ts
+++ b/packages/malloy-db-trino/src/trino_connection.ts
@@ -75,7 +75,7 @@ export interface TrinoConnectionConfiguration {
   schema?: string;
   user?: string;
   password?: string;
-  extraConfig?: Omit<ConnectionOptions, keyof TrinoConnectionConfiguration>;
+  extraConfig?: Partial<Omit<ConnectionOptions, keyof TrinoConnectionConfiguration>>;
 }
 
 export type TrinoConnectionOptions = ConnectionConfig;

--- a/packages/malloy-db-trino/src/trino_connection.ts
+++ b/packages/malloy-db-trino/src/trino_connection.ts
@@ -75,8 +75,7 @@ export interface TrinoConnectionConfiguration {
   schema?: string;
   user?: string;
   password?: string;
-  extraConfig?: any;;
-
+  extraConfig?: any;
 }
 
 export type TrinoConnectionOptions = ConnectionConfig;

--- a/packages/malloy-db-trino/src/trino_connection.ts
+++ b/packages/malloy-db-trino/src/trino_connection.ts
@@ -75,6 +75,7 @@ export interface TrinoConnectionConfiguration {
   schema?: string;
   user?: string;
   password?: string;
+  extraConfig?: any;
 }
 
 export type TrinoConnectionOptions = ConnectionConfig;
@@ -146,6 +147,7 @@ class TrinoRunner implements BaseRunner {
       server: config.server,
       schema: config.schema,
       auth: new BasicAuth(config.user!, config.password || ''),
+      ...config.extraConfig,
     });
   }
   async runSQL(

--- a/packages/malloy-db-trino/src/trino_connection.ts
+++ b/packages/malloy-db-trino/src/trino_connection.ts
@@ -75,7 +75,8 @@ export interface TrinoConnectionConfiguration {
   schema?: string;
   user?: string;
   password?: string;
-  extraConfig?: any;
+  extraConfig?: any;;
+
 }
 
 export type TrinoConnectionOptions = ConnectionConfig;


### PR DESCRIPTION
Add extra field to Trino connector for passing extra values

This field allows us to pass extra values like extraHeaders, SSL, and can support additional fields in the future.