### PR TITLE
Fix drill on join field reference

### DIFF
--- a/packages/malloy-render/src/data_tree/fields/base.ts
+++ b/packages/malloy-render/src/data_tree/fields/base.ts
@@ -74,7 +74,11 @@ export abstract class FieldBase {
     if (this.parent) {
       const view = this.metadataTag.text('drill_view');
       const parentPath = this.parent.drillPath;
-      if (view === undefined) return parentPath;
+      if (view === undefined) {
+        const referencePath = this.metadataTag.textArray('drill_path');
+        if (referencePath) return referencePath;
+        return parentPath;
+      }
       return [...parentPath, view];
     }
     return [];

--- a/packages/malloy/src/model/malloy_query.ts
+++ b/packages/malloy/src/model/malloy_query.ts
@@ -419,7 +419,10 @@ class GenerateState {
 
 abstract class QueryNode {
   readonly referenceId: string;
-  constructor(referenceId?: string) {
+  constructor(
+    referenceId?: string,
+    readonly referencePath?: string[]
+  ) {
     this.referenceId = referenceId ?? uuidv4();
   }
   abstract getIdentifier(): string;
@@ -432,8 +435,13 @@ class QueryField extends QueryNode {
   fieldDef: FieldDef;
   parent: QueryStruct;
 
-  constructor(fieldDef: FieldDef, parent: QueryStruct, referenceId?: string) {
-    super(referenceId);
+  constructor(
+    fieldDef: FieldDef,
+    parent: QueryStruct,
+    referenceId?: string,
+    referencePath?: string[]
+  ) {
+    super(referenceId, referencePath);
     this.fieldDef = fieldDef;
     this.parent = parent;
     this.fieldDef = fieldDef;
@@ -1582,8 +1590,13 @@ type QueryBasicField = QueryAtomicField<BasicAtomicDef>;
 abstract class QueryAtomicField<T extends AtomicFieldDef> extends QueryField {
   fieldDef: T;
 
-  constructor(fieldDef: T, parent: QueryStruct, refId?: string) {
-    super(fieldDef, parent, refId);
+  constructor(
+    fieldDef: T,
+    parent: QueryStruct,
+    refId?: string,
+    referencePath?: string[]
+  ) {
+    super(fieldDef, parent, refId, referencePath);
     this.fieldDef = fieldDef; // wish I didn't have to do this
   }
 
@@ -2836,11 +2849,13 @@ class QueryQuery extends QueryField {
           : undefined;
         const sourceClasses = [sourceField];
         const referenceId = fi.f.referenceId;
+        const referencePath = fi.f.referencePath;
         const base = {
           sourceField,
           sourceExpression,
           sourceClasses,
           referenceId,
+          referencePath,
         };
         if (isBasicCalculation(fi.f)) {
           filterList = fi.f.getFilterList();
@@ -4853,7 +4868,11 @@ class QueryStruct {
   }
 
   /** makes a new queryable field object from a fieldDef */
-  makeQueryField(field: FieldDef, referenceId?: string): QueryField {
+  makeQueryField(
+    field: FieldDef,
+    referenceId?: string,
+    referencePath?: string[]
+  ): QueryField {
     switch (field.type) {
       case 'array':
       case 'record':
@@ -4868,19 +4887,24 @@ class QueryStruct {
           this.prepareResultOptions
         );
       case 'string':
-        return new QueryFieldString(field, this, referenceId);
+        return new QueryFieldString(field, this, referenceId, referencePath);
       case 'date':
-        return new QueryFieldDate(field, this, referenceId);
+        return new QueryFieldDate(field, this, referenceId, referencePath);
       case 'timestamp':
-        return new QueryFieldTimestamp(field, this, referenceId);
+        return new QueryFieldTimestamp(field, this, referenceId, referencePath);
       case 'number':
-        return new QueryFieldNumber(field, this, referenceId);
+        return new QueryFieldNumber(field, this, referenceId, referencePath);
       case 'boolean':
-        return new QueryFieldBoolean(field, this, referenceId);
+        return new QueryFieldBoolean(field, this, referenceId, referencePath);
       case 'json':
-        return new QueryFieldJSON(field, this, referenceId);
+        return new QueryFieldJSON(field, this, referenceId, referencePath);
       case 'sql native':
-        return new QueryFieldUnsupported(field, this, referenceId);
+        return new QueryFieldUnsupported(
+          field,
+          this,
+          referenceId,
+          referencePath
+        );
       case 'turtle':
         return QueryQuery.makeQuery(field, this, undefined, false);
       default:
@@ -5003,7 +5027,7 @@ class QueryStruct {
         );
       } else {
         const newDef = {...field.fieldDef, annotation, drillView};
-        return field.parent.makeQueryField(newDef, field.referenceId);
+        return field.parent.makeQueryField(newDef, field.referenceId, f.path);
       }
     }
     return field;

--- a/packages/malloy/src/model/malloy_types.ts
+++ b/packages/malloy/src/model/malloy_types.ts
@@ -558,6 +558,7 @@ export interface ResultMetadataDef {
   filterList?: FilterCondition[];
   fieldKind: 'measure' | 'dimension' | 'struct';
   referenceId?: string;
+  referencePath?: string[];
   drillable?: boolean;
 }
 

--- a/packages/malloy/src/to_stable.ts
+++ b/packages/malloy/src/to_stable.ts
@@ -267,6 +267,10 @@ function getResultMetadataAnnotation(
     addDrillFiltersTag(tag, resultMetadata.filterList);
     hasAny = true;
   }
+  if (resultMetadata.referencePath) {
+    tag.set(['drill_path'], resultMetadata.referencePath);
+    hasAny = true;
+  }
   if (resultMetadata.fieldKind === 'dimension') {
     const dot = '.';
     // If field is joined-in from another table i.e. of type `tableName.columnName`,


### PR DESCRIPTION
Fixes an issue where drilling on a query that directly references a joined-in field fails because it produces the wrong drill filter (`drill: field = 'value'` rather than `drill: join_name.field = 'value'`)