### PR TITLE
Fix an error message shown for 0-length join path overlaps

### DIFF
--- a/packages/malloy/src/lang/ast/expressions/expr-aggregate-function.ts
+++ b/packages/malloy/src/lang/ast/expressions/expr-aggregate-function.ts
@@ -354,7 +354,7 @@ function suggestNewVersion(
   // Get longest shared prefix
   let longestOverlap = joinUsage[0];
   for (const usage of joinUsage.slice(1)) {
-    for (let i = 0; i < longestOverlap.length; i++) {
+    for (let i = 0; i < longestOverlap.length && i < usage.length; i++) {
       const a = longestOverlap[i];
       const b = usage[i];
       if (a.name !== b.name) {

--- a/packages/malloy/src/lang/test/expressions.spec.ts
+++ b/packages/malloy/src/lang/test/expressions.spec.ts
@@ -799,6 +799,18 @@ describe('expressions', () => {
         }
       `).toTranslate();
     });
+    test('shows the correct error message when the longest overlap between the join usages is length zero', () => {
+      expect(markSource`
+    source: testcase is a extend {
+      join_one: a on true
+
+      measure: value is sum(a.ai * ai)
+    }
+      `).toLog;
+      errorMessage(
+        'Join path is required for this calculation; use `a.sum(a.ai * ai)` or `source.sum(a.ai * ai)` to get a result weighted with respect to `source`'
+      );
+    });
     test('sum(inline.column)', () => {
       expect(modelX`sum(inline.column)`).toLog(
         warningMessage(


### PR DESCRIPTION
A user was hitting a case where they saw a script error while authoring Malloy, instead of a helpful error message:

`"Cannot read property 'name' of undefined"`

Fixes that error by correcting the computation of the join path overlap to avoid reading arrays out of bounds.