### PR TITLE
fix(config): fabricate default connections by name only

### DIFF
--- a/packages/malloy/src/api/foundation/CONTEXT.md
+++ b/packages/malloy/src/api/foundation/CONTEXT.md
@@ -118,51 +118,31 @@ Plain spread. This gives callers three moves without any extra API:
 
 ### Three Failure Modes
 
-Three cases, handled differently on purpose:
+Cases and observed behavior: [configuration.md → Failure Modes](../../doc/configuration.md#failure-modes). Why each behaves the way it does — the rationale that matters when you're tempted to "improve" them in code:
 
-| Case | Example | Behavior | Why |
-|---|---|---|---|
-| Unknown overlay source | `{zzz: "x"}`, no `zzz` registered | Warning to `config.log` at lookup time; property dropped | Almost always a typo or host/config mismatch — silent drop would hide real bugs |
-| Known overlay returns `undefined` | `{env: "PG_PASSWORD"}`, var unset | Silent drop | Legitimate "value not present"; matches env-var behavior. Required-field violations surface at connection-build time, not here |
-| Unresolved reference in a `default` | DuckDB `workingDirectory: {default: {config: "rootDirectory"}}` with no-op `config` overlay | Silent drop | A default is a hint, not a requirement — "no default" is fine |
+| Case | Why it behaves this way |
+|---|---|
+| Unknown overlay source → warning + drop | Almost always a typo or host/config mismatch. Silent-dropping would hide real bugs; throwing would punish a host that hasn't yet registered an optional overlay. The `config.log` warning splits the difference. |
+| Known overlay returns `undefined` → silent drop | Legitimate "value not present" state, matching env-var semantics. A required-field violation surfaces at connection-build time (lazy, at lookup), not here — keeping the resolver out of policy decisions about what's required. |
+| Unresolved reference in a `default` → silent drop | A default is a hint, not a requirement. "No default applicable" is a normal terminal state, not a failure. |
 
-A consequence: cases 2 and 3 make "typo'd env var" and "legitimately unset env var" indistinguishable. Matches today's behavior. Typo detection would need to cross the line between resolver and connection factory — not worth it.
+Consequence: cases 2 and 3 make "typo'd env var" and "legitimately unset env var" indistinguishable. Matches today's behavior. Typo detection would need the resolver to know which properties are required by which factory — not worth crossing that line.
 
 ## Property Defaults vs. `includeDefaultConnections`
 
-Two mechanisms, orthogonal by design. Casually both feel like "defaults," but they answer different questions.
+User-facing description of both mechanisms is in [configuration.md → Defaults](../../doc/configuration.md#defaults). Internals notes that don't belong in the user doc:
 
-**Property defaults** — "if this connection entry doesn't set this property, what fills in?" Registry declares `default` on each property; the resolver applies it to *every* entry, uniformly. Reference-shaped defaults resolve through the same overlays as inline refs (and silent-drop if unresolved — case 3 above).
+- **Orthogonality.** Two mechanisms answering different questions ("what fills in a missing property" vs. "what fills in a missing connection"). Don't conflate them in code — they share neither state nor a code path. Property defaults run *after* fabrication and apply uniformly, so a fabricated entry and a user-written one are indistinguishable downstream.
 
-**`includeDefaultConnections`** — "should we fabricate entries for backends the user didn't mention?" A boolean flag at the top of the POJO. When `true`, fabricate one entry per registered backend type not already represented. Fabricated entries then flow through property defaults just like user-written ones.
+- **Pipeline order.** `prepareConfig` fabricates first (`config_resolve.ts`), then `lookupConnection` applies property defaults (`config_lookup.ts`). The fabricator never reads `default` fields; the resolver doesn't care whether an entry was fabricated.
 
-Composition:
-
-```typescript
-// Soloist: both mechanisms work together
-new MalloyConfig({includeDefaultConnections: true})
-// → fabricator adds duckdb, bigquery, postgres, etc.
-// → property defaults fill in each entry's properties (databasePath: ':memory:',
-//   workingDirectory: {config: 'rootDirectory'} → resolved or dropped, etc.)
-```
-
-**Fabricator skip rules** — skip a type `T` if:
-- **Rule A** — some existing entry has `is: "T"` (user already told us what duckdb looks like).
-- **Rule B** — some existing entry is *named* `T`, even if its `is` is something else. Covers the case where a user writes `{duckdb: {is: 'postgres', ...}}` — entry named `duckdb` but pointing at a different backend. Without Rule B, the fabricator would add a second `duckdb`-named entry and clobber this one. Worth a dedicated test, because the most common user convention ("I have a duckdb, I'll call it `duckdb`") makes the fabricator's natural target name frequently equal to the user's chosen name.
-
-Both flags live in the POJO, so any host reading that file respects them without needing to pass anything in.
+- **Fabricator invariant.** *A phantom default named T exists iff no user entry is named T.* The skip is purely name-based; the `is` of user entries is irrelevant. This is what `lookupConnection` and host UIs (e.g. the VS Code connections sidebar) agree on — UI lists defaults by name, runtime must resolve those same names. An earlier version also skipped on type-already-in-use, which broke the agreement: a user with `{dankdb: {is: 'duckdb'}}` saw `duckdb` in the sidebar but got "No connection named 'duckdb'" at runtime.
 
 ## DuckDB rootDirectory — The Contract
 
-DuckDB resolves relative file paths against a connection-level anchor (`workingDirectory`). Without a stable answer, the same Malloy source can mean different things depending on which file imported it — a referential-transparency hole. The config system handles this with a contract rather than DuckDB-specific code:
+User-facing description: [configuration.md → DuckDB Working Directory](../../doc/configuration.md#duckdb-working-directory).
 
-- DuckDB declares `workingDirectory: {default: {config: 'rootDirectory'}}` in the registry.
-- Hosts that know where the project lives populate `config.rootDirectory` in the overlay (VS Code → workspace root; CLI → directory of discovered/explicit config file; Publisher → `project.metadata.location`).
-- Property defaults do the rest. No DuckDB-specific branch anywhere in the config system.
-
-The entire policy lives in one `default` field on one property in one registry entry. This is the template for backend quirks: declare the property, declare the default, let the host populate the overlay.
-
-`rootDirectory` is the **ceiling** (project root), not the directory where the config file happens to live. This matters when the config file is deep inside a project but data files live at the project root. Hosts that care expose `configURL` separately under a different key.
+The internals point: there is **no DuckDB-specific code anywhere in the config system**. The entire policy lives in one `default` field on one property in one registry entry — `workingDirectory: {default: {config: 'rootDirectory'}}`. Property defaults + the `config` overlay do the rest. This is the template for any backend quirk: declare the property, declare the default, let hosts populate the overlay. If you find yourself reaching for a DuckDB-shaped branch in the resolver, you're solving it wrong.
 
 ## Manifest URL — State Table
 
@@ -202,11 +182,14 @@ VS Code uses this to layer settings connections below the config layer. Publishe
 
 ## `releaseConnections`
 
-Preferred public call site is `runtime.releaseConnections()`, which forwards to `config.releaseConnections()`. The runtime is the natural lifecycle handle; one `MalloyConfig` per `Runtime`.
+User-facing description: [configuration.md → Releasing connections](../../doc/configuration.md#releasing-connections).
 
-`MalloyConfig` itself owns no connection resources — pools, sockets, file handles live inside individual `Connection` objects. What the managed lookup owns is a `name → Connection` cache populated lazily on lookup. `releaseConnections()` walks the cache and calls `Connection.close()` on each. Connections that were never looked up were never constructed and are skipped. Wrappers installed via `wrapConnections()` don't interfere — the managed lookup under the wrap still holds the cache.
+Implementation specifics:
 
-A Runtime constructed without a `MalloyConfig` (legacy `connections`/`connection` constructor forms) has nothing to forward to; `releaseConnections()` is a no-op and the caller owns whatever they passed in.
+- `MalloyConfig` owns no connection resources directly — pools, sockets, file handles all live inside individual `Connection` objects. What the managed lookup owns is a lazily-populated `name → Connection` cache.
+- `releaseConnections()` walks that cache and calls `Connection.close()` on each. Connections that were never looked up were never constructed and are skipped.
+- Wrappers installed via `wrapConnections()` don't interfere — the managed lookup under the wrap still holds the cache, and `runtime.releaseConnections()` forwards through to `config.releaseConnections()` directly, not through the wrap.
+- Legacy constructor forms (`new Runtime({connections})` / `new Runtime({connection})`) build a Runtime with no `MalloyConfig` to forward to; `releaseConnections()` is a no-op and the caller owns whatever they passed in.
 
 ## Discovery
 
@@ -232,7 +215,7 @@ URL-based (not filesystem-based) so the helper works in browser-safe environment
 
 ## Testing Notes
 
-- `config.spec.ts` covers the constructor pipeline, section compilers, overlay resolution, property defaults, `includeDefaultConnections` fabrication including Rule B, reference failure modes, and the manifest URL state table.
+- `config.spec.ts` covers the constructor pipeline, section compilers, overlay resolution, property defaults, `includeDefaultConnections` fabrication (name-based skip), reference failure modes, and the manifest URL state table.
 - `runtime.spec.ts` covers the manifest lazy-read, explicit `buildManifest` wins, `EMPTY_BUILD_MANIFEST`, and `releaseConnections` forwarding.
 - When adding a new backend with a registry default that references an overlay, add a test that the default is dropped (not errored) when the overlay is the no-op.
 

--- a/packages/malloy/src/api/foundation/config.spec.ts
+++ b/packages/malloy/src/api/foundation/config.spec.ts
@@ -411,9 +411,7 @@ describe('MalloyConfig overlay resolution', () => {
       }
     );
     expect(config.log).toEqual([]);
-    const conn = (await config.connections.lookupConnection(
-      'mydb'
-    )) as unknown as {name: string};
+    const conn = await config.connections.lookupConnection('mydb');
     expect(conn.name).toBe('mydb');
   });
 
@@ -437,9 +435,7 @@ describe('MalloyConfig overlay resolution', () => {
     });
     expect(config.log).toEqual([]);
     // ssl is json-typed — the object passes through literally, no env lookup.
-    const conn = (await config.connections.lookupConnection(
-      'mydb'
-    )) as unknown as {name: string};
+    const conn = await config.connections.lookupConnection('mydb');
     expect(conn.name).toBe('mydb');
   });
 });
