### PR TITLE
Fix a broken order_by/group_by interaction

### DIFF
--- a/packages/malloy/src/lang/ast/query-items/field-declaration.ts
+++ b/packages/malloy/src/lang/ast/query-items/field-declaration.ts
@@ -270,8 +270,15 @@ export class FieldDefinitionValue extends SpaceField {
   // A source will call this when it defines the field
   private defInSource?: FieldDef;
   fieldDef(): FieldDef {
+    // Checking `defInQuery` is necessary to support a case where a field needs
+    // to be looked up from the output space (ex: in `order_by: a`), but where
+    // the field is defined in a group_by expression (ex: `group_by: a.day`).
+    // In this case, this.exprDef.fieldDef() only ever returns an
+    // AtomicFieldDef anyways, so it is safe in this particular implementation.
     const def =
-      this.defInSource ?? this.exprDef.fieldDef(this.space, this.name);
+      this.defInSource ??
+      this.defInQuery ??
+      this.exprDef.fieldDef(this.space, this.name);
     this.defInSource = def;
     return def;
   }

--- a/packages/malloy/src/lang/test/query.spec.ts
+++ b/packages/malloy/src/lang/test/query.spec.ts
@@ -522,6 +522,22 @@ describe('query:', () => {
           }
         `).toTranslate();
       });
+      test('use a calculate on a self-named group_by', () => {
+        expect(`
+        run: a -> {
+          group_by: ai is round(ai)
+          calculate: lats is lag(ai)
+        }
+      `).toTranslate();
+      });
+      test('use a having on a self-named aggregate', () => {
+        expect(`
+        run: a -> {
+          aggregate: ai is round(ai.sum())
+          having: ai > 0
+        }
+      `).toTranslate();
+      });
     });
   });
   describe('function typechecking', () => {

--- a/packages/malloy/src/lang/test/query.spec.ts
+++ b/packages/malloy/src/lang/test/query.spec.ts
@@ -514,6 +514,14 @@ describe('query:', () => {
           order_by: c
         }`).toTranslate();
       });
+      test('can order by a date grouped by timeframe', () => {
+        expect(`
+          run: a -> {
+            group_by: ats.day
+            order_by: ats
+          }
+        `).toTranslate();
+      });
     });
   });
   describe('function typechecking', () => {


### PR DESCRIPTION
Currently, if you write a query like this, it leads to an error: `Circular reference to 'dep_time' in definition`

```
run: flights -> {
  group_by: dep_time.day
  order_by: dep_time
}
```

Fix the field lookup to properly resolve the `dep_time` that was already defined in the query, rather than trying to re-create it in the output space, which ends up referencing itself by mistake.