### PR TITLE
add 'through' and 'starting' to temporal filter expressions

### DIFF
--- a/packages/malloy-filter/src/grammars/ftemporal.ne
+++ b/packages/malloy-filter/src/grammars/ftemporal.ne
@@ -25,6 +25,8 @@ const kwList = moo.keywords(
       'FROM': 'from',
       'BEFORE': 'before',
       'AFTER': 'after',
+      'THROUGH': 'through',
+      'STARTING': 'starting',
       'FOR': 'for',
       'TODAY': 'today',
       'YESTERDAY': 'yesterday',
@@ -110,7 +112,9 @@ clause ->
   | parens {% (data) => data[0] %}
   | duration {% ([duration]) => ({operator: 'in_last', ...duration}) %}
   | %BEFORE moment {% ([_, moment]) => ({operator: 'before', before: moment }) %}
+  | %STARTING moment {% ([_, moment]) => ({operator: 'before', before: moment, not: true}) %}
   | %AFTER moment {% ([_, moment]) => ({operator: 'after', after: moment }) %}
+  | %THROUGH moment {% ([_, moment]) => ({operator: 'after', after: moment, not: true}) %}
   | moment %TO moment {% ([fromMoment, _, toMoment]) => ({operator: 'to', fromMoment, toMoment}) %}
   | moment %FOR duration {% ([moment, _, duration]) => ({...duration, operator: 'for', begin: moment}) %}
   | (%LAST|%NEXT) duration {% ([op, duration]) => ({operator: op[0].text, ...duration}) %}

--- a/packages/malloy-filter/src/temporal_filter_expression.ts
+++ b/packages/malloy-filter/src/temporal_filter_expression.ts
@@ -48,9 +48,9 @@ export const TemporalFilterExpression = {
       case 'next':
         return notStr(tc, `${tc.operator} ${durStr(tc)}`);
       case 'before':
-        return notStr(tc, `before ${momentToStr(tc.before)}`);
+        return `${tc.not ? 'starting' : 'before'} ${momentToStr(tc.before)}`;
       case 'after':
-        return notStr(tc, `after ${momentToStr(tc.after)}`);
+        return `${tc.not ? 'through' : 'after'} ${momentToStr(tc.after)}`;
       case 'to':
         return notStr(
           tc,

--- a/packages/malloy-filter/src/test/ftemporal.spec.ts
+++ b/packages/malloy-filter/src/test/ftemporal.spec.ts
@@ -305,8 +305,35 @@ describe('temporal filter expressions', () => {
         before: {moment: 'today'},
       });
     });
+    test('starting today', () => {
+      expect('starting today').isTemporalFilter({
+        operator: 'before',
+        before: {moment: 'today'},
+        not: true,
+      });
+    });
+    test('not before today', () => {
+      expect('not before today').isTemporalFilter(
+        {
+          operator: 'before',
+          before: {moment: 'today'},
+          not: true,
+        },
+        'starting today'
+      );
+    });
     test('not after tomorrow', () => {
-      expect('not after tomorrow').isTemporalFilter({
+      expect('not after tomorrow').isTemporalFilter(
+        {
+          operator: 'after',
+          not: true,
+          after: {moment: 'tomorrow'},
+        },
+        'through tomorrow'
+      );
+    });
+    test('through tomorrow', () => {
+      expect('through tomorrow').isTemporalFilter({
         operator: 'after',
         not: true,
         after: {moment: 'tomorrow'},

--- a/packages/malloy-filter/src/test/ftemporal.spec.ts
+++ b/packages/malloy-filter/src/test/ftemporal.spec.ts
@@ -392,7 +392,7 @@ describe('temporal filter expressions', () => {
             {operator: 'after', after: {moment: 'yesterday'}},
           ],
         },
-        'not before tomorrow and after yesterday'
+        'starting tomorrow and after yesterday'
       );
     });
   });


### PR DESCRIPTION
Explorer UI testing reveals a need for "on or after" in addition to after.

The filter expressions words are ( where _X_ is a time-literal like `today` or `2023-01-17` )

| Expression | Meaning |
| ---- | ---- |
| `before` _X_ | All time strictly before (less than) _X_ |
| `through` _X_ | All time up to the end of _X_ |
| _X_ | All time >= the beginning of _X_ and < the end |
| `starting` _X_ | All time >= the beginning of _X_ |
| `after` _X_ | All after the end of _X_ |