### PR TITLE
Improve complex composite error messages

### DIFF
--- a/packages/malloy/src/lang/ast/field-space/reference-field.ts
+++ b/packages/malloy/src/lang/ast/field-space/reference-field.ts
@@ -23,6 +23,7 @@
 
 import type {
   Annotation,
+  FieldUsage,
   QueryFieldDef,
   TypeDesc,
 } from '../../../model/malloy_types';
@@ -111,17 +112,17 @@ export class ReferenceField extends SpaceField {
     if (refTo) {
       const joinPath = this.fieldRef.list.slice(0, -1).map(x => x.refString);
       const typeDesc = refTo.typeDesc();
+      const usage: FieldUsage = {
+        path: this.fieldRef.path,
+        at: this.fieldRef.location,
+      };
       this.memoTypeDesc = {
         ...typeDesc,
-        fieldUsage: [
-          {
-            path: this.fieldRef.path,
-            at: this.fieldRef.location,
-          },
-        ],
+        fieldUsage: [usage],
         requiresGroupBy: typeDesc.requiresGroupBy?.map(gb => ({
           ...gb,
           path: [...joinPath, ...gb.path],
+          fieldUsage: usage,
         })),
       };
       return this.memoTypeDesc;

--- a/packages/malloy/src/lang/parse-log.ts
+++ b/packages/malloy/src/lang/parse-log.ts
@@ -21,12 +21,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import {
-  fieldUsageIsPlural,
-  formatFieldUsages,
-} from '../model/composite_source_utils';
 import type {
-  FieldUsage,
   DocumentLocation,
   ExpressionValueType,
 } from '../model/malloy_types';
@@ -202,11 +197,6 @@ type MessageParameterTypes = {
   'field-not-found': string;
   'composite-field-type-mismatch': string;
   'invalid-composite-source-input': string;
-  'invalid-composite-field-usage': {
-    newUsage: FieldUsage[];
-    allUsage: FieldUsage[];
-    conflictingUsage: FieldUsage[];
-  };
   'could-not-resolve-composite-source': string;
   'empty-composite-source': string;
   'unnecessary-composite-source': string;
@@ -478,15 +468,6 @@ export const MESSAGE_FORMATTERS: PartialErrorCodeMessageMap = {
     `Case when expression must be boolean, not ${e.whenType}`,
   'case-when-type-does-not-match': e =>
     `Case when type ${e.whenType} does not match value type ${e.valueType}`,
-  'invalid-composite-field-usage': e => {
-    const formattedNewCompositeUsage = formatFieldUsages(e.newUsage);
-    const formattedConflictingCompositeUsage = formatFieldUsages(
-      e.conflictingUsage
-    );
-    const formattedAllCompositeUsage = formatFieldUsages(e.allUsage);
-    const pluralUse = fieldUsageIsPlural(e.newUsage) ? 's' : '';
-    return `This operation uses field${pluralUse} ${formattedNewCompositeUsage}, resulting in invalid usage of the composite source, as there is no composite input source which defines all of ${formattedConflictingCompositeUsage}\nFields required in source: ${formattedAllCompositeUsage}`;
-  },
 };
 
 export type MessageCode = keyof MessageParameterTypes;

--- a/packages/malloy/src/lang/test/composite-field-usage.spec.ts
+++ b/packages/malloy/src/lang/test/composite-field-usage.spec.ts
@@ -142,6 +142,28 @@ describe('composite sources', () => {
         `
       ).toTranslate();
     });
+    test('required group by mixed with missing field', () => {
+      expect(
+        `
+              ##! experimental { composite_sources grouped_by }
+              source: aext is compose(
+                a extend {
+                  dimension: x is 1
+                  dimension: y is 1
+                  measure: aisum is ai.sum() { grouped_by: x }
+                },
+                a extend {
+                  measure: aisum is ai.sum()
+                }
+              )
+              run: aext -> { aggregate: aisum, group_by: y }
+            `
+      ).toLog(
+        errorMessage(
+          'This operation uses field `y`, resulting in invalid usage of the composite source, as there is no composite input source which defines all of `y` and some composite input sources have unsatisfied required grouping on `x` (fields required in source: `aisum` and `y`)'
+        )
+      );
+    });
     test('error message when composited join (join is a nested composite) results in failure', () => {
       expect(`
         ##! experimental.composite_sources

--- a/packages/malloy/src/lang/test/composite-field-usage.spec.ts
+++ b/packages/malloy/src/lang/test/composite-field-usage.spec.ts
@@ -160,7 +160,7 @@ describe('composite sources', () => {
             `
       ).toLog(
         errorMessage(
-          'This operation uses field `y`, resulting in invalid usage of the composite source, as there is no composite input source which defines all of `y` and some composite input sources have unsatisfied required grouping on `x` (fields required in source: `aisum` and `y`)'
+          'This operation uses field `y`, resulting in invalid usage of the composite source, as there is no composite input source which defines `y` without having an unsatisfied required group by or single value filter on `x` (fields required in source: `aisum` and `y`)'
         )
       );
     });

--- a/packages/malloy/src/lang/test/composite-field-usage.spec.ts
+++ b/packages/malloy/src/lang/test/composite-field-usage.spec.ts
@@ -92,7 +92,7 @@ describe('composite sources', () => {
         }
       `).toLog(
         errorMessage(
-          'This operation uses field `two`, resulting in invalid usage of the composite source, as there is no composite input source which defines all of `three` and `two`\nFields required in source: `one`, `three`, and `two`'
+          'This operation uses field `two`, resulting in invalid usage of the composite source, as there is no composite input source which defines all of `three` and `two` (fields required in source: `one`, `three`, and `two`)'
         )
       );
     });
@@ -108,7 +108,7 @@ describe('composite sources', () => {
         } + ${'two'}
       `).toLog(
         errorMessage(
-          'This operation uses field `two`, resulting in invalid usage of the composite source, as there is no composite input source which defines all of `three` and `two`\nFields required in source: `one`, `three`, and `two`'
+          'This operation uses field `two`, resulting in invalid usage of the composite source, as there is no composite input source which defines all of `three` and `two` (fields required in source: `one`, `three`, and `two`)'
         )
       );
     });
@@ -126,7 +126,7 @@ describe('composite sources', () => {
         } + ${'v'}
       `).toLog(
         errorMessage(
-          'This operation uses field `two`, resulting in invalid usage of the composite source, as there is no composite input source which defines all of `three` and `two`\nFields required in source: `one`, `three`, and `two`'
+          'This operation uses field `two`, resulting in invalid usage of the composite source, as there is no composite input source which defines all of `three` and `two` (fields required in source: `one`, `three`, and `two`)'
         )
       );
     });
@@ -163,10 +163,7 @@ describe('composite sources', () => {
         run: c -> { group_by: ${'j.jf2'}, j.jf1 }
       `).toLog(
         errorMessage(
-          'Could not resolve composite source: join `j` could not be resolved in composed source #1 (`s1`)\nFields required in source: `j.jf2` and `j.jf1`'
-        ),
-        errorMessage(
-          'Could not resolve composite source: join `j` could not be resolved in composed source #2 (`s2`)\nFields required in source: `j.jf2` and `j.jf1`'
+          'This operation results in invalid usage of the composite source, as join `j` could not be resolved (fields required in source: `j.jf2` and `j.jf1`)'
         )
       );
     });
@@ -189,7 +186,7 @@ describe('composite sources', () => {
         run: c -> { group_by: f1, ${'j.jf2'} }
       `).toLog(
         errorMessage(
-          'This operation uses field `j.jf2`, resulting in invalid usage of the composite source, as there is no composite input source which defines all of `f1` and `j.jf2`\nFields required in source: `f1` and `j.jf2`'
+          'This operation uses field `j.jf2`, resulting in invalid usage of the composite source, as there is no composite input source which defines all of `f1` and `j.jf2` (fields required in source: `f1` and `j.jf2`)'
         )
       );
     });
@@ -210,7 +207,7 @@ describe('composite sources', () => {
         run: c -> { group_by: j.jf2, ${'j.jf1'} }
       `).toLog(
         errorMessage(
-          'This operation uses field `j.jf1`, resulting in invalid usage of the composite source, as there is no composite input source which defines all of `j.jf2` and `j.jf1`\nFields required in source: `j.jf2` and `j.jf1`'
+          'This operation uses field `j.jf1`, resulting in invalid usage of the composite source, as there is no composite input source which defines all of `j.jf2` and `j.jf1` (fields required in source: `j.jf2` and `j.jf1`)'
         )
       );
     });
@@ -228,7 +225,7 @@ describe('composite sources', () => {
         } + ${'x'}
       `).toLog(
         errorMessage(
-          'This operation uses field `two`, resulting in invalid usage of the composite source, as there is no composite input source which defines all of `three` and `two`\nFields required in source: `one`, `three`, and `two`'
+          'This operation uses field `two`, resulting in invalid usage of the composite source, as there is no composite input source which defines all of `three` and `two` (fields required in source: `one`, `three`, and `two`)'
         )
       );
     });
