### PR TITLE
add a dense_rank to standard functions

### DIFF
--- a/packages/malloy/src/dialect/functions/malloy_standard_functions.ts
+++ b/packages/malloy/src/dialect/functions/malloy_standard_functions.ts
@@ -83,6 +83,7 @@ type Standard = {
   min_cumulative: D;
   min_window: D;
   rank: D;
+  dense_rank: D;
   row_number: D;
   sum_cumulative: D;
   sum_moving: {preceding: D; following: D};
@@ -596,6 +597,12 @@ const rank: DefinitionFor<Standard['rank']> = {
   impl: {function: 'RANK', needsWindowOrderBy: true},
 };
 
+const dense_rank: DefinitionFor<Standard['dense_rank']> = {
+  takes: {},
+  returns: {calculation: 'number'},
+  impl: {function: 'DENSE_RANK', needsWindowOrderBy: true},
+};
+
 const row_number: DefinitionFor<Standard['row_number']> = {
   takes: {},
   returns: {calculation: 'number'},
@@ -732,6 +739,7 @@ export const MALLOY_STANDARD_FUNCTIONS: MalloyStandardFunctionDefinitions = {
 
   // Analytic functions
   avg_moving,
+  dense_rank,
   first_value,
   lag,
   last_value,

--- a/test/src/databases/all/functions.spec.ts
+++ b/test/src/databases/all/functions.spec.ts
@@ -459,6 +459,25 @@ expressionModels.forEach((x, databaseName) => {
       expect(result.data.path(3, 'r').value).toBe(3);
     });
 
+    it(`dense_rank is supported - ${databaseName}`, async () => {
+      const result = await expressionModel
+        .loadQuery(
+          ` run: state_facts -> {
+            group_by:
+              first_letter is substr(state, 1, 1)
+            aggregate: state_count is count()
+            calculate: r is dense_rank() {order_by: state_count desc}
+          }`
+        )
+        .run();
+      // console.log(result.sql);
+      // console.log(result.data);
+      expect(result.data.path(0, 'r').value).toBe(1);
+      expect(result.data.path(1, 'r').value).toBe(1);
+      expect(result.data.path(2, 'r').value).toBe(2);
+      expect(result.data.path(3, 'r').value).toBe(2);
+    });
+
     it(`works using unary minus in calculate block - ${databaseName}`, async () => {
       const result = await expressionModel
         .loadQuery(


### PR DESCRIPTION
We support row_number() and rank() but not dense_rank(), adding it.