### PR TITLE
allow forwarded filter expression parameters

### DIFF
--- a/packages/malloy/src/lang/ast/source-elements/named-source.ts
+++ b/packages/malloy/src/lang/ast/source-elements/named-source.ts
@@ -202,7 +202,20 @@ export class NamedSource extends Source {
           parameter.type === 'filter expression' &&
           parameter.filterType
         ) {
-          checkFilterExpression(argument.value, parameter.filterType, value);
+          if (
+            value.node === 'parameter' &&
+            pVal.type === 'filter expression' &&
+            'filterType' in pVal
+          ) {
+            if (parameter.filterType !== pVal.filterType) {
+              argument.value.logError(
+                'filter-expression-type',
+                `Parameter types filter<${parameter.filterType}> and filter<${pVal.filterType}> do not match`
+              );
+            }
+          } else {
+            checkFilterExpression(argument.value, parameter.filterType, value);
+          }
         }
         if (pVal.type !== parameter.type && isCastType(parameter.type)) {
           value = castTo(parameter.type, pVal.value, pVal.type, true);

--- a/packages/malloy/src/lang/ast/typedesc-utils.ts
+++ b/packages/malloy/src/lang/ast/typedesc-utils.ts
@@ -26,6 +26,7 @@ import type {
   EvalSpace,
   ExpressionType,
   ExpressionValueType,
+  Parameter,
   TypeDesc,
 } from '../../model';
 import {expressionIsScalar, isRepeatedRecord, TD} from '../../model';
@@ -171,4 +172,21 @@ export function atomicDef(td: AtomicTypeDef | TypeDesc): AtomicTypeDef {
     }
   }
   return {type: 'error'};
+}
+
+export function parameterTypeDesc(
+  p: Parameter,
+  evalSpace: EvalSpace
+): TypeDesc {
+  const t = p.type;
+  const theType =
+    t === 'filter expression'
+      ? {type: t, filterType: p.filterType}
+      : atomicDef(p);
+  return {
+    ...theType,
+    expressionType: 'scalar',
+    evalSpace,
+    fieldUsage: [],
+  };
 }

--- a/packages/malloy/src/lang/ast/types/space-param.ts
+++ b/packages/malloy/src/lang/ast/types/space-param.ts
@@ -45,15 +45,7 @@ export class AbstractParameter extends SpaceParam {
   }
 
   typeDesc(): TypeDesc {
-    const p = this.parameter();
-    const t = p.type;
-    const theType = t === 'filter expression' ? {type: t} : TDU.atomicDef(p);
-    return {
-      ...theType,
-      expressionType: 'scalar',
-      evalSpace: 'constant',
-      fieldUsage: [],
-    };
+    return TDU.parameterTypeDesc(this.parameter(), 'constant');
   }
 }
 
@@ -67,16 +59,8 @@ export class DefinedParameter extends SpaceParam {
   }
 
   typeDesc(): TypeDesc {
-    const p = this.parameter();
-    const t = p.type;
-    const theType = t === 'filter expression' ? {type: t} : TDU.atomicDef(p);
-    return {
-      ...theType,
-      expressionType: 'scalar',
-      // TODO Not sure whether params are considered "input space". It seems like they
-      // could be input or constant, depending on usage (same as above).
-      evalSpace: 'input',
-      fieldUsage: [],
-    };
+    // TODO Not sure whether params are considered "input space". It seems like they
+    // could be input or constant, depending on usage (same as above).
+    return TDU.parameterTypeDesc(this.parameter(), 'input');
   }
 }

--- a/packages/malloy/src/lang/test/parameters.spec.ts
+++ b/packages/malloy/src/lang/test/parameters.spec.ts
@@ -730,4 +730,11 @@ describe('parameters', () => {
       source: ab7 is abx(param is f'dog%')
     `).toLog(errorMessage(/Filter syntax error:/));
   });
+  test('pass through filter expression parameters', () => {
+    expect(`
+      ##! experimental.parameters
+      source: a1(p1::filter<number> is f'1') is a extend { where: ai ~ p1 }
+      source: a2(p2::filter<number> is f'2') is a1(p1 is p2)
+    `).toTranslate();
+  });
 });


### PR DESCRIPTION
```
source: a(x::filter<TYPE>) is ...
source: b(y::filter<TYPE>) is a(x is y)
```

this was getting a compile error. now fixed.