### PR TITLE
fix: header width setting; scroll override story

### DIFF
--- a/packages/malloy-render/src/component/table/table.tsx
+++ b/packages/malloy-render/src/component/table/table.tsx
@@ -49,12 +49,12 @@ const Cell = (props: {
     const width = layout.fieldLayout(props.field).width;
     const height = layout.fieldLayout(props.field).height;
     const style: JSX.CSSProperties = {};
+    if (width) {
+      style.width = `${width}px`;
+      style['min-width'] = `${width}px`;
+      style['max-width'] = `${width}px;`;
+    }
     if (!props.isHeader) {
-      if (width) {
-        style.width = `${width}px`;
-        style['min-width'] = `${width}px`;
-        style['max-width'] = `${width}px;`;
-      }
       if (height) {
         style.height = `${height}px`;
       }

--- a/packages/malloy-render/src/stories/scroll-override.stories.malloy
+++ b/packages/malloy-render/src/stories/scroll-override.stories.malloy
@@ -1,0 +1,92 @@
+source: products is duckdb.table("static/data/products.parquet") extend {
+
+  #(story)
+  view: full_products_table is {
+    select: *
+    limit: 100
+    order_by: id desc
+  }
+
+  #(story)
+  view: small_products_table is {
+    select: *
+    limit: 2
+    order_by: id desc
+  }
+
+  #(story)
+  view: simple_nested_table is {
+    group_by: category
+    aggregate:
+      avg_retail is retail_price.avg()
+      total_cost is cost.sum()
+      product_count is count()
+    limit: 10
+    nest:
+      by_brand is {
+        group_by: brand
+        aggregate:
+          avg_retail is retail_price.avg()
+          total_cost is cost.sum()
+        limit: 15
+      }
+      by_department is {
+        group_by: department
+        aggregate:
+          avg_retail is retail_price.avg()
+          product_count is count()
+        limit: 15
+      }
+  }
+
+  #(story)
+  view: deeply_nested_table is {
+    group_by: category
+    aggregate:
+      avg_retail is retail_price.avg()
+      total_products is count()
+    limit: 5
+    nest:
+      by_department is {
+        group_by: department
+        aggregate:
+          avg_retail is retail_price.avg()
+          product_count is count()
+        nest:
+          by_brand is {
+            group_by: brand
+            aggregate:
+              avg_retail is retail_price.avg()
+              total_cost is cost.sum()
+            limit: 10
+          }
+          top_products is {
+            select: name, retail_price, cost
+            order_by: retail_price desc
+            limit: 5
+          }
+        limit: 8
+      }
+  }
+
+  #(story)
+  view: wide_table is {
+    select:
+      id,
+      sku,
+      name,
+      brand,
+      category,
+      department,
+      retail_price,
+      cost,
+      margin is retail_price - cost,
+      margin_percent is (retail_price - cost) / nullif(retail_price, 0) * 100,
+      # column {width=200}
+      description is concat('Product: ', name, ' | Brand: ', brand, ' | Category: ', category, ' | Department: ', department),
+      # column {width=300}
+      long_text is 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.'
+    limit: 50
+    order_by: retail_price desc
+  }
+}

--- a/packages/malloy-render/src/stories/scroll-override.stories.ts
+++ b/packages/malloy-render/src/stories/scroll-override.stories.ts
@@ -5,7 +5,7 @@ import {MalloyRenderer} from '../api/malloy-renderer';
 
 const meta: Meta = {
   title: 'Malloy Next/Scroll Override Test',
-  render: ({view}, context) => {
+  render: context => {
     const mainContainer = document.createElement('div');
 
     const scrollContainer = document.createElement('div');

--- a/packages/malloy-render/src/stories/scroll-override.stories.ts
+++ b/packages/malloy-render/src/stories/scroll-override.stories.ts
@@ -1,0 +1,102 @@
+import type {Meta} from '@storybook/html';
+import script from './scroll-override.stories.malloy?raw';
+import {createLoader} from './util';
+import {MalloyRenderer} from '../api/malloy-renderer';
+
+const meta: Meta = {
+  title: 'Malloy Next/Scroll Override Test',
+  render: ({view}, context) => {
+    const mainContainer = document.createElement('div');
+
+    const scrollContainer = document.createElement('div');
+    scrollContainer.style.maxHeight = '400px';
+    scrollContainer.style.border = '3px solid red';
+    scrollContainer.style.borderRadius = '8px';
+    scrollContainer.style.overflow = 'auto';
+    scrollContainer.style.position = 'relative';
+    scrollContainer.style.backgroundColor = 'white';
+
+    const targetElement = document.createElement('div');
+    targetElement.style.width = '100%';
+    scrollContainer.appendChild(targetElement);
+
+    const renderer = new MalloyRenderer();
+    const viz = renderer.createViz({
+      onError: error => {
+        console.error('Malloy render error:', error);
+        const errorDiv = document.createElement('div');
+        errorDiv.style.color = 'red';
+        errorDiv.style.padding = '10px';
+        errorDiv.textContent = `Error: ${error.message || error}`;
+        targetElement.appendChild(errorDiv);
+      },
+      scrollEl: scrollContainer,
+    });
+
+    if (context.loaded && context.loaded['result']) {
+      viz.setResult(context.loaded['result']);
+
+      const metadata = viz.getMetadata();
+      console.log('Render metadata:', metadata);
+      console.log('Scroll container:', scrollContainer);
+
+      viz.render(targetElement);
+    } else {
+      console.error('No result loaded');
+    }
+
+    mainContainer.appendChild(scrollContainer);
+
+    return mainContainer;
+  },
+  loaders: [createLoader(script)],
+  argTypes: {
+    view: {
+      control: {type: 'select'},
+      options: [
+        'full_products_table',
+        'simple_nested_table',
+        'deeply_nested_table',
+        'wide_table',
+      ],
+      description: 'Select which view to render',
+    },
+  },
+};
+
+export default meta;
+
+export const FullProductsTable = {
+  args: {
+    source: 'products',
+    view: 'full_products_table',
+  },
+};
+
+export const SmallProductsTable = {
+  args: {
+    source: 'products',
+    view: 'small_products_table',
+  },
+};
+
+export const SimpleNestedTable = {
+  args: {
+    source: 'products',
+    view: 'simple_nested_table',
+  },
+};
+
+export const DeeplyNestedTable = {
+  args: {
+    source: 'products',
+    view: 'deeply_nested_table',
+  },
+};
+
+export const WideTable = {
+  args: {
+    source: 'products',
+    view: 'wide_table',
+  },
+};


### PR DESCRIPTION
Fixes a bug where we weren't hardcoding the width when appropriate on table header cells. This was causing content overflow issues.

Also added a story for testing the scroll override feature of the renderer API