### PR TITLE
Simplify undefined checking in filter_interface.ts

### DIFF
--- a/packages/malloy-filter/src/filter_interface.ts
+++ b/packages/malloy-filter/src/filter_interface.ts
@@ -275,8 +275,10 @@ export type FilterExpression =
   | StringFilter
   | TemporalFilter;
 
-export function isFilterExpression(obj: Object): obj is FilterExpression {
-  return obj && 'operator' in obj;
+export function isFilterExpression(
+  obj: Object | undefined
+): obj is FilterExpression {
+  return !!obj && 'operator' in obj;
 }
 
 export type FilterLogSeverity = 'error' | 'warn';

--- a/packages/malloy-filter/src/nearley_parse.ts
+++ b/packages/malloy-filter/src/nearley_parse.ts
@@ -17,7 +17,7 @@ export function run_parser(
     parser.feed(src);
     const results = parser.finish();
     const expr = results[0];
-    if (expr && isFilterExpression(expr)) {
+    if (isFilterExpression(expr)) {
       return {parsed: expr, log: []};
     }
     return {parsed: null, log: []};

--- a/packages/malloy/src/model/malloy_query.ts
+++ b/packages/malloy/src/model/malloy_query.ts
@@ -1366,7 +1366,7 @@ class QueryField extends QueryNode {
           expr.dataType === 'timestamp' ||
           expr.dataType === 'boolean'
         ) {
-          if (!expr.filter || isFilterExpression(expr.filter)) {
+          if (expr.filter === null || isFilterExpression(expr.filter)) {
             return FilterCompilers.compile(
               expr.dataType,
               expr.filter,


### PR DESCRIPTION
Followup to https://github.com/malloydata/malloy/pull/2226

Reverts two unnecessary `if` conditions because we updated the `isFilterExpression()` to handle undefined properly.

The core issue was this block of code:

```
const expr = results[0];
if (isFilterExpression(expr)) {
```

If results.length === 0, then `expr` will be undefined. TypeScript does *not* enforce strict undefined checking, especially when reading from an array. Essentially, the lesson here is that all functions should always assume that values provided could be undefined.