### PR TITLE
Fix render tag override

### DIFF
--- a/packages/malloy-render/src/component/render-result-metadata.ts
+++ b/packages/malloy-render/src/component/render-result-metadata.ts
@@ -84,8 +84,11 @@ function populateAllVegaSpecs(
 const CHART_TAG_LIST = ['bar_chart', 'line_chart'];
 
 export function shouldRenderChartAs(tag: Tag) {
-  const tagNamesInOrder = Object.keys(tag.properties ?? {}).reverse();
-  return tagNamesInOrder.find(name => CHART_TAG_LIST.includes(name));
+  const properties = tag.properties ?? {};
+  const tagNamesInOrder = Object.keys(properties).reverse();
+  return tagNamesInOrder.find(
+    name => CHART_TAG_LIST.includes(name) && !properties[name].deleted
+  );
 }
 
 function populateVegaSpec(

--- a/packages/malloy-render/src/data_tree.ts
+++ b/packages/malloy-render/src/data_tree.ts
@@ -248,9 +248,10 @@ export function shouldRenderAs(
   tagOverride?: Tag
 ) {
   const tag = tagOverride ?? tagFor(field);
-  const tagNamesInOrder = Object.keys(tag.properties ?? {}).reverse();
+  const properties = tag.properties ?? {};
+  const tagNamesInOrder = Object.keys(properties).reverse();
   for (const tagName of tagNamesInOrder) {
-    if (RENDER_TAG_LIST.includes(tagName)) {
+    if (RENDER_TAG_LIST.includes(tagName) && !properties[tagName].deleted) {
       if (['list', 'list_detail'].includes(tagName)) return 'list';
       if (['bar_chart', 'line_chart'].includes(tagName)) return 'chart';
       return tagName;

--- a/packages/malloy-render/src/stories/line_charts.stories.malloy
+++ b/packages/malloy-render/src/stories/line_charts.stories.malloy
@@ -409,6 +409,10 @@ source: missing_data is duckdb.table("static/data/missing_data.csv") extend {
     limit: 20
     order_by: id
   }
+
+  #(story)
+  # -line_chart table
+    view: OverrideLineChartWithTable is WithNullMeasureValue + {}
 }
 
 run: products -> { group_by: distribution_center_id}


### PR DESCRIPTION
Deleted tags were still being recognized. Possibly there's a better API for this but this a quick fix.