### PR TITLE
Treat null values as undefined in thrift unions

### DIFF
--- a/packages/malloy-interfaces/src/nest_unions.spec.ts
+++ b/packages/malloy-interfaces/src/nest_unions.spec.ts
@@ -301,6 +301,21 @@ describe('convert between default thrift and Malloy types', () => {
     };
     thriftBidirectional(typescript, thrift, 'Data');
   });
+  test('handles null values in enum', () => {
+    const typescript: Malloy.AtomicTypeWithNumberType = {
+      kind: 'number_type',
+      subtype: 'integer',
+    };
+    const thrift = {
+      boolean_type: null,
+      string_type: null,
+      number_type: {subtype: 1},
+      _type: 3,
+    };
+    const actualTypescript = convertFromThrift(thrift, 'AtomicType');
+    console.log('Actual typescript', actualTypescript);
+    expect(actualTypescript).toMatchObject(typescript);
+  });
 });
 
 function thriftBidirectional(typescript: {}, thrift: {}, type: string) {

--- a/packages/malloy-interfaces/src/nest_unions.ts
+++ b/packages/malloy-interfaces/src/nest_unions.ts
@@ -101,7 +101,7 @@ export function convertFromThrift(obj: unknown, type: string): unknown {
     const typeDefinition = getType(type);
     if (typeDefinition.type === 'union') {
       for (const kind in typeDefinition.options) {
-        if (obj[kind] !== undefined) {
+        if (obj[kind] !== undefined && obj[kind] !== null) {
           const result = convertFromThrift(
             obj[kind],
             typeDefinition.options[kind]


### PR DESCRIPTION
I am trying to convert a thrift interface, but the Thrift object has 'null' as the value for all the non-active items in a union, like this:

```
array_type: null,
boolean_type: null,
date_type: null,
json_type: null,
number_type: {subtype: 1},
record_type: null,
sql_native_type: null,
string_type: null,
timestamp_type: null,
```

I have not exhaustively thought through the implications of this, so wanted to run it by the team before digging too deep.