### PR TITLE
fix: Top level run statement Annotation parsing

### DIFF
--- a/packages/malloy/src/lang/malloy-to-stable-query.ts
+++ b/packages/malloy/src/lang/malloy-to-stable-query.ts
@@ -105,12 +105,7 @@ export class MalloyToQuery
     cx: HasAnnotations
   ): Malloy.Annotation[] | undefined {
     const annotations = cx.ANNOTATION().map(a => {
-      // Strip trailing newline/EOF from annotation text but keep the '#' prefix
-      let value = a.text;
-      if (value.endsWith('\n')) {
-        value = value.slice(0, -1);
-      }
-      return {value};
+      return {value: a.text};
     });
     return annotations.length > 0 ? annotations : undefined;
   }

--- a/packages/malloy/src/lang/test/malloy-to-stable-query.spec.ts
+++ b/packages/malloy/src/lang/test/malloy-to-stable-query.spec.ts
@@ -355,7 +355,7 @@ describe('Malloy to Stable Query', () => {
                 ],
               },
             },
-            annotations: [{value: "# bar_chart"}],
+            annotations: [{value: "# bar_chart\n"}],
           },
           logs: [],
         }

--- a/packages/malloy/src/lang/test/malloy-to-stable-query.spec.ts
+++ b/packages/malloy/src/lang/test/malloy-to-stable-query.spec.ts
@@ -325,6 +325,43 @@ describe('Malloy to Stable Query', () => {
       });
     });
   });
+  describe('Render annotations', () => {
+    test('single render annotation', () => {
+      idempotent(
+        '# bar_chart\nrun: flights -> { group_by: carrier }',
+        {
+          query: {
+            definition: {
+              kind: 'arrow',
+              source: {
+                kind: 'source_reference',
+                name: 'flights',
+              },
+              view: {
+                kind: 'segment',
+                operations: [
+                  {
+                    'field': {
+                      'annotations': undefined,
+                      'expression': {
+                        'kind': 'field_reference',
+                        'name': 'carrier',
+                        'path': undefined,
+                      },
+                    },
+                    'kind': 'group_by',
+                    'name': undefined,
+                  },
+                ],
+              },
+            },
+            annotations: [{value: "# bar_chart"}],
+          },
+          logs: [],
+        }
+      );
+    });
+  });
 });
 
 function idempotent(query: string, expected?: QueryAndLogs) {


### PR DESCRIPTION
Fixes the function malloyToQuery, originally created in https://github.com/malloydata/malloy/pull/2181

