### PR TITLE
Add better error messages when a keyword is spelled wrong

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9633,6 +9633,13 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "node_modules/@types/jaro-winkler": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@types/jaro-winkler/-/jaro-winkler-0.2.4.tgz",
+      "integrity": "sha512-TNVu6vL0Z3h+hYcW78IRloINA0y0MTVJ1PFVtVpBSgk+ejmaH5aVfcVghzNXZ0fa6gXe4zapNMQtMGWOJKTLig==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/jasmine": {
       "version": "4.3.5",
       "dev": true,
@@ -16949,6 +16956,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/jaro-winkler": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/jaro-winkler/-/jaro-winkler-0.2.8.tgz",
+      "integrity": "sha512-yr+mElb6dWxA1mzFu0+26njV5DWAQRNTi5pB6fFMm79zHrfAs3d0qjhe/IpZI4AHIUJkzvu5QXQRWOw2O0GQyw==",
+      "license": "MIT"
     },
     "node_modules/jasmine-core": {
       "version": "5.1.1",
@@ -26602,12 +26615,14 @@
         "@malloydata/malloy-tag": "^0.0.260",
         "antlr4ts": "^0.5.0-alpha.4",
         "assert": "^2.0.0",
+        "jaro-winkler": "^0.2.8",
         "jest-diff": "^29.6.2",
         "lodash": "^4.17.20",
         "luxon": "^2.4.0",
         "uuid": "^8.3.2"
       },
       "devDependencies": {
+        "@types/jaro-winkler": "^0.2.3",
         "@types/lodash": "^4.14.165",
         "@types/luxon": "^2.4.0",
         "antlr4ts-cli": "^0.5.0-alpha.4"

--- a/packages/malloy/package.json
+++ b/packages/malloy/package.json
@@ -49,11 +49,13 @@
     "jest-diff": "^29.6.2",
     "lodash": "^4.17.20",
     "luxon": "^2.4.0",
+    "jaro-winkler": "^0.2.8",
     "uuid": "^8.3.2"
   },
   "devDependencies": {
     "@types/lodash": "^4.14.165",
     "@types/luxon": "^2.4.0",
+    "@types/jaro-winkler": "^0.2.3",
     "antlr4ts-cli": "^0.5.0-alpha.4"
   }
 }

--- a/packages/malloy/src/lang/syntax-errors/custom-error-messages.ts
+++ b/packages/malloy/src/lang/syntax-errors/custom-error-messages.ts
@@ -71,7 +71,7 @@ export interface ErrorCase {
     replace: string;
     with: string[];
   };
-};
+}
 
 export const checkCustomErrorMessage = (
   parser: Parser,

--- a/packages/malloy/src/lang/syntax-errors/custom-error-messages.ts
+++ b/packages/malloy/src/lang/syntax-errors/custom-error-messages.ts
@@ -164,8 +164,7 @@ export const checkCustomErrorMessage = (
         }
       }
 
-      // eslint-disable-next-line no-inner-declarations
-      function errReplace(s: string): string {
+      const errReplace = (s: string) => {
         const rs = s
           .replace('${currentToken}', currentToken.text || '')
           .replace('${offendingSymbol}', offendingSymbol?.text || '');
@@ -176,7 +175,7 @@ export const checkCustomErrorMessage = (
           // This shouldn't ever occur, but if it does, just leave the untokenized message.
         }
         return rs;
-      }
+      };
 
       // If all cases match, return the custom error message
       let message = errReplace(errorCase.errorMessage);

--- a/packages/malloy/src/lang/syntax-errors/malloy-parser-error-listener.ts
+++ b/packages/malloy/src/lang/syntax-errors/malloy-parser-error-listener.ts
@@ -153,6 +153,13 @@ export const malloyCustomErrorCases: ErrorCase[] = [
     ],
     ruleContextOptions: ['queryStatement'],
   },
