### PR TITLE
Remove a bunch of unnecessary deep copy operations

### DIFF
--- a/packages/malloy/src/lang/ast/field-space/dynamic-space.ts
+++ b/packages/malloy/src/lang/ast/field-space/dynamic-space.ts
@@ -50,7 +50,7 @@ export abstract class DynamicSpace
   protected newNotes = new Map<string, model.Annotation>();
 
   constructor(extending: SourceDef) {
-    super(structuredClone(extending), extending.dialect, extending.connection);
+    super({...extending}, extending.dialect, extending.connection);
     this.fromSource = extending;
     this.sourceDef = undefined;
   }

--- a/packages/malloy/src/lang/ast/source-elements/refined-source.ts
+++ b/packages/malloy/src/lang/ast/source-elements/refined-source.ts
@@ -131,7 +131,7 @@ export class RefinedSource extends Source {
     }
 
     const paramSpace = pList ? new ParameterSpace(pList) : undefined;
-    const from = structuredClone(this.source.getSourceDef(paramSpace));
+    const from = {...this.source.getSourceDef(paramSpace)};
     const includeState = processIncludeList(this.includeList, from);
     const thisIncludeState = getIncludeStateForJoin([], includeState);
     for (const modifier of inlineAccessModifiers) {
@@ -140,7 +140,7 @@ export class RefinedSource extends Source {
       }
     }
     // Note that this is explicitly not:
-    // const from = structuredClone(this.source.withParameters(parameterSpace, pList));
+    // const from = this.source.withParameters(parameterSpace, pList);
     // Because the parameters are added to the resulting struct, not the base struct
     if (primaryKey) {
       from.primaryKey = primaryKey.field.name;

--- a/packages/malloy/src/lang/ast/types/malloy-element.ts
+++ b/packages/malloy/src/lang/ast/types/malloy-element.ts
@@ -522,7 +522,7 @@ export class Document extends MalloyElement implements NameSpace {
         this.annotation.inherits = extendingModelDef.annotation;
       }
       for (const [nm, orig] of Object.entries(extendingModelDef.contents)) {
-        const entry = structuredClone(orig);
+        const entry = {...orig};
         if (
           isSourceDef(entry) ||
           entry.type === 'query' ||
@@ -598,7 +598,7 @@ export class Document extends MalloyElement implements NameSpace {
         if (this.documentModel[entry].exported) {
           def.exports.push(entry);
         }
-        const newEntry = structuredClone(entryDef);
+        const newEntry = {...entryDef};
         if (newEntry.modelAnnotation === undefined && def.annotation) {
           newEntry.modelAnnotation = def.annotation;
         }

--- a/packages/malloy/src/model/malloy_query.ts
+++ b/packages/malloy/src/model/malloy_query.ts
@@ -5082,15 +5082,17 @@ class QueryStruct {
   applyStructFiltersToTurtleDef(
     turtleDef: TurtleDef | TurtleDefPlus
   ): TurtleDef {
-    let pipeline = turtleDef.pipeline;
+    const pipeline = [...turtleDef.pipeline];
     const annotation = turtleDef.annotation;
 
     const addedFilters = (turtleDef as TurtleDefPlus).filterList || [];
-    pipeline = structuredClone(pipeline);
-    pipeline[0].filterList = addedFilters.concat(
-      pipeline[0].filterList || [],
-      isSourceDef(this.structDef) ? this.structDef.filterList || [] : []
-    );
+    pipeline[0] = {
+      ...pipeline[0],
+      filterList: addedFilters.concat(
+        pipeline[0].filterList || [],
+        isSourceDef(this.structDef) ? this.structDef.filterList || [] : []
+      ),
+    };
 
     const flatTurtleDef: TurtleDef = {
       type: 'turtle',


### PR DESCRIPTION
In general, we don't mutate objects much in the compiler/translator, so deep copy operations (which are slow) should not be necessary. If we hit issues with mutations causing issues, replace the _mutation_ with a shallow copy and update rather than a deep copy. 

For a large example cube request, this improved performance from an average of 99.57ms to 41.73ms (57.84ms savings on average, or 58% reduction in compile time).

As the Malloy IR is becoming bigger/more complex, deep copy results in a bigger performance impact. 

There are separate issues with larger IR, some of which can be solved with smarter choices in the translator; others may require making design tradeoffs to keep the IR small.

Some obvious candidates:
- Nest references in queries copy the view definition
- Joins copy the source definition
- Composite sources copy the source definitions
- Queries against composite sources have a full clone of the source tree with composites resolved
- All code location fields ("at", "location")