### PR TITLE
Fix "@malloydata/render" types path

### DIFF
--- a/packages/malloy-render/package.json
+++ b/packages/malloy-render/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.307",
   "license": "MIT",
   "main": "dist/module/index.umd.js",
-  "types": "dist/index.d.ts",
+  "types": "dist/module/index.d.ts",
   "homepage": "https://github.com/malloydata/malloy#readme",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR fixes a bug where `@malloydata/render` types couldn't be resolved.

## Before
<img width="1505" height="323" alt="image" src="https://github.com/user-attachments/assets/c14d4dfc-df5c-49ed-83e3-3d2375f97657" />


## After
<img width="1500" height="452" alt="image" src="https://github.com/user-attachments/assets/f6e1b345-32c8-4386-ba7a-dad49066c5f3" />
