### PR TITLE
Fix a script exception if the filter is undefined

### DIFF
--- a/packages/malloy-filter/src/filter_interface.ts
+++ b/packages/malloy-filter/src/filter_interface.ts
@@ -276,7 +276,7 @@ export type FilterExpression =
   | TemporalFilter;
 
 export function isFilterExpression(obj: Object): obj is FilterExpression {
-  return 'operator' in obj;
+  return obj && 'operator' in obj;
 }
 
 export type FilterLogSeverity = 'error' | 'warn';

--- a/packages/malloy-filter/src/nearley_parse.ts
+++ b/packages/malloy-filter/src/nearley_parse.ts
@@ -17,7 +17,7 @@ export function run_parser(
     parser.feed(src);
     const results = parser.finish();
     const expr = results[0];
-    if (isFilterExpression(expr)) {
+    if (expr && isFilterExpression(expr)) {
       return {parsed: expr, log: []};
     }
     return {parsed: null, log: []};

--- a/packages/malloy/src/model/malloy_query.ts
+++ b/packages/malloy/src/model/malloy_query.ts
@@ -1366,7 +1366,7 @@ class QueryField extends QueryNode {
           expr.dataType === 'timestamp' ||
           expr.dataType === 'boolean'
         ) {
-          if (expr.filter === null || isFilterExpression(expr.filter)) {
+          if (!expr.filter || isFilterExpression(expr.filter)) {
             return FilterCompilers.compile(
               expr.dataType,
               expr.filter,


### PR DESCRIPTION
In the case the filter is undefined, make sure we return the default value (also handled in the `null` case) instead of throwing an unexpected script error.