### PR TITLE
in BigQuery, on select: queries, don't use the lateral join bag

### DIFF
--- a/packages/malloy/src/model/malloy_query.ts
+++ b/packages/malloy/src/model/malloy_query.ts
@@ -2579,7 +2579,8 @@ class QueryQuery extends QueryField {
       if (expr.node === 'function_call') {
         if (
           expressionIsAnalytic(expr.overload.returnType.expressionType) &&
-          this.parent.dialect.cantPartitionWindowFunctionsOnExpressions
+          this.parent.dialect.cantPartitionWindowFunctionsOnExpressions &&
+          resultStruct.firstSegment.type === 'reduce'
         ) {
           // force the use of a lateral_join_bag
           resultStruct.root().isComplexQuery = true;
@@ -3393,7 +3394,8 @@ class QueryQuery extends QueryField {
           if (isScalarField(fi.f)) {
             if (
               this.parent.dialect.cantPartitionWindowFunctionsOnExpressions &&
-              this.rootResult.queryUsesPartitioning
+              this.rootResult.queryUsesPartitioning &&
+              resultSet.firstSegment.type === 'reduce'
             ) {
               // BigQuery can't partition aggregate function except when the field has no
               //  expression.  Additionally it can't partition by floats.  We stuff expressions


### PR DESCRIPTION
BigQuery can't use expressions as  'partition by:' fields in queries with a 'group by', but they work in regular select queries (or mostly anyway).

This skips the logic that works around the problem when the query is just a select query.

The one side effect is that you won't be able to `partition by` a float64 in a select query.  As this is a bigquery limitation, I don't think it is a big deal.