@@ -245,7 +242,7 @@ describe('composite sources', () => {
         }
       `).toLog(
         errorMessage(
-          'This operation uses field `two`, resulting in invalid usage of the composite source, as there is no composite input source which defines all of `three` and `two`\nFields required in source: `one`, `three`, and `two`'
+          'This operation uses field `two`, resulting in invalid usage of the composite source, as there is no composite input source which defines all of `three` and `two` (fields required in source: `one`, `three`, and `two`)'
         )
       );
     });
@@ -261,7 +258,7 @@ describe('composite sources', () => {
         }
       `).toLog(
         errorMessage(
-          'This operation uses field `two`, resulting in invalid usage of the composite source, as there is no composite input source which defines all of `one` and `two`\nFields required in source: `one` and `two`'
+          'This operation uses field `two`, resulting in invalid usage of the composite source, as there is no composite input source which defines all of `one` and `two` (fields required in source: `one` and `two`)'
         )
       );
     });
@@ -344,7 +341,7 @@ describe('composite sources', () => {
         run: foo -> { group_by: x, y }
       `).toLog(
         errorMessage(
-          'This operation uses field `y`, resulting in invalid usage of the composite source, as there is no composite input source which defines all of `x` and `y`\nFields required in source: `x` and `y`'
+          'This operation uses field `y`, resulting in invalid usage of the composite source, as there is no composite input source which defines all of `x` and `y` (fields required in source: `x` and `y`)'
         )
       );
     });

--- a/packages/malloy/src/lang/test/query.spec.ts
+++ b/packages/malloy/src/lang/test/query.spec.ts
@@ -2399,10 +2399,7 @@ describe('query:', () => {
         `
       ).toLog(
         errorMessage(
-          'Could not resolve composite source: missing group by or single value filter of `x` as required in composed source #1 (`a`)\nFields required in source: `aisum`'
-        ),
-        errorMessage(
-          'Could not resolve composite source: missing group by or single value filter of `y` as required in composed source #2 (`a`)\nFields required in source: `aisum`'
+          'This operation uses field `aisum`, resulting in invalid usage of the composite source, as some composite input sources have unsatisfied required grouping on `x` and/or `y` (fields required in source: `aisum`)'
         )
       );
     });

