### PR TITLE
Implement parser for Malloy.Query

### DIFF
--- a/packages/malloy-interfaces/src/index.ts
+++ b/packages/malloy-interfaces/src/index.ts
@@ -195,7 +195,10 @@ export const thingy1: Malloy.Query = {
 export const thingy123r: Malloy.Query = {
   definition: {
     kind: 'arrow',
-    source_reference: {name: 'flights'},
+    source: {
+      kind: 'source_reference',
+      name: 'flights',
+    },
     view: {
       kind: 'view_reference',
       name: 'by_carrier',
@@ -206,7 +209,10 @@ export const thingy123r: Malloy.Query = {
 export const thingyssdfg: Malloy.Query = {
   definition: {
     kind: 'refinement',
-    query_reference: {name: 'flights'},
+    base: {
+      kind: 'query_reference',
+      name: 'flights',
+    },
     refinement: {
       kind: 'view_reference',
       name: 'by_carrier',
@@ -217,7 +223,10 @@ export const thingyssdfg: Malloy.Query = {
 export const thingy2asdf: Malloy.Query = {
   definition: {
     kind: 'arrow',
-    source_reference: {name: 'flights'},
+    source: {
+      kind: 'source_reference',
+      name: 'flights',
+    },
     view: {
       kind: 'refinement',
       base: {
@@ -244,7 +253,8 @@ export const thingy2asdf: Malloy.Query = {
 export const thingy3: Malloy.Query = {
   definition: {
     kind: 'arrow',
-    source_reference: {
+    source: {
+      kind: 'source_reference',
       name: 'flights',
     },
     view: {
@@ -283,7 +293,8 @@ export const thingy3: Malloy.Query = {
 export const thingy3dfdf: Malloy.Query = {
   definition: {
     kind: 'arrow',
-    source_reference: {
+    source: {
+      kind: 'source_reference',
       name: 'flights',
     },
     view: {
@@ -303,7 +314,8 @@ export const thingy3dfdf: Malloy.Query = {
 export const thingy4asdfasdf: Malloy.Query = {
   definition: {
     kind: 'arrow',
-    source_reference: {
+    source: {
+      kind: 'source_reference',
       name: 'flights',
     },
     view: {
@@ -336,7 +348,8 @@ export const thingy4asdfasdf: Malloy.Query = {
 export const thingy4asdfas: Malloy.Query = {
   definition: {
     kind: 'arrow',
-    source_reference: {
+    source: {
+      kind: 'source_reference',
       name: 'flights',
     },
     view: {
@@ -350,7 +363,8 @@ export const thingy4asdfas: Malloy.Query = {
 export const thingy4dfdsfs: Malloy.Query = {
   definition: {
     kind: 'arrow',
-    source_reference: {
+    source: {
+      kind: 'source_reference',
       name: 'flights',
     },
     view: {
@@ -376,7 +390,8 @@ export const thingy4dfdsfs: Malloy.Query = {
 export const thingy4sdfsd: Malloy.Query = {
   definition: {
     kind: 'arrow',
-    source_reference: {
+    source: {
+      kind: 'source_reference',
       name: 'flights',
     },
     view: {
@@ -404,7 +419,8 @@ export const thingy4sdfsd: Malloy.Query = {
 export const thingy4sddfdfsd: Malloy.Query = {
   definition: {
     kind: 'arrow',
-    source_reference: {
+    source: {
+      kind: 'source_reference',
       name: 'flights',
     },
     view: {

--- a/packages/malloy-interfaces/src/nest_unions.spec.ts
+++ b/packages/malloy-interfaces/src/nest_unions.spec.ts
@@ -13,7 +13,8 @@ describe('unnest unions', () => {
     const query: Malloy.Query = {
       definition: {
         kind: 'arrow',
-        source_reference: {
+        source: {
+          kind: 'source_reference',
           name: 'flights',
         },
         view: {
@@ -39,8 +40,10 @@ describe('unnest unions', () => {
     expect(nestUnions(query)).toMatchObject({
       definition: {
         arrow: {
-          source_reference: {
-            name: 'flights',
+          source: {
+            source_reference: {
+              name: 'flights',
+            },
           },
           view: {
             segment: {

--- a/packages/malloy-interfaces/src/types.ts
+++ b/packages/malloy-interfaces/src/types.ts
@@ -326,9 +326,19 @@ export type Query = {
   annotations?: Array<Annotation>;
 };
 export type QueryArrow = {
-  source_reference: Reference;
+  source: QueryArrowSource;
   view: ViewDefinition;
 };
+export type QueryArrowSourceType = 'refinement' | 'source_reference';
+export type QueryArrowSource =
+  | QueryArrowSourceWithRefinement
+  | QueryArrowSourceWithSourceReference;
+export type QueryArrowSourceWithRefinement = {
+  kind: 'refinement';
+} & QueryRefinement;
+export type QueryArrowSourceWithSourceReference = {
+  kind: 'source_reference';
+} & Reference;
 export type QueryDefinitionType = 'arrow' | 'query_reference' | 'refinement';
 export type QueryDefinition =
   | QueryDefinitionWithArrow
@@ -350,7 +360,7 @@ export type QueryInfo = {
   location?: Location;
 };
 export type QueryRefinement = {
-  query_reference: Reference;
+  base: QueryDefinition;
   refinement: ViewDefinition;
 };
 export type Range = {

--- a/packages/malloy-interfaces/thrift/malloy.thrift
+++ b/packages/malloy-interfaces/thrift/malloy.thrift
@@ -319,13 +319,18 @@ union QueryDefinition {
   3: QueryRefinement refinement,
 }
 
+union QueryArrowSource {
+  3: QueryRefinement refinement,
+  2: Reference source_reference,
+}
+
 struct QueryArrow {
-  1: required Reference source_reference,
+  1: required QueryArrowSource source,
   2: required ViewDefinition view,
 }
 
 struct QueryRefinement {
-  1: required Reference query_reference,
+  1: required QueryDefinition base,
   2: required ViewDefinition refinement,
 }
 

--- a/packages/malloy-interfaces/thrift/malloy.thrift
+++ b/packages/malloy-interfaces/thrift/malloy.thrift
@@ -305,7 +305,6 @@ stages: [
     ]
   }
 ]
-
 */
 
 struct Query {

--- a/packages/malloy-query-builder/README.md
+++ b/packages/malloy-query-builder/README.md
@@ -325,10 +325,10 @@ run: flights -> { aggregate: flight_count { where: carrier ~ f`WN, AA`} }
 
 ## Specify or remove source parameter value
 
-{@link ASTSourceReference.setParameter}
+{@link ASTReferenceQueryArrowSource.setParameter}
 
 ```ts
-query.definition.asArrowQueryDefinition().sourceReference.parameters.setParameter("param", 1)
+query.definition.as.ArrowQueryDefinition().source.as.ReferenceQueryArrowSource().parameters.setParameter("param", 1)
 ```
 ```
 run: flights(param is 1) ->
@@ -336,10 +336,10 @@ run: flights(param is 1) ->
 
 ## List parameters of the source and whether they are required
 
-{@link ASTSourceReference.getSourceParameters}
+{@link ASTReferenceQueryArrowSource.getSourceParameters}
 
 ```ts
-query.definition.asArrowQueryDefinition().sourceReference.getSourceParameters();
+query.definition.as.ArrowQueryDefinition().source.as.ReferenceQueryArrowSource().getSourceParameters();
 ```
 
 ## To a particular field in the query (including nests), add/edit/delete annotation

--- a/packages/malloy-query-builder/src/query-ast.spec.ts
+++ b/packages/malloy-query-builder/src/query-ast.spec.ts
@@ -37,7 +37,10 @@ describe('query builder', () => {
     const from: Malloy.Query = {
       definition: {
         kind: 'arrow',
-        source_reference: {name: 'flights'},
+        source: {
+          kind: 'source_reference',
+          name: 'flights',
+        },
         view: {
           kind: 'segment',
           operations: [
@@ -62,7 +65,10 @@ describe('query builder', () => {
       to: {
         definition: {
           kind: 'arrow',
-          source_reference: {name: 'flights'},
+          source: {
+            kind: 'source_reference',
+            name: 'flights',
+          },
           view: {
             kind: 'segment',
             operations: [
@@ -96,7 +102,10 @@ describe('query builder', () => {
     const from: Malloy.Query = {
       definition: {
         kind: 'arrow',
-        source_reference: {name: 'flights'},
+        source: {
+          kind: 'source_reference',
+          name: 'flights',
+        },
         view: {
           kind: 'segment',
           operations: [],
@@ -111,7 +120,10 @@ describe('query builder', () => {
       to: {
         definition: {
           kind: 'arrow',
-          source_reference: {name: 'flights'},
+          source: {
+            kind: 'source_reference',
+            name: 'flights',
+          },
           view: {
             kind: 'segment',
             operations: [
@@ -135,7 +147,10 @@ describe('query builder', () => {
     const from: Malloy.Query = {
       definition: {
         kind: 'arrow',
-        source_reference: {name: 'flights'},
+        source: {
+          kind: 'source_reference',
+          name: 'flights',
+        },
         view: {
           kind: 'segment',
           operations: [],
@@ -151,7 +166,10 @@ describe('query builder', () => {
       to: {
         definition: {
           kind: 'arrow',
-          source_reference: {name: 'flights'},
+          source: {
+            kind: 'source_reference',
+            name: 'flights',
+          },
           view: {
             kind: 'segment',
             operations: [
@@ -191,7 +209,10 @@ describe('query builder', () => {
     const from: Malloy.Query = {
       definition: {
         kind: 'arrow',
-        source_reference: {name: 'flights'},
+        source: {
+          kind: 'source_reference',
+          name: 'flights',
+        },
         view: {
           kind: 'segment',
           operations: [],
@@ -208,7 +229,10 @@ describe('query builder', () => {
       to: {
         definition: {
           kind: 'arrow',
-          source_reference: {name: 'flights'},
+          source: {
+            kind: 'source_reference',
+            name: 'flights',
+          },
           view: {
             kind: 'segment',
             operations: [
@@ -244,7 +268,10 @@ describe('query builder', () => {
       const from: Malloy.Query = {
         definition: {
           kind: 'arrow',
-          source_reference: {name: 'flights'},
+          source: {
+            kind: 'source_reference',
+            name: 'flights',
+          },
           view: {
             kind: 'segment',
             operations: [],
@@ -264,7 +291,10 @@ describe('query builder', () => {
         to: {
           definition: {
             kind: 'arrow',
-            source_reference: {name: 'flights'},
+            source: {
+              kind: 'source_reference',
+              name: 'flights',
+            },
             view: {
               kind: 'segment',
               operations: [
@@ -288,7 +318,10 @@ describe('query builder', () => {
       const from: Malloy.Query = {
         definition: {
           kind: 'arrow',
-          source_reference: {name: 'flights'},
+          source: {
+            kind: 'source_reference',
+            name: 'flights',
+          },
           view: {
             kind: 'segment',
             operations: [],
@@ -305,7 +338,10 @@ describe('query builder', () => {
         to: {
           definition: {
             kind: 'arrow',
-            source_reference: {name: 'flights'},
+            source: {
+              kind: 'source_reference',
+              name: 'flights',
+            },
             view: {
               kind: 'segment',
               operations: [
@@ -340,7 +376,10 @@ describe('query builder', () => {
     const from: Malloy.Query = {
       definition: {
         kind: 'arrow',
-        source_reference: {name: 'flights'},
+        source: {
+          kind: 'source_reference',
+          name: 'flights',
+        },
         view: {
           kind: 'segment',
           operations: [],
@@ -355,7 +394,10 @@ describe('query builder', () => {
       to: {
         definition: {
           kind: 'arrow',
-          source_reference: {name: 'flights'},
+          source: {
+            kind: 'source_reference',
+            name: 'flights',
+          },
           view: {
             kind: 'segment',
             operations: [
@@ -378,7 +420,10 @@ describe('query builder', () => {
     const from: Malloy.Query = {
       definition: {
         kind: 'arrow',
-        source_reference: {name: 'flights'},
+        source: {
+          kind: 'source_reference',
+          name: 'flights',
+        },
         view: {
           kind: 'segment',
           operations: [],
@@ -396,7 +441,10 @@ describe('query builder', () => {
       to: {
         definition: {
           kind: 'arrow',
-          source_reference: {name: 'flights'},
+          source: {
+            kind: 'source_reference',
+            name: 'flights',
+          },
           view: {
             kind: 'segment',
             operations: [
@@ -419,7 +467,10 @@ describe('query builder', () => {
     const from: Malloy.Query = {
       definition: {
         kind: 'arrow',
-        source_reference: {name: 'flights'},
+        source: {
+          kind: 'source_reference',
+          name: 'flights',
+        },
         view: {
           kind: 'segment',
           operations: [],
@@ -446,7 +497,10 @@ describe('query builder', () => {
       to: {
         definition: {
           kind: 'arrow',
-          source_reference: {name: 'flights'},
+          source: {
+            kind: 'source_reference',
+            name: 'flights',
+          },
           view: {
             kind: 'segment',
             operations: [
@@ -518,7 +572,10 @@ describe('query builder', () => {
     const from: Malloy.Query = {
       definition: {
         kind: 'arrow',
-        source_reference: {name: 'flights'},
+        source: {
+          kind: 'source_reference',
+          name: 'flights',
+        },
         view: {
           kind: 'segment',
           operations: [],
@@ -533,7 +590,10 @@ describe('query builder', () => {
       to: {
         definition: {
           kind: 'arrow',
-          source_reference: {name: 'flights'},
+          source: {
+            kind: 'source_reference',
+            name: 'flights',
+          },
           view: {
             kind: 'segment',
             operations: [
@@ -558,7 +618,10 @@ describe('query builder', () => {
     const from: Malloy.Query = {
       definition: {
         kind: 'arrow',
-        source_reference: {name: 'flights'},
+        source: {
+          kind: 'source_reference',
+          name: 'flights',
+        },
         view: {
           kind: 'segment',
           operations: [],
@@ -575,7 +638,10 @@ describe('query builder', () => {
       to: {
         definition: {
           kind: 'arrow',
-          source_reference: {name: 'flights'},
+          source: {
+            kind: 'source_reference',
+            name: 'flights',
+          },
           view: {
             kind: 'segment',
             operations: [
@@ -613,7 +679,10 @@ describe('query builder', () => {
     const from: Malloy.Query = {
       definition: {
         kind: 'arrow',
-        source_reference: {name: 'flights'},
+        source: {
+          kind: 'source_reference',
+          name: 'flights',
+        },
         view: {
           kind: 'segment',
           operations: [
@@ -648,7 +717,10 @@ describe('query builder', () => {
       to: {
         definition: {
           kind: 'arrow',
-          source_reference: {name: 'flights'},
+          source: {
+            kind: 'source_reference',
+            name: 'flights',
+          },
           view: {
             kind: 'segment',
             operations: [
@@ -686,7 +758,10 @@ describe('query builder', () => {
     const from: Malloy.Query = {
       definition: {
         kind: 'arrow',
-        source_reference: {name: 'flights'},
+        source: {
+          kind: 'source_reference',
+          name: 'flights',
+        },
         view: {
           kind: 'segment',
           operations: [],
@@ -704,7 +779,10 @@ describe('query builder', () => {
       to: {
         definition: {
           kind: 'arrow',
-          source_reference: {name: 'flights'},
+          source: {
+            kind: 'source_reference',
+            name: 'flights',
+          },
           view: {
             kind: 'segment',
             operations: [
@@ -739,7 +817,10 @@ describe('query builder', () => {
     const from: Malloy.Query = {
       definition: {
         kind: 'arrow',
-        source_reference: {name: 'flights'},
+        source: {
+          kind: 'source_reference',
+          name: 'flights',
+        },
         view: {
           kind: 'segment',
           operations: [],
@@ -755,7 +836,10 @@ describe('query builder', () => {
       to: {
         definition: {
           kind: 'arrow',
-          source_reference: {name: 'flights'},
+          source: {
+            kind: 'source_reference',
+            name: 'flights',
+          },
           view: {
             kind: 'segment',
             operations: [
@@ -779,7 +863,10 @@ describe('query builder', () => {
     const from: Malloy.Query = {
       definition: {
         kind: 'arrow',
-        source_reference: {name: 'flights'},
+        source: {
+          kind: 'source_reference',
+          name: 'flights',
+        },
         view: {
           kind: 'segment',
           operations: [],
@@ -794,7 +881,10 @@ describe('query builder', () => {
       to: {
         definition: {
           kind: 'arrow',
-          source_reference: {name: 'flights'},
+          source: {
+            kind: 'source_reference',
+            name: 'flights',
+          },
           view: {
             kind: 'view_reference',
             name: 'by_month',
@@ -808,7 +898,10 @@ describe('query builder', () => {
     const from: Malloy.Query = {
       definition: {
         kind: 'arrow',
-        source_reference: {name: 'flights'},
+        source: {
+          kind: 'source_reference',
+          name: 'flights',
+        },
         view: {
           kind: 'segment',
           operations: [],
@@ -824,7 +917,10 @@ describe('query builder', () => {
       to: {
         definition: {
           kind: 'arrow',
-          source_reference: {name: 'flights'},
+          source: {
+            kind: 'source_reference',
+            name: 'flights',
+          },
           view: {
             kind: 'view_reference',
             name: 'by_month',
@@ -841,7 +937,10 @@ describe('query builder', () => {
     const from: Malloy.Query = {
       definition: {
         kind: 'arrow',
-        source_reference: {name: 'flights'},
+        source: {
+          kind: 'source_reference',
+          name: 'flights',
+        },
         view: {
           kind: 'segment',
           operations: [],
@@ -858,7 +957,10 @@ describe('query builder', () => {
       to: {
         definition: {
           kind: 'arrow',
-          source_reference: {name: 'flights'},
+          source: {
+            kind: 'source_reference',
+            name: 'flights',
+          },
           view: {
             kind: 'refinement',
             base: {
@@ -885,7 +987,8 @@ describe('query builder', () => {
       const from: Malloy.Query = {
         definition: {
           kind: 'arrow',
-          source_reference: {
+          source: {
+            kind: 'source_reference',
             name: 'flights',
           },
           view: {
@@ -937,7 +1040,8 @@ describe('query builder', () => {
         to: {
           definition: {
             kind: 'arrow',
-            source_reference: {
+            source: {
+              kind: 'source_reference',
               name: 'flights',
             },
             view: {
@@ -1001,7 +1105,10 @@ describe('query builder', () => {
       const from: Malloy.Query = {
         definition: {
           kind: 'arrow',
-          source_reference: {name: 'flights'},
+          source: {
+            kind: 'source_reference',
+            name: 'flights',
+          },
           view: {
             kind: 'view_reference',
             name: 'by_month',
@@ -1016,7 +1123,10 @@ describe('query builder', () => {
         to: {
           definition: {
             kind: 'arrow',
-            source_reference: {name: 'flights'},
+            source: {
+              kind: 'source_reference',
+              name: 'flights',
+            },
             view: {
               kind: 'refinement',
               base: {
@@ -1050,7 +1160,10 @@ describe('query builder', () => {
       from: {
         definition: {
           kind: 'arrow',
-          source_reference: {name: 'flights'},
+          source: {
+            kind: 'source_reference',
+            name: 'flights',
+          },
           view: {
             kind: 'segment',
             operations: [],
@@ -1060,7 +1173,10 @@ describe('query builder', () => {
       to: {
         definition: {
           kind: 'arrow',
-          source_reference: {name: 'flights'},
+          source: {
+            kind: 'source_reference',
+            name: 'flights',
+          },
           view: {
             kind: 'segment',
             operations: [],
@@ -1074,7 +1190,10 @@ describe('query builder', () => {
     const from: Malloy.Query = {
       definition: {
         kind: 'arrow',
-        source_reference: {name: 'flights'},
+        source: {
+          kind: 'source_reference',
+          name: 'flights',
+        },
         view: {
           kind: 'view_reference',
           name: 'by_carrier',
@@ -1143,7 +1262,10 @@ describe('query builder', () => {
       to: {
         definition: {
           kind: 'arrow',
-          source_reference: {name: 'flights'},
+          source: {
+            kind: 'source_reference',
+            name: 'flights',
+          },
           view: {
             kind: 'refinement',
             base: {
@@ -1164,7 +1286,10 @@ describe('query builder', () => {
     const from: Malloy.Query = {
       definition: {
         kind: 'arrow',
-        source_reference: {name: 'flights'},
+        source: {
+          kind: 'source_reference',
+          name: 'flights',
+        },
         view: {
           kind: 'segment',
           operations: [],
@@ -1180,7 +1305,10 @@ describe('query builder', () => {
       to: {
         definition: {
           kind: 'arrow',
-          source_reference: {name: 'flights'},
+          source: {
+            kind: 'source_reference',
+            name: 'flights',
+          },
           view: {
             kind: 'segment',
             operations: [
@@ -1199,7 +1327,10 @@ describe('query builder', () => {
     const from: Malloy.Query = {
       definition: {
         kind: 'arrow',
-        source_reference: {name: 'flights'},
+        source: {
+          kind: 'source_reference',
+          name: 'flights',
+        },
         view: {
           kind: 'segment',
           operations: [
@@ -1220,7 +1351,10 @@ describe('query builder', () => {
       to: {
         definition: {
           kind: 'arrow',
-          source_reference: {name: 'flights'},
+          source: {
+            kind: 'source_reference',
+            name: 'flights',
+          },
           view: {
             kind: 'segment',
             operations: [
@@ -1240,7 +1374,10 @@ describe('query builder', () => {
       const from: Malloy.Query = {
         definition: {
           kind: 'arrow',
-          source_reference: {name: 'flights'},
+          source: {
+            kind: 'source_reference',
+            name: 'flights',
+          },
           view: {
             kind: 'segment',
             operations: [],
@@ -1256,7 +1393,10 @@ describe('query builder', () => {
         to: {
           definition: {
             kind: 'arrow',
-            source_reference: {name: 'flights'},
+            source: {
+              kind: 'source_reference',
+              name: 'flights',
+            },
             view: {
               kind: 'segment',
               operations: [
@@ -1285,7 +1425,10 @@ describe('query builder', () => {
       const from: Malloy.Query = {
         definition: {
           kind: 'arrow',
-          source_reference: {name: 'flights'},
+          source: {
+            kind: 'source_reference',
+            name: 'flights',
+          },
           view: {
             kind: 'segment',
             operations: [],
@@ -1300,7 +1443,10 @@ describe('query builder', () => {
         to: {
           definition: {
             kind: 'arrow',
-            source_reference: {name: 'flights'},
+            source: {
+              kind: 'source_reference',
+              name: 'flights',
+            },
             view: {
               kind: 'segment',
               operations: [],
@@ -1318,7 +1464,10 @@ describe('query builder', () => {
       const from: Malloy.Query = {
         definition: {
           kind: 'arrow',
-          source_reference: {name: 'flights'},
+          source: {
+            kind: 'source_reference',
+            name: 'flights',
+          },
           view: {
             kind: 'segment',
             operations: [],
@@ -1347,7 +1496,10 @@ describe('query builder', () => {
         to: {
           definition: {
             kind: 'arrow',
-            source_reference: {name: 'flights'},
+            source: {
+              kind: 'source_reference',
+              name: 'flights',
+            },
             view: {
               kind: 'segment',
               operations: [
@@ -1377,7 +1529,10 @@ describe('query builder', () => {
     const from: Malloy.Query = {
       definition: {
         kind: 'arrow',
-        source_reference: {name: 'flights'},
+        source: {
+          kind: 'source_reference',
+          name: 'flights',
+        },
         view: {
           kind: 'segment',
           operations: [
@@ -1406,7 +1561,10 @@ describe('query builder', () => {
       to: {
         definition: {
           kind: 'arrow',
-          source_reference: {name: 'flights'},
+          source: {
+            kind: 'source_reference',
+            name: 'flights',
+          },
           view: {
             kind: 'segment',
             operations: [
@@ -1440,7 +1598,10 @@ describe('query builder', () => {
     const from: Malloy.Query = {
       definition: {
         kind: 'arrow',
-        source_reference: {name: 'flights'},
+        source: {
+          kind: 'source_reference',
+          name: 'flights',
+        },
         view: {
           kind: 'refinement',
           base: {
@@ -1481,7 +1642,10 @@ describe('query builder', () => {
       to: {
         definition: {
           kind: 'arrow',
-          source_reference: {name: 'flights'},
+          source: {
+            kind: 'source_reference',
+            name: 'flights',
+          },
           view: {
             kind: 'refinement',
             base: {
@@ -1519,7 +1683,10 @@ describe('query builder', () => {
     const from: Malloy.Query = {
       definition: {
         kind: 'arrow',
-        source_reference: {name: 'flights'},
+        source: {
+          kind: 'source_reference',
+          name: 'flights',
+        },
         view: {
           kind: 'refinement',
           base: {
@@ -1560,7 +1727,10 @@ describe('query builder', () => {
       to: {
         definition: {
           kind: 'arrow',
-          source_reference: {name: 'flights'},
+          source: {
+            kind: 'source_reference',
+            name: 'flights',
+          },
           view: {
             kind: 'refinement',
             base: {
@@ -1581,7 +1751,10 @@ describe('query builder', () => {
     const from: Malloy.Query = {
       definition: {
         kind: 'arrow',
-        source_reference: {name: 'flights'},
+        source: {
+          kind: 'source_reference',
+          name: 'flights',
+        },
         view: {
           kind: 'arrow',
           source: {
@@ -1627,7 +1800,10 @@ describe('query builder', () => {
       to: {
         definition: {
           kind: 'arrow',
-          source_reference: {name: 'flights'},
+          source: {
+            kind: 'source_reference',
+            name: 'flights',
+          },
           view: {
             kind: 'arrow',
             source: {
@@ -1653,7 +1829,10 @@ describe('query builder', () => {
         from: {
           definition: {
             kind: 'arrow',
-            source_reference: {name: 'flights'},
+            source: {
+              kind: 'source_reference',
+              name: 'flights',
+            },
             view: {
               kind: 'segment',
               operations: [],
@@ -1663,7 +1842,10 @@ describe('query builder', () => {
         to: {
           definition: {
             kind: 'arrow',
-            source_reference: {name: 'flights'},
+            source: {
+              kind: 'source_reference',
+              name: 'flights',
+            },
             view: {
               kind: 'segment',
               operations: [],
@@ -1681,7 +1863,10 @@ describe('query builder', () => {
         from: {
           definition: {
             kind: 'arrow',
-            source_reference: {name: 'flights'},
+            source: {
+              kind: 'source_reference',
+              name: 'flights',
+            },
             view: {
               kind: 'view_reference',
               name: 'by_month',
@@ -1691,7 +1876,10 @@ describe('query builder', () => {
         to: {
           definition: {
             kind: 'arrow',
-            source_reference: {name: 'flights'},
+            source: {
+              kind: 'source_reference',
+              name: 'flights',
+            },
             view: {
               kind: 'refinement',
               base: {
@@ -1716,7 +1904,10 @@ describe('query builder', () => {
         from: {
           definition: {
             kind: 'arrow',
-            source_reference: {name: 'flights'},
+            source: {
+              kind: 'source_reference',
+              name: 'flights',
+            },
             view: {
               kind: 'refinement',
               base: {
@@ -1733,7 +1924,10 @@ describe('query builder', () => {
         to: {
           definition: {
             kind: 'arrow',
-            source_reference: {name: 'flights'},
+            source: {
+              kind: 'source_reference',
+              name: 'flights',
+            },
             view: {
               kind: 'refinement',
               base: {
@@ -1764,7 +1958,10 @@ describe('query builder', () => {
         to: {
           definition: {
             kind: 'refinement',
-            query_reference: {name: 'flights_by_carrier'},
+            base: {
+              kind: 'query_reference',
+              name: 'flights_by_carrier',
+            },
             refinement: {
               kind: 'segment',
               operations: [],
@@ -1783,7 +1980,10 @@ describe('query builder', () => {
       from: {
         definition: {
           kind: 'arrow',
-          source_reference: {name: 'flights'},
+          source: {
+            kind: 'source_reference',
+            name: 'flights',
+          },
           view: {
             kind: 'refinement',
             base: {
@@ -1800,7 +2000,10 @@ describe('query builder', () => {
       to: {
         definition: {
           kind: 'arrow',
-          source_reference: {name: 'flights'},
+          source: {
+            kind: 'source_reference',
+            name: 'flights',
+          },
           view: {
             kind: 'refinement',
             base: {
@@ -1829,7 +2032,7 @@ describe('query builder', () => {
       const from: Malloy.Query = {
         definition: {
           kind: 'arrow',
-          source_reference: {name: 'foo'},
+          source: {kind: 'source_reference', name: 'foo'},
           view: {
             kind: 'segment',
             operations: [],
@@ -1837,7 +2040,9 @@ describe('query builder', () => {
         },
       };
       expect((q: ASTQuery) => {
-        const source = q.definition.as.ArrowQueryDefinition().sourceReference;
+        const source = q.definition.as
+          .ArrowQueryDefinition()
+          .source.as.ReferenceQueryArrowSource();
         source.setParameter('string_param', 'COOL');
         source.setParameter('number_param', 7);
         source.setParameter('boolean_param', true);
@@ -1886,7 +2091,8 @@ describe('query builder', () => {
         to: {
           definition: {
             kind: 'arrow',
-            source_reference: {
+            source: {
+              kind: 'source_reference',
               name: 'foo',
               parameters: [
                 {

--- a/packages/malloy/src/api/asynchronous.spec.ts
+++ b/packages/malloy/src/api/asynchronous.spec.ts
@@ -112,7 +112,7 @@ describe('api', () => {
           query: {
             definition: {
               kind: 'arrow',
-              source_reference: {name: 'flights'},
+              source: {kind: 'source_reference', name: 'flights'},
               view: {
                 kind: 'segment',
                 operations: [
@@ -205,7 +205,7 @@ ORDER BY 1 asc NULLS LAST
           query: {
             definition: {
               kind: 'arrow',
-              source_reference: {name: 'flights'},
+              source: {kind: 'source_reference', name: 'flights'},
               view: {
                 kind: 'segment',
                 operations: [

--- a/packages/malloy/src/api/core.ts
+++ b/packages/malloy/src/api/core.ts
@@ -397,7 +397,10 @@ export const DEFAULT_LOG_RANGE: Malloy.DocumentRange = {
   },
 };
 
-function mapLogs(logs: LogMessage[], defaultURL: string): Malloy.LogMessage[] {
+export function mapLogs(
+  logs: LogMessage[],
+  defaultURL: string
+): Malloy.LogMessage[] {
   return logs.map(log => ({
     severity: log.severity,
     message: log.message,

--- a/packages/malloy/src/api/sessioned.spec.ts
+++ b/packages/malloy/src/api/sessioned.spec.ts
@@ -171,7 +171,7 @@ describe('api', () => {
       const query: Malloy.Query = {
         definition: {
           kind: 'arrow',
-          source_reference: {name: 'flights'},
+          source: {kind: 'source_reference', name: 'flights'},
           view: {
             kind: 'segment',
             operations: [

--- a/packages/malloy/src/api/stateless.spec.ts
+++ b/packages/malloy/src/api/stateless.spec.ts
@@ -273,7 +273,7 @@ describe('api', () => {
         query: {
           definition: {
             kind: 'arrow',
-            source_reference: {name: 'flights'},
+            source: {kind: 'source_reference', name: 'flights'},
             view: {
               kind: 'segment',
               operations: [

--- a/packages/malloy/src/lang/malloy-parse-info.ts
+++ b/packages/malloy/src/lang/malloy-parse-info.ts
@@ -21,20 +21,8 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import {
-  CodePointCharStream,
-  CommonTokenStream,
-  ParserRuleContext,
-} from 'antlr4ts';
-import {ParseTree} from 'antlr4ts/tree';
-import {DocumentRange} from '../model/malloy_types';
+import {ParseInfo} from './run-malloy-parser';
 
-export interface MalloyParseInfo {
-  root: ParseTree;
-  tokenStream: CommonTokenStream;
-  sourceStream: CodePointCharStream;
-  sourceURL: string;
+export interface MalloyParseInfo extends ParseInfo {
   importBaseURL: string;
-  rangeFromContext: (pcx: ParserRuleContext) => DocumentRange;
-  malloyVersion: string;
 }

--- a/packages/malloy/src/lang/malloy-parse-info.ts
+++ b/packages/malloy/src/lang/malloy-parse-info.ts
@@ -21,7 +21,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import {ParseInfo} from './run-malloy-parser';
+import {ParseInfo} from './utils';
 
 export interface MalloyParseInfo extends ParseInfo {
   importBaseURL: string;

--- a/packages/malloy/src/lang/malloy-to-ast.ts
+++ b/packages/malloy/src/lang/malloy-to-ast.ts
@@ -61,6 +61,7 @@ import {
 import {Tag} from '@malloydata/malloy-tag';
 import {ConstantExpression} from './ast/expressions/constant-expression';
 import {isNotUndefined} from './utils';
+import {rangeFromContext} from './run-malloy-parser';
 
 class ErrorNode extends ast.SourceQueryElement {
   elementType = 'parseErrorSourceQuery';
@@ -124,10 +125,14 @@ export class MalloyToAST
     this.msgLog.log(makeLogMessage(code, data, {at: el.location, ...options}));
   }
 
+  protected rangeFromContext(cx: ParserRuleContext) {
+    return rangeFromContext(this.parseInfo.sourceInfo, cx);
+  }
+
   protected getLocation(cx: ParserRuleContext): DocumentLocation {
     return {
       url: this.parseInfo.sourceURL,
-      range: this.parseInfo.rangeFromContext(cx),
+      range: this.rangeFromContext(cx),
     };
   }
 
@@ -246,7 +251,7 @@ export class MalloyToAST
   ): MT {
     el.location = {
       url: this.parseInfo.sourceURL,
-      range: this.parseInfo.rangeFromContext(cx),
+      range: this.rangeFromContext(cx),
     };
     return el;
   }
@@ -1381,7 +1386,7 @@ export class MalloyToAST
     const left = this.getFieldExpr(pcx.fieldExpr(0));
     const right = this.getFieldExpr(pcx.fieldExpr(1));
     if (ast.isEquality(op)) {
-      const wholeRange = this.parseInfo.rangeFromContext(pcx);
+      const wholeRange = this.rangeFromContext(pcx);
       if (right instanceof ast.ExprNULL) {
         if (op === '=') {
           this.warnWithReplacement(
@@ -1693,7 +1698,7 @@ export class MalloyToAST
     this.warnWithReplacement(
       'sql-case',
       'Use a `pick` statement instead of `case`',
-      this.parseInfo.rangeFromContext(pcx),
+      this.rangeFromContext(pcx),
       `${[
         ...(valueCx ? [`${this.getSourceCode(valueCx)} ?`] : []),
         ...whenCxs.map(
@@ -2148,7 +2153,7 @@ export class MalloyToAST
     let op: ast.CompareMalloyOperator = '~';
     const left = pcx.fieldExpr(0);
     const right = pcx.fieldExpr(1);
-    const wholeRange = this.parseInfo.rangeFromContext(pcx);
+    const wholeRange = this.rangeFromContext(pcx);
     if (pcx.NOT()) {
       op = '!~';
       this.warnWithReplacement(
@@ -2198,7 +2203,7 @@ export class MalloyToAST
     this.warnWithReplacement(
       'sql-in',
       `Use = (a|b|c) instead of${isNot ? ' NOT' : ''} IN (a,b,c)`,
-      this.parseInfo.rangeFromContext(pcx),
+      this.rangeFromContext(pcx),
       `${this.getSourceCode(pcx.fieldExpr())} ${isNot ? '!=' : '='} (${from
         .map(f => this.getSourceCode(f))
         .join(' | ')})`

--- a/packages/malloy/src/lang/malloy-to-ast.ts
+++ b/packages/malloy/src/lang/malloy-to-ast.ts
@@ -60,8 +60,7 @@ import {
 } from '../model/malloy_types';
 import {Tag} from '@malloydata/malloy-tag';
 import {ConstantExpression} from './ast/expressions/constant-expression';
-import {isNotUndefined} from './utils';
-import {rangeFromContext} from './run-malloy-parser';
+import {isNotUndefined, rangeFromContext} from './utils';
 
 class ErrorNode extends ast.SourceQueryElement {
   elementType = 'parseErrorSourceQuery';

--- a/packages/malloy/src/lang/malloy-to-stable-query.ts
+++ b/packages/malloy/src/lang/malloy-to-stable-query.ts
@@ -1,25 +1,8 @@
 /*
- * Copyright 2023 Google LLC
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
- * Permission is hereby granted, free of charge, to any person obtaining
- * a copy of this software and associated documentation files
- * (the "Software"), to deal in the Software without restriction,
- * including without limitation the rights to use, copy, modify, merge,
- * publish, distribute, sublicense, and/or sell copies of the Software,
- * and to permit persons to whom the Software is furnished to do so,
- * subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
- * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
- * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
- * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
- * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 import {ParserRuleContext} from 'antlr4ts';

--- a/packages/malloy/src/lang/malloy-to-stable-query.ts
+++ b/packages/malloy/src/lang/malloy-to-stable-query.ts
@@ -21,13 +21,9 @@ import {
 } from './parse-log';
 import {getId} from './parse-utils';
 import {DocumentLocation, isTimestampUnit} from '../model/malloy_types';
-import {
-  getSourceInfo,
-  ParseInfo,
-  rangeFromContext,
-  runMalloyParser,
-} from './run-malloy-parser';
+import {runMalloyParser} from './run-malloy-parser';
 import {mapLogs} from '../api/core';
+import {getSourceInfo, ParseInfo, rangeFromContext} from './utils';
 
 type HasAnnotations = ParserRuleContext & {ANNOTATION: () => TerminalNode[]};
 

--- a/packages/malloy/src/lang/malloy-to-stable-query.ts
+++ b/packages/malloy/src/lang/malloy-to-stable-query.ts
@@ -1,0 +1,401 @@
+/*
+ * Copyright 2023 Google LLC
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files
+ * (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import {ParserRuleContext} from 'antlr4ts';
+import {ParseTree, TerminalNode} from 'antlr4ts/tree';
+import {AbstractParseTreeVisitor} from 'antlr4ts/tree/AbstractParseTreeVisitor';
+import {MalloyParserVisitor} from './lib/Malloy/MalloyParserVisitor';
+import * as Malloy from '@malloydata/malloy-interfaces';
+import * as parse from './lib/Malloy/MalloyParser';
+import {
+  BaseMessageLogger,
+  LogMessageOptions,
+  MessageCode,
+  MessageLogger,
+  MessageParameterType,
+  makeLogMessage,
+} from './parse-log';
+import {getId} from './parse-utils';
+import {DocumentLocation, isTimestampUnit} from '../model/malloy_types';
+import {
+  getSourceInfo,
+  ParseInfo,
+  rangeFromContext,
+  runMalloyParser,
+} from './run-malloy-parser';
+import {mapLogs} from '../api/core';
+
+type HasAnnotations = ParserRuleContext & {ANNOTATION: () => TerminalNode[]};
+
+type Node =
+  | Malloy.Query
+  | Malloy.QueryDefinitionWithArrow
+  | Malloy.QueryDefinitionWithQueryReference
+  | Malloy.QueryDefinitionWithRefinement
+  | null;
+
+const MLQs = 'Malloy query documents';
+
+/**
+ * ANTLR visitor pattern parse tree traversal. Generates a Malloy
+ * AST from an ANTLR parse tree.
+ */
+export class MalloyToQuery
+  extends AbstractParseTreeVisitor<Node>
+  implements MalloyParserVisitor<Node>
+{
+  constructor(
+    readonly parseInfo: ParseInfo,
+    readonly msgLog: MessageLogger
+  ) {
+    super();
+  }
+
+  /**
+   * Mostly used to flag a case where the grammar and the type system are
+   * no longer in sync. A visitor was written based on a grammar which
+   * apparently has changed and now an unexpected element type has appeared.
+   * This is a non recoverable error, since the parser and the grammar
+   * are not compatible.
+   * @return an error object to throw.
+   */
+  protected internalError(cx: ParserRuleContext, message: string): Error {
+    this.contextError(cx, 'internal-translator-error', {message});
+    return new Error(`Internal Translator Error: ${message}`);
+  }
+
+  protected getLocation(cx: ParserRuleContext): DocumentLocation {
+    return {
+      url: this.parseInfo.sourceURL,
+      range: rangeFromContext(this.parseInfo.sourceInfo, cx),
+    };
+  }
+
+  /**
+   * Log an error message relative to a parse node
+   */
+  protected contextError<T extends MessageCode>(
+    cx: ParserRuleContext,
+    code: T,
+    data: MessageParameterType<T>,
+    options?: LogMessageOptions
+  ): void {
+    this.msgLog.log(
+      makeLogMessage(code, data, {
+        at: this.getLocation(cx),
+        ...options,
+      })
+    );
+  }
+
+  protected getNumber(term: ParseTree): number {
+    return Number.parseInt(term.text);
+  }
+
+  protected defaultResult(): Node {
+    return null;
+  }
+
+  /**
+   * Get all the possibly missing annotations from this parse rule
+   * @param cx Any parse context which has an ANNOTATION* rules
+   * @returns Array of texts for the annotations
+   */
+  protected getAnnotations(
+    cx: HasAnnotations
+  ): Malloy.Annotation[] | undefined {
+    const annotations = cx.ANNOTATION().map(a => {
+      return {value: a.text};
+    });
+    return annotations.length > 0 ? annotations : undefined;
+  }
+
+  protected getIsAnnotations(
+    cx: parse.IsDefineContext
+  ): Malloy.Annotation[] | undefined {
+    const before = this.getAnnotations(cx._beforeIs) ?? [];
+    const annotations = before.concat(this.getAnnotations(cx._afterIs) ?? []);
+    return annotations.length > 0 ? annotations : undefined;
+  }
+
+  protected notAllowed(pcx: ParserRuleContext, what: string) {
+    this.illegal(pcx, `${what} are not allowed in ${MLQs}`);
+  }
+
+  protected illegal(pcx: ParserRuleContext, what: string) {
+    this.contextError(pcx, 'invalid-malloy-query-document', what);
+  }
+
+  visitMalloyDocument(pcx: parse.MalloyDocumentContext): Malloy.Query | null {
+    const statements = pcx.malloyStatement();
+    let runStatement: parse.RunStatementContext | undefined = undefined;
+    for (const statement of statements) {
+      if (statement.defineSourceStatement()) {
+        this.notAllowed(statement, 'Source definitions');
+      } else if (statement.defineQuery()) {
+        this.notAllowed(statement, 'Query definitions');
+      } else if (statement.importStatement()) {
+        this.notAllowed(statement, 'Import statements');
+      } else if (statement.docAnnotations()) {
+        this.notAllowed(statement, 'Model annotations');
+      } else if (statement.ignoredObjectAnnotations()) {
+        this.notAllowed(statement, 'Detatched object annotations');
+      } else if (statement.experimentalStatementForTesting()) {
+        this.notAllowed(statement, 'Experimental testing statements');
+      } else {
+        if (runStatement === undefined) {
+          runStatement = statement.runStatement();
+        } else {
+          this.illegal(statement, `${MLQs} may only have one run statement`);
+        }
+      }
+    }
+    if (runStatement === undefined) {
+      this.illegal(pcx, `${MLQs} must have a run statement`);
+      return null;
+    }
+    return this.visitRunStatement(runStatement);
+  }
+
+  visitRunStatement(pcx: parse.RunStatementContext): Malloy.Query | null {
+    const defCx = pcx.topLevelAnonQueryDef();
+    const definition = this.getQueryDefinition(defCx.sqExpr());
+    const annotations = this.getAnnotations(pcx.topLevelAnonQueryDef().tags());
+    if (definition !== null) {
+      return {
+        annotations,
+        definition,
+      };
+    }
+    return null;
+  }
+
+  protected getQueryReference(cx: parse.SQIDContext): Malloy.Reference | null {
+    if (cx.sourceArguments()) {
+      this.illegal(cx, 'Queries do not support parameters');
+    } else {
+      return {
+        name: getId(cx),
+      };
+    }
+    return null;
+  }
+
+  protected getQueryDefinition(
+    cx: parse.SqExprContext
+  ): Malloy.QueryDefinition | null {
+    if (cx instanceof parse.SQIDContext) {
+      const ref = this.getQueryReference(cx);
+      if (ref !== null) {
+        return {
+          kind: 'query_reference',
+          ...ref,
+        };
+      }
+    } else if (cx instanceof parse.SQParensContext) {
+      this.notAllowed(cx, 'Parenthesized query expressions');
+    } else if (cx instanceof parse.SQComposeContext) {
+      this.notAllowed(cx, 'Source compositions');
+    } else if (cx instanceof parse.SQRefinedQueryContext) {
+      const seg = this.getRefinementSegment(cx.segExpr());
+      if (seg === null) return null;
+      const qrefCx = cx.sqExpr();
+      if (qrefCx instanceof parse.SQIDContext) {
+        const qref = this.getQueryReference(qrefCx);
+        if (qref === null) return null;
+        return {
+          kind: 'refinement',
+          query_reference: qref,
+          refinement: seg,
+        };
+      }
+    } else if (cx instanceof parse.SQExtendedSourceContext) {
+      this.notAllowed(cx, 'Source extensions');
+    } else if (cx instanceof parse.SQIncludeContext) {
+      this.notAllowed(cx, 'Source inclusions');
+    } else if (cx instanceof parse.SQTableContext) {
+      this.notAllowed(cx, 'Table statements');
+    } else if (cx instanceof parse.SQSQLContext) {
+      this.notAllowed(cx, 'SQL statements');
+    } else if (cx instanceof parse.SQArrowContext) {
+      const qrefCx = cx.sqExpr();
+      const seg = this.getRefinementSegment(cx.segExpr());
+      if (seg === null) return null;
+      // TODO really I need to allow getting any sqExpr that starts with a query reference,
+      // then flip the precedence
+      if (qrefCx instanceof parse.SQIDContext) {
+        const qref = this.getQueryReference(qrefCx);
+        if (qref === null) return null;
+        return {
+          kind: 'arrow',
+          source_reference: qref,
+          view: seg,
+        };
+      }
+    }
+    return null;
+  }
+
+  protected getRefinementSegment(
+    cx: parse.SegExprContext
+  ): Malloy.ViewDefinition | null {
+    if (cx instanceof parse.SegOpsContext) {
+      const operations = cx
+        .queryProperties()
+        .queryStatement()
+        .flatMap(stmt => this.getSegmentOperation(stmt));
+      if (operations.some(o => o === null)) {
+        return null;
+      }
+      return {
+        kind: 'segment',
+        operations: operations as Malloy.ViewOperation[],
+      };
+    }
+    // TODO other kinds
+    return null;
+  }
+
+  protected getSegmentOperation(
+    cx: parse.QueryStatementContext
+  ): Malloy.ViewOperation[] | null {
+    if (cx.groupByStatement()) {
+      const gbcx = cx.groupByStatement()!;
+      const groupAnnotations = this.getAnnotations(gbcx.tags());
+      const fieldCxs = gbcx.queryFieldList().queryFieldEntry();
+      const fields = fieldCxs.map(f => this.getQueryField(f));
+      if (fields.some(o => o === null)) {
+        return null;
+      }
+      if (fields === null) return null;
+      return (fields as {name?: string; field: Malloy.Field}[]).map(f => {
+        const annotations = [
+          ...(groupAnnotations ?? []),
+          ...(f.field.annotations ?? []),
+        ];
+        const gb: Malloy.ViewOperationWithGroupBy = {
+          kind: 'group_by',
+          name: f.name,
+          field: {
+            ...f.field,
+            annotations: annotations.length > 0 ? annotations : undefined,
+          },
+        };
+        return gb;
+      });
+    }
+    return null;
+  }
+
+  protected getFieldPath(pcx: parse.FieldPathContext): {
+    name: string;
+    path?: string[];
+  } {
+    const names = pcx.fieldName().map(nameCx => getId(nameCx));
+    const name = names[0];
+    const path = names.slice(1);
+    return {name, path: path.length > 0 ? path : undefined};
+  }
+
+  protected getTimeframe(
+    cx: parse.TimeframeContext
+  ): Malloy.TimestampTimeframe | null {
+    const text = cx.text;
+    if (isTimestampUnit(text)) {
+      return text;
+    }
+    this.illegal(cx, `Invalid timeframe ${text}`);
+    return null;
+  }
+
+  protected getQueryField(
+    cx: parse.QueryFieldEntryContext
+  ): {name?: string; field: Malloy.Field} | null {
+    if (cx.taggedRef()) {
+      const trcx = cx.taggedRef()!;
+      const annotations = this.getAnnotations(trcx.tags());
+      const {name, path} = this.getFieldPath(trcx.fieldPath());
+      if (trcx.refExpr()) {
+        const refexpr = trcx.refExpr()!;
+        if (refexpr.timeframe()) {
+          const tf = this.getTimeframe(refexpr.timeframe()!);
+          if (tf === null) return null;
+          return {
+            name: undefined,
+            field: {
+              annotations,
+              expression: {
+                kind: 'time_truncation',
+                field_reference: {
+                  name,
+                  path,
+                },
+                truncation: tf,
+              },
+            },
+          };
+        } else if (refexpr.aggregate()) {
+          this.notAllowed(refexpr, 'Aggregate expressions');
+        }
+      } else {
+        return {
+          name: undefined,
+          field: {
+            annotations,
+            expression: {
+              kind: 'field_reference',
+              name,
+              path,
+            },
+          },
+        };
+      }
+    }
+    // TODO other kinds
+    return null;
+  }
+}
+
+export function malloyToQuery(code: string): {
+  query?: Malloy.Query;
+  logs: Malloy.LogMessage[];
+} {
+  const sourceInfo = getSourceInfo(code);
+  const logger = new BaseMessageLogger(null);
+  const url = 'internal://query.malloy';
+  const parse = runMalloyParser(code, url, sourceInfo, logger);
+  const secondPass = new MalloyToQuery(parse, logger);
+  const query = secondPass.visit(parse.root);
+  const logs = mapLogs(logger.getLog(), url);
+  if (query === null) {
+    return {logs};
+  }
+  if (!('definition' in query)) {
+    throw new Error('Expected a query');
+  }
+  return {
+    query: query as Malloy.Query,
+    logs,
+  };
+}

--- a/packages/malloy/src/lang/parse-log.ts
+++ b/packages/malloy/src/lang/parse-log.ts
@@ -403,6 +403,7 @@ type MessageParameterTypes = {
   'unsupported-path-in-include': string;
   'wildcard-include-rename': string;
   'literal-string-newline': string;
+  'invalid-malloy-query-document': string;
 };
 
 export const MESSAGE_FORMATTERS: PartialErrorCodeMessageMap = {

--- a/packages/malloy/src/lang/parse-malloy.ts
+++ b/packages/malloy/src/lang/parse-malloy.ts
@@ -75,18 +75,18 @@ import {
   ModelAnnotationResponse,
   TablePathResponse,
 } from './translate-response';
-import {locationContainsPosition} from './utils';
+import {
+  getSourceInfo,
+  locationContainsPosition,
+  rangeFromContext,
+} from './utils';
 import {Tag} from '@malloydata/malloy-tag';
 import {MalloyParseInfo} from './malloy-parse-info';
 import {walkForModelAnnotation} from './parse-tree-walkers/model-annotation-walker';
 import {walkForTablePath} from './parse-tree-walkers/find-table-path-walker';
 import {EventStream} from '../runtime_types';
 import {annotationToTag} from '../annotation';
-import {
-  getSourceInfo,
-  rangeFromContext,
-  runMalloyParser,
-} from './run-malloy-parser';
+import {runMalloyParser} from './run-malloy-parser';
 import {ParserRuleContext} from 'antlr4ts';
 
 export type StepResponses =

--- a/packages/malloy/src/lang/parse-tree-walkers/model-annotation-walker.ts
+++ b/packages/malloy/src/lang/parse-tree-walkers/model-annotation-walker.ts
@@ -40,7 +40,7 @@ class ModelAnnotationWalker implements MalloyParserListener {
   protected getLocation(cx: ParserRuleContext): DocumentLocation {
     return {
       url: this.parseInfo.sourceURL,
-      range: this.parseInfo.rangeFromContext(cx),
+      range: this.translator.rangeFromContext(cx),
     };
   }
 

--- a/packages/malloy/src/lang/run-malloy-parser.ts
+++ b/packages/malloy/src/lang/run-malloy-parser.ts
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {
+  CharStreams,
+  CodePointCharStream,
+  CommonTokenStream,
+  ParserRuleContext,
+  Token,
+} from 'antlr4ts';
+import {MalloyLexer} from './lib/Malloy/MalloyLexer';
+import {MalloyParser} from './lib/Malloy/MalloyParser';
+import {MalloyParserErrorListener} from './syntax-errors/malloy-parser-error-listener';
+import {MalloyErrorStrategy} from './syntax-errors/malloy-error-strategy';
+import {ParseTree} from 'antlr4ts/tree';
+import {MessageLogger} from './parse-log';
+import {DocumentRange} from '../model/malloy_types';
+
+/**
+ * This ignores a -> popMode when the mode stack is empty, which is a hack,
+ * but it let's us parse }%
+ */
+class HandlesOverpoppingLexer extends MalloyLexer {
+  popMode(): number {
+    if (this._modeStack.isEmpty) {
+      return this._mode;
+    }
+    return super.popMode();
+  }
+}
+
+export interface SourceInfo {
+  lines: string[];
+  at: {begin: number; end: number}[];
+  length: number;
+}
+
+export function rangeFromTokens(
+  sourceInfo: SourceInfo | undefined,
+  startToken: Token,
+  stopToken: Token
+): DocumentRange {
+  const start = {
+    line: startToken.line - 1,
+    character: startToken.charPositionInLine,
+  };
+  if (sourceInfo && stopToken.stopIndex !== -1) {
+    // Find the line which contains the stopIndex
+    const lastLine = sourceInfo.lines.length - 1;
+    for (let lineNo = startToken.line - 1; lineNo <= lastLine; lineNo++) {
+      const at = sourceInfo.at[lineNo];
+      if (stopToken.stopIndex >= at.begin && stopToken.stopIndex < at.end) {
+        return {
+          start,
+          end: {
+            line: lineNo,
+            character: stopToken.stopIndex - at.begin + 1,
+          },
+        };
+      }
+    }
+    // Should be impossible to get here, but if we do ... return the last
+    // character of the last line of the file
+    return {
+      start,
+      end: {
+        line: lastLine,
+        character: sourceInfo.lines[lastLine].length,
+      },
+    };
+  }
+  return {start, end: start};
+}
+
+export function rangeFromToken(
+  sourceInfo: SourceInfo | undefined,
+  token: Token
+): DocumentRange {
+  return rangeFromTokens(sourceInfo, token, token);
+}
+
+export function rangeFromContext(
+  sourceInfo: SourceInfo | undefined,
+  pcx: ParserRuleContext
+): DocumentRange {
+  return rangeFromTokens(sourceInfo, pcx.start, pcx.stop || pcx.start);
+}
+
+/**
+ * Split the source up into lines so we can correctly compute offset
+ * to the line/char positions favored by LSP and VSCode.
+ */
+export function getSourceInfo(code: string): SourceInfo {
+  const eolRegex = /\r?\n/;
+  const info: SourceInfo = {
+    at: [],
+    lines: [],
+    length: code.length,
+  };
+  let src = code;
+  let lineStart = 0;
+  while (src !== '') {
+    const eol = src.match(eolRegex);
+    if (eol && eol.index !== undefined) {
+      // line text DOES NOT include the EOL
+      info.lines.push(src.slice(0, eol.index));
+      const lineLength = eol.index + eol[0].length;
+      info.at.push({
+        begin: lineStart,
+        end: lineStart + lineLength,
+      });
+      lineStart += lineLength;
+      src = src.slice(lineLength);
+    } else {
+      // last line, does not have a line end
+      info.lines.push(src);
+      info.at.push({begin: lineStart, end: lineStart + src.length});
+      break;
+    }
+  }
+  return info;
+}
+
+export interface ParseInfo {
+  root: ParseTree;
+  tokenStream: CommonTokenStream;
+  sourceStream: CodePointCharStream;
+  sourceURL: string;
+  malloyVersion: string;
+  sourceInfo: SourceInfo;
+}
+
+export function runMalloyParser(
+  code: string,
+  sourceURL: string,
+  sourceInfo: SourceInfo,
+  logger: MessageLogger,
+  grammarRule = 'malloyDocument'
+): ParseInfo {
+  const inputStream = CharStreams.fromString(code);
+  const lexer = new HandlesOverpoppingLexer(inputStream);
+  const tokenStream = new CommonTokenStream(lexer);
+  const malloyParser = new MalloyParser(tokenStream);
+  malloyParser.removeErrorListeners();
+  malloyParser.addErrorListener(
+    new MalloyParserErrorListener(logger, sourceURL, sourceInfo)
+  );
+  malloyParser.errorHandler = new MalloyErrorStrategy();
+
+  // Admitted code smell here, testing likes to parse from an arbitrary
+  // node and this is the simplest way to allow that.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const parseFunc = (malloyParser as any)[grammarRule];
+  if (!parseFunc) {
+    throw new Error(`No such parse rule as ${grammarRule}`);
+  }
+
+  return {
+    root: parseFunc.call(malloyParser) as ParseTree,
+    tokenStream: tokenStream,
+    sourceStream: inputStream,
+    sourceInfo,
+    sourceURL,
+    // TODO some way to not forget to update this
+    malloyVersion: '4.0.0',
+  };
+}

--- a/packages/malloy/src/lang/run-malloy-parser.ts
+++ b/packages/malloy/src/lang/run-malloy-parser.ts
@@ -5,20 +5,14 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {
-  CharStreams,
-  CodePointCharStream,
-  CommonTokenStream,
-  ParserRuleContext,
-  Token,
-} from 'antlr4ts';
+import {CharStreams, CommonTokenStream} from 'antlr4ts';
 import {MalloyLexer} from './lib/Malloy/MalloyLexer';
 import {MalloyParser} from './lib/Malloy/MalloyParser';
-import {MalloyParserErrorListener} from './syntax-errors/malloy-parser-error-listener';
 import {MalloyErrorStrategy} from './syntax-errors/malloy-error-strategy';
 import {ParseTree} from 'antlr4ts/tree';
 import {MessageLogger} from './parse-log';
-import {DocumentRange} from '../model/malloy_types';
+import {ParseInfo, SourceInfo} from './utils';
+import {MalloyParserErrorListener} from './syntax-errors/malloy-parser-error-listener';
 
 /**
  * This ignores a -> popMode when the mode stack is empty, which is a hack,
@@ -31,107 +25,6 @@ class HandlesOverpoppingLexer extends MalloyLexer {
     }
     return super.popMode();
   }
-}
-
-export interface SourceInfo {
-  lines: string[];
-  at: {begin: number; end: number}[];
-  length: number;
-}
-
-export function rangeFromTokens(
-  sourceInfo: SourceInfo | undefined,
-  startToken: Token,
-  stopToken: Token
-): DocumentRange {
-  const start = {
-    line: startToken.line - 1,
-    character: startToken.charPositionInLine,
-  };
-  if (sourceInfo && stopToken.stopIndex !== -1) {
-    // Find the line which contains the stopIndex
-    const lastLine = sourceInfo.lines.length - 1;
-    for (let lineNo = startToken.line - 1; lineNo <= lastLine; lineNo++) {
-      const at = sourceInfo.at[lineNo];
-      if (stopToken.stopIndex >= at.begin && stopToken.stopIndex < at.end) {
-        return {
-          start,
-          end: {
-            line: lineNo,
-            character: stopToken.stopIndex - at.begin + 1,
-          },
-        };
-      }
-    }
-    // Should be impossible to get here, but if we do ... return the last
-    // character of the last line of the file
-    return {
-      start,
-      end: {
-        line: lastLine,
-        character: sourceInfo.lines[lastLine].length,
-      },
-    };
-  }
-  return {start, end: start};
-}
-
-export function rangeFromToken(
-  sourceInfo: SourceInfo | undefined,
-  token: Token
-): DocumentRange {
-  return rangeFromTokens(sourceInfo, token, token);
-}
-
-export function rangeFromContext(
-  sourceInfo: SourceInfo | undefined,
-  pcx: ParserRuleContext
-): DocumentRange {
-  return rangeFromTokens(sourceInfo, pcx.start, pcx.stop || pcx.start);
-}
-
-/**
- * Split the source up into lines so we can correctly compute offset
- * to the line/char positions favored by LSP and VSCode.
- */
-export function getSourceInfo(code: string): SourceInfo {
-  const eolRegex = /\r?\n/;
-  const info: SourceInfo = {
-    at: [],
-    lines: [],
-    length: code.length,
-  };
-  let src = code;
-  let lineStart = 0;
-  while (src !== '') {
-    const eol = src.match(eolRegex);
-    if (eol && eol.index !== undefined) {
-      // line text DOES NOT include the EOL
-      info.lines.push(src.slice(0, eol.index));
-      const lineLength = eol.index + eol[0].length;
-      info.at.push({
-        begin: lineStart,
-        end: lineStart + lineLength,
-      });
-      lineStart += lineLength;
-      src = src.slice(lineLength);
-    } else {
-      // last line, does not have a line end
-      info.lines.push(src);
-      info.at.push({begin: lineStart, end: lineStart + src.length});
-      break;
-    }
-  }
-  return info;
-}
-
-export interface ParseInfo {
-  root: ParseTree;
-  tokenStream: CommonTokenStream;
-  sourceStream: CodePointCharStream;
-  sourceURL: string;
-  malloyVersion: string;
-  sourceInfo: SourceInfo;
 }
 
 export function runMalloyParser(

--- a/packages/malloy/src/lang/syntax-errors/malloy-parser-error-listener.ts
+++ b/packages/malloy/src/lang/syntax-errors/malloy-parser-error-listener.ts
@@ -15,7 +15,7 @@ import {
   LogMessageOptions,
   makeLogMessage,
 } from '../parse-log';
-import {rangeFromToken, SourceInfo} from '../run-malloy-parser';
+import {rangeFromToken, SourceInfo} from '../utils';
 
 // A set of custom error messages and their triggering cases,
 // used for syntax error message re-writing when ANTLR would

--- a/packages/malloy/src/lang/syntax-errors/malloy-parser-error-listener.ts
+++ b/packages/malloy/src/lang/syntax-errors/malloy-parser-error-listener.ts
@@ -15,7 +15,7 @@ import {
   LogMessageOptions,
   makeLogMessage,
 } from '../parse-log';
-import {MalloyTranslation} from '../parse-malloy';
+import {rangeFromToken, SourceInfo} from '../run-malloy-parser';
 
 // A set of custom error messages and their triggering cases,
 // used for syntax error message re-writing when ANTLR would
@@ -155,8 +155,10 @@ export const malloyCustomErrorCases: ErrorCase[] = [
 
 export class MalloyParserErrorListener implements ANTLRErrorListener<Token> {
   constructor(
-    readonly translator: MalloyTranslation,
-    readonly messages: MessageLogger
+    // readonly translator: MalloyTranslation,
+    readonly messages: MessageLogger,
+    readonly sourceURL: string,
+    readonly sourceInfo: SourceInfo
   ) {}
 
   logError<T extends MessageCode>(
@@ -180,7 +182,7 @@ export class MalloyParserErrorListener implements ANTLRErrorListener<Token> {
   ): void {
     const errAt = {line: line - 1, character: charPositionInLine};
     const range = offendingSymbol
-      ? this.translator.rangeFromToken(offendingSymbol)
+      ? rangeFromToken(this.sourceInfo, offendingSymbol)
       : {start: errAt, end: errAt};
 
     const overrideMessage = checkCustomErrorMessage(
@@ -196,7 +198,7 @@ export class MalloyParserErrorListener implements ANTLRErrorListener<Token> {
       'syntax-error',
       {message},
       {
-        at: {url: this.translator.sourceURL, range},
+        at: {url: this.sourceURL, range},
       }
     );
   }

--- a/packages/malloy/src/lang/test/malloy-to-stable-query.spec.ts
+++ b/packages/malloy/src/lang/test/malloy-to-stable-query.spec.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {malloyToQuery} from '../malloy-to-stable-query';
+import * as Malloy from '@malloydata/malloy-interfaces';
+
+type QueryAndLogs = {query: Malloy.Query; logs: Malloy.LogMessage[]};
+
+describe('Malloy to Stable Query', () => {
+  test('basic', () => {
+    const result = malloyToQuery('run: flights -> { group_by: carrier }');
+    const expected: QueryAndLogs = {
+      query: {
+        definition: {
+          kind: 'arrow',
+          source_reference: {name: 'flights'},
+          view: {
+            kind: 'segment',
+            operations: [
+              {
+                kind: 'group_by',
+                field: {
+                  expression: {
+                    kind: 'field_reference',
+                    name: 'carrier',
+                  },
+                },
+              },
+            ],
+          },
+        },
+      },
+      logs: [],
+    };
+    expect(result).toMatchObject(expected);
+  });
+});

--- a/packages/malloy/src/lang/test/malloy-to-stable-query.spec.ts
+++ b/packages/malloy/src/lang/test/malloy-to-stable-query.spec.ts
@@ -8,34 +8,345 @@
 import {malloyToQuery} from '../malloy-to-stable-query';
 import * as Malloy from '@malloydata/malloy-interfaces';
 
-type QueryAndLogs = {query: Malloy.Query; logs: Malloy.LogMessage[]};
+type QueryAndLogs = {query?: Malloy.Query; logs: Partial<Malloy.LogMessage>[]};
 
 describe('Malloy to Stable Query', () => {
-  test('basic', () => {
-    const result = malloyToQuery('run: flights -> { group_by: carrier }');
-    const expected: QueryAndLogs = {
-      query: {
-        definition: {
-          kind: 'arrow',
-          source_reference: {name: 'flights'},
-          view: {
-            kind: 'segment',
-            operations: [
-              {
-                kind: 'group_by',
-                field: {
-                  expression: {
-                    kind: 'field_reference',
-                    name: 'carrier',
+  describe('field exprs', () => {
+    test('field reference (not renamed)', () => {
+      idempotent('run: flights -> { group_by: carrier }', {
+        query: {
+          definition: {
+            kind: 'arrow',
+            source: {
+              kind: 'source_reference',
+              name: 'flights',
+            },
+            view: {
+              kind: 'segment',
+              operations: [
+                {
+                  kind: 'group_by',
+                  field: {
+                    expression: {
+                      kind: 'field_reference',
+                      name: 'carrier',
+                    },
                   },
                 },
-              },
-            ],
+              ],
+            },
           },
         },
-      },
-      logs: [],
-    };
-    expect(result).toMatchObject(expected);
+        logs: [],
+      });
+    });
+    test('field reference (renamed)', () => {
+      idempotent('run: flights -> { group_by: carrier2 is carrier }', {
+        query: {
+          definition: {
+            kind: 'arrow',
+            source: {
+              kind: 'source_reference',
+              name: 'flights',
+            },
+            view: {
+              kind: 'segment',
+              operations: [
+                {
+                  kind: 'group_by',
+                  name: 'carrier2',
+                  field: {
+                    expression: {
+                      kind: 'field_reference',
+                      name: 'carrier',
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        },
+        logs: [],
+      });
+    });
+    test('field time trunctation (not renamed)', () => {
+      idempotent('run: flights -> { group_by: dep_time.day }', {
+        query: {
+          definition: {
+            kind: 'arrow',
+            source: {
+              kind: 'source_reference',
+              name: 'flights',
+            },
+            view: {
+              kind: 'segment',
+              operations: [
+                {
+                  kind: 'group_by',
+                  field: {
+                    expression: {
+                      kind: 'time_truncation',
+                      field_reference: {name: 'dep_time'},
+                      truncation: 'day',
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        },
+        logs: [],
+      });
+    });
+    test('field time trunctation (renamed)', () => {
+      idempotent('run: flights -> { group_by: dep_day is dep_time.day }', {
+        query: {
+          definition: {
+            kind: 'arrow',
+            source: {
+              kind: 'source_reference',
+              name: 'flights',
+            },
+            view: {
+              kind: 'segment',
+              operations: [
+                {
+                  kind: 'group_by',
+                  name: 'dep_day',
+                  field: {
+                    expression: {
+                      kind: 'time_truncation',
+                      field_reference: {name: 'dep_time'},
+                      truncation: 'day',
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        },
+        logs: [],
+      });
+    });
+  });
+  describe('nests', () => {
+    test('simple named nest', () => {
+      idempotent(
+        'run: flights -> { nest: carriers is { group_by: carrier } }',
+        {
+          logs: [],
+          query: {
+            definition: {
+              kind: 'arrow',
+              source: {
+                kind: 'source_reference',
+                name: 'flights',
+              },
+              view: {
+                kind: 'segment',
+                operations: [
+                  {
+                    kind: 'nest',
+                    name: 'carriers',
+                    view: {
+                      definition: {
+                        kind: 'segment',
+                        operations: [
+                          {
+                            kind: 'group_by',
+                            field: {
+                              expression: {
+                                kind: 'field_reference',
+                                name: 'carrier',
+                              },
+                            },
+                          },
+                        ],
+                      },
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        }
+      );
+    });
+  });
+  describe('query combinations', () => {
+    test('a -> b -> c', () => {
+      idempotent('run: a -> b -> c', {
+        query: {
+          definition: {
+            kind: 'arrow',
+            source: {
+              kind: 'source_reference',
+              name: 'a',
+            },
+            view: {
+              kind: 'arrow',
+              source: {
+                kind: 'view_reference',
+                name: 'b',
+              },
+              view: {
+                kind: 'view_reference',
+                name: 'c',
+              },
+            },
+          },
+        },
+        logs: [],
+      });
+    });
+    test('a -> b + c', () => {
+      idempotent('run: a -> b + c', {
+        query: {
+          definition: {
+            kind: 'arrow',
+            source: {
+              kind: 'source_reference',
+              name: 'a',
+            },
+            view: {
+              kind: 'refinement',
+              base: {
+                kind: 'view_reference',
+                name: 'b',
+              },
+              refinement: {
+                kind: 'view_reference',
+                name: 'c',
+              },
+            },
+          },
+        },
+        logs: [],
+      });
+    });
+    test('a + b -> c', () => {
+      idempotent('run: a + b -> c', {
+        query: {
+          definition: {
+            kind: 'arrow',
+            source: {
+              kind: 'refinement',
+              base: {
+                kind: 'query_reference',
+                name: 'a',
+              },
+              refinement: {
+                kind: 'view_reference',
+                name: 'b',
+              },
+            },
+            view: {
+              kind: 'view_reference',
+              name: 'c',
+            },
+          },
+        },
+        logs: [],
+      });
+    });
+    test('(a + b) -> c', () => {
+      simplified('run: (a + b) -> c', 'run: a + b -> c', {
+        query: {
+          definition: {
+            kind: 'arrow',
+            source: {
+              kind: 'refinement',
+              base: {
+                kind: 'query_reference',
+                name: 'a',
+              },
+              refinement: {
+                kind: 'view_reference',
+                name: 'b',
+              },
+            },
+            view: {
+              kind: 'view_reference',
+              name: 'c',
+            },
+          },
+        },
+        logs: [],
+      });
+    });
+    test('(a -> b) + c', () => {
+      idempotent('run: (a -> b) + c', {
+        query: {
+          definition: {
+            kind: 'refinement',
+            base: {
+              kind: 'arrow',
+              source: {
+                kind: 'source_reference',
+                name: 'a',
+              },
+              view: {
+                kind: 'view_reference',
+                name: 'b',
+              },
+            },
+            refinement: {
+              kind: 'view_reference',
+              name: 'c',
+            },
+          },
+        },
+        logs: [],
+      });
+    });
+    test('a + b + c', () => {
+      idempotent('run: a + b + c', {
+        query: {
+          definition: {
+            kind: 'refinement',
+            base: {
+              kind: 'query_reference',
+              name: 'a',
+            },
+            refinement: {
+              kind: 'refinement',
+              base: {
+                kind: 'view_reference',
+                name: 'b',
+              },
+              refinement: {
+                kind: 'view_reference',
+                name: 'c',
+              },
+            },
+          },
+        },
+        logs: [],
+      });
+    });
   });
 });
+
+function idempotent(query: string, expected?: QueryAndLogs) {
+  const result = malloyToQuery(query);
+  if (expected) {
+    expect(result).toMatchObject(expected);
+  }
+  expect(result.query).not.toBeUndefined();
+  const malloy = Malloy.queryToMalloy(result.query!);
+  expect(query).toEqual(malloy);
+}
+
+function simplified(
+  query: string,
+  expected: string,
+  expectedParsed?: QueryAndLogs
+) {
+  const result = malloyToQuery(query);
+  expect(result.query).not.toBeUndefined();
+  if (expectedParsed) {
+    expect(result).toMatchObject(expectedParsed);
+  }
+  const malloy = Malloy.queryToMalloy(result.query!);
+  expect(malloy).toEqual(expected);
+}

--- a/packages/malloy/src/lang/utils.ts
+++ b/packages/malloy/src/lang/utils.ts
@@ -21,7 +21,18 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import {DocumentLocation, DocumentPosition} from '../model/malloy_types';
+import {
+  CodePointCharStream,
+  CommonTokenStream,
+  ParserRuleContext,
+  Token,
+} from 'antlr4ts';
+import {
+  DocumentLocation,
+  DocumentPosition,
+  DocumentRange,
+} from '../model/malloy_types';
+import {ParseTree} from 'antlr4ts/tree';
 
 export function locationContainsPosition(
   location: DocumentLocation,
@@ -39,4 +50,105 @@ export function locationContainsPosition(
 
 export function isNotUndefined<T>(value: T | undefined): value is T {
   return value !== undefined;
+}
+
+export interface SourceInfo {
+  lines: string[];
+  at: {begin: number; end: number}[];
+  length: number;
+}
+
+export function rangeFromTokens(
+  sourceInfo: SourceInfo | undefined,
+  startToken: Token,
+  stopToken: Token
+): DocumentRange {
+  const start = {
+    line: startToken.line - 1,
+    character: startToken.charPositionInLine,
+  };
+  if (sourceInfo && stopToken.stopIndex !== -1) {
+    // Find the line which contains the stopIndex
+    const lastLine = sourceInfo.lines.length - 1;
+    for (let lineNo = startToken.line - 1; lineNo <= lastLine; lineNo++) {
+      const at = sourceInfo.at[lineNo];
+      if (stopToken.stopIndex >= at.begin && stopToken.stopIndex < at.end) {
+        return {
+          start,
+          end: {
+            line: lineNo,
+            character: stopToken.stopIndex - at.begin + 1,
+          },
+        };
+      }
+    }
+    // Should be impossible to get here, but if we do ... return the last
+    // character of the last line of the file
+    return {
+      start,
+      end: {
+        line: lastLine,
+        character: sourceInfo.lines[lastLine].length,
+      },
+    };
+  }
+  return {start, end: start};
+}
+
+export function rangeFromToken(
+  sourceInfo: SourceInfo | undefined,
+  token: Token
+): DocumentRange {
+  return rangeFromTokens(sourceInfo, token, token);
+}
+
+export function rangeFromContext(
+  sourceInfo: SourceInfo | undefined,
+  pcx: ParserRuleContext
+): DocumentRange {
+  return rangeFromTokens(sourceInfo, pcx.start, pcx.stop || pcx.start);
+}
+
+/**
+ * Split the source up into lines so we can correctly compute offset
+ * to the line/char positions favored by LSP and VSCode.
+ */
+export function getSourceInfo(code: string): SourceInfo {
+  const eolRegex = /\r?\n/;
+  const info: SourceInfo = {
+    at: [],
+    lines: [],
+    length: code.length,
+  };
+  let src = code;
+  let lineStart = 0;
+  while (src !== '') {
+    const eol = src.match(eolRegex);
+    if (eol && eol.index !== undefined) {
+      // line text DOES NOT include the EOL
+      info.lines.push(src.slice(0, eol.index));
+      const lineLength = eol.index + eol[0].length;
+      info.at.push({
+        begin: lineStart,
+        end: lineStart + lineLength,
+      });
+      lineStart += lineLength;
+      src = src.slice(lineLength);
+    } else {
+      // last line, does not have a line end
+      info.lines.push(src);
+      info.at.push({begin: lineStart, end: lineStart + src.length});
+      break;
+    }
+  }
+  return info;
+}
+
+export interface ParseInfo {
+  root: ParseTree;
+  tokenStream: CommonTokenStream;
+  sourceStream: CodePointCharStream;
+  sourceURL: string;
+  malloyVersion: string;
+  sourceInfo: SourceInfo;
 }


### PR DESCRIPTION
Adds a function `malloyToQuery` (name is not final), which converts Malloy code into a `Malloy.Query` (from `@malloydata/interfaces`). This runs the real parser with a different parse tree walker.

Where clauses (in both views and filtered aggregates) are not implemented, because the Malloy syntax for filter string filters has not been implemented.

This also changes the thrift interface for queries slightly. Arrow queries can now have a source which is query refinement (e.g. `run: (cool_query + { group_by: x }) -> { group_by: y }`). The query builder `QueryAST` data structure has been updated to account for this.