### PR TITLE
 Update package.json exports to support types.

### DIFF
--- a/packages/malloy-render/package.json
+++ b/packages/malloy-render/package.json
@@ -13,9 +13,18 @@
     "node": ">=20"
   },
   "exports": {
-    ".": "./dist/module/index.umd.js",
-    "./webcomponent": "./dist/webcomponent/malloy-render.umd.js",
-    "./webcomponent/register": "./dist/register/register.umd.js"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/module/index.umd.js"
+    },
+    "./webcomponent": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/webcomponent/malloy-render.umd.js"
+    },
+    "./webcomponent/register": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/register/register.umd.js"
+    }
   },
   "scripts": {
     "bundle_renderer": "node src/bundle/esbuild_bundler.js",


### PR DESCRIPTION
As title, package.json didn't previously include types with its exports; now it does.

**Why is this an issue/why now?**

Older ts module resolution strategies (like 'node') don't reference package.json exports; instead, they use 'main' and 'types'. These are the module resolution strategies used by 'malloy-composer' and 'malloy-vscode-extension.' Newer resolution strategies (like 'bunder', used in malloy-explorer) use package.json exports, and as such don't get types from the package.json 'types' field. Thus, this is needed.

**Testing**
- 'npm link'ed malloy-render to malloy-vscode-extension & checked things still worked. If there's a more robust way to test this I'd love to hear it.