### PR TITLE
[render] feat: chart misconfiguration error messages

### DIFF
--- a/packages/malloy-render/src/component/apply-renderer.tsx
+++ b/packages/malloy-render/src/component/apply-renderer.tsx
@@ -17,6 +17,7 @@ import {renderTime} from './render-time';
 import {LegacyChart} from './legacy-charts/legacy_chart';
 import {NULL_SYMBOL} from '../util';
 import type {RendererProps} from './types';
+import {ErrorMessage} from './error-message/error-message';
 
 export function applyRenderer(props: RendererProps) {
   const {dataColumn, customProps = {}} = props;
@@ -59,7 +60,10 @@ export function applyRenderer(props: RendererProps) {
       case 'chart': {
         if (dataColumn.isRepeatedRecord()) {
           renderValue = <Chart data={dataColumn} {...propsToPass} />;
-        }
+        } else
+          renderValue = (
+            <ErrorMessage message="Malloy Render: Charts require tabular data" />
+          );
         break;
       }
       case 'dashboard': {

--- a/packages/malloy-render/src/component/bar-chart/get-bar_chart-settings.ts
+++ b/packages/malloy-render/src/component/bar-chart/get-bar_chart-settings.ts
@@ -106,6 +106,24 @@ export function getBarChartSettings(
     f => f.isBasic() && f.wasDimension()
   );
 
+  const measures = explore.fields.filter(f => f.wasCalculation());
+
+  if (dimensions.length > 2) {
+    throw new Error(
+      'Malloy Bar Chart: Too many dimensions. A bar chart can have at most 2 dimensions: 1 for the x axis, and 1 for the series.'
+    );
+  }
+  if (dimensions.length === 0) {
+    throw new Error(
+      'Malloy Bar Chart: No dimensions found. A bar chart must have at least 1 dimension for the x axis.'
+    );
+  }
+  if (measures.length === 0) {
+    throw new Error(
+      'Malloy Bar Chart: No measures found. A bar chart must have at least 1 measure for the y axis.'
+    );
+  }
+
   // If still no x or y, attempt to pick the best choice
   if (xChannel.fields.length === 0) {
     // Pick date/time field first if it exists

--- a/packages/malloy-render/src/component/chart/chart-dev-tool.tsx
+++ b/packages/malloy-render/src/component/chart/chart-dev-tool.tsx
@@ -13,10 +13,11 @@ import type {View} from 'vega';
 import {parse} from 'vega';
 import {createStore} from 'solid-js/store';
 import {addSignalListenerIfExists} from '../vega/vega-utils';
-import {useResultContext} from '../result-context';
+import type {VegaChartProps} from '../types';
 
 type ChartDevToolProps = {
   onClose: () => void;
+  chartProps: VegaChartProps;
 } & ChartProps;
 
 function stripMalloyRecord(record: Record<string, unknown>) {
@@ -36,10 +37,8 @@ function stripMalloyRecord(record: Record<string, unknown>) {
 }
 
 export default function ChartDevTool(props: ChartDevToolProps) {
-  const metadata = useResultContext();
-  const chartProps = metadata.vega[props.data.field.key].props;
   const [specString, setSpecString] = createSignal(
-    JSON.stringify(chartProps.spec, null, 2)
+    JSON.stringify(props.chartProps.spec, null, 2)
   );
 
   const runtime = createMemo(() => {

--- a/packages/malloy-render/src/component/error-message/error-message.css
+++ b/packages/malloy-render/src/component/error-message/error-message.css
@@ -1,0 +1,12 @@
+.malloy-error-message {
+  padding: 16px;
+  width: fit-content;
+  border-radius: 8px;
+  margin: 16px;
+  background: color(display-p3 0.863 0.024 0.024/0.028);
+  box-shadow: inset 0 0 0 1px color(display-p3 0.831 0.02 0.004/0.251);
+  color: color(display-p3 0.744 0.234 0.222);
+  font-family: var(--malloy-render--font-family);
+  font-size: 13px;
+  line-height: 1.5;
+}

--- a/packages/malloy-render/src/component/error-message/error-message.tsx
+++ b/packages/malloy-render/src/component/error-message/error-message.tsx
@@ -1,0 +1,8 @@
+import {useConfig} from '../render';
+import css from './error-message.css?raw';
+
+export function ErrorMessage(props: {message: string}) {
+  const config = useConfig();
+  config.addCSSToShadowRoot(css);
+  return <div class="malloy-error-message">{props.message}</div>;
+}

--- a/packages/malloy-render/src/component/line-chart/generate-line_chart-vega-spec.ts
+++ b/packages/malloy-render/src/component/line-chart/generate-line_chart-vega-spec.ts
@@ -285,7 +285,7 @@ export function generateLineChartVegaSpec(
     encode: {
       enter: {
         x: {
-          signal: xScaling('datum.x_pos'),
+          signal: xScaling('datum.x'),
         },
         y: {
           value: 0,
@@ -324,7 +324,7 @@ export function generateLineChartVegaSpec(
           enter: {
             fill: {value: 'transparent'},
             size: {value: 36},
-            x: {signal: xScaling('datum.x_pos')},
+            x: {signal: xScaling('datum.x')},
             y: {signal: 'height /2'},
           },
         },

--- a/packages/malloy-render/src/component/line-chart/generate-line_chart-vega-spec.ts
+++ b/packages/malloy-render/src/component/line-chart/generate-line_chart-vega-spec.ts
@@ -71,14 +71,17 @@ export function generateLineChartVegaSpec(
 
   if (!lineChartPlugin) {
     throw new Error(
-      'Trying to render a line chart when Line chart series plugin not found'
+      'Malloy Line Chart: Trying to render a line chart when Line chart series plugin not found'
     );
   }
 
   const tag = explore.tag;
   const chartTag = tag.tag('line_chart');
   if (!chartTag)
-    throw new Error('Line chart should only be rendered for line_chart tag');
+    throw new Error(
+      'Malloy Line Chart: Line chart should only be rendered for line_chart tag'
+    );
+
   const settings = getLineChartSettings(explore, tag);
   /**************************************
    *
@@ -89,8 +92,8 @@ export function generateLineChartVegaSpec(
   const yFieldPath = settings.yChannel.fields.at(0);
   const seriesFieldPath = settings.seriesChannel.fields.at(0);
 
-  if (!xFieldPath) throw new Error('Malloy Bar Chart: Missing x field');
-  if (!yFieldPath) throw new Error('Malloy Bar Chart: Missing y field');
+  if (!xFieldPath) throw new Error('Malloy Line Chart: Missing x field');
+  if (!yFieldPath) throw new Error('Malloy Line Chart: Missing y field');
 
   const xField = explore.fieldAt(xFieldPath);
   const xIsDateorTime = xField.isTime();

--- a/packages/malloy-render/src/component/line-chart/get-line_chart-settings.ts
+++ b/packages/malloy-render/src/component/line-chart/get-line_chart-settings.ts
@@ -26,7 +26,7 @@ export function getLineChartSettings(
   const chart = tag.tag('line_chart');
   if (!chart) {
     throw new Error(
-      'Tried to render a bar_chart, but no bar_chart tag was found'
+      'Malloy Line Chart: Tried to render a line chart, but no line_chart tag was found'
     );
   }
 
@@ -105,6 +105,24 @@ export function getLineChartSettings(
   const dimensions = explore.fields.filter(
     f => f.isBasic() && f.wasDimension()
   );
+
+  const measures = explore.fields.filter(f => f.wasCalculation());
+
+  if (dimensions.length > 2) {
+    throw new Error(
+      'Malloy Line Chart: Too many dimensions. A line chart can have at most 2 dimensions: 1 for the x axis, and 1 for the series.'
+    );
+  }
+  if (dimensions.length === 0) {
+    throw new Error(
+      'Malloy Line Chart: No dimensions found. A line chart must have at least 1 dimension for the x axis.'
+    );
+  }
+  if (measures.length === 0) {
+    throw new Error(
+      'Malloy Line Chart: No measures found. A line chart must have at least 1 measure for the y axis.'
+    );
+  }
 
   // If still no x or y, attempt to pick the best choice
   if (xChannel.fields.length === 0) {

--- a/packages/malloy-render/src/component/register-webcomponent.ts
+++ b/packages/malloy-render/src/component/register-webcomponent.ts
@@ -25,6 +25,7 @@ export default function registerWebComponent({
           tableConfig: undefined,
           dashboardConfig: undefined,
           modalElement: undefined,
+          renderAs: undefined,
         },
         {customElements, BaseElement: HTMLElement}
       ),
@@ -51,9 +52,13 @@ export default function registerWebComponent({
   }
 }
 
+type MalloyRenderApi = {
+  renderAs?: string;
+};
+
 declare global {
   interface HTMLElementTagNameMap {
-    'malloy-render': HTMLElement & MalloyRenderProps;
+    'malloy-render': HTMLElement & MalloyRenderProps & MalloyRenderApi;
     'malloy-modal': HTMLElement & MalloyModalWCProps;
   }
 }

--- a/packages/malloy-render/src/component/render-result-metadata.ts
+++ b/packages/malloy-render/src/component/render-result-metadata.ts
@@ -32,7 +32,11 @@ import {createResultStore} from './result-store/result-store';
 import {generateLineChartVegaSpec} from './line-chart/generate-line_chart-vega-spec';
 import type {Config, Runtime} from 'vega';
 import {parse} from 'vega';
-import type {NestField, RepeatedRecordField, RootCell} from '../data_tree';
+import {
+  type NestField,
+  type RepeatedRecordField,
+  type RootCell,
+} from '../data_tree';
 
 export type GetResultMetadataOptions = {
   getVegaConfigOverride?: VegaConfigHandler;
@@ -49,6 +53,7 @@ export interface RenderMetadata {
   vega: Record<string, FieldVegaInfo>;
   root: RootCell;
   parentSize: {width: number; height: number};
+  renderAs: string;
 }
 
 export function getResultMetadata(
@@ -60,6 +65,7 @@ export function getResultMetadata(
     vega: {},
     root,
     parentSize: options.parentSize,
+    renderAs: root.field.renderAs,
   };
   populateAllVegaSpecs(root.field, metadata, options);
 

--- a/packages/malloy-render/src/component/render.tsx
+++ b/packages/malloy-render/src/component/render.tsx
@@ -253,6 +253,13 @@ export function MalloyRenderInner(props: {
     });
   };
 
+  createEffect(() => {
+    if (props.element && metadata().renderAs) {
+      // @ts-ignore will refactor this as part of web component removal
+      props.element.renderAs = metadata().renderAs;
+    }
+  });
+
   return (
     <>
       <ResultContext.Provider value={metadata}>

--- a/packages/malloy-render/src/component/render.tsx
+++ b/packages/malloy-render/src/component/render.tsx
@@ -255,6 +255,7 @@ export function MalloyRenderInner(props: {
 
   createEffect(() => {
     if (props.element && metadata().renderAs) {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore will refactor this as part of web component removal
       props.element.renderAs = metadata().renderAs;
     }

--- a/packages/malloy-render/src/plugins/line-chart-series-plugin.ts
+++ b/packages/malloy-render/src/plugins/line-chart-series-plugin.ts
@@ -34,78 +34,86 @@ export const LineChartSeriesPluginFactory: RenderPlugin<LineChartPluginInstance>
       );
     },
     plugin: field => {
-      if (!field.isNest()) {
-        throw new Error('Line chart: must be a nest field');
-      }
-      const chartSettings = getLineChartSettings(field);
-      const globalSeriesStats = new Map<string, SeriesStats>();
-      const yField = field.fieldAt(chartSettings.yChannel.fields[0]);
-      const maybeSeriesFieldPath = chartSettings.seriesChannel.fields[0];
-      const seriesField = maybeSeriesFieldPath
-        ? field.fieldAt(maybeSeriesFieldPath)
-        : null;
-      if (!yField) {
-        throw new Error(
-          'Line chart: missing a y field. Did you add an aggregation?'
-        );
-      }
       const name = 'line_chart_series';
-
       const matches = (fieldTag: Tag, fieldType: FieldType): boolean => {
         return (
           fieldTag.has('line_chart') && fieldType === FieldType.RepeatedRecord
         );
       };
-
-      const processData = (field: NestField, cell: NestCell): void => {
-        let rows: RecordCell[];
-        if (cell instanceof RepeatedRecordCell) {
-          rows = cell.rows;
-        } else if (cell instanceof RecordCell) {
-          rows = [cell];
-        } else {
-          return; // Skip if not a record cell
+      try {
+        if (!field.isNest()) {
+          throw new Error('Line chart: must be a nest field');
+        }
+        const chartSettings = getLineChartSettings(field);
+        const globalSeriesStats = new Map<string, SeriesStats>();
+        const yField = field.fieldAt(chartSettings.yChannel.fields[0]);
+        const maybeSeriesFieldPath = chartSettings.seriesChannel.fields[0];
+        const seriesField = maybeSeriesFieldPath
+          ? field.fieldAt(maybeSeriesFieldPath)
+          : null;
+        if (!yField) {
+          throw new Error(
+            'Line chart: missing a y field. Did you add an aggregation?'
+          );
         }
 
-        // Process all rows in this cell, aggregating by series value
-        for (const row of rows) {
-          if (seriesField) {
-            const seriesValue =
-              row.column(seriesField.name).value ?? NULL_SYMBOL;
-            const yValue = row.column(yField.name).value;
-            const stats = globalSeriesStats.get(seriesValue) ?? {
-              sum: 0,
-              count: 0,
-              avg: 0,
-            };
-            stats.sum += yValue;
-            stats.count += 1;
-            stats.avg = stats.sum / stats.count;
-            globalSeriesStats.set(seriesValue, stats);
+        const processData = (field: NestField, cell: NestCell): void => {
+          let rows: RecordCell[];
+          if (cell instanceof RepeatedRecordCell) {
+            rows = cell.rows;
+          } else if (cell instanceof RecordCell) {
+            rows = [cell];
+          } else {
+            return; // Skip if not a record cell
           }
-        }
-      };
 
-      const getTopNSeries = (n: number): (string | number | boolean)[] => {
-        // TODO make configurable from tag
-        const rankType = 'sum';
-        const data = globalSeriesStats;
-        if (!data) {
-          return [];
-        }
+          // Process all rows in this cell, aggregating by series value
+          for (const row of rows) {
+            if (seriesField) {
+              const seriesValue =
+                row.column(seriesField.name).value ?? NULL_SYMBOL;
+              const yValue = row.column(yField.name).value;
+              const stats = globalSeriesStats.get(seriesValue) ?? {
+                sum: 0,
+                count: 0,
+                avg: 0,
+              };
+              stats.sum += yValue;
+              stats.count += 1;
+              stats.avg = stats.sum / stats.count;
+              globalSeriesStats.set(seriesValue, stats);
+            }
+          }
+        };
 
-        return Array.from(globalSeriesStats.entries())
-          .sort((a, b) => b[1][rankType] - a[1][rankType])
-          .slice(0, n)
-          .map(entry => entry[0]);
-      };
+        const getTopNSeries = (n: number): (string | number | boolean)[] => {
+          // TODO make configurable from tag
+          const rankType = 'sum';
+          const data = globalSeriesStats;
+          if (!data) {
+            return [];
+          }
 
-      return {
-        name,
-        matches,
-        processData,
-        getTopNSeries,
-      } as LineChartPluginInstance;
+          return Array.from(globalSeriesStats.entries())
+            .sort((a, b) => b[1][rankType] - a[1][rankType])
+            .slice(0, n)
+            .map(entry => entry[0]);
+        };
+
+        return {
+          name,
+          matches,
+          processData,
+          getTopNSeries,
+        } as LineChartPluginInstance;
+      } catch (err) {
+        return {
+          name,
+          matches,
+          processData: () => {},
+          getTopNSeries: () => [],
+        };
+      }
     },
   };
 

--- a/packages/malloy-render/src/stories/bar_chart.stories.malloy
+++ b/packages/malloy-render/src/stories/bar_chart.stories.malloy
@@ -394,6 +394,22 @@ source: products is duckdb.table("static/data/products.parquet") extend {
   view: dimension_series is baseLineData + { group_by: department }
 
   #(story)
+  view: misconfigurations is {
+    # bar_chart
+    nest:
+      not_enough_dimensions is {
+        aggregate: total_sales
+      }
+      too_many_dimensions is {
+        group_by: a is 1, b is 2, c is 3
+        aggregate: total_sales
+      }
+      no_measures is {
+        group_by: a is 1
+      }
+  }
+
+  #(story)
   # bar_chart
   view: short_legend_labels is {
     group_by: brand, l is 'foo'

--- a/packages/malloy-render/src/stories/line_charts.stories.malloy
+++ b/packages/malloy-render/src/stories/line_charts.stories.malloy
@@ -134,6 +134,12 @@ source: products is duckdb.table("static/data/products.parquet") extend {
   view: dimension_series_fill is baseLineData + { group_by: department }
 
   #(story)
+  # line_chartx
+  view: dimension_series_concatenated is baseLineData + {
+    group_by: department, foo is id%2
+  }
+
+  #(story)
   view: single_nest is {
     nest: topSellingBrands
   }

--- a/packages/malloy-render/src/stories/line_charts.stories.malloy
+++ b/packages/malloy-render/src/stories/line_charts.stories.malloy
@@ -121,22 +121,26 @@ source: products is duckdb.table("static/data/products.parquet") extend {
   #(story)
   view: root_chart is topSellingBrands
 
-  #(story)
-  # size=fill
-  view: root_chart_fill is topSellingBrands
 
   #(story)
   # line_chart
   view: dimension_series is baseLineData + { group_by: department }
 
-  #(story)
-  # line_chart size=fill
-  view: dimension_series_fill is baseLineData + { group_by: department }
 
   #(story)
-  # line_chartx
-  view: dimension_series_concatenated is baseLineData + {
-    group_by: department, foo is id%2
+  view: misconfigurations is {
+    # line_chart
+    nest:
+      not_enough_dimensions is {
+        aggregate: total_sales
+      }
+      too_many_dimensions is {
+        group_by: a is 1, b is 2, c is 3
+        aggregate: total_sales
+      }
+      no_measures is {
+        group_by: a is 1
+      }
   }
 
   #(story)


### PR DESCRIPTION
Adds
- error messages when charts are misconfigured
- `renderAs` property on malloy render element for inspecting which renderer is used

Fixes
- broken line chart x hovering