### PR TITLE
fix access of property from generated record

### DIFF
--- a/packages/malloy/src/model/malloy_query.ts
+++ b/packages/malloy/src/model/malloy_query.ts
@@ -4670,7 +4670,14 @@ class QueryStruct {
   ) {
     let parentRef = this.getSQLIdentifier();
     if (expand && isAtomic(this.structDef) && hasExpression(this.structDef)) {
-      parentRef = expand.field.exprToSQL(expand.result, this, this.structDef.e);
+      if (!this.parent) {
+        throw new Error(`Cannot expand reference to ${name} without parent`);
+      }
+      parentRef = expand.field.exprToSQL(
+        expand.result,
+        this.parent,
+        this.structDef.e
+      );
     }
     let refType: FieldReferenceType = 'table';
     if (this.structDef.type === 'record') {

--- a/test/src/databases/all/compound-atomic.spec.ts
+++ b/test/src/databases/all/compound-atomic.spec.ts
@@ -328,8 +328,8 @@ describe.each(runtimes.runtimeList)(
         'can read schema of record object',
         async () => {
           await expect(`run: ${conName}.sql("""
-          SELECT ${sizesSQL} AS ${quote('sizes')}
-        """)`).malloyResultMatches(runtime, rec_eq());
+              SELECT ${sizesSQL} AS ${quote('sizes')}
+          """)`).malloyResultMatches(runtime, rec_eq());
         }
       );
       test('simple record.property access', async () => {
@@ -338,6 +338,14 @@ describe.each(runtimes.runtimeList)(
           runtime,
           {small: 0}
         );
+      });
+      test('property accessed from aliased record dimension', async () => {
+        await expect(`
+          source: sx is ${sizes} extend {
+            dimension: copy_sizes is sizes
+          }
+          run: sx -> {select: xl is copy_sizes.xl}
+        `).matchesRows(runtime, {xl: 3});
       });
       test('nested data looks like a record', async () => {
         await expect(`

--- a/test/src/util/db-matcher-support.ts
+++ b/test/src/util/db-matcher-support.ts
@@ -69,7 +69,8 @@ export async function runQuery(
   try {
     result = await query.run();
   } catch (e) {
-    let failMsg = `QUERY RUN FAILED: ${tq.src}\nMESSAGE: ${e.message}\n`;
+    const src = tq.src.replace(/^\n+/m, '').trimEnd();
+    let failMsg = `QUERY RUN FAILED:\n${src}`;
     if (e instanceof MalloyError) {
       failMsg = `Error in query compilation\n${errorLogToString(
         tq.src,
@@ -77,11 +78,13 @@ export async function runQuery(
       )}`;
     } else {
       try {
-        failMsg += `SQL: ${await query.getSQL()}\n`;
+        failMsg += `\nMESSAGE: ${e.message}\nSQL: ${await query.getSQL()}\n`;
       } catch (e2) {
-        failMsg += `SQL FOR FAILING QUERY COULD NOT BE COMPUTED: ${e2.message}\n`;
+        failMsg += '\nSQL FOR QUERY COULD NOT BE COMPUTED\n';
       }
-      failMsg += e.stack;
+      if (e.stack) {
+        failMsg += `STACK:\n${e.stack}\n`;
+      }
     }
     return {fail: {pass: false, message: () => failMsg}, query};
   }


### PR DESCRIPTION
Something like

```
dimension: my_record is existing_record
...
-> { select: my_record.property }
```

results in a compiler error saying `'existing_record' not found`

This fixes that