--- a/packages/malloy/src/lang/test/query.spec.ts
+++ b/packages/malloy/src/lang/test/query.spec.ts
@@ -2418,16 +2418,13 @@ describe('query:', () => {
             }
           )
           run: aext -> {
-            aggregate: ${'aisum'}
+            aggregate: aisum
             group_by: ${'foo'}
           }
         `
       ).toLog(
         errorMessage(
-          'Could not resolve composite source: missing group by or single value filter of `x` as required in composed source #1 (`a`)\nFields required in source: `aisum` and `foo`'
-        ),
-        errorMessage(
-          'Could not resolve composite source: missing field `foo` in composed source #2 (`a`)\nFields required in source: `aisum` and `foo`'
+          'This operation uses field `foo`, resulting in invalid usage of the composite source, as there is no composite input source which defines `foo` without having an unsatisfied required group by or single value filter on `x` (fields required in source: `aisum` and `foo`)'
         )
       );
     });
@@ -2683,10 +2680,7 @@ describe('query:', () => {
         `
       ).toLog(
         errorMessage(
-          'Could not resolve composite source: missing group by or single value filter of `astr` as required in composed source #1 (`slice_1`)\nFields required in source: `astr`, `abool`, and `aisum`'
-        ),
-        errorMessage(
-          'Could not resolve composite source: missing group by or single value filter of `abool` as required in composed source #2 (`a`)\nFields required in source: `astr`, `abool`, and `aisum`'
+          'This operation uses field `aisum`, resulting in invalid usage of the composite source, as there is a missing required group by or single value filter of `x` and/or `y` (fields required in source: `aisum`)'
         )
       );
     });

