### PR TITLE
Allow setting parameters with literal objects

### DIFF
--- a/packages/malloy-interfaces/src/to_malloy.ts
+++ b/packages/malloy-interfaces/src/to_malloy.ts
@@ -96,67 +96,59 @@ function literalToFragments(literal: Malloy.LiteralValue): Fragment[] {
   }
 }
 
-function parseDate(date: string): Date {
-  return new Date(date);
-}
+function parseDate(date: string): string[] {
+  let parts: string[] | null;
 
-function digits(value: number, digits: number) {
-  return value.toString().padStart(digits, '0');
+  if ((parts = /(\d\d\d\d)-(\d\d)-(\d\d) (\d\d):(\d\d):(\d\d)/.exec(date))) {
+    const [_, year, month, day, hours, minutes, seconds] = parts;
+    return [year, month, day, hours, minutes, seconds];
+  } else if ((parts = /(\d\d\d\d)-(\d\d)-(\d\d) (\d\d):(\d\d)/.exec(date))) {
+    const [_, year, month, day, hours, minutes] = parts;
+    return [year, month, day, hours, minutes, '00'];
+  } else if ((parts = /(\d\d\d\d)-(\d\d)-(\d\d) (\d\d)(?:00)?/.exec(date))) {
+    const [_, year, month, day, hours] = parts;
+    return [year, month, day, hours, '00', '00'];
+  } else if ((parts = /(\d\d\d\d)-(\d\d)-(\d\d)/.exec(date))) {
+    const [_, year, month, day] = parts;
+    return [year, month, day, '00', '00', '00'];
+  } else if ((parts = /(\d\d\d\d)-(\d\d)/.exec(date))) {
+    const [_, year, month] = parts;
+    return [year, month, '01', '00', '00', '00'];
+  } else if ((parts = /(\d\d\d\d)/.exec(date))) {
+    const [_, year] = parts;
+    return [year, '01', '01', '00', '00', '00'];
+  }
+  return ['1970', '01', '01', '00', '00', '00'];
 }
 
 function serializeDateAsLiteral(
-  date: Date,
+  [year, month, day, hour, minute, second]: string[],
   granularity: Malloy.TimestampTimeframe
 ): string {
   switch (granularity) {
     case 'year': {
-      const year = digits(date.getUTCFullYear(), 4);
       return `@${year}`;
     }
     case 'quarter': {
-      const year = digits(date.getUTCFullYear(), 4);
-      const quarter = Math.floor(date.getUTCMonth() / 3) + 1;
+      const quarter = Math.floor(+month / 3) + 1;
       return `@${year}-Q${quarter}`;
     }
     case 'month': {
-      const year = digits(date.getUTCFullYear(), 4);
-      const month = digits(date.getUTCMonth() + 1, 2);
       return `@${year}-${month}`;
     }
     case 'week': {
-      const year = digits(date.getUTCFullYear(), 4);
-      const month = digits(date.getUTCMonth() + 1, 2);
-      const day = digits(date.getUTCDate(), 2);
       return `@WK${year}-${month}-${day}`;
     }
     case 'day': {
-      const year = digits(date.getUTCFullYear(), 4);
-      const month = digits(date.getUTCMonth() + 1, 2);
-      const day = digits(date.getUTCDate(), 2);
       return `@${year}-${month}-${day}`;
     }
     case 'hour': {
-      const year = digits(date.getUTCFullYear(), 4);
-      const month = digits(date.getUTCMonth() + 1, 2);
-      const day = digits(date.getUTCDate(), 2);
-      const hour = digits(date.getUTCHours(), 2);
       return `@${year}-${month}-${day} ${hour}`;
     }
     case 'minute': {
-      const year = digits(date.getUTCFullYear(), 4);
-      const month = digits(date.getUTCMonth() + 1, 2);
-      const day = digits(date.getUTCDate(), 2);
-      const hour = digits(date.getUTCHours(), 2);
-      const minute = digits(date.getUTCMinutes(), 2);
       return `@${year}-${month}-${day} ${hour}:${minute}`;
     }
     case 'second': {
-      const year = digits(date.getUTCFullYear(), 4);
-      const month = digits(date.getUTCMonth() + 1, 2);
-      const day = digits(date.getUTCDate(), 2);
-      const hour = digits(date.getUTCHours(), 2);
-      const minute = digits(date.getUTCMinutes(), 2);
-      const second = digits(date.getUTCSeconds(), 2);
       return `@${year}-${month}-${day} ${hour}:${minute}:${second}`;
     }
     default:

--- a/packages/malloy-query-builder/src/query-ast.spec.ts
+++ b/packages/malloy-query-builder/src/query-ast.spec.ts
@@ -2295,6 +2295,10 @@ describe('query builder', () => {
           date: new Date('2020-01-01 10:00:00+00:00'),
           granularity: 'minute',
         });
+        source.setParameter('filter_param', {
+          kind: 'filter_expression_literal',
+          filter_expression_value: '7 days',
+        });
         source.setParameter('null_param', null);
       }).toModifyQuery({
         source: {
@@ -2323,6 +2327,10 @@ describe('query builder', () => {
             },
             {
               name: 'timestamp_param',
+              type: {kind: 'timestamp_type'},
+            },
+            {
+              name: 'filter_param',
               type: {kind: 'timestamp_type'},
             },
             {
@@ -2376,6 +2384,13 @@ describe('query builder', () => {
                   },
                 },
                 {
+                  name: 'filter_param',
+                  value: {
+                    kind: 'filter_expression_literal',
+                    filter_expression_value: '7 days',
+                  },
+                },
+                {
                   name: 'null_param',
                   value: {kind: 'null_literal'},
                 },
@@ -2394,7 +2409,8 @@ describe('query builder', () => {
             boolean_param is true,
             date_param is @2020-01,
             short_date_param is @0123-01-01,
-            timestamp_param is @2020-01-01 18:00,
+            timestamp_param is @2020-01-01 10:00,
+            filter_param is f\`7 days\`,
             null_param is null
           ) -> { }
         `,

--- a/packages/malloy-query-builder/src/query-ast.ts
+++ b/packages/malloy-query-builder/src/query-ast.ts
@@ -953,7 +953,10 @@ export interface IASTReference extends ASTAny {
    * @param name The name of the parameter to set
    * @param value The value of the parameter to set
    */
-  setParameter(name: string, value: RawLiteralValue): void;
+  setParameter(
+    name: string,
+    value: RawLiteralValue | Malloy.LiteralValue
+  ): void;
 
   tryGetParameter(name: string): ASTParameterValue | undefined;
 
@@ -1023,7 +1026,7 @@ export class ASTReference
   static setParameter(
     reference: IASTReference,
     name: string,
-    value: RawLiteralValue
+    value: RawLiteralValue | Malloy.LiteralValue
   ) {
     const existing = ASTReference.tryGetParameter(reference, name);
     if (existing !== undefined) {
@@ -1049,7 +1052,10 @@ export class ASTReference
     return ASTReference.getOrAddParameters(this);
   }
 
-  public setParameter(name: string, value: RawLiteralValue) {
+  public setParameter(
+    name: string,
+    value: RawLiteralValue | Malloy.LiteralValue
+  ) {
     return ASTReference.setParameter(this, name, value);
   }
 
@@ -1118,7 +1124,7 @@ export class ASTParameterValueList extends ASTListNode<
     return this.children;
   }
 
-  addParameter(name: string, value: RawLiteralValue) {
+  addParameter(name: string, value: RawLiteralValue | Malloy.LiteralValue) {
     // TODO validate that the parameter is valid (name and type)
     this.add(
       new ASTParameterValue({
@@ -1184,8 +1190,12 @@ export const ASTLiteralValue = {
         return new ASTFilterExpressionLiteralValue(value);
     }
   },
-  makeLiteral(value: RawLiteralValue): Malloy.LiteralValue {
-    if (typeof value === 'string') {
+  makeLiteral(
+    value: RawLiteralValue | Malloy.LiteralValue
+  ): Malloy.LiteralValue {
+    if (value !== null && typeof value === 'object' && 'kind' in value) {
+      return value;
+    } else if (typeof value === 'string') {
       return {
         kind: 'string_literal',
         string_value: value,
@@ -1658,7 +1668,10 @@ export class ASTReferenceQueryDefinition
     return ASTReference.getOrAddParameters(this);
   }
 
-  public setParameter(name: string, value: RawLiteralValue) {
+  public setParameter(
+    name: string,
+    value: RawLiteralValue | Malloy.LiteralValue
+  ) {
     return ASTReference.setParameter(this, name, value);
   }
 
@@ -1774,7 +1787,10 @@ export class ASTReferenceQueryArrowSource
     return ASTReference.getOrAddParameters(this);
   }
 
-  public setParameter(name: string, value: RawLiteralValue) {
+  public setParameter(
+    name: string,
+    value: RawLiteralValue | Malloy.LiteralValue
+  ) {
     return ASTReference.setParameter(this, name, value);
   }
 
@@ -2050,7 +2066,10 @@ export class ASTReferenceViewDefinition
     return ASTReference.getOrAddParameters(this);
   }
 
-  public setParameter(name: string, value: RawLiteralValue) {
+  public setParameter(
+    name: string,
+    value: RawLiteralValue | Malloy.LiteralValue
+  ) {
     return ASTReference.setParameter(this, name, value);
   }
 
@@ -3852,7 +3871,10 @@ export class ASTReferenceExpression
     return ASTReference.getOrAddParameters(this);
   }
 
-  public setParameter(name: string, value: RawLiteralValue) {
+  public setParameter(
+    name: string,
+    value: RawLiteralValue | Malloy.LiteralValue
+  ) {
     return ASTReference.setParameter(this, name, value);
   }
 


### PR DESCRIPTION
Avoid any string -> Date -> string conversions, and allow for disambiguating filter expressions and strings.