### PR TITLE
feat(db-snowflake): expose pool size knobs in connection registry

### DIFF
--- a/packages/malloy-db-snowflake/src/index.ts
+++ b/packages/malloy-db-snowflake/src/index.ts
@@ -22,11 +22,13 @@
  */
 
 export {SnowflakeConnection} from './snowflake_connection';
+export {buildPoolOptions} from './snowflake_pool_options';
 
 import {registerConnectionType} from '@malloydata/malloy';
 import type {ConnectionConfig} from '@malloydata/malloy';
 import type {ConnectionOptions} from 'snowflake-sdk';
 import {SnowflakeConnection} from './snowflake_connection';
+import {buildPoolOptions} from './snowflake_pool_options';
 
 registerConnectionType('snowflake', {
   displayName: 'Snowflake',
@@ -39,6 +41,9 @@ registerConnectionType('snowflake', {
       schemaSampleTimeoutMs,
       schemaSampleRowLimit,
       schemaSampleFullScanMaxBytes,
+      poolMin,
+      poolMax,
+      poolTestOnBorrow,
       ...props
     } = config;
     // ConnectionConfig values are trusted to match ConnectionOptions fields
@@ -74,6 +79,7 @@ registerConnectionType('snowflake', {
           : typeof schemaSampleFullScanMaxBytes === 'string'
             ? parseInt(schemaSampleFullScanMaxBytes, 10)
             : undefined,
+      poolOptions: buildPoolOptions({poolMin, poolMax, poolTestOnBorrow}),
     });
   },
   properties: [
@@ -155,6 +161,33 @@ registerConnectionType('snowflake', {
       type: 'text',
       optional: true,
       description: 'SQL statements to run when the connection is established',
+    },
+    {
+      name: 'poolMin',
+      displayName: 'Pool Min',
+      type: 'number',
+      optional: true,
+      advanced: true,
+      description:
+        'Minimum number of pooled snowflake-sdk connections kept warm. Defaults to 1.',
+    },
+    {
+      name: 'poolMax',
+      displayName: 'Pool Max',
+      type: 'number',
+      optional: true,
+      advanced: true,
+      description:
+        'Maximum number of pooled snowflake-sdk connections. Defaults to 1.',
+    },
+    {
+      name: 'poolTestOnBorrow',
+      displayName: 'Test On Borrow',
+      type: 'boolean',
+      optional: true,
+      advanced: true,
+      description:
+        'If true, the pool validates each connection when checked out. Defaults to true.',
     },
   ],
 });

--- a/packages/malloy-db-snowflake/src/snowflake_pool_options.spec.ts
+++ b/packages/malloy-db-snowflake/src/snowflake_pool_options.spec.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright Contributors to the Malloy project
+ * SPDX-License-Identifier: MIT
+ */
+
+import {buildPoolOptions} from './snowflake_pool_options';
+
+describe('buildPoolOptions', () => {
+  it('returns undefined when no pool fields are supplied', () => {
+    expect(buildPoolOptions({})).toBeUndefined();
+  });
+
+  it('forwards a single supplied field and leaves others absent', () => {
+    expect(buildPoolOptions({poolMax: 20})).toEqual({max: 20});
+  });
+
+  it('forwards all three fields when supplied', () => {
+    expect(
+      buildPoolOptions({poolMin: 2, poolMax: 20, poolTestOnBorrow: false})
+    ).toEqual({min: 2, max: 20, testOnBorrow: false});
+  });
+
+  it('treats poolTestOnBorrow: false as a real value, not a default', () => {
+    // false is falsy; guard against a `||` regression that would drop it.
+    expect(buildPoolOptions({poolTestOnBorrow: false})).toEqual({
+      testOnBorrow: false,
+    });
+  });
+
+  it('treats poolMin: 0 as a real value, not a default', () => {
+    // 0 is falsy; guard against a `||` regression that would drop it.
+    expect(buildPoolOptions({poolMin: 0})).toEqual({min: 0});
+  });
+
+  it('drops fields with the wrong type rather than coercing them', () => {
+    expect(
+      buildPoolOptions({
+        poolMin: '2',
+        poolMax: null,
+        poolTestOnBorrow: 'yes',
+      })
+    ).toBeUndefined();
+  });
+
+  it('keeps valid fields when other fields are wrong-typed', () => {
+    expect(
+      buildPoolOptions({
+        poolMin: 2,
+        poolMax: 'oops',
+      })
+    ).toEqual({min: 2});
+  });
+});

--- a/packages/malloy-db-snowflake/src/snowflake_pool_options.ts
+++ b/packages/malloy-db-snowflake/src/snowflake_pool_options.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Contributors to the Malloy project
+ * SPDX-License-Identifier: MIT
+ */
+
+import type {Options as PoolOptions} from 'generic-pool';
+
+/** Assemble generic-pool options from the registry's pool fields; undefined when none supplied. */
+export function buildPoolOptions(config: {
+  poolMin?: unknown;
+  poolMax?: unknown;
+  poolTestOnBorrow?: unknown;
+}): PoolOptions | undefined {
+  const opts: PoolOptions = {};
+  if (typeof config.poolMin === 'number') opts.min = config.poolMin;
+  if (typeof config.poolMax === 'number') opts.max = config.poolMax;
+  if (typeof config.poolTestOnBorrow === 'boolean') {
+    opts.testOnBorrow = config.poolTestOnBorrow;
+  }
+  return Object.keys(opts).length > 0 ? opts : undefined;
+}

--- a/packages/malloy/src/connection/CONTEXT.md
+++ b/packages/malloy/src/connection/CONTEXT.md
@@ -126,8 +126,8 @@ Each `ConnectionPropertyDefinition` has a `type` field that determines UI render
 `host` (string), `port` (number), `username` (string), `password` (password), `databaseName` (string), `connectionString` (string), `setupSQL` (text)
 
 **Snowflake** (`displayName: "Snowflake"`):
-`account` (string, required), `username` (string), `password` (password), `role` (string), `warehouse` (string), `database` (string), `schema` (string), `privateKeyPath` (file), `privateKeyPass` (password), `timeoutMs` (number), `setupSQL` (text)
-Factory extracts `name`, `setupSQL`, `timeoutMs`; passes remaining properties as snowflake-sdk `ConnectionOptions`.
+`account` (string, required), `username` (string), `password` (password), `role` (string), `warehouse` (string), `database` (string), `schema` (string), `privateKeyPath` (file), `privateKeyPass` (password), `timeoutMs` (number), `setupSQL` (text), `poolMin` (number, advanced), `poolMax` (number, advanced), `poolTestOnBorrow` (boolean, advanced)
+Factory extracts `name`, `setupSQL`, `timeoutMs`, and the three pool fields; passes remaining properties as snowflake-sdk `ConnectionOptions`. The pool fields are assembled into a `generic-pool` options object via `buildPoolOptions()` and shallow-merged with `SnowflakeExecutor.defaultPoolOptions_` (`{min: 1, max: 1, testOnBorrow: true, testOnReturn: true}`); omitting all three preserves the defaults.
 
 **Trino** (`displayName: "Trino"`):
 `server` (string), `port` (number), `catalog` (string), `schema` (string), `user` (string), `password` (password), `setupSQL` (text), `source` (string), `ssl` (json), `session` (json), `extraCredential` (json), `extraHeaders` (json)
@@ -154,6 +154,10 @@ interface ConnectionPropertyDefinition {
   displayName: string;
   type: 'string' | 'number' | 'boolean' | 'password' | 'secret' | 'file' | 'json' | 'text';
   optional?: true;
+  // Advisory hint to editors: this property is not part of typical
+  // configuration and may be hidden, folded under an "advanced" toggle, or
+  // ignored entirely. Has no effect on the registry or factory.
+  advanced?: boolean;
   // Literal default, or a single-key reference-shaped object that the
   // MalloyConfig resolver expands against the config overlays
   // (e.g. {config: 'rootDirectory'}).

--- a/packages/malloy/src/connection/CONTEXT.md
+++ b/packages/malloy/src/connection/CONTEXT.md
@@ -114,6 +114,17 @@ Each `ConnectionPropertyDefinition` has a `type` field that determines UI render
 | `json` | JSON object (structured config like SSL options, headers) |
 | `text` | Multi-line text input |
 
+## Cross-Repo: User-Facing Docs
+
+The user-facing list of connection types and their parameters lives in a
+separate repository: [`malloydata/malloydata.github.io`](https://github.com/malloydata/malloydata.github.io)
+at `src/documentation/setup/config.malloynb`. When you add, remove, or rename
+a registered property — or change its semantics — open a companion PR there
+so the docs site stays in sync. Add to the PR checklist:
+
+- [ ] Updated `malloydata.github.io/src/documentation/setup/config.malloynb`
+      if any registered connection property changed.
+
 ## Per-Backend Properties
 
 **DuckDB** (`displayName: "DuckDB"`):

--- a/packages/malloy/src/connection/registry.ts
+++ b/packages/malloy/src/connection/registry.ts
@@ -42,6 +42,12 @@ export interface ConnectionPropertyDefinition {
   optional?: true;
   default?: string | number | boolean | {[source: string]: string | string[]};
   description?: string;
+  /**
+   * Advisory hint to editors that this property is not part of typical
+   * configuration and may be hidden, folded under an "advanced" toggle, or
+   * ignored. Does not affect registry or factory behavior — purely UI guidance.
+   */
+  advanced?: boolean;
   /** For type 'file': extension filters for picker dialogs. */
   fileFilters?: Record<string, string[]>;
   /**


### PR DESCRIPTION
## Summary

- Adds three advanced scalar properties to the snowflake registry entry — `poolMin` (number), `poolMax` (number), `poolTestOnBorrow` (boolean) — so hosts can tune the underlying `generic-pool` through `MalloyConfig`. Without these, every connection built through the registry was locked to `SnowflakeExecutor.defaultPoolOptions_` (`{min: 1, max: 1, testOnBorrow: true, testOnReturn: true}`).
- Adds `advanced?: boolean` to `ConnectionPropertyDefinition` as an advisory hint to editors. Has no effect on registry or factory behavior — editors are encouraged to fold `advanced: true` properties under a toggle or hide them, and the three new pool fields are the first usages.
- Factory destructures the three pool fields and assembles them into `PoolOptions` via a small `buildPoolOptions()` helper. Wrong-typed values are dropped (defensive: a stray string from a hand-edited config does not become NaN inside the pool). When all three fields are absent, `poolOptions` stays `undefined` and the executor's defaults apply unchanged.
- The executor already shallow-merges with defaults, so supplying only `poolMax: 20` correctly yields `{min: 1, max: 20, testOnBorrow: true, testOnReturn: true}` at the pool layer.
- No change to `snowflake_connection.ts` or `snowflake_executor.ts` — they already accepted and forwarded `poolOptions`.

## Why scalars and not a single `poolOptions` JSON blob

Earlier draft used a single `type: 'json'` blob (mirroring Trino's `ssl`/`session`/etc.). Switched to scalars because:
- Editors get real form fields with per-knob validation instead of a JSON-shaped footgun.
- Each scalar carries its own `advanced: true` hint.
- The three knobs hosts actually want (`min`, `max`, `testOnBorrow`) cover Publisher's case; further generic-pool fields can be added when a concrete caller asks.

## Unblocks

Publisher's pool tuning path (recovers pre-PR #674 behavior of `poolMin: 1, poolMax: 20`) without a wrapper carve-out.

## Test plan

- [x] New unit test `snowflake_pool_options.spec.ts` covering: empty config → undefined, single field, all three fields, falsy-but-real values (`testOnBorrow: false`, `min: 0`), wrong-type rejection, partial wrong-type. 7/7 passing locally, no DB required.
- [x] Existing `packages/malloy/src/connection/registry.spec.ts` still passes (19/19) after adding `advanced?: boolean` to `ConnectionPropertyDefinition`.
- [x] `npm run lint-fix` clean.
- [ ] CI to verify: build, full test suite, snowflake DB tests (registry change is purely additive on the snowflake side).