### PR TITLE
Avoid non-string values in row[4] of the presto/trino response

### DIFF
--- a/packages/malloy-db-trino/src/trino_connection.ts
+++ b/packages/malloy-db-trino/src/trino_connection.ts
@@ -383,7 +383,7 @@ export abstract class TrinoPrestoConnection
   structDefFromSchema(rows: string[][], structDef: StructDef): void {
     for (const row of rows) {
       const name = row[0];
-      const type = row[4] || row[1];
+      const type = row[4] && typeof row[4] === 'string' ? row[4] : row[1];
       const malloyType = mkFieldDef(this.malloyTypeFromTrinoType(type), name);
       structDef.fields.push(mkFieldDef(malloyType, name));
     }


### PR DESCRIPTION
Handle an issue where row[4] is `19` (meaning `<eof>`) rather than a type.

Only use that entry as a type when it is a string value as opposed to if it merely exists.