### PR TITLE
Limit size of line chart tooltip and sort the conents

### DIFF
--- a/packages/malloy-render/src/component/line-chart/generate-line_chart-vega-spec.ts
+++ b/packages/malloy-render/src/component/line-chart/generate-line_chart-vega-spec.ts
@@ -803,10 +803,9 @@ export function generateLineChartVegaSpec(explore: NestField): VegaChartProps {
           ? renderTimeString(new Date(x), xField.isDate(), xField.timeframe)
           : x;
 
-        let sortedRecords = [...records].sort((a, b) => b.y - a.y);
-        if (sortedRecords.length > tooltipItemCountLimit) {
-          sortedRecords = sortedRecords.slice(0, tooltipItemCountLimit);
-        }
+        const sortedRecords = [...records]
+          .sort((a, b) => b.y - a.y)
+          .slice(0, tooltipItemCountLimit);
 
         tooltipData = {
           title: [title],
@@ -843,14 +842,14 @@ export function generateLineChartVegaSpec(explore: NestField): VegaChartProps {
         // If the highlighted item is not included in the first ~20,
         // then it will probably be cut off.
 
-        let sortedRecords = [...records].sort((a, b) => b.y - a.y);
-        if (sortedRecords.length > tooltipItemCountLimit) {
-          sortedRecords = sortedRecords.filter(
+        const sortedRecords = [...records]
+          .sort((a, b) => b.y - a.y)
+          .filter(
             (item, index) =>
               index <= tooltipItemCountLimit ||
               item.series === highlightedSeries
           );
-        }
+
         tooltipData = {
           title: [title],
           entries: sortedRecords.map(rec => {

--- a/packages/malloy-render/src/stories/line_charts.stories.malloy
+++ b/packages/malloy-render/src/stories/line_charts.stories.malloy
@@ -308,6 +308,23 @@ source: products is duckdb.table("static/data/products.parquet") extend {
     where: date_of_sale >= @2001-02-01 and date_of_sale < @2001-04-01
     order_by: date_of_sale
   }
+
+  dimension: sale_year is year(date_of_sale)
+
+
+  #(story)
+  # line_chart
+  view: lots_of_lines is {
+    # x
+    group_by: sale_year
+
+    # series
+    group_by: brand
+
+    aggregate: total is count()
+
+    order_by: sale_year
+  }
 }
 
 run: products -> { group_by: distribution_center_id}


### PR DESCRIPTION
The current line chart tooltip contains unlimited items and is unsorted.

See: https://www.internalfb.com/intern/px/p/73M7B

Limits the visible items to 10 (plus the hovered item), and sorts them:

<img width="517" alt="image" src="https://github.com/user-attachments/assets/5eff2d27-3391-4df0-8fff-81e5c79424da" />


