### PR TITLE
Parse map types to sql_native

### DIFF
--- a/packages/malloy-db-trino/src/trino_connection.ts
+++ b/packages/malloy-db-trino/src/trino_connection.ts
@@ -677,6 +677,12 @@ class TrinoPrestoSchemaParser extends TinyParser {
             fields: elType.fields,
           }
         : {type: 'array', elementTypeDef: elType};
+    } else if (typToken.text === 'map' && this.next('(')) {
+      const _keyType = this.typeDef();
+      this.next(',');
+      const _valType = this.typeDef();
+      this.next(')');
+      return {type: 'sql native'};
     } else if (typToken.type === 'id') {
       const sqlType = typToken.text.toLowerCase();
       if (sqlType === 'varchar') {

--- a/test/src/databases/presto-trino/presto-trino.spec.ts
+++ b/test/src/databases/presto-trino/presto-trino.spec.ts
@@ -564,6 +564,13 @@ describe.each(runtimes.runtimeList)(
       });
       // mtoy todo document missing lambda sort
     });
+
+    it('can read a map data type from an sql schema', async () => {
+      await expect(`run: ${databaseName}.sql("""
+          SELECT MAP(ARRAY['key1', 'key2', 'key3' ], ARRAY['v1', 'v2', 'v3']) as KEY_TO_V
+        """) -> { aggregate: n is count() }
+      `).matchesRows(runtime, {n: 1});
+    });
   }
 );
 


### PR DESCRIPTION
Allows schemas with maps to be read without errors.