--- a/packages/malloy/src/lang/test/query.spec.ts
+++ b/packages/malloy/src/lang/test/query.spec.ts
@@ -2399,7 +2399,7 @@ describe('query:', () => {
         `
       ).toLog(
         errorMessage(
-          'This operation uses field `aisum`, resulting in invalid usage of the composite source, as some composite input sources have unsatisfied required grouping on `x` and/or `y` (fields required in source: `aisum`)'
+          'This operation uses field `aisum`, resulting in invalid usage of the composite source, as there is a missing required group by or single value filter of `x` and/or `y` (fields required in source: `aisum`)'
         )
       );
     });
@@ -2680,7 +2680,7 @@ describe('query:', () => {
         `
       ).toLog(
         errorMessage(
-          'This operation uses field `aisum`, resulting in invalid usage of the composite source, as there is a missing required group by or single value filter of `x` and/or `y` (fields required in source: `aisum`)'
+          'This operation uses field `aisum`, resulting in invalid usage of the composite source, as there is a missing required group by or single value filter of `astr` and/or `abool` (fields required in source: `astr`, `abool`, and `aisum`)'
         )
       );
     });

--- a/packages/malloy/src/model/composite_source_utils.ts
+++ b/packages/malloy/src/model/composite_source_utils.ts
@@ -40,6 +40,7 @@ import {
   isTurtle,
 } from './malloy_types';
 import {exprWalk} from './utils';
