### PR TITLE
Fix styling of single value dashboard cells

### DIFF
--- a/packages/malloy-render/src/component/dashboard/dashboard.css
+++ b/packages/malloy-render/src/component/dashboard/dashboard.css
@@ -59,6 +59,7 @@
   .dashboard-item-value {
     overflow: auto;
     text-align: left;
+    color: var(--malloy-render--table-body-color);
   }
 
   .dashboard-item-title {
@@ -70,6 +71,7 @@
 
   .dashboard-item-value-measure {
     font-size: 20px;
+    min-height: 1.1em; // Prevent scrollbar when one line
   }
 
   .dashboard-dimension-wrapper {


### PR DESCRIPTION
Fixes foreground color in single value cells when embedded in a contrasting theme, and removes the default scrollbar when the value is only one line.

Before:
<img width="289" height="100" alt="Screenshot 2025-08-15 at 4 24 49 PM" src="https://github.com/user-attachments/assets/bb91d9b9-13fa-48fa-8f41-4ac074c0ff6b" />

After:
<img width="280" height="111" alt="Screenshot 2025-08-15 at 4 11 45 PM" src="https://github.com/user-attachments/assets/607f60e1-1927-4b35-a8bf-95baba9cae1d" />

Argument could be made to make title bold and darker like it is in tables?
<img width="126" height="70" alt="Screenshot 2025-08-15 at 4 24 57 PM" src="https://github.com/user-attachments/assets/d7276626-3f85-4f70-ad6b-2c751ea21de1" />
