### PR TITLE
refactor: Eliminate boolean trap in RecordField constructor

### DIFF
--- a/packages/malloy-render/src/data_tree/fields/nest.ts
+++ b/packages/malloy-render/src/data_tree/fields/nest.ts
@@ -80,7 +80,7 @@ export class RepeatedRecordField extends ArrayField {
 
     this.nestedRecordField = new RecordField(recordFieldInfo, this, {
       fields: this.fields,
-      skipTagParsing: true
+      skipTagParsing: true,
     });
   }
 
@@ -167,7 +167,7 @@ export class RecordField extends FieldBase {
   public fields: Field[];
   public fieldsByName: Record<string, Field>;
   public readonly maxUniqueFieldValueCounts: Map<string, number> = new Map();
-  
+
   constructor(
     public readonly field: RecordFieldInfo,
     parent: Field | undefined,
@@ -182,7 +182,7 @@ export class RecordField extends FieldBase {
     }
   ) {
     super(field, parent, options?.skipTagParsing);
-    
+
     if (options?.fields) {
       // Use provided fields to avoid duplication
       this.fields = options.fields;


### PR DESCRIPTION
Refactors RecordField constructor to use an options object instead of boolean parameters, making the code more readable and self-documenting.

Addresses review feedback on #2455.