### PR TITLE
Add source annotations to query compile output

### DIFF
--- a/packages/malloy-interfaces/src/types.ts
+++ b/packages/malloy-interfaces/src/types.ts
@@ -1145,6 +1145,11 @@ export const MALLOY_INTERFACE_TYPES: Record<string, MalloyInterfaceType> = {
         'optional': true,
         'array': false,
       },
+      'source_annotations': {
+        'type': 'Annotation',
+        'array': true,
+        'optional': true,
+      },
     },
   },
   'RunIndexQueryRequest': {
@@ -2131,6 +2136,7 @@ export type Result = {
   annotations?: Array<Annotation>;
   model_annotations?: Array<Annotation>;
   query_timezone?: string;
+  source_annotations?: Array<Annotation>;
 };
 
 export type RunIndexQueryRequest = {

--- a/packages/malloy-interfaces/thrift/malloy.thrift
+++ b/packages/malloy-interfaces/thrift/malloy.thrift
@@ -504,6 +504,7 @@ struct Result {
   5: optional list<Annotation> annotations,
   6: optional list<Annotation> model_annotations,
   7: optional string query_timezone,
+  8: optional list<Annotation> source_annotations,
 }
 
 /*

--- a/packages/malloy/src/api/core.ts
+++ b/packages/malloy/src/api/core.ts
@@ -15,9 +15,10 @@ import type {
   FieldDef,
   ModelDef,
   SQLSourceDef,
+  StructDef,
   TableSourceDef,
 } from '../model';
-import {mkFieldDef, QueryModel} from '../model';
+import {mkFieldDef, QueryModel, refIsStructDef} from '../model';
 import {modelDefToModelInfo} from '../to_stable';
 import {sqlKey} from '../model/sql_block';
 import type {SQLSourceRequest} from '../lang/translate-response';
@@ -557,6 +558,26 @@ export function statedCompileQuery(
       ).map(l => ({
         value: l,
       }));
+      let source: StructDef;
+      if (refIsStructDef(query.structRef)) {
+        source = query.structRef;
+      } else {
+        source = result.modelDef.contents[query.structRef] as StructDef;
+      }
+      const sourceAnnotations = annotationToTaglines(source.annotation).map(
+        l => ({
+          value: l,
+        })
+      );
+      if (query.compositeResolvedSourceDef) {
+        sourceAnnotations.push(
+          ...annotationToTaglines(
+            query.compositeResolvedSourceDef.annotation
+          ).map(l => ({
+            value: l,
+          }))
+        );
+      }
       annotations.push({
         value: Tag.withPrefix('#(malloy) ')
           .set(['source_name'], translatedQuery.sourceExplore)
@@ -574,10 +595,10 @@ export function statedCompileQuery(
           sql: translatedQuery.sql,
           schema,
           connection_name: translatedQuery.connectionName,
-          annotations: annotations.length > 0 ? annotations : undefined,
-          model_annotations:
-            modelAnnotations.length > 0 ? modelAnnotations : undefined,
+          annotations: annotationsOrUndefined(annotations),
+          model_annotations: annotationsOrUndefined(modelAnnotations),
           query_timezone: translatedQuery.queryTimezone,
+          source_annotations: annotationsOrUndefined(sourceAnnotations),
         },
         default_row_limit_added: translatedQuery.defaultRowLimitAdded,
       };
@@ -597,4 +618,10 @@ export function statedCompileQuery(
   } else {
     return {compiler_needs: result.compilerNeeds, logs};
   }
+}
+
+function annotationsOrUndefined(
+  annotations: Malloy.Annotation[]
+): Malloy.Annotation[] | undefined {
+  return annotations.length > 0 ? annotations : undefined;
 }

--- a/packages/malloy/src/api/stateless.spec.ts
+++ b/packages/malloy/src/api/stateless.spec.ts
@@ -8,6 +8,12 @@
 import {compileModel, compileQuery, compileSource} from './stateless';
 import type * as Malloy from '@malloydata/malloy-interfaces';
 
+type DeepPartial<T> = T extends object
+  ? {
+      [P in keyof T]?: DeepPartial<T[P]>;
+    }
+  : T;
+
 describe('api', () => {
   describe('compile model', () => {
     test('compile model with table dependency', () => {
@@ -733,6 +739,130 @@ LIMIT 101
       };
       expect(result).toMatchObject(expected);
     });
+  });
+  test('compile and get source annotations', () => {
+    const result = compileQuery({
+      model_url: 'file://test.malloy',
+      query: {
+        definition: {
+          kind: 'arrow',
+          source: {kind: 'source_reference', name: 'flights'},
+          view: {
+            kind: 'segment',
+            operations: [
+              {
+                kind: 'group_by',
+                field: {
+                  expression: {kind: 'field_reference', name: 'carrier'},
+                },
+              },
+            ],
+          },
+        },
+      },
+      compiler_needs: {
+        table_schemas: [
+          {
+            connection_name: 'connection',
+            name: 'flights',
+            schema: {
+              fields: [
+                {
+                  kind: 'dimension',
+                  name: 'carrier',
+                  type: {kind: 'string_type'},
+                },
+              ],
+            },
+          },
+        ],
+        files: [
+          {
+            url: 'file://test.malloy',
+            contents: `
+              # cool_source_annotation
+              source: flights is connection.table('flights')
+            `,
+          },
+        ],
+        connections: [{name: 'connection', dialect: 'duckdb'}],
+      },
+    });
+    const expected: DeepPartial<Malloy.CompileQueryResponse> = {
+      result: {
+        source_annotations: [{value: '# cool_source_annotation\n'}],
+      },
+    };
+    expect(result).toMatchObject(expected);
+  });
+  test('source annotations from composite slice and composite are selected', () => {
+    const result = compileQuery({
+      model_url: 'file://test.malloy',
+      query: {
+        definition: {
+          kind: 'arrow',
+          source: {kind: 'source_reference', name: 'flights_cube'},
+          view: {
+            kind: 'segment',
+            operations: [
+              {
+                kind: 'group_by',
+                field: {
+                  expression: {kind: 'field_reference', name: 'x'},
+                },
+              },
+            ],
+          },
+        },
+      },
+      compiler_needs: {
+        table_schemas: [
+          {
+            connection_name: 'connection',
+            name: 'flights',
+            schema: {
+              fields: [
+                {
+                  kind: 'dimension',
+                  name: 'carrier',
+                  type: {kind: 'string_type'},
+                },
+              ],
+            },
+          },
+        ],
+        files: [
+          {
+            url: 'file://test.malloy',
+            contents: `
+              ##! experimental.composite_sources
+              source: flights is connection.table('flights')
+
+              # slice_one
+              source: slice_one is flights
+
+              # slice_two
+              source: slice_two is flights extend {
+                dimension: x is 1
+              }
+
+              # composite
+              source: flights_cube is compose(slice_one, slice_two)
+            `,
+          },
+        ],
+        connections: [{name: 'connection', dialect: 'duckdb'}],
+      },
+    });
+    const expected: DeepPartial<Malloy.CompileQueryResponse> = {
+      result: {
+        source_annotations: [
+          {value: '# composite\n'},
+          {value: '# slice_two\n'},
+        ],
+      },
+    };
+    expect(result).toMatchObject(expected);
   });
   describe('compiler errors', () => {
     test('parse error should come back as a log', () => {


### PR DESCRIPTION
Adds a field `source_annotations` to the `Result` data structure. For non-composite sources, this is just whatever annotations were on the source of the query. For composite sources, the annotations of both the composite source and selected slice are included.