### PR TITLE
keywords in filter expressions should not be case sensitive

### DIFF
--- a/packages/malloy-filter/src/clause_utils.ts
+++ b/packages/malloy-filter/src/clause_utils.ts
@@ -134,10 +134,10 @@ export function matchOp(matchSrc: string): StringFilter {
     }
     return {operator: '~', escaped_values: [matchTxt]};
   }
-  if (matchTxt.toLowerCase() === 'null' || matchTxt === 'NULL') {
+  if (matchTxt.toLowerCase() === 'null') {
     return {operator: 'null'};
   }
-  if (matchTxt === 'empty' || matchTxt === 'EMPTY') {
+  if (matchTxt.toLowerCase() === 'empty') {
     return {operator: 'empty'};
   }
   return {operator: '=', values: [unescape(matchTxt)]};

--- a/packages/malloy-filter/src/clause_utils.ts
+++ b/packages/malloy-filter/src/clause_utils.ts
@@ -154,6 +154,7 @@ export function conjoin(
   op: string,
   right: Object
 ): StringFilter | null {
+  op = op.toLowerCase();
   if (isStringFilter(left) && isStringFilter(right)) {
     if (op === ',') {
       if (left.operator === '~' && sameAs(left, right)) {
@@ -183,6 +184,7 @@ export function joinNumbers(
   op: string,
   right: Object
 ): NumberFilter | null {
+  op = op.toLowerCase();
   if (isNumberFilter(left) && isNumberFilter(right)) {
     if (op === 'or' && left.operator === '=' && sameAs(left, right)) {
       const ret: NumberFilter = {
@@ -244,6 +246,7 @@ export function joinTemporal(
   op: string,
   right: Object
 ): TemporalFilter | null {
+  op = op.toLowerCase();
   if (isTemporalFilter(left) && isTemporalFilter(right)) {
     // if (
     //   (op === ',' || op === 'or') &&

--- a/packages/malloy-filter/src/grammars/fexpr_number.ne
+++ b/packages/malloy-filter/src/grammars/fexpr_number.ne
@@ -10,17 +10,19 @@
 import moo from 'moo';
 import {numNot, mkRange, joinNumbers, mkValues} from '../clause_utils';
 
+const kwList = moo.keywords({
+  'AND': 'and',
+  'OR': 'or',
+  'NOT': 'not',
+  'NULL_KW': 'null',
+  'TO': 'to',
+});
+
 const fnumber_lexer = moo.compile({
   WS: /[ \t]+/,
   id: {
     match: /[a-zA-Z]+/,
-    type: moo.keywords({
-      'AND': 'and',
-      'OR': 'or',
-      'NOT': 'not',
-      'NULL_KW': 'null',
-      'TO': 'to',
-    }),
+    type: kw => kwList(kw.toLowerCase()),
   },
   oparen: '(',
   cparen: ')',

--- a/packages/malloy-filter/src/grammars/ftemporal.ne
+++ b/packages/malloy-filter/src/grammars/ftemporal.ne
@@ -10,12 +10,8 @@
 import moo from 'moo';
 import {temporalNot, joinTemporal, timeLiteral, mkUnits} from '../clause_utils';
 
-const temporal_lexer = moo.compile({
-  WS: /[ \t]+/,
-  id: {
-    match: /[a-zA-Z]+/,
-    type: moo.keywords({
-      'AND': 'and',
+const kwList = moo.keywords(
+  {
       'OR': 'or',
       'NOT': 'not',
       'NULL_KW': 'null',
@@ -55,7 +51,14 @@ const temporal_lexer = moo.compile({
       'FRIDAY': 'friday',
       'SATURDAY': 'saturday',
       'SUNDAY': 'sunday',
-    }),
+    }
+);
+
+const temporal_lexer = moo.compile({
+  WS: /[ \t]+/,
+  id: {
+    match: /[a-zA-Z]+/,
+    type: kw => kwList(kw.toLowerCase()),
   },
   oparen: '(',
   cparen: ')',

--- a/packages/malloy-filter/src/grammars/ftemporal.ne
+++ b/packages/malloy-filter/src/grammars/ftemporal.ne
@@ -12,6 +12,7 @@ import {temporalNot, joinTemporal, timeLiteral, mkUnits} from '../clause_utils';
 
 const kwList = moo.keywords(
   {
+      'AND': 'and',
       'OR': 'or',
       'NOT': 'not',
       'NULL_KW': 'null',

--- a/packages/malloy-filter/src/test/ftemporal.spec.ts
+++ b/packages/malloy-filter/src/test/ftemporal.spec.ts
@@ -357,13 +357,16 @@ describe('temporal filter expressions', () => {
       });
     });
     test('and', () => {
-      expect('not before tomorrow and after yesterday').isTemporalFilter({
-        operator: 'and',
-        members: [
-          {operator: 'before', not: true, before: {moment: 'tomorrow'}},
-          {operator: 'after', after: {moment: 'yesterday'}},
-        ],
-      });
+      expect('Not bEfore toMorrow anD aftEr yesterDay').isTemporalFilter(
+        {
+          operator: 'and',
+          members: [
+            {operator: 'before', not: true, before: {moment: 'tomorrow'}},
+            {operator: 'after', after: {moment: 'yesterday'}},
+          ],
+        },
+        'not before tomorrow and after yesterday'
+      );
     });
   });
 

--- a/test/src/databases/all/db_filter_expressions.spec.ts
+++ b/test/src/databases/all/db_filter_expressions.spec.ts
@@ -42,13 +42,7 @@ describe.each(runtimes.runtimeList)('filter expressions %s', (dbName, db) => {
         }`).malloyResultMatches(abc, [{s: 'abc'}]);
     });
     test('empty string filter expression', async () => {
-      /*
-        since the sql generated works when pasted into mysql
-        my next suggestion is that there is some funky re-ordering
-        happening in the result processing which will test tomorrow
-      */
       await expect(`
-        # test.verbose
         run: abc -> {
           where: s ~ f'';
           select: *; order_by: nm asc
@@ -111,11 +105,15 @@ describe.each(runtimes.runtimeList)('filter expressions %s', (dbName, db) => {
     });
     test('empty', async () => {
       await expect(`
-        # test.verbose
         run: abc -> {
           where: s ~ f'empty'
           select: nm; order_by: nm asc
         }`).malloyResultMatches(abc, got('z-empty,z-null'));
+      await expect(`
+          run: abc -> {
+            where: s ~ f'EmpTy'
+            select: nm; order_by: nm asc
+          }`).malloyResultMatches(abc, got('z-empty,z-null'));
     });
     test('-empty', async () => {
       await expect(`
@@ -127,9 +125,13 @@ describe.each(runtimes.runtimeList)('filter expressions %s', (dbName, db) => {
     });
     test('null', async () => {
       await expect(`
-        # test.verbose
         run: abc -> {
           where: s ~ f'null'
+          select: nm
+        }`).malloyResultMatches(abc, got('z-null'));
+      await expect(`
+        run: abc -> {
+          where: s ~ f'nULl'
           select: nm
         }`).malloyResultMatches(abc, got('z-null'));
     });

--- a/test/src/databases/all/db_filter_expressions.spec.ts
+++ b/test/src/databases/all/db_filter_expressions.spec.ts
@@ -332,42 +332,35 @@ describe.each(runtimes.runtimeList)('filter expressions %s', (dbName, db) => {
     test.when(testBoolean)('true', async () => {
       await expect(`
         run: facts -> {
-          where: b ~ f'true'
-          select: t; order_by: t asc
-        }`).malloyResultMatches(facts, [{t: 'true'}]);
-    });
-    test.when(testBoolean)('true', async () => {
-      await expect(`
-        run: facts -> {
-          where: b ~ f'true'
+          where: b ~ f'tRuE'
           select: t; order_by: t asc
         }`).malloyResultMatches(facts, [{t: 'true'}]);
     });
     test.when(testBoolean)('false', async () => {
       await expect(`
         run: facts -> {
-          where: b ~ f'false'
+          where: b ~ f'FalSE'
           select: t; order_by: t asc
         }`).malloyResultMatches(facts, [{t: 'false'}, {t: 'null'}]);
     });
     test.when(testBoolean)('=false', async () => {
       await expect(`
         run: facts -> {
-          where: b ~ f'=false'
+          where: b ~ f'=FALSE'
           select: t; order_by: t asc
         }`).malloyResultMatches(facts, [{t: 'false'}]);
     });
     test.when(testBoolean)('null', async () => {
       await expect(`
         run: facts -> {
-          where: b ~ f'null'
+          where: b ~ f'Null'
           select: t; order_by: t asc
         }`).malloyResultMatches(facts, [{t: 'null'}]);
     });
     test.when(testBoolean)('not null', async () => {
       await expect(`
         run: facts -> {
-          where: b ~ f'not null'
+          where: b ~ f'nOt NuLL'
           select: t; order_by: t asc
         }`).malloyResultMatches(facts, [{t: 'false'}, {t: 'true'}]);
     });


### PR DESCRIPTION
@narreola hit this, and after some discussion with language group, it was agreed these should not be case sensitive. I skipped this work when implementing filter expressions because it required me to learn something about the lexer generator (moo) that I didn't feel like i had time to learn.

Coming back to it later, it is pretty simple.

Fixes #2265 

keywords in boolean filters were already insensitive, I did add a test.