### PR TITLE
don't find deleted tags (plus a test)

### DIFF
--- a/packages/malloy-tag/src/tags.ts
+++ b/packages/malloy-tag/src/tags.ts
@@ -387,7 +387,7 @@ export class Tag implements TagInterface {
         }
       }
     }
-    return currentTag;
+    return currentTag.deleted ? undefined : currentTag;
   }
 
   has(...path: Path): boolean {


### PR DESCRIPTION
@skokenes found that adding `-line_chart` to a run statement does not remove the line chart tag inherited from a view.

test and fix included.