### PR TITLE
Fix bugs with default field order in query builder

### DIFF
--- a/packages/malloy-query-builder/src/query-ast.ts
+++ b/packages/malloy-query-builder/src/query-ast.ts
@@ -2574,11 +2574,13 @@ export class ASTSegmentViewDefinition
   }
 
   private DEFAULT_INSERTION_ORDER: Malloy.ViewOperationType[] = [
-    'where',
     'group_by',
     'aggregate',
+    'where',
+    'having',
     'nest',
     'order_by',
+    'limit',
   ];
 
   private findInsertionPoint(kind: Malloy.ViewOperationType): number {
@@ -2600,7 +2602,7 @@ export class ASTSegmentViewDefinition
     );
     for (const laterType of laterOperations) {
       const firstOfType = this.firstIndexOfOperationType(laterType);
-      return firstOfType;
+      if (firstOfType > -1) return firstOfType;
     }
     return this.operations.length;
   }
@@ -4191,7 +4193,7 @@ export class ASTWhereViewOperation extends ASTObjectNode<
     filter: ASTFilter;
   }
 > {
-  readonly kind: Malloy.ViewOperationType = 'nest';
+  readonly kind: Malloy.ViewOperationType = 'where';
   constructor(public node: Malloy.ViewOperationWithWhere) {
     super(node, {
       kind: 'where',
@@ -4222,7 +4224,7 @@ export class ASTHavingViewOperation extends ASTObjectNode<
     filter: ASTFilter;
   }
 > {
-  readonly kind: Malloy.ViewOperationType = 'nest';
+  readonly kind: Malloy.ViewOperationType = 'having';
   constructor(public node: Malloy.ViewOperationWithHaving) {
     super(node, {
       kind: 'having',
@@ -4580,8 +4582,6 @@ export class ASTAnnotation extends ASTObjectNode<
     value: string;
   }
 > {
-  readonly kind: Malloy.ViewOperationType = 'limit';
-
   get value() {
     return this.children.value;
   }


### PR DESCRIPTION
Fixed a couple bugs with the code to handle default field order in the query builder. The intended behavior is that as long as operations are never re-ordered, they will always appear in this order: `group_by`, `aggregate`, `where`, `having`, `nest`, `order_by`, `limit`, with fields of each type of operation appearing in the order in which they were inserted.

The following rules allow us to implement this slightly more generally so that it has the desired behavior when operations are never re-ordered, and sensible behavior after they've been meddled with. When adding a new operation:

1. If an operation of that kind already exists, add the new operation after the last operation in the first consecutive run of that kind
```
group_by: existing
group_by: existing
group_by: new
aggregate: existing
group_by: existing
```

2. For each operation type AFTER the operation in question in the following list: `group_by`, `aggregate`, `where`, `having`, `nest`, `order_by`, `limit`, if any operation of that kind exists, insert before it (the first instance)
```
group_by: existing
aggregate: new
nest: existing
```

3. Add the operation at the end of the list
```
group_by: existing
aggregate: new
```