### PR TITLE
Don't double-process compiler needs

### DIFF
--- a/packages/malloy/src/api/core.ts
+++ b/packages/malloy/src/api/core.ts
@@ -296,14 +296,12 @@ export function updateCompileModelState(
 function _newCompileModelState(
   modelURL: string,
   compilerNeeds?: Malloy.CompilerNeeds,
+  parseUpdate?: ParseUpdate | undefined,
   extendURL?: string,
   excludeReferences = false
 ): CompileModelState {
-  const translator = new MalloyTranslator(
-    modelURL,
-    null,
-    compilerNeedsToUpdate(compilerNeeds)
-  );
+  parseUpdate ??= compilerNeedsToUpdate(compilerNeeds);
+  const translator = new MalloyTranslator(modelURL, null, parseUpdate);
   const hasSource =
     (compilerNeeds?.files?.some(f => f.url === modelURL) ?? false) ||
     (compilerNeeds?.translations?.some(t => t.url === modelURL) ?? false);
@@ -312,6 +310,7 @@ function _newCompileModelState(
       extending: _newCompileModelState(
         extendURL,
         compilerNeeds,
+        parseUpdate,
         undefined,
         excludeReferences
       ),
@@ -336,6 +335,7 @@ export function newCompileModelState(
   return _newCompileModelState(
     request.model_url,
     request.compiler_needs,
+    undefined,
     request.extend_model_url,
     request.exclude_references
   );
@@ -347,6 +347,7 @@ export function newCompileSourceState(
   return _newCompileModelState(
     request.model_url,
     request.compiler_needs,
+    undefined,
     request.extend_model_url,
     request.exclude_references
   );
@@ -568,6 +569,7 @@ export function newCompileQueryState(
     ..._newCompileModelState(
       queryURL,
       needs,
+      undefined,
       request.model_url,
       request.exclude_references
     ),


### PR DESCRIPTION
When compiling a query, we would take the `compiler_needs` and convert them into a `ParseUpdate` to pass to the translator, but we did that twice; once to pass to the translator responsible for compiling the model (or loading it from the cached JSON) and once for the translator responsible for compiling the query. Since parsing a JSON model is slow, doing this once and passing the resulting `ParseUpdate` saves a lot of time.

In my testing, this reduces compilation time of a query against a complex cube model from 40.78ms to 20.14ms (20.64ms or a 51% reduction in compilation time).