+import {isNotUndefined} from '../lang/utils';
 
 type CompositeCouldNotFindFieldError = {
   code: 'could_not_find_field';
@@ -570,27 +571,47 @@ export function fieldUsagePaths(fieldUsage: FieldUsage[]): string[][] {
   return fieldUsage.map(u => u.path);
 }
 
-export function formatFieldUsages(fieldUsage: FieldUsage[]) {
+function dedupPaths(paths: string[][]) {
   const deduped: string[][] = [];
-  for (const usage of fieldUsage) {
-    if (!deduped.some(p => pathEq(p, usage.path))) {
-      deduped.push(usage.path);
+  for (const path of paths) {
+    if (!deduped.some(p => pathEq(p, path))) {
+      deduped.push(path);
     }
   }
+  return deduped;
+}
+
+function formatPaths(paths: string[][], combinator = 'and') {
+  const deduped = dedupPaths(paths);
   const formattedUsages = deduped.map(fieldUsage =>
     formatFieldUsage(fieldUsage)
   );
-  if (formattedUsages.length === 0) {
+  return commaAndList(formattedUsages, combinator);
+}
+
+function formatRequiredGroupings(requiredGroupings: RequiredGroupBy[]) {
+  return formatPaths(
+    requiredGroupings.map(g => g.path),
+    'and/or'
+  );
+}
+
+function commaAndList(strs: string[], combinator = 'and') {
+  if (strs.length === 0) {
     return '';
-  } else if (formattedUsages.length === 1) {
-    return formattedUsages[0];
-  } else if (formattedUsages.length === 2) {
-    return `${formattedUsages[0]} and ${formattedUsages[1]}`;
+  } else if (strs.length === 1) {
+    return strs[0];
+  } else if (strs.length === 2) {
+    return `${strs[0]} ${combinator} ${strs[1]}`;
   } else {
-    return `${formattedUsages.slice(0, -1).join(', ')}, and ${
-      formattedUsages[formattedUsages.length - 1]
+    return `${strs.slice(0, -1).join(', ')}, ${combinator} ${
+      strs[strs.length - 1]
     }`;
   }
+}
+
+export function formatFieldUsages(fieldUsage: FieldUsage[]) {
+  return formatPaths(fieldUsage.map(u => u.path));
 }
 
 function countFieldUsage(fieldUsage: FieldUsage[]): number {
@@ -728,6 +749,7 @@ function requiredGroupBysAt(
   if (at === undefined) return requiredGroupBys;
   return requiredGroupBys?.map(r => ({
     ...r,
+    fieldUsage: r.fieldUsage ? fieldUsageAt([r.fieldUsage], at)[0] : undefined,
     at,
   }));
 }
@@ -917,7 +939,7 @@ function expandRefs(
             missingFields.push(field);
             continue;
           }
-          requiredGroupBys.push({path, at: field.at});
+          requiredGroupBys.push({path, at: field.at, fieldUsage: field});
         }
       }
       if (def.ungroupings) {
@@ -1081,8 +1103,20 @@ function compareLocations(
   return 0;
 }
 
-export function sortFieldUsageByReferenceLocation(usage: FieldUsage[]) {
-  return usage.sort((a, b) => compareLocations(a.at, b.at));
+function issueLocation(issue: CompositeIssue) {
+  if (issue.type === 'missing-field') {
+    return issue.field.at;
+  } else if (issue.type === 'missing-required-group-by') {
+    return issue.requiredGroupBy.at;
+  } else {
+    return issue.firstUsage.at;
+  }
+}
+
+function sortIssuesByReferenceLocation(issues: CompositeIssue[]) {
+  return issues.sort((a, b) => {
+    return compareLocations(issueLocation(a), issueLocation(b));
+  });
 }
 
 export function hasCompositesAnywhere(source: StructDef): boolean {
@@ -1095,75 +1129,69 @@ export function hasCompositesAnywhere(source: StructDef): boolean {
   return false;
 }
 
+function issueFieldUsage(issue: CompositeIssue): FieldUsage | undefined {
+  if (issue.type === 'missing-field') {
+    return issue.field;
+  } else if (issue.type === 'missing-required-group-by') {
+    return issue.requiredGroupBy.fieldUsage;
+  } else {
+    return undefined;
+  }
+}
+
 export function logCompositeError(error: CompositeError, logTo: MalloyElement) {
   if (error.code === 'no_suitable_composite_source_input') {
-    if (
-      error.data.failures.length > 0 &&
-      error.data.failures.every(failure => {
-        return (
-          failure.issues.length > 0 &&
-          failure.issues.every(issue => issue.type === 'missing-field')
-        );
-      })
-    ) {
-      const firstFails = error.data.failures.map(failure => {
-        if (failure.issues[0].type !== 'missing-field')
-          throw new Error('Programmer error');
-        return failure.issues[0].field;
-      });
-      const sorted = sortFieldUsageByReferenceLocation(firstFails);
-      const lastUsage = sorted[sorted.length - 1];
-      logTo.logError(
-        'invalid-composite-field-usage',
-        {
-          newUsage: [lastUsage],
-          conflictingUsage: sorted,
-          allUsage: error.data.usage,
-        },
-        {
-          at: lastUsage.at,
-        }
-      );
-    } else {
-      for (let i = 0; i < error.data.failures.length; i++) {
-        const failure = error.data.failures[i];
-        const sourceName = failure.source.as
-          ? ` (\`${failure.source.as}\`)`
-          : '';
-        const join =
-          error.data.path.length === 0
-            ? ''
-            : `join ${error.data.path.join('.')} of `;
-        const source = `${join}composed source #${i + 1}${sourceName}`;
-        const requiredFields = `\nFields required in source: ${formatFieldUsages(
-          error.data.usage
-        )}`;
-        for (const issue of failure.issues) {
-          if (issue.type === 'missing-field') {
-            const fieldRef = `\`${issue.field.path.join('.')}\``;
-            logTo.logError(
-              'could-not-resolve-composite-source',
-              `Could not resolve composite source: missing field ${fieldRef} in ${source}${requiredFields}`,
-              {at: issue.field.at}
-            );
-          } else if (issue.type === 'missing-required-group-by') {
-            const fieldRef = `\`${issue.requiredGroupBy.path.join('.')}\``;
-            logTo.logError(
-              'could-not-resolve-composite-source',
-              `Could not resolve composite source: missing group by or single value filter of ${fieldRef} as required in ${source}${requiredFields}`,
-              {at: issue.requiredGroupBy.at}
-            );
-          } else {
-            const joinRef = `\`${issue.path.join('.')}\``;
-            logTo.logError(
-              'could-not-resolve-composite-source',
-              `Could not resolve composite source: join ${joinRef} could not be resolved in ${source}${requiredFields}`,
-              {at: issue.firstUsage.at}
-            );
-          }
-        }
-      }
-    }
+    const firstFails = error.data.failures.map(failure => failure.issues[0]);
+    const sorted = sortIssuesByReferenceLocation(firstFails);
+    const usages = sorted.map(issueFieldUsage);
+    const lastIssue = sorted[sorted.length - 1];
+    const lastUsage = usages[usages.length - 1];
+    const conflictingUsage = firstFails
+      .filter(i => i.type === 'missing-field')
+      .map(i => i.field);
+    const conflictingUsageProblem =
+      conflictingUsage.length > 0
+        ? `there is no composite input source which defines all of ${formatFieldUsages(
+            conflictingUsage
+          )}`
+        : undefined;
+    const missingGroupBys = firstFails
+      .filter(i => i.type === 'missing-required-group-by')
+      .map(i => i.requiredGroupBy);
+    const missingGroupingProblem =
+      missingGroupBys.length > 0
+        ? `some composite input sources have unsatisfied required grouping on ${formatRequiredGroupings(
+            missingGroupBys
+          )}`
+        : undefined;
+    const failedJoins = firstFails
+      .filter(i => i.type === 'join-failed')
+      .map(i => i.path);
+    const uniqueFailedJoins = dedupPaths(failedJoins);
+    const joinPlural = uniqueFailedJoins.length > 1 ? 'joins' : 'join';
+    const failedJoinProblem =
+      failedJoins.length > 0
+        ? `${joinPlural} ${formatPaths(
+            uniqueFailedJoins
+          )} could not be resolved`
+        : undefined;
+    const lastIssueProblem = lastUsage
+      ? `uses field ${formatFieldUsages([lastUsage])}, resulting in`
+      : 'results in';
+    const allProblems = commaAndList(
+      [
+        conflictingUsageProblem,
+        missingGroupingProblem,
+        failedJoinProblem,
+      ].filter(isNotUndefined)
+    );
+    const message = `This operation ${lastIssueProblem} invalid usage of the composite source, as ${allProblems} (fields required in source: ${formatFieldUsages(
+      error.data.usage
+    )})`;
+
+    logTo.logError('could-not-resolve-composite-source', message, {
+      at: issueLocation(lastIssue),
+    });
   } else {
     logTo.logError(
       'could-not-resolve-composite-source',

--- a/packages/malloy/src/model/malloy_types.ts
+++ b/packages/malloy/src/model/malloy_types.ts
@@ -1310,6 +1310,7 @@ export type BasicExpressionType = Exclude<
 >;
 
 export interface RequiredGroupBy {
+  fieldUsage?: FieldUsage;
   at?: DocumentLocation;
   path: string[];
 }


### PR DESCRIPTION
Simplifies error message reporting for composite errors involving issues other than just conflicting fields, e.g. a required group by issue in one source and a missing field in another source.