### PR TITLE
write nested joins as 1=1 with where

### DIFF
--- a/packages/malloy/src/lang/ast/source-properties/join.ts
+++ b/packages/malloy/src/lang/ast/source-properties/join.ts
@@ -206,7 +206,7 @@ export class ExpressionJoin extends Join {
     // This allows the dependency system to track which field references come from ON conditions
     inStruct.fieldUsage = exprX.fieldUsage?.map(usage => ({
       ...usage,
-      fromOnExpression: true
+      fromOnExpression: true,
     }));
   }
 

--- a/packages/malloy/src/lang/ast/source-properties/join.ts
+++ b/packages/malloy/src/lang/ast/source-properties/join.ts
@@ -202,7 +202,12 @@ export class ExpressionJoin extends Join {
       return;
     }
     inStruct.onExpression = exprX.value;
-    inStruct.fieldUsage = exprX.fieldUsage;
+    // [REVIEW] Mark all field usage from JOIN ON expressions with fromOnExpression=true
+    // This allows the dependency system to track which field references come from ON conditions
+    inStruct.fieldUsage = exprX.fieldUsage?.map(usage => ({
+      ...usage,
+      fromOnExpression: true
+    }));
   }
 
   getStructDef(parameterSpace: ParameterSpace): JoinFieldDef {

--- a/packages/malloy/src/lang/composite-source-utils.ts
+++ b/packages/malloy/src/lang/composite-source-utils.ts
@@ -453,7 +453,7 @@ function findActiveJoins(
     if (dep) {
       sorted.push({
         path: dep.path,
-        onReferencesChildren: dep.onReferencesChildren
+        onReferencesChildren: dep.onReferencesChildren,
       });
     }
   };
@@ -575,12 +575,15 @@ function expandFieldUsage(
           }
 
           // Check if this join's ON expression references nested source joins
-          if (usage.fromOnExpression && usage.path.length > joinPath.length + 1) {
+          if (
+            usage.fromOnExpression &&
+            usage.path.length > joinPath.length + 1
+          ) {
             const nestedPath = usage.path.slice(0, joinPath.length + 1);
             const nestedDef = inNamespace(nestedPath, fieldNameSpace);
-              if (nestedDef && isSourceDef(nestedDef)) {
-                thisDep.onReferencesChildren = true;
-              }
+            if (nestedDef && isSourceDef(nestedDef)) {
+              thisDep.onReferencesChildren = true;
+            }
           }
 
           // Track join-to-join dependencies
@@ -594,10 +597,13 @@ function expandFieldUsage(
             thisDep.dependsOn.add(dependencyKey);
           }
         }
-        
+
         // After processing all field usage, check for nested references in the seen map
         for (const seenUsage of Object.values(seen)) {
-          if (seenUsage.fromOnExpression && seenUsage.path.length > joinPath.length + 1) {
+          if (
+            seenUsage.fromOnExpression &&
+            seenUsage.path.length > joinPath.length + 1
+          ) {
             // Check if this path goes through the current join
             if (pathBegins(seenUsage.path, joinPath)) {
               const nestedPath = seenUsage.path.slice(0, joinPath.length + 1);

--- a/packages/malloy/src/lang/composite-source-utils.ts
+++ b/packages/malloy/src/lang/composite-source-utils.ts
@@ -31,6 +31,7 @@ import type {
   PartitionCompositeDesc,
   FilterCondition,
   StructDef,
+  ActiveJoin,
 } from '../model/malloy_types';
 import {
   expressionIsScalar,
@@ -410,6 +411,7 @@ interface JoinDependency {
   path: string[];
   dependsOn: Set<string>;
   checked?: boolean;
+  onReferencesChildren?: boolean;
 }
 
 function getJoin(
@@ -425,8 +427,8 @@ function getJoin(
 
 function findActiveJoins(
   dependencies: Record<string, JoinDependency>
-): FieldUsage[] {
-  const sorted: FieldUsage[] = [];
+): ActiveJoin[] {
+  const sorted: ActiveJoin[] = [];
   const visited = new Set<string>();
   const visiting = new Set<string>();
 
@@ -449,7 +451,10 @@ function findActiveJoins(
 
     // Add this join's path to the sorted list after its dependencies
     if (dep) {
-      sorted.push({path: dep.path});
+      sorted.push({
+        path: dep.path,
+        onReferencesChildren: dep.onReferencesChildren
+      });
     }
   };
 
@@ -476,7 +481,7 @@ function expandFieldUsage(
 ): {
   result: FieldUsage[];
   missingFields: FieldUsage[];
-  activeJoins: FieldUsage[];
+  activeJoins: ActiveJoin[];
   ungroupings: AggregateUngrouping[];
 } {
   const seen: Record<string, FieldUsage> = {};
@@ -484,6 +489,21 @@ function expandFieldUsage(
   const toProcess: FieldUsage[] = [];
   const activeJoinGraph: Record<string, JoinDependency> = {};
   const ungroupings: AggregateUngrouping[] = [];
+  // Track field dependencies: childFieldKey -> parentFieldKey
+  const fieldDependencies: Record<string, string> = {};
+
+  // Helper function to propagate fromOnExpression updates through dependency tree
+  const propagateFromOnExpression = (fieldKey: string, value: boolean) => {
+    if (seen[fieldKey] && !seen[fieldKey].fromOnExpression && value) {
+      seen[fieldKey].fromOnExpression = true;
+      // Recursively propagate to all fields that depend on this one
+      for (const [childKey, parentKey] of Object.entries(fieldDependencies)) {
+        if (parentKey === fieldKey) {
+          propagateFromOnExpression(childKey, true);
+        }
+      }
+    }
+  };
 
   // Initialize: mark original inputs and add them to processing queue
   for (const usage of fieldUsage) {
@@ -511,8 +531,11 @@ function expandFieldUsage(
       for (const usage of joinedFieldUsage(refPath, fieldUsage)) {
         const key = pathToKey('field', usage.path);
         if (!seen[key]) {
-          seen[key] = usage;
+          seen[key] = {...usage, fromOnExpression: reference.fromOnExpression};
           toProcess.push(usage);
+          // Record that this field was added because of the reference field
+          const parentKey = pathToKey('field', reference.path);
+          fieldDependencies[key] = parentKey;
         } else if (usage.uniqueKeyRequirement) {
           seen[key].uniqueKeyRequirement = {
             isCount:
@@ -546,6 +569,18 @@ function expandFieldUsage(
           if (!seen[key]) {
             seen[key] = usage;
             toProcess.push(usage);
+          } else if (usage.fromOnExpression && !seen[key].fromOnExpression) {
+            // Update existing entry and propagate to dependencies
+            propagateFromOnExpression(key, true);
+          }
+
+          // Check if this join's ON expression references nested source joins
+          if (usage.fromOnExpression && usage.path.length > joinPath.length + 1) {
+            const nestedPath = usage.path.slice(0, joinPath.length + 1);
+            const nestedDef = inNamespace(nestedPath, fieldNameSpace);
+              if (nestedDef && isSourceDef(nestedDef)) {
+                thisDep.onReferencesChildren = true;
+              }
           }
 
           // Track join-to-join dependencies
@@ -557,6 +592,21 @@ function expandFieldUsage(
             const dependencyKey = pathToKey('join', dependencyPath);
             getJoin(activeJoinGraph, dependencyKey, dependencyPath);
             thisDep.dependsOn.add(dependencyKey);
+          }
+        }
+        
+        // After processing all field usage, check for nested references in the seen map
+        for (const seenUsage of Object.values(seen)) {
+          if (seenUsage.fromOnExpression && seenUsage.path.length > joinPath.length + 1) {
+            // Check if this path goes through the current join
+            if (pathBegins(seenUsage.path, joinPath)) {
+              const nestedPath = seenUsage.path.slice(0, joinPath.length + 1);
+              const nestedDef = inNamespace(nestedPath, fieldNameSpace);
+              if (nestedDef && isSourceDef(nestedDef)) {
+                thisDep.onReferencesChildren = true;
+                break; // Only need to set it once
+              }
+            }
           }
         }
       }

--- a/packages/malloy/src/model/field_instance.ts
+++ b/packages/malloy/src/model/field_instance.ts
@@ -458,7 +458,8 @@ export class FieldInstanceResult implements FieldInstance {
 
   addStructToJoin(
     qs: QueryStruct,
-    uniqueKeyRequirement: UniqueKeyRequirement
+    uniqueKeyRequirement: UniqueKeyRequirement,
+    onReferencesChildren?: boolean
   ): void {
     const name = qs.getIdentifier();
 
@@ -482,6 +483,9 @@ export class FieldInstanceResult implements FieldInstance {
 
     if (!(join = this.root().joins.get(name))) {
       join = new JoinInstance(qs, name, parent);
+      if (onReferencesChildren) {
+        join.onReferencesChildren = true;
+      }
       this.root().joins.set(name, join);
     }
     join.uniqueKeyRequirement = mergeUniqueKeyRequirement(

--- a/packages/malloy/src/model/join_instance.ts
+++ b/packages/malloy/src/model/join_instance.ts
@@ -15,6 +15,9 @@ export class JoinInstance {
   uniqueKeyRequirement?: UniqueKeyRequirement;
   makeUniqueKey = false;
   leafiest = false;
+  // [REVIEW] Flag indicating this join's ON expression references nested joins
+  // Used by SQL generation to determine when to rewrite ON conditions  
+  onReferencesChildren?: boolean;
   joinFilterConditions?: QueryFieldBoolean[];
   children: JoinInstance[] = [];
   constructor(

--- a/packages/malloy/src/model/join_instance.ts
+++ b/packages/malloy/src/model/join_instance.ts
@@ -16,7 +16,7 @@ export class JoinInstance {
   makeUniqueKey = false;
   leafiest = false;
   // [REVIEW] Flag indicating this join's ON expression references nested joins
-  // Used by SQL generation to determine when to rewrite ON conditions  
+  // Used by SQL generation to determine when to rewrite ON conditions
   onReferencesChildren?: boolean;
   joinFilterConditions?: QueryFieldBoolean[];
   children: JoinInstance[] = [];

--- a/packages/malloy/src/model/malloy_types.ts
+++ b/packages/malloy/src/model/malloy_types.ts
@@ -1180,7 +1180,7 @@ export type SegmentFieldDef = IndexFieldDef | QueryFieldDef;
  */
 
 export interface SegmentUsageSummary {
-  activeJoins?: FieldUsage[];
+  activeJoins?: ActiveJoin[];
   expandedFieldUsage?: FieldUsage[];
   expandedUngroupings?: AggregateUngrouping[];
 }
@@ -1205,6 +1205,16 @@ export interface FieldUsage {
   at?: DocumentLocation;
   uniqueKeyRequirement?: UniqueKeyRequirement;
   analyticFunctionUse?: boolean;
+  // [REVIEW] Added flag to track field usage originating from JOIN ON expressions
+  // This is essential for detecting when ON expressions reference nested joins
+  fromOnExpression?: boolean;
+}
+
+export interface ActiveJoin {
+  path: string[];
+  // [REVIEW] Added flag to indicate when a join's ON expression references nested joins
+  // When true, SQL generation will rewrite ON condition to 1=1 and move logic to WHERE clause
+  onReferencesChildren?: boolean;
 }
 
 export function bareFieldUsage(fu: FieldUsage): boolean {

--- a/packages/malloy/src/model/query_query.ts
+++ b/packages/malloy/src/model/query_query.ts
@@ -256,7 +256,11 @@ export class QueryQuery extends QueryField {
       node instanceof QueryFieldStruct
         ? node.queryStruct.getJoinableParent()
         : node.parent.getJoinableParent();
-    this.rootResult.addStructToJoin(joinableParent, uniqueKeyRequirement, onReferencesChildren);
+    this.rootResult.addStructToJoin(
+      joinableParent,
+      uniqueKeyRequirement,
+      onReferencesChildren
+    );
   }
 
   private dependenciesFromFieldUsage() {
@@ -270,7 +274,11 @@ export class QueryQuery extends QueryField {
     }
 
     for (const joinUsage of this.firstSegment.activeJoins || []) {
-      this.addDependantPath(joinUsage.path, undefined, joinUsage.onReferencesChildren);
+      this.addDependantPath(
+        joinUsage.path,
+        undefined,
+        joinUsage.onReferencesChildren
+      );
     }
     for (const usage of this.firstSegment.expandedFieldUsage || []) {
       if (usage.analyticFunctionUse) {

--- a/packages/malloy/src/model/query_query.ts
+++ b/packages/malloy/src/model/query_query.ts
@@ -248,14 +248,15 @@ export class QueryQuery extends QueryField {
 
   private addDependantPath(
     path: string[],
-    uniqueKeyRequirement: UniqueKeyRequirement
+    uniqueKeyRequirement: UniqueKeyRequirement,
+    onReferencesChildren?: boolean
   ) {
     const node = this.parent.getFieldByName(path);
     const joinableParent =
       node instanceof QueryFieldStruct
         ? node.queryStruct.getJoinableParent()
         : node.parent.getJoinableParent();
-    this.rootResult.addStructToJoin(joinableParent, uniqueKeyRequirement);
+    this.rootResult.addStructToJoin(joinableParent, uniqueKeyRequirement, onReferencesChildren);
   }
 
   private dependenciesFromFieldUsage() {
@@ -269,7 +270,7 @@ export class QueryQuery extends QueryField {
     }
 
     for (const joinUsage of this.firstSegment.activeJoins || []) {
-      this.addDependantPath(joinUsage.path, undefined);
+      this.addDependantPath(joinUsage.path, undefined, joinUsage.onReferencesChildren);
     }
     for (const usage of this.firstSegment.expandedFieldUsage || []) {
       if (usage.analyticFunctionUse) {
@@ -857,22 +858,45 @@ export class QueryQuery extends QueryField {
         throw new Error('Expected joined struct to have a parent.');
       }
       if (qsDef.onExpression) {
-        // Create a temporary field instance to generate the SQL
-        const boolField = new QueryFieldBoolean(
-          {
-            type: 'boolean',
-            name: 'ignoreme',
-            e: qsDef.onExpression,
-          },
-          qs.parent
-        );
-        const tempInstance = new FieldInstanceField(
-          boolField,
-          {type: 'where'}, // It's used in a WHERE-like context
-          this.rootResult,
-          undefined
-        );
-        onCondition = tempInstance.generateExpression();
+        // If this join's ON references nested joins, move it to WHERE
+        if (ji.onReferencesChildren) {
+          // Add ON expression to filter conditions
+          const onAsFilter = new QueryFieldBoolean(
+            {
+              type: 'boolean',
+              name: 'ignoreme',
+              e: qsDef.onExpression,
+            },
+            qs.parent
+          );
+
+          // Add to existing filter conditions or create new array
+          if (ji.joinFilterConditions) {
+            ji.joinFilterConditions.push(onAsFilter);
+          } else {
+            ji.joinFilterConditions = [onAsFilter];
+          }
+
+          // Replace ON with 1=1
+          onCondition = '1=1';
+        } else {
+          // Normal ON expression handling (existing code)
+          const boolField = new QueryFieldBoolean(
+            {
+              type: 'boolean',
+              name: 'ignoreme',
+              e: qsDef.onExpression,
+            },
+            qs.parent
+          );
+          const tempInstance = new FieldInstanceField(
+            boolField,
+            {type: 'where'}, // It's used in a WHERE-like context
+            this.rootResult,
+            undefined
+          );
+          onCondition = tempInstance.generateExpression();
+        }
       } else {
         onCondition = '1=1';
       }

--- a/test/src/databases/all/join.spec.ts
+++ b/test/src/databases/all/join.spec.ts
@@ -24,6 +24,7 @@
 /* eslint-disable no-console */
 
 import {RuntimeList, allDatabases} from '../../runtimes';
+import {TestSelect} from '../../test-select';
 import {databasesFromEnvironmentOr} from '../../util';
 import '../../util/db-jest-matchers';
 
@@ -320,13 +321,17 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
   );
 
   test('join through join', async () => {
+    const ts = new TestSelect(runtime.dialect);
+    const usr = ts.generate({id: 1, email: 'email'});
+    const res = ts.generate({id: 1, user_id: 1});
+    const msg = ts.generate({id: 1, msg_email: 'email'});
     await expect(`
-      source: usr is ${databaseName}.sql("""select 1 as id, 'email' as email""")
-      source: res is ${databaseName}.sql("""select 1 as id, 1 as user_id""") extend {
+      source: usr is ${databaseName}.sql("""${usr}""")
+      source: res is ${databaseName}.sql("""${res}""") extend {
         join_one: usr is usr on usr.id = user_id
         dimension: usr_email is usr.email
       }
-      source: msg is ${databaseName}.sql("""select 1 as id, 'email' as msg_email""") extend {
+      source: msg is ${databaseName}.sql("""${msg}""") extend {
         join_many: res is res on msg_email = res.usr_email
       }
       run: msg -> {


### PR DESCRIPTION
ok there are four pieces to this

1) mark field usage from an on expression as coming from an on expression
2) when expanding field usage, propogate the on expression to all fields needed to satisfy the on expression
3) when building the active join list, look for joins with on expressions which go through another join and mark that
4) when generating joins, for marked joins, move the on expression to the filters and make the on expression be 1=1

the approach was suggested by lloyd
the hard parts of this were written by and and claude