### PR TITLE
add split_part and regexp_extract to tresto dialect functions

### DIFF
--- a/packages/malloy/src/dialect/trino/dialect_functions.ts
+++ b/packages/malloy/src/dialect/trino/dialect_functions.ts
@@ -146,6 +146,26 @@ const regexp_replace: OverloadedDefinitionBlueprint = {
   },
 };
 
+const regexp_extract: OverloadedDefinitionBlueprint = {
+  extract: {
+    takes: {
+      input_val: 'string',
+      pattern: ['string', 'regular expression'],
+    },
+    returns: 'string',
+    impl: {function: 'regexp_extract'},
+  },
+  extract_group: {
+    takes: {
+      input_val: 'string',
+      pattern: ['string', 'regular expression'],
+      group: 'number',
+    },
+    returns: 'string',
+    impl: {function: 'regexp_extract'},
+  },
+};
+
 const percent_rank: DefinitionBlueprint = {
   takes: {},
   returns: {calculation: 'number'},
@@ -318,8 +338,12 @@ export const TRINO_DIALECT_FUNCTIONS: DefinitionBlueprintMap = {
   date_parse,
   ...def('from_unixtime', {'unixtime': 'number'}, 'timestamp'),
   json_extract_scalar,
+
+  // regex fnctions
   regexp_like,
   regexp_replace,
+  regexp_extract,
+
   ...def('to_unixtime', {'ts_val': 'timestamp'}, 'number'),
   ...def('url_extract_fragment', {'url': 'string'}, 'string'),
   ...def('url_extract_host', {'url': 'string'}, 'string'),
@@ -363,6 +387,11 @@ export const TRINO_DIALECT_FUNCTIONS: DefinitionBlueprintMap = {
     {array: T}
   ),
   ...def('split', {to_split: 'string', seperator: 'string'}, {array: 'string'}),
+  ...def(
+    'split_part',
+    {to_split: 'string', seperator: 'string', idx: 'number'},
+    'string'
+  ),
   ...def('trim_array', {'x': {array: T}, 'n': 'number'}, {array: T}),
   ...def(
     'array_split_into_chunks',

--- a/test/src/databases/presto-trino/presto-trino.spec.ts
+++ b/test/src/databases/presto-trino/presto-trino.spec.ts
@@ -100,6 +100,26 @@ describe.each(runtimes.runtimeList)(
       });
     });
 
+    it(`runs the regexp_extract function - ${databaseName}`, async () => {
+      await expect(`run: ${databaseName}.sql("SELECT 1 as n") -> {
+      select:
+        extract is regexp_extract('1a 2b 14m', r'\\d+')
+        group is regexp_extract('1a 2b 14m', r'(\\d+)([a-z]+)', 2)
+      }`).malloyResultMatches(runtime, {
+        extract: '1',
+        group: 'a',
+      });
+    });
+
+    it(`runs the split_part function - ${databaseName}`, async () => {
+      await expect(`run: ${databaseName}.sql("SELECT 1 as n") -> {
+      select:
+        part is split_part('one/two/three', '/', 2)
+      }`).malloyResultMatches(runtime, {
+        part: 'two',
+      });
+    });
+
     it(`runs the approx_percentile function - ${databaseName}`, async () => {
       await expect(`run: ${databaseName}.sql("""
       SELECT 1 as n


### PR DESCRIPTION
Examination of current production models, found these used a few times.