+  {
+    errorMessage:
+      "Expected a query statement, '${offendingSymbol}:' is not a keyword",
+    ruleContextOptions: ['queryStatement'],
+    offendingSymbol: MalloyParser.IDENTIFIER,
+    lookAheadOptions: [[MalloyParser.COLON, MalloyParser.IDENTIFIER]],
+  },
 ];
 
 export class MalloyParserErrorListener implements ANTLRErrorListener<Token> {

--- a/packages/malloy/src/lang/syntax-errors/malloy-parser-error-listener.ts
+++ b/packages/malloy/src/lang/syntax-errors/malloy-parser-error-listener.ts
@@ -155,10 +155,36 @@ export const malloyCustomErrorCases: ErrorCase[] = [
   },
   {
     errorMessage:
-      "Expected a query statement, '${offendingSymbol}:' is not a keyword",
+      "Expected a query statement, '${offendingSymbol}:' is not a keyword.",
     ruleContextOptions: ['queryStatement'],
     offendingSymbol: MalloyParser.IDENTIFIER,
     lookAheadOptions: [[MalloyParser.COLON, MalloyParser.IDENTIFIER]],
+    alternatives: {
+      replace: '${offendingSymbol}:',
+      with: ['group_by:', 'select:', 'aggregate:', 'calculate:', 'nest:'],
+    },
+  },
+  {
+    errorMessage:
+      "Expected a source statement, '${offendingSymbol}:' is not a keyword.",
+    ruleContextOptions: ['exploreStatement'],
+    offendingSymbol: MalloyParser.IDENTIFIER,
+    lookAheadOptions: [[MalloyParser.COLON, MalloyParser.IDENTIFIER]],
+    alternatives: {
+      replace: '${offendingSymbol}:',
+      with: ['dimension:', 'measure:', 'primary_key:', 'view:', 'join:'],
+    },
+  },
+  {
+    errorMessage:
+      "Expected a statement, '${offendingSymbol}:' is not a keyword.",
+    ruleContextOptions: ['malloyDocument'],
+    offendingSymbol: MalloyParser.IDENTIFIER,
+    lookAheadOptions: [[MalloyParser.COLON, MalloyParser.IDENTIFIER]],
+    alternatives: {
+      replace: '${offendingSymbol}:',
+      with: ['run:', 'query:', 'source:'],
+    },
   },
 ];
 

--- a/packages/malloy/src/lang/test/syntax-errors.spec.ts
+++ b/packages/malloy/src/lang/test/syntax-errors.spec.ts
@@ -205,6 +205,12 @@ describe('custom error messages', () => {
         errorMessage("Expected ':' following 'order_by'")
       );
     });
+
+    test('mis-spelled keyword in query', () => {
+      expect('run: a -> { groop_by: astr }').toLog(
+        errorMessage("Expected a query statement, 'groop_by:' is not a keyword")
+      );
+    });
   });
 
   describe('run', () => {

--- a/packages/malloy/src/lang/test/syntax-errors.spec.ts
+++ b/packages/malloy/src/lang/test/syntax-errors.spec.ts
@@ -17,6 +17,15 @@ import './parse-expects';
  * for a good reason.
  */
 describe('custom error messages', () => {
+  test('mis-spelled keyword in top-level', () => {
+    expect(
+      'sourc: aplus is a extend { dimension: one_more is ai + 1 }'
+    ).toLogAtLeast(
+      errorMessage(
+        "Expected a statement, 'sourc:' is not a keyword. Did you mean 'source:'?"
+      )
+    );
+  });
   describe('source', () => {
     test('missing alias', () => {
       expect('source: x extend { }').toLogAtLeast(
@@ -61,6 +70,15 @@ describe('custom error messages', () => {
   });
 
   describe('exploreProperties', () => {
+    test('mis-spelled keyword in extends block', () => {
+      expect(
+        'source: aplus is a extend { dinemsion: one_more is ai + 1 }'
+      ).toLogAtLeast(
+        errorMessage(
+          "Expected a source statement, 'dinemsion:' is not a keyword. Did you mean 'dimension:'?"
+        )
+      );
+    });
     test('misspelled "join"', () => {
       expect(`source: x is a extend {
         join: data is y on dataId = data.id
@@ -208,7 +226,9 @@ describe('custom error messages', () => {
 
     test('mis-spelled keyword in query', () => {
       expect('run: a -> { groop_by: astr }').toLog(
-        errorMessage("Expected a query statement, 'groop_by:' is not a keyword")
+        errorMessage(
+          "Expected a query statement, 'groop_by:' is not a keyword. Did you mean 'group_by:'?"
+        )
       );
     });
   });


### PR DESCRIPTION
A common pattern is

```
keyword: name DEFINITIONTION
```

this looks for IDENTIFIER COLOR IDENTIFIER error messages and prints something more helpful.