### PR TITLE
Maybe prettify some malloy_types?

### DIFF
--- a/packages/malloy/src/model/malloy_types.ts
+++ b/packages/malloy/src/model/malloy_types.ts
@@ -1367,8 +1367,12 @@ export type BasicArrayFunctionParameterTypeDef =
 export type FunctionParameterFieldDef =
   ExtFieldDef<FunctionParameterTypeExtensions>;
 
+type Prettify<T> = {
+  [K in keyof T]: T[K];
+} & {};
+
 export type RecordFunctionParameterTypeDef =
-  RecordExtTypeDef<FunctionParameterTypeExtensions>;
+  Prettify<RecordExtTypeDef<FunctionParameterTypeExtensions>>;
 
 export type RepeatedRecordFunctionParameterTypeDef =
   RepeatedRecordExtTypeDef<FunctionParameterTypeExtensions>;


### PR DESCRIPTION
We can define a type `Prettify<T>`

```ts
type Prettify<T> = {
  [K in keyof T]: T[K];
} & {};
```

which computes/flattens a type. 

This turns a compiler error like `Object literal may only specify known properties, and 'foo' does not exist in type 'RecordExtTypeDef<FunctionParameterTypeExtensions>'.ts(2353)` into `Object literal may only specify known properties, and 'foo' does not exist in type '{ type: "record"; fields: ExtFieldDef<FunctionParameterTypeExtensions>[]; }'.ts(2353)`, which is maybe more helpful.

We could theoretically even do `DeepPrettify<T>`, but this gives us less control over what things get computed...

```ts
type DeepPrettify<T> = {
  [K in keyof T]: DeepPrettify<T[K]>;
} & {};
```

