### PR TITLE
Experimental partition composites

### DIFF
--- a/packages/malloy/src/lang/ast/statements/define-source.ts
+++ b/packages/malloy/src/lang/ast/statements/define-source.ts
@@ -22,7 +22,6 @@
  */
 
 import type {Annotation, StructDef} from '../../../model/malloy_types';
-
 import {ErrorFactory} from '../error-factory';
 import type {HasParameter} from '../parameters/has-parameter';
 import type {DocStatement, Document} from '../types/malloy-element';
@@ -30,6 +29,7 @@ import {MalloyElement, DocStatementList} from '../types/malloy-element';
 import type {Noteable} from '../types/noteable';
 import {extendNoteMethod} from '../types/noteable';
 import type {SourceQueryElement} from '../source-query-elements/source-query-element';
+import {getPartitionCompositeDesc} from '../../../model/composite_source_utils';
 
 export class DefineSource
   extends MalloyElement
@@ -60,29 +60,35 @@ export class DefineSource
         'source-definition-name-conflict',
         `Cannot redefine '${this.name}'`
       );
-    } else {
-      const theSource = this.sourceExpr?.getSource();
-      if (theSource === undefined) {
-        return;
-      }
-      const parameters = this.deduplicatedParameters();
-      const structDef = theSource.withParameters(undefined, this.parameters);
-      this.validateParameterShadowing(parameters, structDef);
-      if (ErrorFactory.didCreate(structDef)) {
-        return;
-      }
-      const entry: StructDef = {
-        ...structDef,
-        as: this.name,
-        location: this.location,
-      };
-      if (this.note) {
-        entry.annotation = structDef.annotation
-          ? {...this.note, inherits: structDef.annotation}
-          : this.note;
-      }
-      doc.setEntry(this.name, {entry, exported: this.exported});
+      return;
     }
