### PR TITLE
Draft: Add a Calculate View Operation and MovingAverageExpression

### DIFF
--- a/packages/malloy-interfaces/src/types.ts
+++ b/packages/malloy-interfaces/src/types.ts
@@ -147,6 +147,22 @@ export const MALLOY_INTERFACE_TYPES: Record<string, MalloyInterfaceType> = {
     'name': 'BooleanType',
     'fields': {},
   },
+  'CalculateOperation': {
+    'type': 'struct',
+    'name': 'CalculateOperation',
+    'fields': {
+      'name': {
+        'type': 'string',
+        'optional': false,
+        'array': false,
+      },
+      'field': {
+        'type': 'Field',
+        'optional': false,
+        'array': false,
+      },
+    },
+  },
   'Cell': {
     'type': 'union',
     'name': 'Cell',
@@ -495,6 +511,7 @@ export const MALLOY_INTERFACE_TYPES: Record<string, MalloyInterfaceType> = {
       'time_truncation': 'TimeTruncationFieldReference',
       'filtered_field': 'FilteredField',
       'literal_value': 'LiteralValueExpression',
+      'moving_average': 'MovingAverage',
     },
   },
   'Field': {
@@ -836,6 +853,27 @@ export const MALLOY_INTERFACE_TYPES: Record<string, MalloyInterfaceType> = {
         'type': 'AnonymousQueryInfo',
         'array': true,
         'optional': false,
+      },
+    },
+  },
+  'MovingAverage': {
+    'type': 'struct',
+    'name': 'MovingAverage',
+    'fields': {
+      'field_reference': {
+        'type': 'Reference',
+        'optional': false,
+        'array': false,
+      },
+      'rows_preceding': {
+        'type': 'number',
+        'optional': true,
+        'array': false,
+      },
+      'rows_following': {
+        'type': 'number',
+        'optional': true,
+        'array': false,
       },
     },
   },
@@ -1600,6 +1638,7 @@ export const MALLOY_INTERFACE_TYPES: Record<string, MalloyInterfaceType> = {
       'nest': 'Nest',
       'having': 'FilterOperation',
       'drill': 'DrillOperation',
+      'calculate': 'CalculateOperation',
     },
   },
   'ViewRefinement': {
@@ -1709,6 +1748,11 @@ export type BooleanLiteral = {
 };
 
 export type BooleanType = {};
+
+export type CalculateOperation = {
+  name: string;
+  field: Field;
+};
 
 export type CellType =
   | 'string_cell'
@@ -1856,13 +1900,15 @@ export type ExpressionType =
   | 'field_reference'
   | 'time_truncation'
   | 'filtered_field'
-  | 'literal_value';
+  | 'literal_value'
+  | 'moving_average';
 
 export type Expression =
   | ExpressionWithFieldReference
   | ExpressionWithTimeTruncation
   | ExpressionWithFilteredField
-  | ExpressionWithLiteralValue;
+  | ExpressionWithLiteralValue
+  | ExpressionWithMovingAverage;
 
 export type ExpressionWithFieldReference = {
   kind: 'field_reference';
@@ -1879,6 +1925,10 @@ export type ExpressionWithFilteredField = {
 export type ExpressionWithLiteralValue = {
   kind: 'literal_value';
 } & LiteralValueExpression;
+
+export type ExpressionWithMovingAverage = {
+  kind: 'moving_average';
+} & MovingAverage;
 
 export type Field = {
   expression: Expression;
@@ -2076,6 +2126,12 @@ export type ModelInfo = {
   entries: Array<ModelEntryValue>;
   annotations?: Array<Annotation>;
   anonymous_queries: Array<AnonymousQueryInfo>;
+};
+
+export type MovingAverage = {
+  field_reference: Reference;
+  rows_preceding?: number;
+  rows_following?: number;
 };
 
 export type Nest = {
@@ -2410,7 +2466,8 @@ export type ViewOperationType =
   | 'where'
   | 'nest'
   | 'having'
-  | 'drill';
+  | 'drill'
+  | 'calculate';
 
 export type ViewOperation =
   | ViewOperationWithGroupBy
@@ -2420,7 +2477,8 @@ export type ViewOperation =
   | ViewOperationWithWhere
   | ViewOperationWithNest
   | ViewOperationWithHaving
-  | ViewOperationWithDrill;
+  | ViewOperationWithDrill
+  | ViewOperationWithCalculate;
 
 export type ViewOperationWithGroupBy = {kind: 'group_by'} & GroupBy;
 
@@ -2437,6 +2495,10 @@ export type ViewOperationWithNest = {kind: 'nest'} & Nest;
 export type ViewOperationWithHaving = {kind: 'having'} & FilterOperation;
 
 export type ViewOperationWithDrill = {kind: 'drill'} & DrillOperation;
+
+export type ViewOperationWithCalculate = {
+  kind: 'calculate';
+} & CalculateOperation;
 
 export type ViewRefinement = {
   base: ViewDefinition;

--- a/packages/malloy-interfaces/thrift/malloy.thrift
+++ b/packages/malloy-interfaces/thrift/malloy.thrift
@@ -265,6 +265,7 @@ union ViewOperation {
   6: required Nest nest,
   7: required FilterOperation having,
   8: required DrillOperation drill,
+  9: required CalculateOperation calculate,
 }
 
 struct GroupBy {
@@ -308,6 +309,11 @@ struct FilterOperation {
 
 struct DrillOperation {
   1: required Filter filter,
+}
+
+struct CalculateOperation {
+  1: required string name,
+  2: required Field field,
 }
 
 union Filter {
@@ -452,6 +458,7 @@ union Expression {
   2: required TimeTruncationFieldReference time_truncation,
   3: required FilteredField filtered_field,
   4: required LiteralValueExpression literal_value,
+  5: required MovingAverage moving_average
 }
 
 struct TimeTruncationFieldReference {
@@ -462,6 +469,12 @@ struct TimeTruncationFieldReference {
 struct FilteredField {
   1: required Reference field_reference,
   2: required list<FilterOperation> where,
+}
+
+struct MovingAverage {
+  1: required Reference field_reference,
+  2: optional i32 rows_preceding
+  3: optional i32 rows_following
 }
 
 struct StringCell {


### PR DESCRIPTION
In order to support smoothing in Malloy Explorer, we need a way to express the appropriate calculation in the Stable Query.


This is a draft because there are a few more tasks to complete:

**TO DO**
- The Calculate Expression will need a `partition_by` list added to it
- Probably need a function to convert a Calculate back into an Aggregate by removing the moving average