### PR TITLE
Allow internal fields to be used in joins (in sources; not queries)

### DIFF
--- a/packages/malloy/src/lang/ast/expressions/constant-expression.ts
+++ b/packages/malloy/src/lang/ast/expressions/constant-expression.ts
@@ -21,7 +21,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import type {StructDef} from '../../../model/malloy_types';
+import type {AccessModifierLabel, StructDef} from '../../../model/malloy_types';
 import type {BinaryMalloyOperator} from '../types/binary_operators';
 
 import type {ExprValue} from '../types/expr-value';
@@ -63,8 +63,8 @@ export class ConstantFieldSpace implements FieldSpace {
     return false;
   }
 
-  isProtectedAccessSpace(): boolean {
-    return false;
+  accessProtectionLevel(): AccessModifierLabel {
+    return 'private';
   }
 }
 

--- a/packages/malloy/src/lang/ast/field-space/dynamic-space.ts
+++ b/packages/malloy/src/lang/ast/field-space/dynamic-space.ts
@@ -151,7 +151,7 @@ export abstract class DynamicSpace
       // Add access modifiers at the end so views don't obey them
       for (const [name, access] of this.newAccessModifiers) {
         const index = this.sourceDef.fields.findIndex(
-          f => f.as ?? f.name === name
+          f => (f.as ?? f.name) === name
         );
         if (index === -1) {
           throw new Error(`Can't find field '${name}' to set access modifier`);

--- a/packages/malloy/src/lang/ast/field-space/include-utils.ts
+++ b/packages/malloy/src/lang/ast/field-space/include-utils.ts
@@ -1,0 +1,279 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import type {
+  AccessModifierLabel,
+  Annotation,
+  DocumentLocation,
+  FieldDef,
+  SourceDef,
+} from '../../../model/malloy_types';
+import {isJoined} from '../../../model/malloy_types';
+import type {IncludeItem} from '../source-query-elements/include-item';
+import {
+  IncludeAccessItem,
+  IncludeExceptItem,
+} from '../source-query-elements/include-item';
+import type {FieldReference} from '../query-items/field-references';
+import {WildcardFieldReference} from '../query-items/field-references';
+import {pathEq} from '../../../model/composite_source_utils';
+import type {MalloyElement} from '../types/malloy-element';
+
+export interface JoinIncludeProcessingState {
+  star: AccessModifierLabel | 'inherit' | undefined;
+  starNote: Annotation | undefined;
+  mode: 'exclude' | 'include' | undefined;
+  fieldsMentioned: Set<string>;
+  allFields: Set<string>;
+  alreadyPrivateFields: Set<string>;
+  modifiers: Map<string, AccessModifierLabel>;
+  renames: {
+    as: string;
+    name: FieldReference;
+    location: DocumentLocation;
+  }[];
+  fieldsToInclude: Set<string> | undefined;
+  notes: Map<string, Annotation>;
+}
+
+export interface IncludeProcessingState {
+  joins: {
+    path: string[];
+    state: JoinIncludeProcessingState;
+  }[];
+}
+
+function getJoinFields(
+  from: SourceDef,
+  joinPath: string[],
+  logTo: MalloyElement
+): FieldDef[] {
+  let fields = from.fields;
+  for (const joinName of joinPath) {
+    const join = fields.find(f => (f.as ?? f.name) === joinName);
+    if (join === undefined) {
+      logTo.logError('field-not-found', `\`${joinName}\` not found`);
+      return [];
+    }
+    if (!isJoined(join)) {
+      logTo.logError('field-not-found', `\`${joinName}\` is not a join`);
+      return [];
+    }
+    fields = join.fields;
+  }
+  return fields;
+}
+
+export function getIncludeStateForJoin(
+  joinPath: string[],
+  state: IncludeProcessingState
+): JoinIncludeProcessingState {
+  const joinState = state.joins.find(s => pathEq(s.path, joinPath));
+  if (joinState !== undefined) return joinState.state;
+  return {
+    star: undefined,
+    starNote: undefined,
+    mode: undefined,
+    fieldsMentioned: new Set(),
+    allFields: new Set(),
+    alreadyPrivateFields: new Set(),
+    modifiers: new Map(),
+    renames: [],
+    notes: new Map(),
+    fieldsToInclude: undefined,
+  };
+}
+
+function getOrCreateIncludeStateForJoin(
+  joinPath: string[],
+  state: IncludeProcessingState,
+  from: SourceDef,
+  logTo: MalloyElement
+): JoinIncludeProcessingState {
+  const joinState = state.joins.find(s => pathEq(s.path, joinPath));
+  if (joinState !== undefined) return joinState.state;
+  else {
+    const fromFields = getJoinFields(from, joinPath, logTo);
+    const allFields = new Set(fromFields.map(f => f.as ?? f.name));
+    const alreadyPrivateFields = new Set(
+      fromFields
+        .filter(f => f.accessModifier === 'private')
+        .map(f => f.as ?? f.name)
+    );
+    const joinState: JoinIncludeProcessingState = {
+      star: undefined,
+      starNote: undefined,
+      mode: undefined,
+      fieldsMentioned: new Set(),
+      allFields,
+      alreadyPrivateFields,
+      modifiers: new Map(),
+      renames: [],
+      notes: new Map(),
+      fieldsToInclude: new Set(),
+    };
+    state.joins.push({path: [...joinPath], state: joinState});
+    return joinState;
+  }
+}
+
+export function processIncludeList(
+  includeItems: IncludeItem[] | undefined,
+  from: SourceDef
+): IncludeProcessingState {
+  const state: IncludeProcessingState = {joins: []};
+  if (includeItems === undefined) {
+    return state;
+  }
+  for (const item of includeItems) {
+    if (item instanceof IncludeAccessItem) {
+      for (const f of item.fields) {
+        const joinPath =
+          f.name instanceof WildcardFieldReference
+            ? f.name.joinPath?.path ?? []
+            : f.name.path.slice(0, -1);
+        const joinState = getOrCreateIncludeStateForJoin(
+          joinPath,
+          state,
+          from,
+          f
+        );
+
+        if (f.name instanceof WildcardFieldReference) {
+          if (joinState.star !== undefined) {
+            item.logError(
+              'already-used-star-in-include',
+              'Wildcard already used in this include block'
+            );
+          } else {
+            joinState.star = item.kind ?? 'inherit';
+            joinState.starNote = {
+              notes: f.note?.notes ?? [],
+              blockNotes: item.note?.blockNotes ?? [],
+            };
+          }
+        } else {
+          if (!joinState.allFields.has(f.name.getName())) {
+            item.logError(
+              'field-not-found',
+              `\`${f.name.refString}\` not found`
+            );
+            continue;
+          }
+          if (joinState.mode === 'exclude') {
+            item.logError(
+              'include-after-exclude',
+              'Cannot include specific fields if specific fields are already excluded'
+            );
+            continue;
+          }
+          joinState.mode = 'include';
+          const name = f.name.nameString;
+          if (joinState.alreadyPrivateFields.has(name)) {
+            f.logError(
+              'cannot-expand-access',
+              `Cannot expand access of \`${name}\` from private to ${item.kind}`
+            );
+          }
+          if (joinState.modifiers.has(name)) {
+            f.logError(
+              'duplicate-include',
+              `Field \`${name}\` already referenced in include list`
+            );
+          } else {
+            if (item.kind !== undefined) {
+              joinState.modifiers.set(name, item.kind);
+            }
+            joinState.fieldsMentioned.add(name);
+            if (f.note || item.note) {
+              joinState.notes.set(name, {
+                notes: f.note?.notes ?? [],
+                blockNotes: item.note?.blockNotes ?? [],
+              });
+            }
+          }
+          if (f.as) {
+            if (f.name instanceof WildcardFieldReference) {
+              f.logError(
+                'wildcard-include-rename',
+                'Cannot rename a wildcard field in an `include` block'
+              );
+            } else {
+              joinState.renames.push({
+                name: f.name,
+                as: f.as,
+                location: f.location,
+              });
+            }
+          }
+        }
+      }
+    } else if (item instanceof IncludeExceptItem) {
+      for (const f of item.fields) {
+        const joinPath =
+          f instanceof WildcardFieldReference
+            ? f.joinPath?.path ?? []
+            : f.path.slice(0, -1);
+        const joinState = getOrCreateIncludeStateForJoin(
+          joinPath,
+          state,
+          from,
+          f
+        );
+        if (f instanceof WildcardFieldReference) {
+          f.logWarning(
+            'wildcard-except-redundant',
+            '`except: *` is implied, unless another clause uses *'
+          );
+        } else {
+          if (!joinState.allFields.has(f.getName())) {
+            item.logError('field-not-found', `\`${f.refString}\` not found`);
+          } else if (joinState.mode === 'include') {
+            item.logError(
+              'exclude-after-include',
+              'Cannot exclude specific fields if specific fields are already included'
+            );
+          } else {
+            joinState.mode = 'exclude';
+            joinState.star = 'inherit';
+            joinState.fieldsMentioned.add(f.nameString);
+          }
+        }
+      }
+    }
+  }
+  for (const join of state.joins) {
+    const joinState = join.state;
+    const starFields: Set<string> = new Set(joinState.allFields);
+    joinState.fieldsMentioned.forEach(f => starFields.delete(f));
+    joinState.alreadyPrivateFields.forEach(f => starFields.delete(f));
+    if (joinState.star !== undefined) {
+      for (const field of starFields) {
+        if (joinState.star !== 'inherit') {
+          joinState.modifiers.set(field, joinState.star);
+        }
+        if (joinState.starNote) {
+          joinState.notes.set(field, {...joinState.starNote});
+        }
+      }
+    }
+    if (joinState.mode !== 'exclude') {
+      if (joinState.star !== undefined) {
+        joinState.fieldsToInclude = joinState.allFields;
+      } else {
+        joinState.fieldsToInclude = joinState.fieldsMentioned;
+      }
+    } else {
+      joinState.fieldsToInclude = starFields;
+    }
+  }
+  // TODO: validate that a field isn't renamed more than once
+  // TODO: validate that excluded fields are not referenced by included fields
+  // TODO: make renames fields work in existing references
+  // TODO: make renames that would replace an excluded field don't do that
+  return state;
+}

--- a/packages/malloy/src/lang/ast/field-space/include-utils.ts
+++ b/packages/malloy/src/lang/ast/field-space/include-utils.ts
@@ -203,6 +203,12 @@ export function processIncludeList(
                 'Cannot rename a wildcard field in an `include` block'
               );
             } else {
+              if (joinPath.length > 0) {
+                f.logError(
+                  'cannot-rename-join-field',
+                  'Cannot rename a joined field in an `include` block'
+                );
+              }
               joinState.renames.push({
                 name: f.name,
                 as: f.as,

--- a/packages/malloy/src/lang/ast/field-space/include-utils.ts
+++ b/packages/malloy/src/lang/ast/field-space/include-utils.ts
@@ -11,7 +11,6 @@ import type {
   DocumentLocation,
   FieldDef,
   SourceDef,
-  StructDef,
 } from '../../../model/malloy_types';
 import {isJoined} from '../../../model/malloy_types';
 import type {IncludeItem} from '../source-query-elements/include-item';

--- a/packages/malloy/src/lang/ast/field-space/parameter-space.ts
+++ b/packages/malloy/src/lang/ast/field-space/parameter-space.ts
@@ -6,7 +6,7 @@
  */
 
 import type {Dialect} from '../../../dialect';
-import type {StructDef} from '../../../model';
+import type {AccessModifierLabel, StructDef} from '../../../model';
 import type {HasParameter} from '../parameters/has-parameter';
 import type {
   FieldName,
@@ -95,7 +95,7 @@ export class ParameterSpace implements FieldSpace {
     return false;
   }
 
-  isProtectedAccessSpace(): boolean {
-    return false;
+  accessProtectionLevel(): AccessModifierLabel {
+    return 'private';
   }
 }

--- a/packages/malloy/src/lang/ast/field-space/query-input-space.ts
+++ b/packages/malloy/src/lang/ast/field-space/query-input-space.ts
@@ -29,7 +29,7 @@
  * specialized QuerySpace for each type of query operation.
  */
 
-import type {SourceDef} from '../../../model';
+import type {AccessModifierLabel, SourceDef} from '../../../model';
 import type {AtomicFieldDeclaration} from '../query-items/field-declaration';
 import {Join} from '../source-properties/join';
 import type {QueryFieldSpace} from '../types/field-space';
@@ -48,7 +48,7 @@ export class QueryInputSpace extends RefinedSpace implements QueryFieldSpace {
   constructor(
     input: SourceDef,
     private queryOutput: QueryOperationSpace,
-    public readonly _isProtectedAccessSpace: boolean
+    public readonly _accessProtectionLevel: AccessModifierLabel
   ) {
     super(input);
   }
@@ -74,7 +74,7 @@ export class QueryInputSpace extends RefinedSpace implements QueryFieldSpace {
     return this;
   }
 
-  isProtectedAccessSpace(): boolean {
-    return this._isProtectedAccessSpace;
+  accessProtectionLevel(): AccessModifierLabel {
+    return this._accessProtectionLevel;
   }
 }

--- a/packages/malloy/src/lang/ast/field-space/query-spaces.ts
+++ b/packages/malloy/src/lang/ast/field-space/query-spaces.ts
@@ -100,7 +100,7 @@ export abstract class QueryOperationSpace
     this.exprSpace = new QueryInputSpace(
       queryInputSpace.structDef(),
       this,
-      queryInputSpace.isProtectedAccessSpace()
+      queryInputSpace.accessProtectionLevel()
     );
     if (refineThis) this.addRefineFromFields(refineThis);
   }
@@ -116,6 +116,10 @@ export abstract class QueryOperationSpace
       this.astEl.logError(code, parameters, options);
     }
     return code;
+  }
+
+  accessProtectionLevel(): model.AccessModifierLabel {
+    return 'public';
   }
 
   inputSpace(): QueryInputSpace {

--- a/packages/malloy/src/lang/ast/field-space/refined-space.ts
+++ b/packages/malloy/src/lang/ast/field-space/refined-space.ts
@@ -163,7 +163,7 @@ export class RefinedSpace extends DynamicSpace {
     }
   }
 
-  isProtectedAccessSpace(): boolean {
-    return true;
+  accessProtectionLevel(): AccessModifierLabel {
+    return 'internal';
   }
 }

--- a/packages/malloy/src/lang/ast/query-elements/query-arrow.ts
+++ b/packages/malloy/src/lang/ast/query-elements/query-arrow.ts
@@ -66,13 +66,13 @@ export class QueryArrow extends QueryBase implements QueryElement {
       inputStruct = refIsStructDef(invoked.structRef)
         ? invoked.structRef
         : this.source.getSourceDef(undefined);
-      fieldSpace = new StaticSourceSpace(inputStruct);
+      fieldSpace = new StaticSourceSpace(inputStruct, 'public');
     } else {
       // We are adding a second stage to the given "source" query; we get the query and add a segment
       const lhsQuery = this.source.queryComp(isRefOk);
       queryBase = lhsQuery.query;
       inputStruct = lhsQuery.outputStruct;
-      fieldSpace = new StaticSourceSpace(lhsQuery.outputStruct);
+      fieldSpace = new StaticSourceSpace(lhsQuery.outputStruct, 'public');
     }
     const {pipeline, annotation, outputStruct, name} =
       this.view.pipelineComp(fieldSpace);

--- a/packages/malloy/src/lang/ast/query-elements/query-refine.ts
+++ b/packages/malloy/src/lang/ast/query-elements/query-refine.ts
@@ -45,7 +45,7 @@ export class QueryRefine extends QueryBase implements QueryElement {
 
   queryComp(isRefOk: boolean): QueryComp {
     const q = this.base.queryComp(isRefOk);
-    const inputFS = new StaticSourceSpace(q.inputStruct);
+    const inputFS = new StaticSourceSpace(q.inputStruct, 'public');
     const resultPipe = this.refinement.refine(
       inputFS,
       q.query.pipeline,

--- a/packages/malloy/src/lang/ast/query-items/field-declaration.ts
+++ b/packages/malloy/src/lang/ast/query-items/field-declaration.ts
@@ -28,6 +28,7 @@ import type {
   TypeDesc,
   FieldDef,
   AtomicFieldDef,
+  AccessModifierLabel,
 } from '../../../model/malloy_types';
 import {
   isAtomicFieldType,
@@ -301,8 +302,8 @@ export class DefSpace implements FieldSpace {
     throw new Error('Not a query field space');
   }
 
-  isProtectedAccessSpace(): boolean {
-    return true;
+  accessProtectionLevel(): AccessModifierLabel {
+    return 'public';
   }
 }
 

--- a/packages/malloy/src/lang/ast/query-properties/qop-desc.ts
+++ b/packages/malloy/src/lang/ast/query-properties/qop-desc.ts
@@ -114,7 +114,8 @@ export class QOpDesc extends ListOf<QueryProperty> {
         // If the `build.resultFS` is correct, then we should be able to just use that
         // in a more direct way.
         new StaticSourceSpace(
-          opOutputStruct(this, inputFS.structDef(), segment)
+          opOutputStruct(this, inputFS.structDef(), segment),
+          'public'
         ),
     };
   }

--- a/packages/malloy/src/lang/ast/source-elements/refined-source.ts
+++ b/packages/malloy/src/lang/ast/source-elements/refined-source.ts
@@ -24,7 +24,6 @@
 import type {
   AccessModifierLabel,
   Annotation,
-  DocumentLocation,
   SourceDef,
 } from '../../../model/malloy_types';
 import {expressionIsCalculation} from '../../../model/malloy_types';
@@ -46,11 +45,9 @@ import {ParameterSpace} from '../field-space/parameter-space';
 import {JoinStatement} from '../source-properties/join';
 import type {IncludeItem} from '../source-query-elements/include-item';
 import {
-  IncludeAccessItem,
-  IncludeExceptItem,
-} from '../source-query-elements/include-item';
-import type {FieldReference} from '../query-items/field-references';
-import {WildcardFieldReference} from '../query-items/field-references';
+  getIncludeStateForJoin,
+  processIncludeList,
+} from '../field-space/include-utils';
 
 /**
  * A Source made from a source reference and a set of refinements
@@ -135,13 +132,11 @@ export class RefinedSource extends Source {
 
     const paramSpace = pList ? new ParameterSpace(pList) : undefined;
     const from = structuredClone(this.source.getSourceDef(paramSpace));
-    const {fieldsToInclude, modifiers, renames, notes} = processIncludeList(
-      this.includeList,
-      from
-    );
+    const includeState = processIncludeList(this.includeList, from);
+    const thisIncludeState = getIncludeStateForJoin([], includeState);
     for (const modifier of inlineAccessModifiers) {
       for (const field of modifier.fields) {
-        modifiers.set(field, modifier.access);
+        thisIncludeState.modifiers.set(field, modifier.access);
       }
     }
     // Note that this is explicitly not:
@@ -153,8 +148,7 @@ export class RefinedSource extends Source {
     const fs = RefinedSpace.filteredFrom(
       from,
       fieldListEdit,
-      fieldsToInclude,
-      renames,
+      includeState,
       paramSpace
     );
     if (newTimezone) {
@@ -170,8 +164,8 @@ export class RefinedSource extends Source {
         primaryKey.logError(keyDef.error.code, keyDef.error.message);
       }
     }
-    fs.addAccessModifiers(modifiers);
-    fs.addNotes(notes);
+    fs.addAccessModifiers(thisIncludeState.modifiers);
+    fs.addNotes(thisIncludeState.notes);
     const retStruct = fs.structDef();
 
     const filterList = retStruct.filterList || [];
@@ -196,157 +190,4 @@ export class RefinedSource extends Source {
     this.document()?.rememberToAddModelAnnotations(retStruct);
     return retStruct;
   }
-}
-
-function processIncludeList(
-  includeItems: IncludeItem[] | undefined,
-  from: SourceDef
-) {
-  // TODO error/warning if you include both star and specific fields with the same modifier...
-  const allFields = new Set(from.fields.map(f => f.name));
-  const alreadyPrivateFields = new Set(
-    from.fields.filter(f => f.accessModifier === 'private').map(f => f.name)
-  );
-  let mode: 'exclude' | 'include' | undefined = undefined;
-  const fieldsMentioned = new Set<string>();
-  let star: AccessModifierLabel | 'inherit' | undefined = undefined;
-  let starNote: Annotation | undefined = undefined;
-  const modifiers = new Map<string, AccessModifierLabel>();
-  const renames: {
-    as: string;
-    name: FieldReference;
-    location: DocumentLocation;
-  }[] = [];
-  const notes = new Map<string, Annotation>();
-  if (includeItems === undefined) {
-    return {fieldsToInclude: undefined, modifiers, renames, notes};
-  }
-  for (const item of includeItems) {
-    if (item instanceof IncludeAccessItem) {
-      for (const f of item.fields) {
-        if (f.name instanceof WildcardFieldReference) {
-          if (f.name.joinPath) {
-            f.logError(
-              'unsupported-path-in-include',
-              'Wildcards with paths are not supported in `include` blocks'
-            );
-          }
-          if (star !== undefined) {
-            item.logError(
-              'already-used-star-in-include',
-              'Wildcard already used in this include block'
-            );
-          } else {
-            star = item.kind ?? 'inherit';
-            starNote = {
-              notes: f.note?.notes ?? [],
-              blockNotes: item.note?.blockNotes ?? [],
-            };
-          }
-        } else {
-          if (mode === 'exclude') {
-            item.logError(
-              'include-after-exclude',
-              'Cannot include specific fields if specific fields are already excluded'
-            );
-            continue;
-          }
-          mode = 'include';
-          const name = f.name.refString;
-          if (alreadyPrivateFields.has(name)) {
-            f.logError(
-              'cannot-expand-access',
-              `Cannot expand access of \`${name}\` from private to ${item.kind}`
-            );
-          }
-          if (modifiers.has(name)) {
-            f.logError(
-              'duplicate-include',
-              `Field \`${name}\` already referenced in include list`
-            );
-          } else {
-            if (item.kind !== undefined) {
-              modifiers.set(name, item.kind);
-            }
-            fieldsMentioned.add(name);
-            if (f.note || item.note) {
-              notes.set(name, {
-                notes: f.note?.notes ?? [],
-                blockNotes: item.note?.blockNotes ?? [],
-              });
-            }
-          }
-          if (f.as) {
-            if (f.name instanceof WildcardFieldReference) {
-              f.logError(
-                'wildcard-include-rename',
-                'Cannot rename a wildcard field in an `include` block'
-              );
-            } else {
-              renames.push({
-                name: f.name,
-                as: f.as,
-                location: f.location,
-              });
-            }
-          }
-        }
-      }
-    } else if (item instanceof IncludeExceptItem) {
-      for (const f of item.fields) {
-        if (f instanceof WildcardFieldReference) {
-          if (f.joinPath) {
-            f.logError(
-              'unsupported-path-in-include',
-              'Wildcards with paths are not supported in `include` blocks'
-            );
-          } else {
-            f.logWarning(
-              'wildcard-except-redundant',
-              '`except: *` is implied, unless another clause uses *'
-            );
-          }
-        } else {
-          if (mode === 'include') {
-            item.logError(
-              'exclude-after-include',
-              'Cannot exclude specific fields if specific fields are already included'
-            );
-          } else {
-            mode = 'exclude';
-            star = 'inherit';
-            fieldsMentioned.add(f.refString);
-          }
-        }
-      }
-    }
-  }
-  const starFields: Set<string> = new Set(allFields);
-  fieldsMentioned.forEach(f => starFields.delete(f));
-  alreadyPrivateFields.forEach(f => starFields.delete(f));
-  let fieldsToInclude: Set<string>;
-  if (star !== undefined) {
-    for (const field of starFields) {
-      if (star !== 'inherit') {
-        modifiers.set(field, star);
-      }
-      if (starNote) {
-        notes.set(field, {...starNote});
-      }
-    }
-  }
-  if (mode !== 'exclude') {
-    if (star !== undefined) {
-      fieldsToInclude = allFields;
-    } else {
-      fieldsToInclude = fieldsMentioned;
-    }
-  } else {
-    fieldsToInclude = starFields;
-  }
-  // TODO: validate that a field isn't renamed more than once
-  // TODO: validate that excluded fields are not referenced by included fields
-  // TODO: make renames fields work in existing references
-  // TODO: make renames that would replace an excluded field don't do that
-  return {fieldsToInclude, modifiers, renames, notes};
 }

--- a/packages/malloy/src/lang/ast/types/field-space.ts
+++ b/packages/malloy/src/lang/ast/types/field-space.ts
@@ -22,7 +22,11 @@
  */
 
 import type {Dialect} from '../../../dialect/dialect';
-import type {SourceDef, StructDef} from '../../../model/malloy_types';
+import type {
+  AccessModifierLabel,
+  SourceDef,
+  StructDef,
+} from '../../../model/malloy_types';
 import type {QueryOperationSpace} from '../field-space/query-spaces';
 import type {LookupResult} from './lookup-result';
 import {MalloyElement} from './malloy-element';
@@ -36,13 +40,16 @@ export interface FieldSpace {
   type: 'fieldSpace';
   structDef(): StructDef;
   emptyStructDef(): StructDef;
-  lookup(symbol: FieldName[]): LookupResult;
+  lookup(
+    symbol: FieldName[],
+    accessLevel?: AccessModifierLabel | undefined
+  ): LookupResult;
   entry(symbol: string): SpaceEntry | undefined;
   entries(): [string, SpaceEntry][];
   dialectObj(): Dialect | undefined;
   dialectName(): string;
   isQueryFieldSpace(): this is QueryFieldSpace;
-  isProtectedAccessSpace(): boolean;
+  accessProtectionLevel(): AccessModifierLabel;
 }
 
 export interface SourceFieldSpace extends FieldSpace {

--- a/packages/malloy/src/lang/ast/view-elements/qop-desc-view.ts
+++ b/packages/malloy/src/lang/ast/view-elements/qop-desc-view.ts
@@ -122,7 +122,7 @@ export class QOpDescView extends View {
         pipeline.slice(-1)
       );
       pipeline[last] = this.getOp(
-        new StaticSourceSpace(finalIn),
+        new StaticSourceSpace(finalIn, 'public'),
         undefined,
         tailRefinements,
         pipeline[last]

--- a/packages/malloy/src/lang/ast/view-elements/view-arrow.ts
+++ b/packages/malloy/src/lang/ast/view-elements/view-arrow.ts
@@ -46,7 +46,7 @@ export class ViewArrow extends View {
 
   pipelineComp(fs: FieldSpace): PipelineComp {
     const baseComp = this.base.pipelineComp(fs);
-    const nextFS = new StaticSourceSpace(baseComp.outputStruct);
+    const nextFS = new StaticSourceSpace(baseComp.outputStruct, 'public');
     const finalComp = this.operation.pipelineComp(nextFS);
     return {
       pipeline: [...baseComp.pipeline, ...finalComp.pipeline],

--- a/packages/malloy/src/lang/grammar/MalloyParser.g4
+++ b/packages/malloy/src/lang/grammar/MalloyParser.g4
@@ -285,7 +285,7 @@ includeExceptList
   ;
 
 includeExceptListItem
-  : tags fieldName
+  : tags fieldPath
   | tags collectionWildCard
   ;
 
@@ -294,8 +294,8 @@ includeList
   ;
 
 includeField
-  : tags (as=fieldName isDefine)? name=fieldName
-  | tags name=fieldName
+  : tags (as=fieldName isDefine)? name=fieldPath
+  | tags name=fieldPath
   | tags collectionWildCard
   ;
 

--- a/packages/malloy/src/lang/malloy-to-ast.ts
+++ b/packages/malloy/src/lang/malloy-to-ast.ts
@@ -1975,7 +1975,7 @@ export class MalloyToAST
     const wildcard = wildcardCx
       ? this.visitCollectionWildCard(wildcardCx)
       : undefined;
-    const as = pcx._as ? pcx._as.text : undefined;
+    const as = pcx._as ? this.getFieldName(pcx._as) : undefined;
     const tags1cx = pcx.tags();
     const tags1 = tags1cx ? this.getNotes(tags1cx) : [];
     const tags2cx = pcx.isDefine();
@@ -1991,7 +1991,10 @@ export class MalloyToAST
     if (reference === undefined) {
       throw this.internalError(pcx, 'Expected a field name or wildcard');
     }
-    const item = this.astAt(new ast.IncludeListItem(reference, as), pcx);
+    const item = this.astAt(
+      new ast.IncludeListItem(reference, as?.refString),
+      pcx
+    );
     item.extendNote({notes});
     return item;
   }

--- a/packages/malloy/src/lang/malloy-to-ast.ts
+++ b/packages/malloy/src/lang/malloy-to-ast.ts
@@ -1955,14 +1955,12 @@ export class MalloyToAST
           {severity: 'warn'}
         );
       }
-      const fieldNameCx = fcx.fieldName();
+      const fieldNameCx = fcx.fieldPath();
       if (fieldNameCx) {
         return this.astAt(
-          new ast.AccessModifierFieldReference([
-            this.astAt(this.getFieldName(fieldNameCx), fcx),
-          ]),
+          this.getFieldPath(fieldNameCx, ast.AccessModifierFieldReference),
           fieldNameCx
-        );
+        ) as ast.AccessModifierFieldReference;
       }
       const wildcardCx = fcx.collectionWildCard();
       if (wildcardCx) {
@@ -1984,12 +1982,10 @@ export class MalloyToAST
     const tags2 = tags2cx ? this.getIsNotes(tags2cx) : [];
     const notes = [...tags1, ...tags2];
     const name = pcx._name
-      ? this.astAt(
-          new ast.AccessModifierFieldReference([
-            this.astAt(this.getFieldName(pcx._name), pcx._name),
-          ]),
+      ? (this.astAt(
+          this.getFieldPath(pcx._name, ast.AccessModifierFieldReference),
           pcx._name
-        )
+        ) as ast.AccessModifierFieldReference)
       : undefined;
     const reference = name ?? wildcard;
     if (reference === undefined) {

--- a/packages/malloy/src/lang/parse-log.ts
+++ b/packages/malloy/src/lang/parse-log.ts
@@ -388,6 +388,7 @@ type MessageParameterTypes = {
   };
   'or-choices-only': string;
   'sql-in': string;
+  'except-star-and-list': string;
   'dialect-cast-unsafe-only': string;
   'field-not-accessible': string;
   'cannot-expand-access': string;
@@ -399,6 +400,7 @@ type MessageParameterTypes = {
   'include-after-exclude': string;
   'duplicate-include': string;
   'exclude-after-include': string;
+  'exclude-after-exclude': string;
   'cannot-rename-non-field': string;
   'array-values-incompatible': string;
   'invalid-resolved-type-for-array': string;

--- a/packages/malloy/src/lang/parse-log.ts
+++ b/packages/malloy/src/lang/parse-log.ts
@@ -371,6 +371,7 @@ type MessageParameterTypes = {
   'illegal-record-property-type': string;
   'record-literal-needs-keys': string;
   'not-yet-implemented': string;
+  'cannot-rename-join-field': string;
   'sql-case': string;
   'case-then-type-does-not-match': {
     thenType: ExpressionValueType;

--- a/packages/malloy/src/lang/test/annotation.spec.ts
+++ b/packages/malloy/src/lang/test/annotation.spec.ts
@@ -826,7 +826,6 @@ describe('query operation annotations', () => {
       expect(m).toLog(
         warningMessage('Tags on `except:` are ignored'),
         warningMessage('Tags on `except:` are ignored'),
-        warningMessage('`except: *` is implied, unless another clause uses *')
       );
     });
     test('oprhaned annotation', () => {

--- a/packages/malloy/src/lang/test/annotation.spec.ts
+++ b/packages/malloy/src/lang/test/annotation.spec.ts
@@ -825,7 +825,7 @@ describe('query operation annotations', () => {
       `);
       expect(m).toLog(
         warningMessage('Tags on `except:` are ignored'),
-        warningMessage('Tags on `except:` are ignored'),
+        warningMessage('Tags on `except:` are ignored')
       );
     });
     test('oprhaned annotation', () => {

--- a/packages/malloy/src/lang/test/field-symbols.spec.ts
+++ b/packages/malloy/src/lang/test/field-symbols.spec.ts
@@ -55,7 +55,7 @@ describe('structdef comprehension', () => {
       type: 'string',
     };
     const struct = mkStructDef(field);
-    const space = new StaticSourceSpace(struct);
+    const space = new StaticSourceSpace(struct, 'public');
     expect(space.lookup(fieldRef('t')).found).toBeInstanceOf(ColumnSpaceField);
     const oField = space.structDef().fields[0];
     expect(oField).toEqual(field);
@@ -68,7 +68,7 @@ describe('structdef comprehension', () => {
       numberType: 'float',
     };
     const struct = mkStructDef(field);
-    const space = new StaticSourceSpace(struct);
+    const space = new StaticSourceSpace(struct, 'public');
     expect(space.lookup(fieldRef('t')).found).toBeInstanceOf(ColumnSpaceField);
     const oField = space.structDef().fields[0];
     expect(oField).toEqual(field);
@@ -81,7 +81,7 @@ describe('structdef comprehension', () => {
       numberType: 'integer',
     };
     const struct = mkStructDef(field);
-    const space = new StaticSourceSpace(struct);
+    const space = new StaticSourceSpace(struct, 'public');
     expect(space.lookup(fieldRef('t')).found).toBeInstanceOf(ColumnSpaceField);
     const oField = space.structDef().fields[0];
     expect(oField).toEqual(field);
@@ -93,7 +93,7 @@ describe('structdef comprehension', () => {
       type: 'boolean',
     };
     const struct = mkStructDef(field);
-    const space = new StaticSourceSpace(struct);
+    const space = new StaticSourceSpace(struct, 'public');
     expect(space.lookup(fieldRef('t')).found).toBeInstanceOf(ColumnSpaceField);
     const oField = space.structDef().fields[0];
     expect(oField).toEqual(field);
@@ -105,7 +105,7 @@ describe('structdef comprehension', () => {
       type: 'sql native',
     };
     const struct = mkStructDef(field);
-    const space = new StaticSourceSpace(struct);
+    const space = new StaticSourceSpace(struct, 'public');
     expect(space.lookup(fieldRef('t')).found).toBeInstanceOf(ColumnSpaceField);
     const oField = space.structDef().fields[0];
     expect(oField).toEqual(field);
@@ -121,7 +121,7 @@ describe('structdef comprehension', () => {
       fields: [{type: 'string', name: 'b'}],
     };
     const struct = mkStructDef(field);
-    const space = new StaticSourceSpace(struct);
+    const space = new StaticSourceSpace(struct, 'public');
     expect(space.lookup(fieldRef('t.b')).found).toBeInstanceOf(
       ColumnSpaceField
     );
@@ -138,7 +138,7 @@ describe('structdef comprehension', () => {
       fields: [{type: 'string', name: 'a'}],
     };
     const struct = mkStructDef(field);
-    const space = new StaticSourceSpace(struct);
+    const space = new StaticSourceSpace(struct, 'public');
     expect(space.lookup(fieldRef('t.a')).found).toBeInstanceOf(
       ColumnSpaceField
     );
@@ -165,7 +165,7 @@ describe('structdef comprehension', () => {
       fields: [{type: 'string', name: 'a'}],
     };
     const struct = mkStructDef(field);
-    const space = new StaticSourceSpace(struct);
+    const space = new StaticSourceSpace(struct, 'public');
     expect(space.lookup(fieldRef('t.a')).found).toBeInstanceOf(
       ColumnSpaceField
     );
@@ -185,7 +185,7 @@ describe('structdef comprehension', () => {
       ],
     };
     const struct = mkStructDef(field);
-    const space = new StaticSourceSpace(struct);
+    const space = new StaticSourceSpace(struct, 'public');
     expect(space.lookup(fieldRef('t')).found).toBeInstanceOf(IRViewField);
     const oField = space.structDef().fields[0];
     expect(oField).toEqual(field);
@@ -205,7 +205,7 @@ describe('structdef comprehension', () => {
         value: {node: 'stringLiteral', literal: 'value'},
       },
     };
-    const space = new StaticSourceSpace(struct);
+    const space = new StaticSourceSpace(struct, 'public');
     expect(space.lookup(fieldRef('cReqStr')).found).toBeInstanceOf(
       DefinedParameter
     );

--- a/packages/malloy/src/lang/test/parse-expects.ts
+++ b/packages/malloy/src/lang/test/parse-expects.ts
@@ -400,7 +400,7 @@ function checkForProblems(
       }
     }
     if (i !== msgs.length) {
-      explain.push(...msgs.slice(i).map(m => `Missing: ${m}`));
+      explain.push(...msgs.slice(i).map(m => `Missing: ${JSON.stringify(m)}`));
     }
     if (!allowAdditionalErrors && i !== errList.length) {
       explain.push(

--- a/packages/malloy/src/lang/test/query.spec.ts
+++ b/packages/malloy/src/lang/test/query.spec.ts
@@ -1923,10 +1923,16 @@ describe('query:', () => {
             measure: aisum is ai.sum() { grouped_by: astr, abool }
           }
           source: aext is compose(
-            abase include { ai, astr, aisum } extend {
+            abase include {
+              except: *
+              public: ai, astr, aisum
+            } extend {
               dimension: x is 1
             },
-            abase include { ai, abool, aisum } extend {
+            abase include {
+              except: *
+              public: ai, abool, aisum
+            } extend {
               dimension: y is 1
             }
           )
@@ -1948,7 +1954,10 @@ describe('query:', () => {
           source: abase is a extend {
             measure: aisum is ai.sum() { grouped_by: astr, abool }
           }
-          source: aext is abase include { ai, astr, aisum } extend {
+          source: aext is abase include {
+            except: *
+            public: ai, astr, aisum
+          } extend {
             dimension: x is 1
           }
           run: aext -> {

--- a/packages/malloy/src/lang/test/source.spec.ts
+++ b/packages/malloy/src/lang/test/source.spec.ts
@@ -249,7 +249,7 @@ describe('source:', () => {
           }
         `).toLog(errorMessage("'ai' is private"));
       });
-      test('internal is inaccessible in joining source on', () => {
+      test('internal is accessible in joining source on', () => {
         expect(markSource`
           ##! experimental.access_modifiers
           source: c is a include {
@@ -259,6 +259,48 @@ describe('source:', () => {
           source: d is a extend {
             join_one: c on ai = ${'c.ai'}
           }
+        `).toTranslate();
+      });
+      test('internal is accessible in joining source view', () => {
+        expect(markSource`
+          ##! experimental.access_modifiers
+          source: c is a include {
+            public: *
+            internal: ai
+          }
+          source: d is a extend {
+            join_one: c on true
+            view: x is {
+              group_by: c.ai
+            }
+          }
+        `).toTranslate();
+      });
+      test('internal is accessible in joining source dimension', () => {
+        expect(markSource`
+          ##! experimental.access_modifiers
+          source: c is a include {
+            public: *
+            internal: ai
+          }
+          source: d is a extend {
+            join_one: c on true
+            dimension: cai is c.ai
+          }
+          run: d -> { group_by: c.astr } // TODO just here for debugging
+        `).toTranslate();
+      });
+      test('joined internal is inaccessible in query', () => {
+        expect(markSource`
+          ##! experimental.access_modifiers
+          source: c is a include {
+            public: *
+            internal: ai
+          }
+          source: d is a extend {
+            join_one: c on true
+          }
+          run: d -> { group_by: c.ai }
         `).toLog(errorMessage("'ai' is internal"));
       });
       test('internal at definition time', () => {
@@ -269,19 +311,6 @@ describe('source:', () => {
           }
           run: c -> x
         `).toLog(errorMessage("'x' is internal"));
-      });
-      test('internal is inaccessible in joining source field', () => {
-        expect(markSource`
-          ##! experimental.access_modifiers
-          source: c is a include {
-            public: *
-            internal: ai
-          }
-          source: d is a extend {
-            join_one: c on true
-            dimension: cai is ${'c.ai'}
-          }
-        `).toLog(errorMessage("'ai' is internal"));
       });
       test('internal is inaccessible in view reference', () => {
         expect(markSource`

--- a/packages/malloy/src/lang/test/source.spec.ts
+++ b/packages/malloy/src/lang/test/source.spec.ts
@@ -249,6 +249,47 @@ describe('source:', () => {
           }
         `).toLog(errorMessage("'ai' is private"));
       });
+      describe('joined paths', () => {
+        test('can use join paths in include block', () => {
+          expect(markSource`
+            ##! experimental.access_modifiers
+            source: c is a
+            source: d is a extend {
+              join_one: c on true
+            } include {
+              *
+              internal: c.ai
+            }
+            run: d -> { group_by: c.ai }
+          `).toLog(errorMessage("'ai' is internal"));
+        });
+        test('can use joined wildcard', () => {
+          expect(markSource`
+            ##! experimental.access_modifiers
+            source: c is a
+            source: d is a extend {
+              join_one: c on true
+            } include {
+              *
+              internal: c.*
+            }
+            run: d -> { group_by: c.ai }
+          `).toLog(errorMessage("'ai' is internal"));
+        });
+        test('can exclude field in join', () => {
+          expect(markSource`
+            ##! experimental.access_modifiers
+            source: c is a
+            source: d is a extend {
+              join_one: c on true
+            } include {
+              *
+              except: c.ai
+            }
+            run: d -> { group_by: c.ai }
+          `).toLog(errorMessage("'ai' is not defined"));
+        });
+      });
       test('internal is accessible in joining source on', () => {
         expect(markSource`
           ##! experimental.access_modifiers

--- a/packages/malloy/src/lang/test/source.spec.ts
+++ b/packages/malloy/src/lang/test/source.spec.ts
@@ -758,6 +758,25 @@ describe('source:', () => {
           run: c -> { group_by: ${'ai'} }
         `).toLog(errorMessage("'ai' is not defined"));
       });
+      test('rename with backticks', () => {
+        expect(markSource`
+          ##! experimental.access_modifiers
+          source: c is a include {
+            public: \`ai2\` is ai
+          }
+          run: c -> { group_by: ai2 }
+          run: c -> { group_by: ${'ai'} }
+        `).toLog(errorMessage("'ai' is not defined"));
+      });
+      test('reference with backticks', () => {
+        expect(markSource`
+          ##! experimental.access_modifiers
+          source: c is a include {
+            internal: \`ai\`
+          }
+          run: c -> { group_by: ${'ai'} }
+        `).toLog(errorMessage("'ai' is internal"));
+      });
       test('not-mentioned fields are private', () => {
         return expect(markSource`
           ##! experimental.access_modifiers

--- a/packages/malloy/src/lang/test/test-translator.ts
+++ b/packages/malloy/src/lang/test/test-translator.ts
@@ -458,7 +458,7 @@ export class BetaExpression extends TestTranslator {
   private testFS() {
     const aStruct = this.internalModel.contents[this.sourceName];
     if (isSourceDef(aStruct)) {
-      const tstFS = new StaticSourceSpace(aStruct);
+      const tstFS = new StaticSourceSpace(aStruct, 'public');
       return tstFS;
     } else {
       throw new Error("Can't get simple namespace for expression tests");

--- a/packages/malloy/src/model/composite_source_utils.ts
+++ b/packages/malloy/src/model/composite_source_utils.ts
@@ -888,7 +888,7 @@ function getUnsatisfiedRequiredGroupBys(
   ];
 }
 
-function pathEq(a: string[], b: string[]) {
+export function pathEq(a: string[], b: string[]) {
   return a.length === b.length && a.every((s, i) => b[i] === s);
 }
 


### PR DESCRIPTION
This allows `internal` fields to be accessed in a joining source.

E.g., this is allowed:

```
source: joined is ... {
  internal dimension: x_internal is 1
}

source: joining is ... {
  join_one: joined on joined.x_internal = 1
  dimension: uses_internal is joined.x_internal
}
```

Using an internal joined field in a query is still not allowed.

```
run: joining -> {
  group_by: joined.x_internal // Error: `x_internal is internal`
}
```

Also allow `include` to mention fields in joins:

```
source: x is y include {
  internal: joined.*
  except: joined.a, joined.b, joined.c
}
```

Also *changes the default behavior of include* to make fields `private` if they are not mentioned.

`include { a }` used to be the same as `include { a; except: * }`. Now it is the same as `include { a; private: * }`