### PR TITLE
feat(render): add size property to bar and line chart plugins

### DIFF
--- a/packages/malloy-render/src/plugins/bar-chart/bar-chart-settings.ts
+++ b/packages/malloy-render/src/plugins/bar-chart/bar-chart-settings.ts
@@ -23,6 +23,14 @@ export interface BarChartSettings extends Record<string, unknown> {
   interactive: boolean;
   hideReferences: boolean;
   disableEmbedded: boolean;
+  size?:
+    | 'xs'
+    | 'sm'
+    | 'md'
+    | 'lg'
+    | 'xl'
+    | '2xl'
+    | {width: number; height: number};
 }
 
 // Default settings object
@@ -84,6 +92,7 @@ export interface IBarChartSettingsSchema extends JSONSchemaObject {
     interactive: JSONSchemaBoolean;
     hideReferences: JSONSchemaBoolean;
     disableEmbedded: JSONSchemaBoolean;
+    size?: JSONSchemaOneOf;
   };
 }
 
@@ -231,6 +240,32 @@ export const barChartSettingsSchema: IBarChartSettingsSchema = {
         'Whether to ignore field-level tags for x, y, and series channel assignment',
       type: 'boolean',
       default: false,
+    },
+    size: {
+      title: 'Chart Size',
+      description:
+        'Size preset (xs, sm, md, lg, xl, 2xl) or custom dimensions with width and height',
+      type: 'oneOf',
+      oneOf: [
+        {
+          type: 'string',
+          enum: ['xs', 'sm', 'md', 'lg', 'xl', '2xl'],
+        },
+        {
+          type: 'object',
+          properties: {
+            width: {
+              type: 'number',
+              minimum: 1,
+            },
+            height: {
+              type: 'number',
+              minimum: 1,
+            },
+          },
+          required: ['width', 'height'],
+        },
+      ],
     },
   },
   required: [

--- a/packages/malloy-render/src/plugins/bar-chart/get-bar_chart-settings.ts
+++ b/packages/malloy-render/src/plugins/bar-chart/get-bar_chart-settings.ts
@@ -41,6 +41,21 @@ export function getBarChartSettings(
     vizTag.text('size') === 'spark' || normalizedTag.text('size') === 'spark';
   const hideReferences = isSpark;
 
+  // Parse size property
+  let size: BarChartSettings['size'];
+  if (vizTag.has('size')) {
+    const sizeText = vizTag.text('size');
+    if (sizeText && ['xs', 'sm', 'md', 'lg', 'xl', '2xl'].includes(sizeText)) {
+      size = sizeText as 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl';
+    }
+  } else if (vizTag.has('size', 'width') && vizTag.has('size', 'height')) {
+    const width = vizTag.numeric('size', 'width');
+    const height = vizTag.numeric('size', 'height');
+    if (width !== undefined && height !== undefined) {
+      size = {width: width, height: height};
+    }
+  }
+
   // X-axis independence
   let xIndependent: boolean | 'auto' =
     defaultBarChartSettings.xChannel.independent;
@@ -255,5 +270,6 @@ export function getBarChartSettings(
     interactive,
     hideReferences,
     disableEmbedded,
+    size,
   };
 }

--- a/packages/malloy-render/src/plugins/line-chart/get-line_chart-settings.ts
+++ b/packages/malloy-render/src/plugins/line-chart/get-line_chart-settings.ts
@@ -169,6 +169,21 @@ export function getLineChartSettings(
   const mode: 'yoy' | 'normal' =
     (vizTag.text('mode') as 'yoy' | 'normal') ?? defaultLineChartSettings.mode;
 
+  // Parse size property
+  let size: LineChartSettings['size'];
+  if (vizTag.has('size')) {
+    const sizeText = vizTag.text('size');
+    if (sizeText && ['xs', 'sm', 'md', 'lg', 'xl', '2xl'].includes(sizeText)) {
+      size = sizeText as 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl';
+    }
+  } else if (vizTag.has('size', 'width') && vizTag.has('size', 'height')) {
+    const width = vizTag.numeric('size', 'width');
+    const height = vizTag.numeric('size', 'height');
+    if (width !== undefined && height !== undefined) {
+      size = {width: width, height: height};
+    }
+  }
+
   const xChannel: Channel = {
     fields: [],
     type: mergedDefaults.xChannel.type,
@@ -351,5 +366,6 @@ export function getLineChartSettings(
     interactive,
     disableEmbedded,
     mode,
+    size,
   };
 }

--- a/packages/malloy-render/src/plugins/line-chart/line-chart-settings.ts
+++ b/packages/malloy-render/src/plugins/line-chart/line-chart-settings.ts
@@ -24,6 +24,14 @@ export interface LineChartSettings extends Record<string, unknown> {
   interactive: boolean;
   disableEmbedded: boolean;
   mode?: 'yoy' | 'normal';
+  size?:
+    | 'xs'
+    | 'sm'
+    | 'md'
+    | 'lg'
+    | 'xl'
+    | '2xl'
+    | {width: number; height: number};
 }
 
 // Plugin options interface for JavaScript API
@@ -90,6 +98,7 @@ export interface ILineChartSettingsSchema extends JSONSchemaObject {
     interactive: JSONSchemaBoolean;
     disableEmbedded: JSONSchemaBoolean;
     mode: JSONSchemaString;
+    size?: JSONSchemaOneOf;
   };
 }
 
@@ -239,6 +248,32 @@ export const lineChartSettingsSchema: ILineChartSettingsSchema = {
       type: 'string',
       enum: ['normal', 'yoy'],
       default: 'normal',
+    },
+    size: {
+      title: 'Chart Size',
+      description:
+        'Size preset (xs, sm, md, lg, xl, 2xl) or custom dimensions with width and height',
+      type: 'oneOf',
+      oneOf: [
+        {
+          type: 'string',
+          enum: ['xs', 'sm', 'md', 'lg', 'xl', '2xl'],
+        },
+        {
+          type: 'object',
+          properties: {
+            width: {
+              type: 'number',
+              minimum: 1,
+            },
+            height: {
+              type: 'number',
+              minimum: 1,
+            },
+          },
+          required: ['width', 'height'],
+        },
+      ],
     },
   },
   required: [


### PR DESCRIPTION
## Summary
This PR adds support for the `size` property in bar and line chart visualization tags, allowing users to control chart dimensions using either preset sizes or custom width/height values.

## Changes
- Added `size` property to `BarChartSettings` and `LineChartSettings` interfaces
- Updated JSON Schema definitions for both chart types to include size validation
- Implemented size tag parsing in `getBarChartSettings` and `getLineChartSettings` functions
- Integration with existing chart layout infrastructure (no changes needed to vega spec generators)

## Usage
Users can now specify chart sizes in two ways:

1. **Preset sizes**: `xs`, `sm`, `md`, `lg`, `xl`, `2xl`
   ```malloy
   # viz=bar { size=lg }
   ```

2. **Custom dimensions**: specific width and height values
   ```malloy
   # viz=line { size.width=400 size.height=200 }
   ```

## Test plan
- [x] All existing tests pass
- [x] Build completes successfully
- [x] Linting passes
- [ ] Manual testing with example queries using the new size property

🤖 Generated with [Claude Code](https://claude.ai/code)