### PR TITLE
Fix parsing filter parameters

### DIFF
--- a/packages/malloy/src/lang/malloy-to-stable-query.ts
+++ b/packages/malloy/src/lang/malloy-to-stable-query.ts
@@ -901,6 +901,17 @@ export class MalloyToQuery
       return {kind: 'number_literal', number_value: n};
     } else if (literalCx instanceof parse.ExprNULLContext) {
       return {kind: 'null_literal'};
+    } else if (literalCx instanceof parse.FilterString_stubContext) {
+      const filterContext = literalCx.getChild(0);
+      if (filterContext instanceof parse.FilterStringContext) {
+        const filterString = this.getFilterString(filterContext);
+        if (filterString) {
+          return {
+            kind: 'filter_expression_literal',
+            filter_expression_value: filterString,
+          };
+        }
+      }
     }
     return null;
   }

--- a/packages/malloy/src/lang/test/malloy-to-stable-query.spec.ts
+++ b/packages/malloy/src/lang/test/malloy-to-stable-query.spec.ts
@@ -224,6 +224,33 @@ describe('Malloy to Stable Query', () => {
         logs: [],
       });
     });
+    test('filter parameter is passed properly', () => {
+      idempotent('run: a(p is f`foo`) -> by_carrier', {
+        query: {
+          definition: {
+            kind: 'arrow',
+            source: {
+              kind: 'source_reference',
+              name: 'a',
+              parameters: [
+                {
+                  name: 'p',
+                  value: {
+                    kind: 'filter_expression_literal',
+                    filter_expression_value: 'foo',
+                  },
+                },
+              ],
+            },
+            view: {
+              kind: 'view_reference',
+              name: 'by_carrier',
+            },
+          },
+        },
+        logs: [],
+      });
+    });
   });
   describe('drill', () => {
     test('drill clauses with all the literal types, as well as a filter string comparison', () => {


### PR DESCRIPTION
This fixes the case where the parser would silently fail when there were filter parameters, like:
```
run: a(b is f`c`) -> {}
```
I'm not certain of the implementation, it seems like with other contexts there are built in methods for this sort of thing, but this does address the issue.