### PR TITLE
Pass along filter type if available

### DIFF
--- a/packages/malloy-interfaces/src/types.ts
+++ b/packages/malloy-interfaces/src/types.ts
@@ -548,7 +548,13 @@ export const MALLOY_INTERFACE_TYPES: Record<string, MalloyInterfaceType> = {
   'FilterExpressionType': {
     'type': 'struct',
     'name': 'FilterExpressionType',
-    'fields': {},
+    'fields': {
+      'filter_type': {
+        'type': 'FilterableType',
+        'optional': true,
+        'array': false,
+      },
+    },
   },
   'FilterOperation': {
     'type': 'struct',
@@ -575,6 +581,17 @@ export const MALLOY_INTERFACE_TYPES: Record<string, MalloyInterfaceType> = {
         'optional': false,
         'array': false,
       },
+    },
+  },
+  'FilterableType': {
+    'type': 'union',
+    'name': 'FilterableType',
+    'options': {
+      'string_type': 'StringType',
+      'boolean_type': 'BooleanType',
+      'number_type': 'NumberType',
+      'date_type': 'DateType',
+      'timestamp_type': 'TimestampType',
     },
   },
   'FilteredField': {
@@ -1840,7 +1857,9 @@ export type FilterExpressionLiteral = {
   filter_expression_value: string;
 };
 
-export type FilterExpressionType = {};
+export type FilterExpressionType = {
+  filter_type?: FilterableType;
+};
 
 export type FilterOperation = {
   filter: Filter;
@@ -1850,6 +1869,34 @@ export type FilterStringApplication = {
   field_reference: Reference;
   filter: string;
 };
+
+export type FilterableTypeType =
+  | 'string_type'
+  | 'boolean_type'
+  | 'number_type'
+  | 'date_type'
+  | 'timestamp_type';
+
+export type FilterableType =
+  | FilterableTypeWithStringType
+  | FilterableTypeWithBooleanType
+  | FilterableTypeWithNumberType
+  | FilterableTypeWithDateType
+  | FilterableTypeWithTimestampType;
+
+export type FilterableTypeWithStringType = {kind: 'string_type'} & StringType;
+
+export type FilterableTypeWithBooleanType = {
+  kind: 'boolean_type';
+} & BooleanType;
+
+export type FilterableTypeWithNumberType = {kind: 'number_type'} & NumberType;
+
+export type FilterableTypeWithDateType = {kind: 'date_type'} & DateType;
+
+export type FilterableTypeWithTimestampType = {
+  kind: 'timestamp_type';
+} & TimestampType;
 
 export type FilteredField = {
   field_reference: Reference;

--- a/packages/malloy-interfaces/src/types.ts
+++ b/packages/malloy-interfaces/src/types.ts
@@ -551,7 +551,7 @@ export const MALLOY_INTERFACE_TYPES: Record<string, MalloyInterfaceType> = {
     'fields': {
       'filter_type': {
         'type': 'FilterableType',
-        'optional': true,
+        'optional': false,
         'array': false,
       },
     },
@@ -1858,7 +1858,7 @@ export type FilterExpressionLiteral = {
 };
 
 export type FilterExpressionType = {
-  filter_type?: FilterableType;
+  filter_type: FilterableType;
 };
 
 export type FilterOperation = {

--- a/packages/malloy-interfaces/thrift/malloy.thrift
+++ b/packages/malloy-interfaces/thrift/malloy.thrift
@@ -177,7 +177,7 @@ struct RecordType {
 }
 
 struct FilterExpressionType {
-  1: optional FilterableType filter_type;
+  1: required FilterableType filter_type;
 }
 
 union FilterableType {

--- a/packages/malloy-interfaces/thrift/malloy.thrift
+++ b/packages/malloy-interfaces/thrift/malloy.thrift
@@ -177,8 +177,16 @@ struct RecordType {
 }
 
 struct FilterExpressionType {
+  1: optional FilterableType filter_type;
 }
 
+union FilterableType {
+  1: required StringType string_type;
+  2: required BooleanType boolean_type;
+  3: required NumberType number_type;
+  6: required DateType date_type;
+  7: required TimestampType timestamp_type;
+}
 
 union AtomicType {
   1: required StringType string_type,

--- a/packages/malloy/src/to_stable.ts
+++ b/packages/malloy/src/to_stable.ts
@@ -56,14 +56,13 @@ export function modelDefToModelInfo(modelDef: ModelDef): Malloy.ModelInfo {
                   default_value: convertParameterDefaultValue(parameter.value),
                 };
               }
-              const filterType = parameter.filterType
-                ? {filter_type: {kind: `${parameter.filterType}_type` as const}}
-                : {};
               return {
                 name,
                 type: {
                   kind: 'filter_expression_type',
-                  ...filterType,
+                  filter_type: {
+                    kind: `${parameter.filterType}_type` as const,
+                  },
                 },
                 default_value: convertParameterDefaultValue(parameter.value),
               };

--- a/packages/malloy/src/to_stable.ts
+++ b/packages/malloy/src/to_stable.ts
@@ -39,14 +39,6 @@ import {
 import {annotationToTaglines} from './annotation';
 import {Tag} from '@malloydata/malloy-tag';
 
-const FilterTypeMap: Record<FilterExprType, Malloy.FilterableType> = {
-  'string': {kind: 'string_type'},
-  'number': {kind: 'number_type'},
-  'boolean': {kind: 'boolean_type'},
-  'date': {kind: 'date_type'},
-  'timestamp': {kind: 'timestamp_type'},
-};
-
 export function modelDefToModelInfo(modelDef: ModelDef): Malloy.ModelInfo {
   const modelInfo: Malloy.ModelInfo = {
     entries: [],
@@ -66,7 +58,7 @@ export function modelDefToModelInfo(modelDef: ModelDef): Malloy.ModelInfo {
                 };
               }
               const filterType = parameter.filterType
-                ? {filter_type: FilterTypeMap[parameter.filterType]}
+                ? {filter_type: {kind: `${parameter.filterType}_type` as const}}
                 : {};
               return {
                 name,

--- a/packages/malloy/src/to_stable.ts
+++ b/packages/malloy/src/to_stable.ts
@@ -11,6 +11,7 @@ import type {
   DateUnit,
   Expr,
   FieldDef,
+  FilterExprType,
   JoinType,
   ModelDef,
   Query,
@@ -38,6 +39,14 @@ import {
 import {annotationToTaglines} from './annotation';
 import {Tag} from '@malloydata/malloy-tag';
 
+const FilterTypeMap: Record<FilterExprType, Malloy.FilterableType> = {
+  'string': {kind: 'string_type'},
+  'number': {kind: 'number_type'},
+  'boolean': {kind: 'boolean_type'},
+  'date': {kind: 'date_type'},
+  'timestamp': {kind: 'timestamp_type'},
+};
+
 export function modelDefToModelInfo(modelDef: ModelDef): Malloy.ModelInfo {
   const modelInfo: Malloy.ModelInfo = {
     entries: [],
@@ -56,9 +65,15 @@ export function modelDefToModelInfo(modelDef: ModelDef): Malloy.ModelInfo {
                   default_value: convertParameterDefaultValue(parameter.value),
                 };
               }
+              const filterType = parameter.filterType
+                ? {filter_type: FilterTypeMap[parameter.filterType]}
+                : {};
               return {
                 name,
-                type: {kind: 'filter_expression_type'},
+                type: {
+                  kind: 'filter_expression_type',
+                  ...filterType,
+                },
                 default_value: convertParameterDefaultValue(parameter.value),
               };
             })

--- a/packages/malloy/src/to_stable.ts
+++ b/packages/malloy/src/to_stable.ts
@@ -11,7 +11,6 @@ import type {
   DateUnit,
   Expr,
   FieldDef,
-  FilterExprType,
   JoinType,
   ModelDef,
   Query,


### PR DESCRIPTION
Required to support the filter UI since each type has a different UI.