### PR TITLE
Updates malloy/duckdb to 1.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14899,9 +14899,9 @@
       }
     },
     "node_modules/duckdb": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/duckdb/-/duckdb-1.2.1.tgz",
-      "integrity": "sha512-gs3KT2J3SOCghai0Q5nw/joYpOs63/gud+RX1hQmJ+ombUn5BEFn/FUqQKa3HSVZ95+otWDDMGsspLVEr4hJzA==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/duckdb/-/duckdb-1.3.1.tgz",
+      "integrity": "sha512-wSCxu6zSkHkGHtLrI5MmHYUOpbi08s2eIY/QCg2f1YsSyohjA3MRnUMdDb88oqgLa7/h+/wHuIe1RXRu4k04Sw==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -29307,7 +29307,7 @@
         "@malloydata/malloy": "0.0.295",
         "@motherduck/wasm-client": "^0.6.6",
         "apache-arrow": "^17.0.0",
-        "duckdb": "1.2.1",
+        "duckdb": "1.3.1",
         "web-worker": "^1.3.0"
       },
       "engines": {

--- a/packages/malloy-db-duckdb/package.json
+++ b/packages/malloy-db-duckdb/package.json
@@ -48,7 +48,7 @@
     "@malloydata/malloy": "0.0.295",
     "@motherduck/wasm-client": "^0.6.6",
     "apache-arrow": "^17.0.0",
-    "duckdb": "1.2.1",
+    "duckdb": "1.3.1",
     "web-worker": "^1.3.0"
   }
 }


### PR DESCRIPTION
DuckDB 1.2.1 has missing binary distributions on NPM.
Building on Linux doesn't work for some HW architectures.
Moving to 1.3.1 seems to resolve this.