### PR TITLE
Add a few additional error message improvements

### DIFF
--- a/packages/malloy/src/lang/ast/query-properties/qop-desc.ts
+++ b/packages/malloy/src/lang/ast/query-properties/qop-desc.ts
@@ -36,6 +36,7 @@ import {StaticSourceSpace} from '../field-space/static-space';
 import {QueryClass} from '../types/query-property-interface';
 import {PartialBuilder} from '../query-builders/partial-builder';
 import type {QueryOperationSpace} from '../field-space/query-spaces';
+import {modernizeTermsForUserText} from '../../utils';
 
 export class QOpDesc extends ListOf<QueryProperty> {
   elementType = 'queryOperation';
@@ -60,7 +61,11 @@ export class QOpDesc extends ListOf<QueryProperty> {
           if (guessType !== el.forceQueryClass) {
             el.logError(
               `illegal-${guessType}-operation`,
-              `Not legal in ${guessType} query`
+              `Use of ${modernizeTermsForUserText(
+                el.forceQueryClass
+              )} is not allowed in a ${modernizeTermsForUserText(
+                guessType
+              )} query`
             );
           }
         } else {

--- a/packages/malloy/src/lang/syntax-errors/custom-error-messages.ts
+++ b/packages/malloy/src/lang/syntax-errors/custom-error-messages.ts
@@ -169,12 +169,20 @@ export const checkCustomErrorMessage = (
       }
 
       const errReplace = (s: string) => {
-        const rs = s
+        let rs = s
           .replace('${currentToken}', currentToken.text || '')
           .replace('${offendingSymbol}', offendingSymbol?.text || '');
         try {
           const previousToken = parser.inputStream.LT(-1);
-          return rs.replace('${previousToken}', previousToken.text || '');
+          rs = rs.replace('${previousToken}', previousToken.text || '');
+
+          const offendingSymbolIndex = offendingSymbol?.tokenIndex;
+          if (offendingSymbolIndex && offendingSymbolIndex > 0) {
+            const previousSymbol = parser.inputStream.get(
+              offendingSymbolIndex - 1
+            );
+            rs = rs.replace('${previousSymbol}', previousSymbol.text || '');
+          }
         } catch (ex) {
           // This shouldn't ever occur, but if it does, just leave the untokenized message.
         }

--- a/packages/malloy/src/lang/syntax-errors/malloy-parser-error-listener.ts
+++ b/packages/malloy/src/lang/syntax-errors/malloy-parser-error-listener.ts
@@ -215,7 +215,7 @@ export const malloyCustomErrorCases: ErrorCase[] = [
   // identifier that does not represent a valid function.
   {
     errorMessage:
-      "Unknown function 'percent_of_total'. You can find available functions here: https://docs.malloydata.dev/documentation/language/functions",
+      "Unknown function '${previousSymbol}'. You can find available functions here: https://docs.malloydata.dev/documentation/language/functions",
     offendingSymbol: MalloyParser.OPAREN,
     ruleContextOptions: ['vExpr'],
     precedingTokenOptions: [[MalloyParser.IDENTIFIER]],

--- a/packages/malloy/src/lang/syntax-errors/malloy-parser-error-listener.ts
+++ b/packages/malloy/src/lang/syntax-errors/malloy-parser-error-listener.ts
@@ -186,6 +186,40 @@ export const malloyCustomErrorCases: ErrorCase[] = [
       with: ['run:', 'query:', 'source:'],
     },
   },
+  {
+    errorMessage:
+      '`count(distinct expression)` deprecated, use `count(expression)` instead.',
+    offendingSymbol: MalloyParser.DISTINCT,
+    ruleContextOptions: ['fieldExpr'],
+    precedingTokenOptions: [[MalloyParser.COUNT], [MalloyParser.OPAREN]],
+  },
+  {
+    errorMessage:
+      "Unexpected type '${offendingSymbol}' in dimension definition. Expected an expression or field reference.",
+    offendingSymbolTextOptions: [
+      'string',
+      'number',
+      'int',
+      'integer',
+      'bool',
+      'boolean',
+      'date',
+      'time',
+      'timestamp',
+      'array',
+    ],
+    ruleContextOptions: ['fieldExpr'],
+    precedingTokenOptions: [[MalloyParser.IDENTIFIER], [MalloyParser.IS]],
+  },
+  // Identify a case where a user is using an open parenthesis following an
+  // identifier that does not represent a valid function.
+  {
+    errorMessage:
+      "Unknown function 'percent_of_total'. You can find available functions here: https://docs.malloydata.dev/documentation/language/functions",
+    offendingSymbol: MalloyParser.OPAREN,
+    ruleContextOptions: ['vExpr'],
+    precedingTokenOptions: [[MalloyParser.IDENTIFIER]],
+  },
 ];
 
 export class MalloyParserErrorListener implements ANTLRErrorListener<Token> {

--- a/packages/malloy/src/lang/syntax-errors/malloy-parser-error-listener.ts
+++ b/packages/malloy/src/lang/syntax-errors/malloy-parser-error-listener.ts
@@ -220,6 +220,11 @@ export const malloyCustomErrorCases: ErrorCase[] = [
     ruleContextOptions: ['vExpr'],
     precedingTokenOptions: [[MalloyParser.IDENTIFIER]],
   },
+  {
+    errorMessage:
+      "The 'project:' keyword is no longer supported. Use 'select:' instead.",
+    offendingSymbol: MalloyParser.PROJECT,
+  },
 ];
 
 export class MalloyParserErrorListener implements ANTLRErrorListener<Token> {

--- a/packages/malloy/src/lang/syntax-errors/malloy-parser-error-listener.ts
+++ b/packages/malloy/src/lang/syntax-errors/malloy-parser-error-listener.ts
@@ -225,6 +225,18 @@ export const malloyCustomErrorCases: ErrorCase[] = [
       "The 'project:' keyword is no longer supported. Use 'select:' instead.",
     offendingSymbol: MalloyParser.PROJECT,
   },
+  {
+    errorMessage:
+      "Unsupported keyword 'as'. Use 'is' to name something (ex: `dimension: name is expression`)",
+    offendingSymbolTextOptions: ['as'],
+    ruleContextOptions: ['isDefine'],
+  },
+  {
+    // Broader catch-all case for the 'as' keyword, including an alternative example.
+    errorMessage:
+      "Unsupported keyword 'as'. Use 'is' to name something (ex: `select: new_name is column_name`)",
+    offendingSymbolTextOptions: ['as'],
+  },
 ];
 
 export class MalloyParserErrorListener implements ANTLRErrorListener<Token> {

--- a/packages/malloy/src/lang/test/locations.spec.ts
+++ b/packages/malloy/src/lang/test/locations.spec.ts
@@ -260,7 +260,7 @@ describe('source locations', () => {
   });
   test('bad query', () => {
     expect(model`run: a -> { group_by: astr; ${'select: *'} }`).toLog(
-      errorMessage(/Not legal in grouping query/)
+      errorMessage(/Use of select is not allowed in a grouping query/)
     );
   });
 

--- a/packages/malloy/src/lang/test/parse.spec.ts
+++ b/packages/malloy/src/lang/test/parse.spec.ts
@@ -177,7 +177,7 @@ describe('error handling', () => {
   });
   test('refine cannot change query type', () => {
     expect('run: ab -> aturtle + { select: astr }').toLog(
-      errorMessage(/Not legal in grouping query/)
+      errorMessage(/Use of select is not allowed in a grouping query/)
     );
   });
   test('undefined field ref in query', () => {

--- a/packages/malloy/src/lang/test/syntax-errors.spec.ts
+++ b/packages/malloy/src/lang/test/syntax-errors.spec.ts
@@ -205,11 +205,11 @@ describe('custom error messages', () => {
       expect(`
         source: x is a extend {
           view: t is {
-            aggregate: percent_of_total(time)
+            aggregate: pct_of_total(time)
           }
       }`).toLogAtLeast(
         errorMessage(
-          "Unknown function 'percent_of_total'. You can find available functions here: https://docs.malloydata.dev/documentation/language/functions"
+          "Unknown function 'pct_of_total'. You can find available functions here: https://docs.malloydata.dev/documentation/language/functions"
         )
       );
     });

--- a/packages/malloy/src/lang/test/syntax-errors.spec.ts
+++ b/packages/malloy/src/lang/test/syntax-errors.spec.ts
@@ -70,7 +70,7 @@ describe('custom error messages', () => {
 
     test('use of the distinct keyword in a count', () => {
       expect(
-        `source: x is a extend { measure: ai_count is count(distinct ai) }`
+        'source: x is a extend { measure: ai_count is count(distinct ai) }'
       ).toLogAtLeast(
         errorMessage(
           '`count(distinct expression)` deprecated, use `count(expression)` instead.'
@@ -79,7 +79,7 @@ describe('custom error messages', () => {
     });
 
     test('mistakenly specifying a type instead of a value', () => {
-      expect(`source: x is a extend { dimension: s is string }`).toLogAtLeast(
+      expect('source: x is a extend { dimension: s is string }').toLogAtLeast(
         errorMessage(
           "Unexpected type 'string' in dimension definition. Expected an expression or field reference."
         )
@@ -146,6 +146,16 @@ describe('custom error messages', () => {
         }
         `).toLogAtLeast(
         errorMessage("extraneous input '{' expecting {BQ_STRING, IDENTIFIER}")
+      );
+    });
+
+    test('use of as in dimension', () => {
+      expect(`source: x is a extend {
+        dimension: ai as dimension_name
+      }`).toLogAtLeast(
+        errorMessage(
+          "Unsupported keyword 'as'. Use 'is' to name something (ex: `dimension: name is expression`)"
+        )
       );
     });
   });
@@ -290,7 +300,7 @@ describe('custom error messages', () => {
             select: ai
           }
         `).toLogAtLeast(
-        errorMessage("Use of select is not allowed in a grouping query")
+        errorMessage('Use of select is not allowed in a grouping query')
       );
     });
 
@@ -301,7 +311,7 @@ describe('custom error messages', () => {
             group_by: astr
           }
         `).toLogAtLeast(
-        errorMessage("Use of grouping is not allowed in a select query")
+        errorMessage('Use of grouping is not allowed in a select query')
       );
     });
 
@@ -311,8 +321,22 @@ describe('custom error messages', () => {
             project: *
           }
         `).toLogAtLeast(
-        errorMessage("The 'project:' keyword is no longer supported. Use 'select:' instead.")
+        errorMessage(
+          "The 'project:' keyword is no longer supported. Use 'select:' instead."
+        )
       );
-    })
+    });
+
+    test('unexpected us of "as" in select query', () => {
+      expect(`
+          run: a -> {
+            select: ai as name
+          }
+        `).toLogAtLeast(
+        errorMessage(
+          "Unsupported keyword 'as'. Use 'is' to name something (ex: `select: new_name is column_name`)"
+        )
+      );
+    });
   });
 });

--- a/packages/malloy/src/lang/test/syntax-errors.spec.ts
+++ b/packages/malloy/src/lang/test/syntax-errors.spec.ts
@@ -304,5 +304,15 @@ describe('custom error messages', () => {
         errorMessage("Use of grouping is not allowed in a select query")
       );
     });
+
+    test('use of project instead of select', () => {
+      expect(`
+          run: a -> {
+            project: *
+          }
+        `).toLogAtLeast(
+        errorMessage("The 'project:' keyword is no longer supported. Use 'select:' instead.")
+      );
+    })
   });
 });

--- a/packages/malloy/src/lang/utils.ts
+++ b/packages/malloy/src/lang/utils.ts
@@ -144,6 +144,19 @@ export function getSourceInfo(code: string): SourceInfo {
   return info;
 }
 
+/**
+ * Rewrites text that is going to be presented to end users to avoid
+ * using terminology that is deprecated or changed.
+ *
+ * @param text raw text that is being used internally in Malloy
+ */
+export function modernizeTermsForUserText(text: string): string {
+  if (text === 'project') {
+    return 'select';
+  }
+  return text;
+}
+
 export interface ParseInfo {
   root: ParseTree;
   tokenStream: CommonTokenStream;


### PR DESCRIPTION
Identifies a few common error messages encountered when an AI system authors Malloy models and queries, and adds clearer error messages in those cases.

Example error messages:
* "Unexpected type 'int' in dimension definition. Expected an expression or field reference."
* "Unknown function 'percent_of_total'. You can find available functions here: https://docs.malloydata.dev/documentation/language/functions"
* "The 'project:' keyword is no longer supported. Use 'select:' instead."
* "Unsupported keyword 'as'. Use 'is' to name something (ex: `dimension: name is expression`)"
* "Use of select is not allowed in a grouping query"