+    const theSource = this.sourceExpr?.getSource();
+    if (theSource === undefined) {
+      return;
+    }
+    const parameters = this.deduplicatedParameters();
+    const structDef = theSource.withParameters(undefined, this.parameters);
+    this.validateParameterShadowing(parameters, structDef);
+    if (ErrorFactory.didCreate(structDef)) {
+      return;
+    }
+    const entry: StructDef = {
+      ...structDef,
+      as: this.name,
+      location: this.location,
+    };
+    if (this.note) {
+      entry.annotation = structDef.annotation
+        ? {...this.note, inherits: structDef.annotation}
+        : this.note;
+    }
+    entry.partitionComposite =
+      getPartitionCompositeDesc(
+        this.note,
+        structDef,
+        this.sourceExpr ?? this
+      ) ?? structDef.partitionComposite;
+    doc.setEntry(this.name, {entry, exported: this.exported});
   }
 
   private deduplicatedParameters(): HasParameter[] {

--- a/packages/malloy/src/lang/parse-log.ts
+++ b/packages/malloy/src/lang/parse-log.ts
@@ -420,6 +420,7 @@ type MessageParameterTypes = {
   'grouped-by-not-found': string;
   'non-scalar-grouped-by': string;
   'missing-required-group-by': string;
+  'invalid-partition-composite': string;
 };
 
 export const MESSAGE_FORMATTERS: PartialErrorCodeMessageMap = {

--- a/packages/malloy/src/lang/test/composite-field-usage.spec.ts
+++ b/packages/malloy/src/lang/test/composite-field-usage.spec.ts
@@ -541,13 +541,13 @@ describe('composite sources', () => {
   describe('partition composites', () => {
     test('basic okay', () => {
       expect(`
-        #! experimental { partition_composite { partition_field=astr partitions=[{id=ai fields=[ai]}] } }
+        #! experimental { partition_composite { partition_field=astr partitions={ai={ai}} } }
         source: a_partition is a
       `).toTranslate();
     });
     test('can use field from extension not mentioned in partition spec', () => {
       expect(`
-        #! experimental { partition_composite { partition_field=astr partitions=[{id=ai fields=[ai]}] } }
+        #! experimental { partition_composite { partition_field=astr partitions={ai={ai}} } }
         source: a_partition is a
 
         source: a_partition_ext is a_partition extend {
@@ -559,7 +559,7 @@ describe('composite sources', () => {
     });
     test('weird field names', () => {
       expect(`
-        #! experimental { partition_composite { partition_field=astr partitions=[{id="colon::foo" fields=["colon::foo"]},{id="plus+" fields=["plus+"]}, {id="Weird Name" fields=["Weird Name"]}, {id=source fields=[source]}, {id=dollarbill$ fields=[dollarbill$]}] } }
+        #! experimental { partition_composite { partition_field=astr partitions={"colon::foo"={"colon::foo"} "plus+"={"plus+"} "Weird Name"={"Weird Name"} source={source} dollarbill$={dollarbill$}} } }
         source: a_partition is a extend {
           dimension: \`Weird Name\` is 1
           dimension: \`source\` is 1
@@ -571,7 +571,7 @@ describe('composite sources', () => {
     });
     test('missing partition field', () => {
       expect(`
-        #! experimental { partition_composite { partitions=[{id=ai fields=[ai]}] } }
+        #! experimental { partition_composite { partitions={ai={ai}} } }
         source: a_partition is a
       `).toLog(
         errorMessage('Partition composite must specify `partition_field`')
@@ -583,30 +583,10 @@ describe('composite sources', () => {
         source: a_partition is a
       `).toLog(errorMessage('Partition composite must specify `partitions`'));
     });
-    test('missing partition id', () => {
-      expect(`
-        #! experimental { partition_composite { partition_field=astr partitions=[{fields=[ai]}] }
-        source: a_partition is a
-      `).toLog(
-        errorMessage(
-          'Must specify `id` for each partition of a partition composite'
-        )
-      );
-    });
-    test('missing partition fields', () => {
-      expect(`
-        #! experimental { partition_composite { partition_field=astr partitions=[{id=ai}] }
-        source: a_partition is a
-      `).toLog(
-        errorMessage(
-          'Must specify `fields` array for each partition of a partition composite'
-        )
-      );
-    });
-    test('missing partition fields', () => {
+    test('already composite', () => {
       expect(`
         ##! experimental.composite_sources
-        #! experimental { partition_composite { partition_field=astr partitions=[{id=ai fields=[ai]}] } }
+        #! experimental { partition_composite { partition_field=astr partitions={ai={ai}} } }
         source: a_partition is compose(a, a)
       `).toLog(
         errorMessage(
@@ -616,7 +596,7 @@ describe('composite sources', () => {
     });
     test('cannot resolve partition composite', () => {
       expect(`
-        #! experimental { partition_composite { partition_field=astr partitions=[{id=ai fields=[ai]}] } }
+        #! experimental { partition_composite { partition_field=astr partitions={ai={ai}} } }
         source: a_partition is a
 
         run: a_partition -> { group_by: ${'af'} }

--- a/packages/malloy/src/lang/test/composite-field-usage.spec.ts
+++ b/packages/malloy/src/lang/test/composite-field-usage.spec.ts
@@ -559,11 +559,13 @@ describe('composite sources', () => {
     });
     test('weird field names', () => {
       expect(`
-        #! experimental { partition_composite { partition_field=astr partitions=[{id="Weird Name" fields=["Weird Name"]}, {id=source fields=[source]}, {id=dollarbill$ fields=[dollarbill$]}] } }
+        #! experimental { partition_composite { partition_field=astr partitions=[{id="colon::foo" fields=["colon::foo"]},{id="plus+" fields=["plus+"]}, {id="Weird Name" fields=["Weird Name"]}, {id=source fields=[source]}, {id=dollarbill$ fields=[dollarbill$]}] } }
         source: a_partition is a extend {
           dimension: \`Weird Name\` is 1
           dimension: \`source\` is 1
           dimension: \`dollarbill$\` is 1
+          dimension: \`plus+\` is 1
+          dimension: \`colon::foo\` is 1
         }
       `).toTranslate();
     });

--- a/packages/malloy/src/lang/test/composite-field-usage.spec.ts
+++ b/packages/malloy/src/lang/test/composite-field-usage.spec.ts
@@ -538,4 +538,81 @@ describe('composite sources', () => {
       `).toTranslate();
     });
   });
+  describe('partition composites', () => {
+    test('basic okay', () => {
+      expect(`
+        #! experimental { partition_composite { partition_field=astr partitions=[{id=ai fields=[ai]}] } }
+        source: a_partition is a
+      `).toTranslate();
+    });
+    test('can use field from extension not mentioned in partition spec', () => {
+      expect(`
+        #! experimental { partition_composite { partition_field=astr partitions=[{id=ai fields=[ai]}] } }
+        source: a_partition is a
+
+        source: a_partition_ext is a_partition extend {
+          measure: ai_sum is ai.sum()
+        }
+
+        run: a_partition_ext -> { aggregate: ${'ai_sum'} }
+      `).toTranslate();
+    });
+    test('missing partition field', () => {
+      expect(`
+        #! experimental { partition_composite { partitions=[{id=ai fields=[ai]}] } }
+        source: a_partition is a
+      `).toLog(
+        errorMessage('Partition composite must specify `partition_field`')
+      );
+    });
+    test('missing partitions', () => {
+      expect(`
+        #! experimental { partition_composite { partition_field=astr } }
+        source: a_partition is a
+      `).toLog(errorMessage('Partition composite must specify `partitions`'));
+    });
+    test('missing partition id', () => {
+      expect(`
+        #! experimental { partition_composite { partition_field=astr partitions=[{fields=[ai]}] }
+        source: a_partition is a
+      `).toLog(
+        errorMessage(
+          'Must specify `id` for each partition of a partition composite'
+        )
+      );
+    });
+    test('missing partition fields', () => {
+      expect(`
+        #! experimental { partition_composite { partition_field=astr partitions=[{id=ai}] }
+        source: a_partition is a
+      `).toLog(
+        errorMessage(
+          'Must specify `fields` array for each partition of a partition composite'
+        )
+      );
+    });
+    test('missing partition fields', () => {
+      expect(`
+        ##! experimental.composite_sources
+        #! experimental { partition_composite { partition_field=astr partitions=[{id=ai fields=[ai]}] } }
+        source: a_partition is compose(a, a)
+      `).toLog(
+        errorMessage(
+          'Source is already composite; cannot apply partition composite'
+        )
+      );
+    });
+    test('cannot resolve partition composite', () => {
+      expect(`
+        #! experimental { partition_composite { partition_field=astr partitions=[{id=ai fields=[ai]}] } }
+        source: a_partition is a
+
+        run: a_partition -> { group_by: ${'af'} }
+      `).toLog(
+        errorMessage(
+          'This operation uses field `af`, resulting in invalid usage of the composite source, as there is no composite input source which defines all of `af` (fields required in source: `af`)'
+        )
+      );
+    });
+  });
 });

--- a/packages/malloy/src/lang/test/composite-field-usage.spec.ts
+++ b/packages/malloy/src/lang/test/composite-field-usage.spec.ts
@@ -557,6 +557,16 @@ describe('composite sources', () => {
         run: a_partition_ext -> { aggregate: ${'ai_sum'} }
       `).toTranslate();
     });
+    test('weird field names', () => {
+      expect(`
+        #! experimental { partition_composite { partition_field=astr partitions=[{id="Weird Name" fields=["Weird Name"]}, {id=source fields=[source]}, {id=dollarbill$ fields=[dollarbill$]}] } }
+        source: a_partition is a extend {
+          dimension: \`Weird Name\` is 1
+          dimension: \`source\` is 1
+          dimension: \`dollarbill$\` is 1
+        }
+      `).toTranslate();
+    });
     test('missing partition field', () => {
       expect(`
         #! experimental { partition_composite { partitions=[{id=ai fields=[ai]}] } }

--- a/packages/malloy/src/model/composite_source_utils.ts
+++ b/packages/malloy/src/model/composite_source_utils.ts
@@ -489,7 +489,7 @@ export function getPartitionCompositeDesc(
     return undefined;
   }
   const partitionField = partitionCompositeTag.text('partition_field');
-  const partitionTags = partitionCompositeTag.array('partitions');
+  const partitionsTag = partitionCompositeTag.tag('partitions');
   if (partitionField === undefined) {
     logTo.logError(
       'invalid-partition-composite',
@@ -497,7 +497,7 @@ export function getPartitionCompositeDesc(
     );
     return undefined;
   }
-  if (partitionTags === undefined) {
+  if (partitionsTag === undefined) {
     logTo.logError(
       'invalid-partition-composite',
       'Partition composite must specify `partitions`'
@@ -506,23 +506,17 @@ export function getPartitionCompositeDesc(
   }
   const partitions: {id: string; fields: string[]}[] = [];
   const allFields = new Set<string>();
-  for (const partitionTag of partitionTags) {
-    const id = partitionTag.text('id');
-    const fields = partitionTag.textArray('fields');
-    if (id === undefined) {
+  const ids = Object.keys(partitionsTag.getProperties());
+  for (const id of ids) {
+    const partitionTag = partitionsTag.tag(id);
+    if (partitionTag === undefined) {
       logTo.logError(
         'invalid-partition-composite',
-        'Must specify `id` for each partition of a partition composite'
+        `Invalid partition specification for \`${id}\`; must be a tag with property \\fields\``
       );
       return undefined;
     }
-    if (fields === undefined) {
-      logTo.logError(
-        'invalid-partition-composite',
-        'Must specify `fields` array for each partition of a partition composite'
-      );
-      return undefined;
-    }
+    const fields = Object.keys(partitionsTag.getProperties());
     allFields.forEach(f => allFields.add(f));
     partitions.push({id, fields});
   }

--- a/packages/malloy/src/model/malloy_types.ts
+++ b/packages/malloy/src/model/malloy_types.ts
@@ -1181,6 +1181,12 @@ interface StructDefBase extends HasLocation, NamedObject {
   fields: FieldDef[];
 }
 
+export interface PartitionCompositeDesc {
+  partitionField: string;
+  partitions: {id: string; fields: string[]}[];
+  compositeFields: string[];
+}
+
 interface SourceDefBase extends StructDefBase, Filtered, ResultStructMetadata {
   arguments?: Record<string, Argument>;
   parameters?: Record<string, Parameter>;
@@ -1188,6 +1194,7 @@ interface SourceDefBase extends StructDefBase, Filtered, ResultStructMetadata {
   connection: string;
   primaryKey?: PrimaryKeyRef;
   dialect: string;
+  partitionComposite?: PartitionCompositeDesc;
 }
 /** which field is the primary key in this struct */
 export type PrimaryKeyRef = string;

--- a/test/src/databases/all/composite_sources.spec.ts
+++ b/test/src/databases/all/composite_sources.spec.ts
@@ -592,7 +592,7 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
 
         source: comp is compose(
           part_comp,
-          ${databaseName}.sql('SELECT 10 AS ${id('c')})
+          ${databaseName}.sql('SELECT 10 AS ${id('c')}')
         )
 
         run: comp -> {

--- a/test/src/databases/all/composite_sources.spec.ts
+++ b/test/src/databases/all/composite_sources.spec.ts
@@ -544,12 +544,12 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
   describe('partition composites', () => {
     test('partition composite basic', async () => {
       await expect(`
-        #! experimental { partition_composite { partition_field=partition partitions=[{id=a fields=[a]}, {id=b fields=[b]}] } }
+        #! experimental { partition_composite { partition_field=partn partitions=[{id=a fields=[a]}, {id=b fields=[b]}] } }
         source: comp is ${databaseName}.sql("""
-                    SELECT 10 as a, 0 as b, 'a' as partition
-          UNION ALL SELECT 20 as a, 0 as b, 'a' as partition
-          UNION ALL SELECT 0  as a, 1 as b, 'b' as partition
-          UNION ALL SELECT 0  as a, 2 as b, 'b' as partition
+                    SELECT 10 as a, 0 as b, 'a' as partn
+          UNION ALL SELECT 20 as a, 0 as b, 'a' as partn
+          UNION ALL SELECT 0  as a, 1 as b, 'b' as partn
+          UNION ALL SELECT 0  as a, 2 as b, 'b' as partn
         """)
 
         run: comp -> {
@@ -560,12 +560,12 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
     });
     test('extended partition composite', async () => {
       await expect(`
-        #! experimental { partition_composite { partition_field=partition partitions=[{id=a fields=[a]}, {id=b fields=[b]}] } }
+        #! experimental { partition_composite { partition_field=partn partitions=[{id=a fields=[a]}, {id=b fields=[b]}] } }
         source: comp is ${databaseName}.sql("""
-                    SELECT 10 as a, 0 as b, 'a' as partition
-          UNION ALL SELECT 20 as a, 0 as b, 'a' as partition
-          UNION ALL SELECT 0  as a, 1 as b, 'b' as partition
-          UNION ALL SELECT 0  as a, 2 as b, 'b' as partition
+                    SELECT 10 as a, 0 as b, 'a' as partn
+          UNION ALL SELECT 20 as a, 0 as b, 'a' as partn
+          UNION ALL SELECT 0  as a, 1 as b, 'b' as partn
+          UNION ALL SELECT 0  as a, 2 as b, 'b' as partn
         """)
 
         source: comp_ext is comp extend {
@@ -581,12 +581,12 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
     test('partition composite nested in composite', async () => {
       await expect(`
         ##! experimental.composite_sources
-        #! experimental { partition_composite { partition_field=partition partitions=[{id=a fields=[a]}, {id=b fields=[b]}] } }
+        #! experimental { partition_composite { partition_field=partn partitions=[{id=a fields=[a]}, {id=b fields=[b]}] } }
         source: part_comp is ${databaseName}.sql("""
-                    SELECT 10 as a, 0 as b, 'a' as partition
-          UNION ALL SELECT 20 as a, 0 as b, 'a' as partition
-          UNION ALL SELECT 0  as a, 1 as b, 'b' as partition
-          UNION ALL SELECT 0  as a, 2 as b, 'b' as partition
+                    SELECT 10 as a, 0 as b, 'a' as partn
+          UNION ALL SELECT 20 as a, 0 as b, 'a' as partn
+          UNION ALL SELECT 0  as a, 1 as b, 'b' as partn
+          UNION ALL SELECT 0  as a, 2 as b, 'b' as partn
         """)
 
         source: comp is compose(

--- a/test/src/databases/all/composite_sources.spec.ts
+++ b/test/src/databases/all/composite_sources.spec.ts
@@ -592,7 +592,7 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
 
         source: comp is compose(
           part_comp,
-          ${databaseName}.sql("""SELECT 10 AS ${id('c')}""")
+          ${databaseName}.sql('SELECT 10 AS ${id('c')})
         )
 
         run: comp -> {

--- a/test/src/databases/all/composite_sources.spec.ts
+++ b/test/src/databases/all/composite_sources.spec.ts
@@ -545,7 +545,7 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
     const id = (n: string) => (databaseName === 'snowflake' ? `"${n}"` : n);
     test('partition composite basic', async () => {
       await expect(`
-        #! experimental { partition_composite { partition_field=p partitions=[{id=a fields=[a]}, {id=b fields=[b]}] } }
+        #! experimental { partition_composite { partition_field=p partitions={a={a} b={b}} } }
         source: comp is ${databaseName}.sql("""
                     SELECT 10 AS ${id('a')}, 0 AS ${id('b')}, 'a' AS ${id('p')}
           UNION ALL SELECT 20 AS ${id('a')}, 0 AS ${id('b')}, 'a' AS ${id('p')}
@@ -561,7 +561,7 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
     });
     test('extended partition composite', async () => {
       await expect(`
-        #! experimental { partition_composite { partition_field=p partitions=[{id=a fields=[a]}, {id=b fields=[b]}] } }
+        #! experimental { partition_composite { partition_field=p partitions={a={a} b={b}} } }
         source: comp is ${databaseName}.sql("""
                     SELECT 10 AS ${id('a')}, 0 AS ${id('b')}, 'a' AS ${id('p')}
           UNION ALL SELECT 20 AS ${id('a')}, 0 AS ${id('b')}, 'a' AS ${id('p')}
@@ -582,7 +582,7 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
     test('partition composite nested in composite', async () => {
       await expect(`
         ##! experimental.composite_sources
-        #! experimental { partition_composite { partition_field=p partitions=[{id=a fields=[a]}, {id=b fields=[b]}] } }
+        #! experimental { partition_composite { partition_field=p partitions={a={a} b={b}} } }
         source: part_comp is ${databaseName}.sql("""
                     SELECT 10 AS ${id('a')}, 0 AS ${id('b')}, 'a' AS ${id('p')}
           UNION ALL SELECT 20 AS ${id('a')}, 0 AS ${id('b')}, 'a' AS ${id('p')}

--- a/test/src/databases/all/composite_sources.spec.ts
+++ b/test/src/databases/all/composite_sources.spec.ts
@@ -592,7 +592,7 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
 
         source: comp is compose(
           part_comp,
-          ${databaseName}.sql("SELECT 10 AS ${id('c')}")
+          ${databaseName}.sql("""SELECT 10 AS ${id('c')}""")
         )
 
         run: comp -> {

--- a/test/src/databases/all/composite_sources.spec.ts
+++ b/test/src/databases/all/composite_sources.spec.ts
@@ -275,7 +275,7 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
         ),
         state_facts extend { dimension: foo is 1.3, bar is 2.3, baz is 3.3 }
       )
-      // even though the first composite has all the fields foo, bar, baz; it is impossible
+      // even though the first composite hAS all the fields foo, bar, baz; it is impossible
       // to resolve it using the first composite, because you can't have both bar and baz
       // so the second input source is used instead
       run: x -> { group_by: foo, bar, baz }
@@ -542,14 +542,15 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
     `).malloyResultMatches(runtime, {x: 'b1'});
   });
   describe('partition composites', () => {
+    const id = (n: string) => (databaseName === 'snowflake' ? `"${n}"` : n);
     test('partition composite basic', async () => {
       await expect(`
-        #! experimental { partition_composite { partition_field=partn partitions=[{id=a fields=[a]}, {id=b fields=[b]}] } }
+        #! experimental { partition_composite { partition_field=p partitions=[{id=a fields=[a]}, {id=b fields=[b]}] } }
         source: comp is ${databaseName}.sql("""
-                    SELECT 10 as a, 0 as b, 'a' as partn
-          UNION ALL SELECT 20 as a, 0 as b, 'a' as partn
-          UNION ALL SELECT 0  as a, 1 as b, 'b' as partn
-          UNION ALL SELECT 0  as a, 2 as b, 'b' as partn
+                    SELECT 10 AS ${id('a')}, 0 AS ${id('b')}, 'a' AS ${id('p')}
+          UNION ALL SELECT 20 AS ${id('a')}, 0 AS ${id('b')}, 'a' AS ${id('p')}
+          UNION ALL SELECT 0  AS ${id('a')}, 1 AS ${id('b')}, 'b' AS ${id('p')}
+          UNION ALL SELECT 0  AS ${id('a')}, 2 AS ${id('b')}, 'b' AS ${id('p')}
         """)
 
         run: comp -> {
@@ -560,12 +561,12 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
     });
     test('extended partition composite', async () => {
       await expect(`
-        #! experimental { partition_composite { partition_field=partn partitions=[{id=a fields=[a]}, {id=b fields=[b]}] } }
+        #! experimental { partition_composite { partition_field=p partitions=[{id=a fields=[a]}, {id=b fields=[b]}] } }
         source: comp is ${databaseName}.sql("""
-                    SELECT 10 as a, 0 as b, 'a' as partn
-          UNION ALL SELECT 20 as a, 0 as b, 'a' as partn
-          UNION ALL SELECT 0  as a, 1 as b, 'b' as partn
-          UNION ALL SELECT 0  as a, 2 as b, 'b' as partn
+                    SELECT 10 AS ${id('a')}, 0 AS ${id('b')}, 'a' AS ${id('p')}
+          UNION ALL SELECT 20 AS ${id('a')}, 0 AS ${id('b')}, 'a' AS ${id('p')}
+          UNION ALL SELECT 0  AS ${id('a')}, 1 AS ${id('b')}, 'b' AS ${id('p')}
+          UNION ALL SELECT 0  AS ${id('a')}, 2 AS ${id('b')}, 'b' AS ${id('p')}
         """)
 
         source: comp_ext is comp extend {
@@ -581,17 +582,17 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
     test('partition composite nested in composite', async () => {
       await expect(`
         ##! experimental.composite_sources
-        #! experimental { partition_composite { partition_field=partn partitions=[{id=a fields=[a]}, {id=b fields=[b]}] } }
+        #! experimental { partition_composite { partition_field=p partitions=[{id=a fields=[a]}, {id=b fields=[b]}] } }
         source: part_comp is ${databaseName}.sql("""
-                    SELECT 10 as a, 0 as b, 'a' as partn
-          UNION ALL SELECT 20 as a, 0 as b, 'a' as partn
-          UNION ALL SELECT 0  as a, 1 as b, 'b' as partn
-          UNION ALL SELECT 0  as a, 2 as b, 'b' as partn
+                    SELECT 10 AS ${id('a')}, 0 AS ${id('b')}, 'a' AS ${id('p')}
+          UNION ALL SELECT 20 AS ${id('a')}, 0 AS ${id('b')}, 'a' AS ${id('p')}
+          UNION ALL SELECT 0  AS ${id('a')}, 1 AS ${id('b')}, 'b' AS ${id('p')}
+          UNION ALL SELECT 0  AS ${id('a')}, 2 AS ${id('b')}, 'b' AS ${id('p')}
         """)
 
         source: comp is compose(
           part_comp,
-          ${databaseName}.sql("SELECT 10 as c")
+          ${databaseName}.sql("SELECT 10 AS ${id('c')}")
         )
 
         run: comp -> {


### PR DESCRIPTION
One of the primary uses for composite sources is to handle partition selection of cubes stored as partition tables. This results in a pattern like:

```malloy
##! experimental.composite_sources
source: partition_a is connection.table('cube_table') include { a } extend {
  where: partition = 'a'
}
source: partition_b is connection.table('cube_table') include { b } extend {
  where: partition = 'b'
}
source: partition_c is connection.table('cube_table') include { c } extend {
  where: partition = 'c'
}
source: cube is compose(partition_a, partition_b, partition_c)
```

For large cubes, this can result in significantly bloated models, since each partition gets its own source definition complete with its own field list; then based on the (not yet optimized) way composite sources are stored in model IR, each of those sources' IR is duplicated in the composite source's IR. 

Larger models lead to significant cache speed degradation, both in terms of fetching the pre-compiled model from the cache as well as deserializing the model to load into the translator. 

Since this is such a common pattern, we are experimenting with a more IR-space-efficient feature for handling this type of case. 

```malloy
#! experimental { partition_composite { partition_field=partition partitions={a = {a} b = {b} c = {c}} } }
source: cube is connection.table('cube_table')
```

**Important Note: because this first version is using annotations, the partition specification applies to the whole `source:` definition, including extensions. If you want to extend a cube table without making the new fields part of the composite selection, you must do so in a separate `source:` definition.**

If the experiment proves valuable, we should design and implement actual Malloy syntax for this feature rather than relying on compiler annotations. This may be as simple as:

```malloy
##! experimental.partition_composites
source: cube is connection.table('cube_table') extend {
  partition_composite: {
    partition_by: partition
    partition: a is [a]
    partition: b is [b]
    partition: b is [b]
  }
}
```