### PR TITLE
Next iteration of custom jest matchers for executing queries

### DIFF
--- a/test/src/databases/all/compound-atomic.spec.ts
+++ b/test/src/databases/all/compound-atomic.spec.ts
@@ -244,6 +244,20 @@ describe.each(runtimes.runtimeList)(
           run: ${empty} extend { dimension: aoa is [[1,2]] } -> { select: aoa.each.each }
         `).malloyResultMatches(runtime, [{each: 1}, {each: 2}]);
       });
+      test('group by an array', async () => {
+        const oddsSQL = arraySelectVal(1, 3, 5, 7);
+        const two_evens = `${conName}.sql("""
+          SELECT ${evensSQL} AS ${quote('num_array')}, 100 as ${quote('x')}
+          UNION ALL SELECT ${evensSQL} , 10
+          UNION ALL SELECT ${oddsSQL}, 1
+        """)`;
+        await expect(
+          query(
+            runtime,
+            `run: ${two_evens} -> { group_by: num_array; aggregate: allx is sum(x) }`
+          )
+        ).matchesResult({allx: 110}, {allx: 1});
+      });
     });
     describe('record', () => {
       function rec_eq(as?: string): Record<string, Number> {

--- a/test/src/databases/all/compound-atomic.spec.ts
+++ b/test/src/databases/all/compound-atomic.spec.ts
@@ -16,6 +16,7 @@ import type {
   Expr,
   SQLSourceRequest,
 } from '@malloydata/malloy';
+import {query} from '../../util/db-matcher-support';
 
 const runtimes = new RuntimeList(databasesFromEnvironmentOr(allDatabases));
 
@@ -545,15 +546,13 @@ describe.each(runtimes.runtimeList)(
       });
       // test for https://github.com/malloydata/malloy/issues/2065
       test('nest a group_by repeated record', async () => {
-        await expect(`
-          run: ${conName}.sql(""" ${selectAB('ab')} """)
-          -> {
-            nest: gab is {group_by: ab }
-          } -> {
-            // mtoy todo fix malloyResultMatches, this un-nest should not be needed
-            select: gab.ab
-          }
-        `).malloyResultMatches(runtime, {ab: ab_eq});
+        await expect(
+          query(
+            runtime,
+            `run: ${conName}.sql(""" ${selectAB('ab')} """)
+             -> { nest: gab is {group_by: ab } }`
+          )
+        ).matchesResult({gab: {ab: ab_eq}});
       });
     });
   }

--- a/test/src/databases/all/db_filter_expressions.spec.ts
+++ b/test/src/databases/all/db_filter_expressions.spec.ts
@@ -43,13 +43,7 @@ describe.each(runtimes.runtimeList)('filter expressions %s', (dbName, db) => {
         }`).malloyResultMatches(abc, [{s: 'abc'}]);
     });
     test('empty string filter expression', async () => {
-      /*
-        since the sql generated works when pasted into mysql
-        my next suggestion is that there is some funky re-ordering
-        happening in the result processing which will test tomorrow
-      */
       await expect(`
-        # test.verbose
         run: abc -> {
           where: s ~ f'';
           select: *; order_by: nm asc
@@ -64,7 +58,6 @@ describe.each(runtimes.runtimeList)('filter expressions %s', (dbName, db) => {
     });
     test('-abc', async () => {
       await expect(`
-        # test.verbose
         run: abc -> {
           where: s ~ f'-abc',
           select: nm; order_by: nm asc
@@ -72,7 +65,6 @@ describe.each(runtimes.runtimeList)('filter expressions %s', (dbName, db) => {
     });
     test('-starts', async () => {
       await expect(`
-        # test.verbose
         run: abc -> {
           where: s ~ f'-a%',
           select: nm; order_by: nm asc
@@ -80,7 +72,6 @@ describe.each(runtimes.runtimeList)('filter expressions %s', (dbName, db) => {
     });
     test('-contains', async () => {
       await expect(`
-        # test.verbose
         run: abc -> {
           where: s ~ f'-%b%',
           select: nm; order_by: nm asc
@@ -88,7 +79,6 @@ describe.each(runtimes.runtimeList)('filter expressions %s', (dbName, db) => {
     });
     test('-end', async () => {
       await expect(`
-        # test.verbose
         run: abc -> {
           where: s ~ f'-%c',
           select: nm; order_by: nm asc
@@ -96,7 +86,6 @@ describe.each(runtimes.runtimeList)('filter expressions %s', (dbName, db) => {
     });
     test('unlike', async () => {
       await expect(`
-        # test.verbose
         run: abc -> {
           where: s ~ f'-a%c',
           select: nm; order_by: nm asc
@@ -104,7 +93,6 @@ describe.each(runtimes.runtimeList)('filter expressions %s', (dbName, db) => {
     });
     test('simple but not ___,-abc', async () => {
       await expect(`
-        # test.verbose
         run: abc -> {
           where: s ~ f'___,-abc';
           select: s
@@ -112,7 +100,6 @@ describe.each(runtimes.runtimeList)('filter expressions %s', (dbName, db) => {
     });
     test('empty', async () => {
       await expect(`
-        # test.verbose
         run: abc -> {
           where: s ~ f'empty'
           select: nm; order_by: nm asc
@@ -120,7 +107,6 @@ describe.each(runtimes.runtimeList)('filter expressions %s', (dbName, db) => {
     });
     test('-empty', async () => {
       await expect(`
-        # test.verbose
         run: abc -> {
           where: s ~ f'-empty'
           select: nm; order_by: nm asc
@@ -128,7 +114,6 @@ describe.each(runtimes.runtimeList)('filter expressions %s', (dbName, db) => {
     });
     test('null', async () => {
       await expect(`
-        # test.verbose
         run: abc -> {
           where: s ~ f'null'
           select: nm
@@ -136,7 +121,6 @@ describe.each(runtimes.runtimeList)('filter expressions %s', (dbName, db) => {
     });
     test('-null', async () => {
       await expect(`
-        # test.verbose
         run: abc -> {
           where: s ~ f'-null'
           select: nm; order_by: nm asc
@@ -144,7 +128,6 @@ describe.each(runtimes.runtimeList)('filter expressions %s', (dbName, db) => {
     });
     test('starts', async () => {
       await expect(`
-        # test.verbose
         run: abc -> {
           where: s ~ f'a%';
           select: s
@@ -152,7 +135,6 @@ describe.each(runtimes.runtimeList)('filter expressions %s', (dbName, db) => {
     });
     test('contains', async () => {
       await expect(`
-        # test.verbose
         run: abc -> {
           where: s ~ f'%b%,%e%';
           select: *; order_by: nm asc
@@ -160,7 +142,6 @@ describe.each(runtimes.runtimeList)('filter expressions %s', (dbName, db) => {
     });
     test('simple ends', async () => {
       await expect(`
-        # test.verbose
         run: abc -> {
           where: s ~ f'%c';
           select: s
@@ -168,7 +149,6 @@ describe.each(runtimes.runtimeList)('filter expressions %s', (dbName, db) => {
     });
     test('ends in backslash', async () => {
       await expect(`
-        # test.verbose
         run: abc -> {
           where: s ~ f'%\\\\'
           select: nm
@@ -176,7 +156,6 @@ describe.each(runtimes.runtimeList)('filter expressions %s', (dbName, db) => {
     });
     test('= x backslash', async () => {
       await expect(`
-        # test.verbose
         run: abc -> {
           where: s ~ f'x\\\\'
           select: nm
@@ -587,7 +566,6 @@ describe.each(runtimes.runtimeList)('filter expressions %s', (dbName, db) => {
     test('empty temporal filter', async () => {
       const range = mkRange('2001-01-01 00:00:00', '2002-01-01 00:00:00');
       await expect(`
-        # test.verbose
         run: range + { where: t ~ f''; order_by: n }
       `).malloyResultMatches(range, [
         {n: 'before'},

--- a/test/src/databases/all/db_filter_expressions.spec.ts
+++ b/test/src/databases/all/db_filter_expressions.spec.ts
@@ -9,7 +9,7 @@ import {RuntimeList, allDatabases} from '../../runtimes';
 import '../../util/db-jest-matchers';
 import {databasesFromEnvironmentOr} from '../../util';
 import {DateTime as LuxonDateTime} from 'luxon';
-import {mkSQLSource} from '../../util/db-matcher-support';
+import {mkSQLSource, query} from '../../util/db-matcher-support';
 
 const runtimes = new RuntimeList(databasesFromEnvironmentOr(allDatabases));
 
@@ -632,9 +632,9 @@ describe.each(runtimes.runtimeList)('filter expressions %s', (dbName, db) => {
     test('today', async () => {
       nowIs('2001-02-03 12:00:00');
       const range = mkRange('2001-02-03 00:00:00', '2001-02-04 00:00:00');
-      await expect(`
-        run: range + { where: t ~ f'today' }
-      `).malloyResultMatches(range, inRange);
+      await expect(
+        query(range, "run: range + { where: t ~ f'today' }")
+      ).matchesResult(...inRange);
     });
     test('yesterday', async () => {
       nowIs('2001-02-03 12:00:00');
@@ -696,9 +696,9 @@ describe.each(runtimes.runtimeList)('filter expressions %s', (dbName, db) => {
     test('last-tuesday', async () => {
       nowIs('2023-01-03 00:00:00');
       const range = mkRange('2022-12-27 00:00:00', '2022-12-28 00:00:00');
-      await expect(`
-        run: range + { where: t ~ f'tuesday' }
-      `).malloyResultMatches(range, inRange);
+      await expect(
+        query(range, "run: range + { where: t ~ f'tuesday' }")
+      ).matchesResult(...inRange);
     });
     test('last-wednesday', async () => {
       nowIs('2023-01-03 00:00:00');

--- a/test/src/util/db-jest-matchers.ts
+++ b/test/src/util/db-jest-matchers.ts
@@ -74,23 +74,23 @@ declare global {
        * at the end will be matched for each row of the query.
        *
        * To see if the first row of a query contains a field called num with a value of 7
+       * ( a "runtime"  can be a Runtime, or a Model from load/extend of a Model)
        *
-       *     await expect(query(runtimeOrModel, 'run: ...')).matchesResult({num: 7});
+       *     await expect(query(runtime, 'run: ...')).matchesResult({num: 7});
        *
        * To see if the first two rows of a query contains a field called num with a values 7 and 8
        *
-       *     await expect(query(runtimeOrModel, 'run: ...')).matchesResult({num: 7}, {num:8});
+       *     await expect(query(runtime, 'run: ...')).matchesResult({num: 7}, {num:8});
        *
        * Every symbol in the expect match must be in the row, however there can be columns in the row
        * which are not in the match.
        *
+       * mtoy todo maybe this should be "debug_query()" instead of a tag ... ?
        * In addition, the query is checked for the tags, preceed your run statement with ...
        *
        *   * test.debug -- Force test failure, and the result data will be printed
        *
-       * @param querySrc Malloy source, last query in source will be run
-       * @param runtime Database connection runtime OR Model ( for the call to loadQuery )
-       * @param expected Key value pairs or array of key value pairs
+       * @param matchVals ... list of row objects containing key-value pairs
        */
       matchesResult(...matchVals: unknown[]): Promise<R>;
       toEmitDuringCompile(

--- a/test/src/util/db-matcher-support.ts
+++ b/test/src/util/db-matcher-support.ts
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import type {
+  Result,
+  Runtime,
+  ModelMaterializer,
+  QueryMaterializer,
+  LogMessage,
+  Dialect,
+} from '@malloydata/malloy';
+import {API, MalloyError} from '@malloydata/malloy';
+import type {Tag} from '@malloydata/malloy-tag';
+
+type JestMatcherResult = {
+  pass: boolean;
+  message: () => string;
+};
+
+export type ExpectedResultRow = Record<string, unknown>;
+export type ExpectedResult = ExpectedResultRow | ExpectedResultRow[];
+export type TestRunner = Runtime | ModelMaterializer;
+
+export interface TestQuery {
+  runner: TestRunner;
+  src: string;
+}
+
+export function query(runner: TestRunner, querySource: string): TestQuery {
+  return {runner, src: querySource};
+}
+
+interface QueryRunResult {
+  fail: JestMatcherResult;
+  result: Result;
+  query: QueryMaterializer;
+  queryTestTag: Tag;
+}
+
+export async function runQuery(
+  tq: TestQuery
+): Promise<Partial<QueryRunResult>> {
+  let query: QueryMaterializer;
+  let queryTestTag: Tag | undefined = undefined;
+  try {
+    query = tq.runner.loadQuery(tq.src);
+    const queryTags = (await query.getPreparedQuery()).tagParse().tag;
+    queryTestTag = queryTags.tag('test');
+  } catch (e) {
+    return {
+      fail: {
+        pass: false,
+        message: () =>
+          `Could not prepare query to run: ${e.message}\nQuery:\n${tq.src}`,
+      },
+    };
+  }
+
+  let result: Result;
+  try {
+    result = await query.run();
+  } catch (e) {
+    let failMsg = `query.run failed: ${e.message}\n`;
+    if (e instanceof MalloyError) {
+      failMsg = `Error in query compilation\n${errorLogToString(
+        tq.src,
+        e.problems
+      )}`;
+    } else {
+      try {
+        failMsg += `SQL: ${await query.getSQL()}\n`;
+      } catch (e2) {
+        failMsg += `SQL FOR FAILING QUERY COULD NOT BE COMPUTED: ${e2.message}\n`;
+      }
+      failMsg += e.stack;
+    }
+    return {fail: {pass: false, message: () => failMsg}, query};
+  }
+  try {
+    API.util.wrapResult(result);
+  } catch (error) {
+    return {
+      fail: {
+        pass: false,
+        message: () =>
+          `Result could not be wrapped into new style result: ${error}\n${error.stack}`,
+      },
+    };
+  }
+  return {result, queryTestTag, query};
+}
+
+function errorLogToString(src: string, msgs: LogMessage[]) {
+  let lovely = '';
+  let lineNo = 0;
+  for (const line of src.split('\n')) {
+    lovely += `    | ${line}\n`;
+    for (const entry of msgs) {
+      if (entry.at) {
+        if (entry.at.range.start.line === lineNo) {
+          const charFrom = entry.at.range.start.character;
+          lovely += `!!!!! ${' '.repeat(charFrom)}^ ${entry.message}\n`;
+        }
+      }
+    }
+    lineNo += 1;
+  }
+  return lovely;
+}
+
+type TL = 'timeLiteral';
+
+function lit(d: Dialect, t: string, type: 'timestamp' | 'date'): string {
+  const typeDef: {type: 'timestamp' | 'date'} = {type};
+  const timeLiteral: TL = 'timeLiteral';
+  const n = {
+    node: timeLiteral,
+    typeDef,
+    literal: t,
+  };
+  return d.sqlLiteralTime({}, n);
+}
+
+type SQLDataType = 'string' | 'number' | 'timestamp' | 'date' | 'boolean';
+type SQLRow = unknown[];
+
+/**
+ * Create source built from the SQL for a series of
+ * SELECT ... UNION ALL SELECT statements which returns
+ * the passed data. This uses the dialect object to do
+ * all the quoting and type translation.
+ * @returns '${connectionName}.sql("""SELECT ..."""")'
+ */
+export function mkSQLSource(
+  dialect: Dialect,
+  connectioName: string,
+  schema: Record<string, SQLDataType>,
+  ...dataRows: SQLRow[]
+): string {
+  const stmts: string[] = [];
+  for (const oneRow of dataRows) {
+    const outRow: string[] = [];
+    let colNum = 0;
+    for (const colName of Object.keys(schema)) {
+      const val = oneRow[colNum];
+      colNum += 1;
+      let valStr = `ERROR BAD TYPE FOR STRING ${typeof val}`;
+      if (schema[colName] === 'string' && typeof val === 'string') {
+        valStr = dialect.sqlLiteralString(val);
+      } else if (schema[colName] === 'number' && typeof val === 'number') {
+        valStr = val.toString();
+      } else if (schema[colName] === 'boolean' && typeof val === 'boolean') {
+        valStr = val.toString();
+      } else if (val === null) {
+        valStr = 'NULL';
+      } else if (schema[colName] === 'timestamp' && typeof val === 'string') {
+        valStr = lit(dialect, val, 'timestamp');
+      } else if (schema[colName] === 'date' && typeof val === 'string') {
+        valStr = lit(dialect, val, 'date');
+      }
+      outRow.push(
+        stmts.length === 0
+          ? `${valStr} AS ${dialect.sqlMaybeQuoteIdentifier(colName)}`
+          : valStr
+      );
+    }
+    stmts.push(outRow.join(','));
+  }
+  return `${connectioName}.sql("""SELECT ${stmts.join(
+    '\nUNION ALL SELECT '
+  )}\n""")`;
+}

--- a/test/src/util/db-matcher-support.ts
+++ b/test/src/util/db-matcher-support.ts
@@ -148,7 +148,7 @@ export function mkSQLSource(
     for (const colName of Object.keys(schema)) {
       const val = oneRow[colNum];
       colNum += 1;
-      let valStr = `ERROR BAD TYPE FOR STRING ${typeof val}`;
+      let valStr = `ERROR BAD TYPE FOR ${schema[colName]}: ${typeof val}`;
       if (schema[colName] === 'string' && typeof val === 'string') {
         valStr = dialect.sqlLiteralString(val);
       } else if (schema[colName] === 'number' && typeof val === 'number') {


### PR DESCRIPTION
`malloyResultMatches` has a few problems with compound data types, and the interface to "query result matching" still isn't quite right. Time to fix that maybe?