### PR TITLE
Fix error messages when the dialect is unknown

### DIFF
--- a/packages/malloy/src/lang/ast/error-factory.ts
+++ b/packages/malloy/src/lang/ast/error-factory.ts
@@ -35,6 +35,7 @@ import type {
   ReduceSegment,
   StructDef,
   JoinFieldDef,
+  SourceDef,
 } from '../../model/malloy_types';
 
 const ERR_NAME = '~malformed~';
@@ -70,6 +71,10 @@ export class ErrorFactory {
       errorFactory: true,
     };
     return factoryJoin;
+  }
+
+  static didCreateSourceDef(s: SourceDef): boolean {
+    return 'errorFactory' in s;
   }
 
   static didCreate(s: StructDef | JoinFieldDef): boolean {

--- a/packages/malloy/src/lang/ast/types/malloy-element.ts
+++ b/packages/malloy/src/lang/ast/types/malloy-element.ts
@@ -53,6 +53,7 @@ import type {NameSpace} from './name-space';
 import type {Noteable} from './noteable';
 import {isNoteable, extendNoteMethod} from './noteable';
 import {v5 as uuidv5} from 'uuid';
+import {ErrorFactory} from '../error-factory';
 
 export abstract class MalloyElement {
   abstract elementType: string;
@@ -620,7 +621,8 @@ export class Document extends MalloyElement implements NameSpace {
         `Cannot redefine '${str}', which is in global namespace`
       );
     }
-    if (isSourceDef(ent.entry)) {
+
+    if (isSourceDef(ent.entry) && !ErrorFactory.didCreateSourceDef(ent.entry)) {
       this.checkExperimentalDialect(this, ent.entry.dialect);
     }
 

--- a/packages/malloy/src/lang/test/source.spec.ts
+++ b/packages/malloy/src/lang/test/source.spec.ts
@@ -52,6 +52,17 @@ describe('source:', () => {
   test('source from query', () => {
     expect('source: testA is a->{group_by: astr}').toTranslate();
   });
+  test('An unknown dialect followed by a "->" shows the correct error', () => {
+    const translator = new TestTranslator(`
+      ##! experimental
+
+      source: test is foo.table('bar') -> {}
+    `);
+    translator.update({
+      errors: {tables: {'foo:bar': 'Bad table!'}},
+    });
+    expect(translator).toLog(errorMessage(/Bad table!/));
+  });
   test('refine source', () => {
     expect('source: aa is a extend { dimension: a is astr }').toTranslate();
   });


### PR DESCRIPTION
The `checkExperimentalDialect` function throws a script error if the input is a factory error. Add a guard around that check to make sure a useful error shows up in a predictable location.