### PR TITLE
feat: chart fill size

### DIFF
--- a/packages/malloy-render/src/component/bar-chart/generate-bar_chart-vega-spec.ts
+++ b/packages/malloy-render/src/component/bar-chart/generate-bar_chart-vega-spec.ts
@@ -36,7 +36,7 @@ import type {CellValue, RecordCell, RepeatedRecordField} from '../../data_tree';
 import {Field} from '../../data_tree';
 import {NULL_SYMBOL, renderTimeString} from '../../util';
 import type {Tag} from '@malloydata/malloy-tag';
-import {RenderMetadata} from '../render-result-metadata';
+import type {RenderMetadata} from '../render-result-metadata';
 
 type BarDataRecord = {
   x: string | number;

--- a/packages/malloy-render/src/component/bar-chart/generate-bar_chart-vega-spec.ts
+++ b/packages/malloy-render/src/component/bar-chart/generate-bar_chart-vega-spec.ts
@@ -88,7 +88,9 @@ function getLimitedData({
 
   // Limit x axis values shown
   const subGroupBars = seriesField && isGrouping ? seriesLimit : 1;
-  const maxSizePerXGroup = Math.floor(refinedMaxSizePerBar * subGroupBars);
+  const maxSizePerXGroup = chartSettings.isSpark
+    ? 2
+    : Math.floor(refinedMaxSizePerBar * subGroupBars);
   const barLimitTag = chartTag.numeric('x', 'limit');
   const barLimit =
     barLimitTag ?? Math.floor(chartSettings.plotWidth / maxSizePerXGroup);

--- a/packages/malloy-render/src/component/bar-chart/generate-bar_chart-vega-spec.ts
+++ b/packages/malloy-render/src/component/bar-chart/generate-bar_chart-vega-spec.ts
@@ -36,6 +36,7 @@ import type {CellValue, RecordCell, RepeatedRecordField} from '../../data_tree';
 import {Field} from '../../data_tree';
 import {NULL_SYMBOL, renderTimeString} from '../../util';
 import type {Tag} from '@malloydata/malloy-tag';
+import {RenderMetadata} from '../render-result-metadata';
 
 type BarDataRecord = {
   x: string | number;
@@ -102,7 +103,8 @@ function getLimitedData({
 }
 
 export function generateBarChartVegaSpec(
-  explore: RepeatedRecordField
+  explore: RepeatedRecordField,
+  metadata: RenderMetadata
 ): VegaChartProps {
   const tag = explore.tag;
   const chartTag = tag.tag('bar_chart') ?? tag.tag('bar');
@@ -182,6 +184,7 @@ export function generateBarChartVegaSpec(
   const yDomainMax = Math.max(0, yMax);
 
   const chartSettings = getChartLayoutSettings(explore, chartTag, {
+    metadata,
     xField,
     yField,
     chartType: 'bar_chart',

--- a/packages/malloy-render/src/component/chart-layout-settings.ts
+++ b/packages/malloy-render/src/component/chart-layout-settings.ts
@@ -27,7 +27,7 @@ import {scale, locale} from 'vega';
 import {getTextWidthDOM} from './util';
 import {renderNumericField} from './render-numeric-field';
 import type {Field, NestField} from '../data_tree';
-import {RenderMetadata} from './render-result-metadata';
+import type {RenderMetadata} from './render-result-metadata';
 
 export type ChartLayoutSettings = {
   plotWidth: number;

--- a/packages/malloy-render/src/component/line-chart/generate-line_chart-vega-spec.ts
+++ b/packages/malloy-render/src/component/line-chart/generate-line_chart-vega-spec.ts
@@ -33,6 +33,7 @@ import {getCustomTooltipEntries} from '../bar-chart/get-custom-tooltips-entries'
 import type {CellValue, NestField, RecordCell} from '../../data_tree';
 import {Field} from '../../data_tree';
 import {NULL_SYMBOL, renderTimeString} from '../../util';
+import {RenderMetadata} from '../render-result-metadata';
 
 type LineDataRecord = {
   x: string | number;
@@ -56,7 +57,10 @@ function invertObject(obj: Record<string, string>): Record<string, string> {
   return inverted;
 }
 
-export function generateLineChartVegaSpec(explore: NestField): VegaChartProps {
+export function generateLineChartVegaSpec(
+  explore: NestField,
+  metadata: RenderMetadata
+): VegaChartProps {
   const tag = explore.tag;
   const chartTag = tag.tag('line_chart');
   if (!chartTag)
@@ -130,6 +134,7 @@ export function generateLineChartVegaSpec(explore: NestField): VegaChartProps {
   );
 
   const chartSettings = getChartLayoutSettings(explore, chartTag, {
+    metadata,
     xField,
     yField,
     chartType: 'line_chart',

--- a/packages/malloy-render/src/component/line-chart/generate-line_chart-vega-spec.ts
+++ b/packages/malloy-render/src/component/line-chart/generate-line_chart-vega-spec.ts
@@ -33,7 +33,7 @@ import {getCustomTooltipEntries} from '../bar-chart/get-custom-tooltips-entries'
 import type {CellValue, NestField, RecordCell} from '../../data_tree';
 import {Field} from '../../data_tree';
 import {NULL_SYMBOL, renderTimeString} from '../../util';
-import {RenderMetadata} from '../render-result-metadata';
+import type {RenderMetadata} from '../render-result-metadata';
 
 type LineDataRecord = {
   x: string | number;

--- a/packages/malloy-render/src/component/render-result-metadata.ts
+++ b/packages/malloy-render/src/component/render-result-metadata.ts
@@ -36,6 +36,7 @@ import type {NestField, RepeatedRecordField, RootCell} from '../data_tree';
 
 export type GetResultMetadataOptions = {
   getVegaConfigOverride?: VegaConfigHandler;
+  parentSize: {width: number; height: number};
 };
 
 export interface FieldVegaInfo {
@@ -47,16 +48,18 @@ export interface RenderMetadata {
   store: ResultStore;
   vega: Record<string, FieldVegaInfo>;
   root: RootCell;
+  parentSize: {width: number; height: number};
 }
 
 export function getResultMetadata(
   root: RootCell,
-  options: GetResultMetadataOptions = {}
+  options: GetResultMetadataOptions = {parentSize: {width: 0, height: 0}}
 ): RenderMetadata {
   const metadata: RenderMetadata = {
     store: createResultStore(),
     vega: {},
     root,
+    parentSize: options.parentSize,
   };
   populateAllVegaSpecs(root.field, metadata, options);
 
@@ -94,9 +97,9 @@ function populateVegaSpec(
   let vegaChartProps: VegaChartProps | null = null;
   const chartType = shouldRenderChartAs(field.tag);
   if (chartType === 'bar_chart') {
-    vegaChartProps = generateBarChartVegaSpec(field);
+    vegaChartProps = generateBarChartVegaSpec(field, metadata);
   } else if (chartType === 'line_chart') {
-    vegaChartProps = generateLineChartVegaSpec(field);
+    vegaChartProps = generateLineChartVegaSpec(field, metadata);
   }
 
   if (vegaChartProps) {

--- a/packages/malloy-render/src/component/result-context.ts
+++ b/packages/malloy-render/src/component/result-context.ts
@@ -5,7 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {createContext, useContext, Accessor} from 'solid-js';
+import {createContext, useContext} from 'solid-js';
+import type {Accessor} from 'solid-js';
 import type {RenderMetadata} from './render-result-metadata';
 
 export const ResultContext = createContext<Accessor<RenderMetadata>>();

--- a/packages/malloy-render/src/component/result-context.ts
+++ b/packages/malloy-render/src/component/result-context.ts
@@ -5,15 +5,15 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {createContext, useContext} from 'solid-js';
+import {createContext, useContext, Accessor} from 'solid-js';
 import type {RenderMetadata} from './render-result-metadata';
 
-export const ResultContext = createContext<RenderMetadata>();
+export const ResultContext = createContext<Accessor<RenderMetadata>>();
 export const useResultContext = () => {
   const ctx = useContext(ResultContext);
   if (!ctx)
     throw Error(
       'useResultContext must be used within a ResultContext.Provider'
     );
-  return ctx;
+  return ctx();
 };

--- a/packages/malloy-render/src/component/util.ts
+++ b/packages/malloy-render/src/component/util.ts
@@ -22,6 +22,8 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+import {createSignal} from 'solid-js';
+
 export function getTextWidthCanvas(
   text: string,
   font: string,
@@ -52,4 +54,16 @@ export function clamp(s: number, e: number, v: number) {
 
 export function getRangeSize(range: [number, number]) {
   return range[1] - range[0] + 1;
+}
+
+export function createRAFSignal<T>(initialValue: T) {
+  const [signal, setSignal] = createSignal<T>(initialValue);
+  let rafId: number | null = null;
+  const setRAFSignal = (value: Exclude<T, Function> | ((prev: T) => T)) => {
+    if (rafId) cancelAnimationFrame(rafId);
+    rafId = requestAnimationFrame(() => {
+      setSignal(value);
+    });
+  };
+  return [signal, setRAFSignal] as const;
 }

--- a/packages/malloy-render/src/stories/bar_chart.stories.malloy
+++ b/packages/malloy-render/src/stories/bar_chart.stories.malloy
@@ -380,6 +380,10 @@ source: products is duckdb.table("static/data/products.parquet") extend {
   view: root_chart is topSellingBrands
 
   #(story)
+  # size=fill
+  view: root_chart_fill is topSellingBrands
+
+  #(story)
   # bar_chart { title='My Title' subtitle='My subtitle'}
   view: with_titles is topSellingBrands
 

--- a/packages/malloy-render/src/stories/bar_chart.stories.malloy
+++ b/packages/malloy-render/src/stories/bar_chart.stories.malloy
@@ -380,8 +380,8 @@ source: products is duckdb.table("static/data/products.parquet") extend {
   view: root_chart is topSellingBrands
 
   #(story)
-  # size=fill
-  view: root_chart_fill is topSellingBrands
+  # size=md
+  view: root_chart_preset_size is topSellingBrands
 
   #(story)
   # bar_chart { title='My Title' subtitle='My subtitle'}

--- a/packages/malloy-render/src/stories/line_charts.stories.malloy
+++ b/packages/malloy-render/src/stories/line_charts.stories.malloy
@@ -121,8 +121,16 @@ source: products is duckdb.table("static/data/products.parquet") extend {
   view: root_chart is topSellingBrands
 
   #(story)
+  # size=fill
+  view: root_chart_fill is topSellingBrands
+
+  #(story)
   # line_chart
   view: dimension_series is baseLineData + { group_by: department }
+
+  #(story)
+  # line_chart size=fill
+  view: dimension_series_fill is baseLineData + { group_by: department }
 
   #(story)
   view: single_nest is {


### PR DESCRIPTION
Allows you to set `# size=fill` at the top level of a view, and if its a chart it will size the chart to fit the window

still some kinks to work out with fitting it properly when there are chart titles/subtitles/legends

also need to provide a way to set this programmatically on the <malloy-render> element like we do with some other controls