### PR TITLE
feat: limit bar and line data

### DIFF
--- a/packages/malloy-render/src/component/chart-layout-settings.ts
+++ b/packages/malloy-render/src/component/chart-layout-settings.ts
@@ -84,6 +84,7 @@ export function getChartLayoutSettings(
     chartType: string;
     getXMinMax?: () => [number, number];
     getYMinMax?: () => [number, number];
+    independentY?: boolean;
   }
 ): ChartLayoutSettings {
   // TODO: improve logic for field extraction
@@ -243,7 +244,7 @@ export function getChartLayoutSettings(
       yTitleSize,
     },
     yScale: {
-      domain: chartTag.has('y', 'independent') ? null : yDomain,
+      domain: options.independentY ? null : yDomain,
     },
     padding: isSpark
       ? {top: 0, left: 0, bottom: 0, right: 0}

--- a/packages/malloy-render/src/component/chart/chart.css
+++ b/packages/malloy-render/src/component/chart/chart.css
@@ -41,11 +41,7 @@
 .malloy-chart__titles-bar {
   padding-inline: 8px;
   padding-top: 8px;
-  /* TODO: this feels hacky.
-    Maybe we need to configure the top padding of a chart to have more/less space
-    based on whether we detect there will be a title or not
-  */
-  margin-bottom: -8px;
+  margin-bottom: 6px;
   display: flex;
   flex-direction: column;
   gap: 0px;

--- a/packages/malloy-render/src/component/chart/chart.tsx
+++ b/packages/malloy-render/src/component/chart/chart.tsx
@@ -50,9 +50,15 @@ export function Chart(props: ChartProps) {
   if (!runtime)
     throw new Error('Charts must have a runtime defined in their metadata');
   let values: unknown[] = [];
+  let isDataLimited = false;
+  let dataLimitMessage = 'Showing limited results';
   // New vega charts use mapMalloyDataToChartData handlers
   if (chartProps.mapMalloyDataToChartData) {
-    values = chartProps.mapMalloyDataToChartData(data);
+    const mappedData = chartProps.mapMalloyDataToChartData(data);
+    values = mappedData.data;
+    isDataLimited = mappedData.isDataLimited;
+    if (mappedData.dataLimitMessage)
+      dataLimitMessage = mappedData.dataLimitMessage;
   }
 
   const [viewInterface, setViewInterface] = createSignal<ViewInterface | null>(
@@ -184,7 +190,7 @@ export function Chart(props: ChartProps) {
 
   const chartTitle = chartProps.chartTag.text('title');
   const chartSubtitle = chartProps.chartTag.text('subtitle');
-  const hasTitleBar = chartTitle || chartSubtitle;
+  const hasTitleBar = chartTitle || chartSubtitle || isDataLimited;
 
   return (
     <div
@@ -203,7 +209,14 @@ export function Chart(props: ChartProps) {
         <div class="malloy-chart__titles-bar">
           {chartTitle && <div class="malloy-chart__title">{chartTitle}</div>}
           {chartSubtitle && (
-            <div class="malloy-chart__subtitle">{chartSubtitle}</div>
+            <div class="malloy-chart__subtitle">
+              <div>{chartSubtitle}</div>
+            </div>
+          )}
+          {isDataLimited && (
+            <div class="malloy-chart__subtitle">
+              <div>{dataLimitMessage}</div>
+            </div>
           )}
         </div>
       </Show>

--- a/packages/malloy-render/src/component/line-chart/generate-line_chart-vega-spec.ts
+++ b/packages/malloy-render/src/component/line-chart/generate-line_chart-vega-spec.ts
@@ -42,6 +42,8 @@ type LineDataRecord = {
 
 const LEGEND_PERC = 0.4;
 const LEGEND_MAX = 384;
+const DEFAULT_MAX_SERIES = 12;
+const MAX_DATA_POINTS = 5000;
 
 // Helper to invert mapping for object where values are unique
 function invertObject(obj: Record<string, string>): Record<string, string> {
@@ -122,11 +124,17 @@ export function generateLineChartVegaSpec(explore: NestField): VegaChartProps {
   const yDomainMin = settings.zeroBaseline ? Math.min(0, yMin) : yMin;
   const yDomainMax = settings.zeroBaseline ? Math.max(0, yMax) : yMax;
 
+  const maxSeries = chartTag.numeric('series', 'limit') ?? DEFAULT_MAX_SERIES;
+  const isLimitingSeries = Boolean(
+    seriesField && seriesField.valueSet.size > maxSeries
+  );
+
   const chartSettings = getChartLayoutSettings(explore, chartTag, {
     xField,
     yField,
     chartType: 'line_chart',
     getYMinMax: () => [yDomainMin, yDomainMax],
+    independentY: chartTag.has('y', 'independent') || isLimitingSeries,
   });
 
   // x axes across rows should auto share when distinct values <=20, unless user has explicitly set independent setting
@@ -143,6 +151,9 @@ export function generateLineChartVegaSpec(explore: NestField): VegaChartProps {
     chartTag.has('series', 'independent') && !forceSharedSeries;
   const shouldShareSeriesDomain =
     forceSharedSeries || (autoSharedSeries && !forceIndependentSeries);
+  const seriesSet = seriesField
+    ? new Set([...seriesField.valueSet].slice(0, maxSeries))
+    : null;
 
   /**************************************
    *
@@ -198,9 +209,7 @@ export function generateLineChartVegaSpec(explore: NestField): VegaChartProps {
       enter: {
         x: {scale: 'xscale', field: 'x'},
         y: {scale: 'yscale', field: 'y'},
-        stroke: {scale: 'color', field: 'series'},
         strokeWidth: {value: 2},
-        zindex: {value: 0},
       },
       update: {
         strokeOpacity: [
@@ -210,10 +219,17 @@ export function generateLineChartVegaSpec(explore: NestField): VegaChartProps {
           },
           {value: 1},
         ],
+        stroke: [
+          {
+            test: 'brushSeriesIn && brushSeriesIn != datum.series',
+            value: '#ccc',
+          },
+          {scale: 'color', field: 'series'},
+        ],
         // TODO figure out why this isn't working. We need highlighted line to appear above other lines
         zindex: [
-          {test: 'brushSeriesIn && brushSeriesIn === datum.series', value: 1},
-          {value: 0},
+          {test: 'brushSeriesIn && brushSeriesIn === datum.series', value: 10},
+          {value: 1},
         ],
       },
     },
@@ -589,7 +605,7 @@ export function generateLineChartVegaSpec(explore: NestField): VegaChartProps {
         type: 'ordinal',
         range: 'category',
         domain: shouldShareSeriesDomain
-          ? [...seriesField!.valueSet]
+          ? [...seriesSet!]
           : {
               data: 'values',
               field: 'series',
@@ -728,6 +744,8 @@ export function generateLineChartVegaSpec(explore: NestField): VegaChartProps {
       return cell.isTime() ? cell.value.valueOf() : cell.value;
     };
 
+    // TODO: How to limit data across nested charts? Which are unaware of their data usage?
+    //    this will only limit data per nested chart
     const mappedData: {
       __values: {[name: string]: CellValue};
       __row: RecordCell;
@@ -735,7 +753,29 @@ export function generateLineChartVegaSpec(explore: NestField): VegaChartProps {
       y: CellValue;
       series: CellValue;
     }[] = [];
-    data.rows.forEach(row => {
+    const localSeriesSet = new Set<string | number | boolean>();
+    function skipSeries(seriesVal: string | number | boolean) {
+      if (shouldShareSeriesDomain && seriesSet) {
+        return !seriesSet.has(seriesVal);
+      } else {
+        if (
+          localSeriesSet.size >= maxSeries &&
+          !localSeriesSet.has(seriesVal)
+        ) {
+          return true;
+        }
+        localSeriesSet.add(seriesVal);
+        return false;
+      }
+    }
+    data.rows.slice(0, MAX_DATA_POINTS).forEach(row => {
+      let seriesVal = seriesField
+        ? row.column(seriesField.name).value
+        : yField.name;
+      // Limit # of series
+      if (skipSeries(seriesVal)) {
+        return;
+      }
       // Filter out missing date/time/metric values
       const isMissingX = xIsDateorTime && getXValue(row) === null;
       const isMissingY = row.column(yField.name).value === null;
@@ -743,12 +783,10 @@ export function generateLineChartVegaSpec(explore: NestField): VegaChartProps {
         return;
       }
       // Map data fields to chart properties.  Handle undefined values properly.
-      let seriesVal = seriesField
-        ? row.column(seriesField.name).value
-        : yField.name;
       if (seriesVal === undefined || seriesVal === null) {
         seriesVal = NULL_SYMBOL;
       }
+
       mappedData.push({
         __values: row.allCellValues(),
         __row: row,
@@ -757,7 +795,16 @@ export function generateLineChartVegaSpec(explore: NestField): VegaChartProps {
         series: seriesVal,
       });
     });
-    return mappedData;
+
+    return {
+      data: mappedData,
+      isDataLimited: data.rows.length > mappedData.length,
+      // Distinguish between limiting by record count and limiting by series count
+      dataLimitMessage:
+        seriesField && seriesField.valueSet.size > maxSeries
+          ? `Showing ${maxSeries.toLocaleString()} of ${seriesField.valueSet.size.toLocaleString()} series`
+          : '',
+    };
   };
 
   // Memoize tooltip data

--- a/packages/malloy-render/src/component/types.ts
+++ b/packages/malloy-render/src/component/types.ts
@@ -29,9 +29,11 @@ export type VegaPadding = {
   right?: number;
   bottom?: number;
 };
-export type MalloyDataToChartDataHandler = (
-  data: RepeatedRecordCell
-) => unknown[];
+export type MalloyDataToChartDataHandler = (data: RepeatedRecordCell) => {
+  data: unknown[];
+  isDataLimited: boolean;
+  dataLimitMessage?: string;
+};
 export type VegaChartProps = {
   spec: Spec;
   plotWidth: number;

--- a/packages/malloy-render/src/stories/bar_chart.stories.malloy
+++ b/packages/malloy-render/src/stories/bar_chart.stories.malloy
@@ -423,13 +423,19 @@ source: products is duckdb.table("static/data/products.parquet") extend {
     group_by: category
     aggregate: avg_retail is retail_price.avg()
     # bar_chart
-    nest: top_brands is {
+    nest: `Independent X, Shared Y` is {
       group_by: brand
       aggregate: avg_retail is retail_price.avg()
       limit: 10
     }
-    # label='Custom Column Label' bar_chart { y.independent title="Brand Sales" subtitle="with independent axes" }
-    nest: top_brands_independent is {
+    #  bar_chart { y.independent title="Brand Sales" subtitle="optional subtitle" }
+    nest: `Independent X and Y` is {
+      group_by: brand
+      aggregate: avg_retail is retail_price.avg()
+      limit: 10
+    }
+    #  bar_chart { x.independent=false title="Brand Sales" \ }
+    nest: `Shared X and Y` is {
       group_by: brand
       aggregate: avg_retail is retail_price.avg()
       limit: 10
@@ -495,3 +501,140 @@ source: products is duckdb.table("static/data/products.parquet") extend {
 }
 
 run: products -> { group_by: distribution_center_id}
+
+source: random_data is duckdb.sql("""
+  from (SELECT i  FROM range(0, 1000) t(i))
+  select
+    id: i,
+    id_text: i::text,
+    dim_2: floor(random()*2),
+    dim_3: floor(random()*3),
+    dim_6: floor(random()*6),
+    dim_10: floor(random()*10),
+    dim_25: floor(random()*25),
+    dim_50: floor(random()*50),
+    dim_100: floor(random()*100),
+    dim_250: floor(random()*250),
+    dim_500: floor(random()*500),
+    independent_dim_2: i%2,
+    independent_dim_3: i%3,
+    independent_dim_6: i%6,
+    independent_dim_10: i%10,
+    independent_dim_25: i%25,
+    independent_dim_50: i%50,
+    independent_dim_100: i%100,
+    independent_dim_250: i%250,
+    independent_dim_500: i%500,
+  """) extend {
+
+
+  #(story) story="Lots of Bars"
+  view: lots_of_bars is {
+    # bar_chart
+    nest: s is {
+      group_by:
+        dim_50
+        dim_3
+      aggregate: id.sum()
+      order_by: 1, 2
+      limit: 1000
+    }
+    nest: nests is {
+      group_by: dim_2
+      # bar_chart
+      nest: `Limited with shared axis and legend` is {
+        group_by:
+          dim_50
+          dim_3
+        aggregate: id.sum()
+        order_by: 1, 2
+        limit: 1000
+      }
+      # bar_chart { x.independent }
+      nest: `Limited with independent axis, shared legend` is {
+        group_by:
+          id_text
+          dim_3
+        aggregate: id.sum()
+        order_by: 1, 2
+        limit: 1000
+      }
+       # bar_chart {  x.independent }
+      nest: `Limited with group, independent axis, shared legend` is {
+        group_by:
+          dim_50
+          dim_10
+        aggregate: id.sum()
+        order_by: 1, 2
+        limit: 1000
+      }
+      # bar_chart { stack x.independent }
+      nest: `Limited with stack, independent axis, shared legend` is {
+        group_by:
+          dim_50
+          dim_10
+        aggregate: id.sum()
+        order_by: 1, 2
+        limit: 1000
+      }
+      # bar_chart
+      nest: `Limited with series, shared all` is {
+        group_by:
+          dim_10
+        aggregate:
+          # y
+          m1 is id.sum()
+          # y
+          m2 is id.avg()
+        order_by: 1, 2
+        limit: 1000
+      }
+      # bar_chart { x.independent }
+      nest: `Limited with measures, indie x` is {
+        group_by:
+          dim_10
+        aggregate:
+          # y
+          m1 is id.sum()
+          # y
+          m2 is id.avg()
+        order_by:
+          dim_10
+        limit: 1000
+      }
+      # bar_chart
+      nest: `Limited with shared all, large series` is {
+        group_by:
+          dim_10, dim_50
+        aggregate:
+          # y
+          m1 is id.sum()
+        order_by:
+          1,2
+        limit: 1000
+      }
+      # bar_chart { x.independent }
+      nest: `Limited with indie x, shared series` is {
+        group_by:
+          dim_10, dim_50
+        aggregate:
+          # y
+          m1 is id.sum()
+        order_by:
+          1,2
+        limit: 1000
+      }
+      // independent series?
+      # bar_chart { x.independent series.independent  }
+      nest: `Limited with indie x, indie series` is {
+        group_by:
+          dim_10, dim_50
+        aggregate:
+          # y
+          m1 is id.sum()
+        order_by: 1, 2
+        limit: 1000
+      }
+    }
+  }
+}

--- a/packages/malloy-render/src/stories/line_charts.stories.malloy
+++ b/packages/malloy-render/src/stories/line_charts.stories.malloy
@@ -7,6 +7,7 @@ source: products is duckdb.table("static/data/products.parquet") extend {
   dimension: product is name
   dimension: dcId is distribution_center_id::number
 
+
   # line_chart
   view: topSellingBrands is {
     group_by: brand
@@ -324,6 +325,40 @@ source: products is duckdb.table("static/data/products.parquet") extend {
     aggregate: total is count()
 
     order_by: sale_year
+  }
+
+    #(story)
+  view: lots_of_lines_nested is {
+    group_by: department
+
+    # line_chart { series.limit=5 }
+    nest: lots_of_lines is {
+      # x
+      group_by: sale_year
+      # series
+      group_by: brand
+      aggregate: total is count()
+      order_by: sale_year
+    }
+     # line_chart { y.independent }
+    nest: lots_of_lines_independent_y is {
+      # x
+      group_by: sale_year
+      # series
+      group_by: brand
+      aggregate: total is count()
+      order_by: sale_year
+    }
+    # line_chart { series.independent }
+    nest: lots_of_lines_independent_series is {
+      # x
+      group_by: sale_year
+      # series
+      group_by: brand
+      aggregate: total is count()
+      order_by: sale_year
+    }
+
   }
 
   #(story)


### PR DESCRIPTION
First pass at limiting data rendered into charts to prevent blow ups in the browser

For bar charts:
- sets a lower bound on bar width of 6px for grouped bars, 16px for non-grouped bars. Won't render any more bars than can within a single view.
- sets a max of 20 series that can be rendered at the same time
- handles limiting data both at shared level (when x axis shared across nested rows) and chart by chart level (when having independent x axes)

For line charts:
- sets max number of series to 12 by default. This is overridable via `# line_chart { series.limit=# }`
- sets a max limit of data points per chart to 5k
- when data is limited across line charts with shared y-axis, we disable the y-axis sharing for now because we don't currently capture the min / max values within that limited data scope. follow on work for that

For both charts:
- displays a message in the chart subtitle when data is being limited

![CleanShot 2025-04-30 at 14 47 03@2x](https://github.com/user-attachments/assets/6a207cad-09d5-48aa-93d6-0f834284db13)
