### PR TITLE
feat: auto time axis

### DIFF
--- a/packages/malloy-render/src/component/bar-chart/get-bar_chart-settings.ts
+++ b/packages/malloy-render/src/component/bar-chart/get-bar_chart-settings.ts
@@ -108,8 +108,13 @@ export function getBarChartSettings(
 
   // If still no x or y, attempt to pick the best choice
   if (xChannel.fields.length === 0) {
+    // Pick date/time field first if it exists
+    const dateTimeField = explore.fields.find(
+      f => f.wasDimension() && f.isTime()
+    );
+    if (dateTimeField) xChannel.fields.push(explore.pathTo(dateTimeField));
     // Pick first dimension field for x
-    if (dimensions.length > 0) {
+    else if (dimensions.length > 0) {
       xChannel.fields.push(explore.pathTo(dimensions[0]));
     }
   }

--- a/packages/malloy-render/src/component/line-chart/get-line_chart-settings.ts
+++ b/packages/malloy-render/src/component/line-chart/get-line_chart-settings.ts
@@ -108,8 +108,13 @@ export function getLineChartSettings(
 
   // If still no x or y, attempt to pick the best choice
   if (xChannel.fields.length === 0) {
+    // Pick date/time field first if it exists
+    const dateTimeField = explore.fields.find(
+      f => f.wasDimension() && f.isTime()
+    );
+    if (dateTimeField) xChannel.fields.push(explore.pathTo(dateTimeField));
     // Pick first dimension field for x
-    if (dimensions.length > 0) {
+    else if (dimensions.length > 0) {
       xChannel.fields.push(explore.pathTo(dimensions[0]));
     }
   }

--- a/packages/malloy-render/src/stories/bar_chart.stories.malloy
+++ b/packages/malloy-render/src/stories/bar_chart.stories.malloy
@@ -423,6 +423,20 @@ source: products is duckdb.table("static/data/products.parquet") extend {
   }
 
   #(story)
+  # bar_chart
+  view: auto_select_time_axis is
+    {
+    group_by:
+      department
+      `date` is @2001-02-03 + id day
+    aggregate:
+      `Sales $` is retail_price.avg()*500
+    limit: 10
+    order_by: `date`
+  }
+
+
+  #(story)
   view: indepenent_axis is {
     group_by: category
     aggregate: avg_retail is retail_price.avg()

--- a/packages/malloy-render/src/stories/line_charts.stories.malloy
+++ b/packages/malloy-render/src/stories/line_charts.stories.malloy
@@ -382,6 +382,19 @@ source: products is duckdb.table("static/data/products.parquet") extend {
     limit: 20
     order_by: `date`
   }
+
+  #(story)
+  # line_chart
+  view: auto_select_time_axis is
+    {
+    group_by:
+      department
+      `date` is @2001-02-03 + id day
+    aggregate:
+      `Sales $` is retail_price.avg()*500
+    limit: 10
+    order_by: `date`
+  }
 }
 
 source: missing_data is duckdb.table("static/data/missing_data.csv") extend {


### PR DESCRIPTION
If a chart is using implicit mappings, prefer to use a time field for the x axis, if there is one