@@ -622,17 +618,20 @@ describe('MalloyConfig property defaults and includeDefaultConnections', () => {
     expect(conn.dialectName).toBe('mockdb-dialect');
   });
 
-  it('does not fabricate when the type is already used', async () => {
+  it('still fabricates the type-named phantom when a user entry shares the type', async () => {
     const config = new MalloyConfig({
       connections: {mydb: {is: 'mockdb'}},
       includeDefaultConnections: true,
     });
-    // mockdb is used by 'mydb', so no auto-added connection named 'mockdb'.
-    await expect(
-      config.connections.lookupConnection('mockdb')
-    ).rejects.toThrow();
-    const conn = await config.connections.lookupConnection('mydb');
-    expect(conn.name).toBe('mydb');
+    // The user entry 'mydb' uses type mockdb, but the slot named 'mockdb'
+    // is unoccupied — the phantom default must still be fabricated so that
+    // hosts advertising 'mockdb' by name can resolve it at runtime.
+    const phantom = await config.connections.lookupConnection('mockdb');
+    expect(phantom.name).toBe('mockdb');
+    expect(phantom.dialectName).toBe('mockdb-dialect');
+    const userConn = await config.connections.lookupConnection('mydb');
+    expect(userConn.name).toBe('mydb');
+    expect(userConn.dialectName).toBe('mockdb-dialect');
   });
 
   it('does not clobber a user-named connection that collides with a type name', async () => {

--- a/packages/malloy/src/api/foundation/config_resolve.ts
+++ b/packages/malloy/src/api/foundation/config_resolve.ts
@@ -106,33 +106,26 @@ function extractCompiledConnections(
 }
 
 /**
- * Add a bare `{is: typeName}` compiled entry for each registered connection
- * type not already represented in `compiledConnections`. Only runs when the
- * POJO sets `includeDefaultConnections: true`. Property values (including
- * reference-shaped defaults like DuckDB's `{config: 'rootDirectory'}`) are
- * *not* filled in here — that is the job of the async lookup resolver.
+ * For each registered connection type T, add a bare `{is: T}` compiled
+ * entry named T unless one already exists under that name. Only runs when
+ * the POJO sets `includeDefaultConnections: true`. Property values
+ * (including reference-shaped defaults like DuckDB's
+ * `{config: 'rootDirectory'}`) are filled in later by the async lookup
+ * resolver, not here.
  *
- * Skip rules:
- *   - Type already in use: some existing entry has `is: typeName`.
- *   - Name already taken: some existing entry is *named* `typeName`, even
- *     if its `is` points elsewhere. This protects a user who writes
- *     `{duckdb: {is: 'postgres', ...}}` — naming an entry after a type but
- *     pointing at a different backend — from being clobbered.
+ * The skip is purely name-based: the `is` of a user entry is irrelevant.
+ * `{duckdb: {is: 'postgres'}}` shadows the duckdb phantom (slot taken);
+ * `{dankdb: {is: 'duckdb'}}` does not (slot `duckdb` is still free, and
+ * both end up reachable). This name-only rule is the contract hosts rely
+ * on — e.g. the VS Code connections sidebar advertises defaults by name,
+ * and the runtime must resolve them under those same names.
  *
  * Mutates `compiledConnections` in place.
  */
 function fabricateMissingConnections(
   compiledConnections: Record<string, ConfigDict>
 ): void {
-  const presentTypes = new Set<string>();
-  for (const entry of Object.values(compiledConnections)) {
-    const isNode = entry.entries['is'];
-    if (isNode?.kind === 'value' && typeof isNode.value === 'string') {
-      presentTypes.add(isNode.value);
-    }
-  }
   for (const typeName of getRegisteredConnectionTypes()) {
-    if (presentTypes.has(typeName)) continue;
     if (compiledConnections[typeName]) continue;
     compiledConnections[typeName] = {
       kind: 'dict',

--- a/packages/malloy/src/doc/configuration.md
+++ b/packages/malloy/src/doc/configuration.md
@@ -103,7 +103,7 @@ A soloist can get working connections with nothing but:
 
 …which yields `duckdb`, `bigquery`, `postgres`, etc. — each with registry defaults applied. A host with no config file at all typically does the same thing by constructing `new MalloyConfig({includeDefaultConnections: true})` as a fallback.
 
-The fabricator skips a type `T` if some existing entry either has `is: "T"` or is *named* `T`. The second rule lets a user write `{duckdb: {is: 'postgres', ...}}` — naming an entry `duckdb` but pointing it at a different backend — without the fabricator silently adding a second entry of the same name.
+The fabricator skips a type `T` only if some existing entry is *named* `T`. The `is` of user entries doesn't enter into it: writing `{dankdb: {is: 'duckdb'}}` leaves the slot named `duckdb` free, so a phantom `duckdb` is still added and both are reachable. Writing `{duckdb: {is: 'postgres', ...}}` does occupy the `duckdb` slot — naming wins, regardless of the backend it points at.
 
 ## Discovery
 


### PR DESCRIPTION
## Summary

`includeDefaultConnections: true` is supposed to fabricate a phantom `{is: T}` entry named T for every registered backend type T that the user didn't list. The skip rule should be: *a phantom named T exists iff no user entry is named T*. The `is` of user entries is irrelevant.
