### PR TITLE
fix(lang): prettifier corpus fixes from sample review

### DIFF
--- a/packages/malloy/src/lang/prettify/block-body.ts
+++ b/packages/malloy/src/lang/prettify/block-body.ts
@@ -5,9 +5,13 @@
  * RULE: BLOCK BODY
  *
  * A `{ … }` body containing statements (extend body, view body, etc.). Walks
- * children; between adjacent statements, preserves a single user-supplied
- * blank line *only if the kinds differ*. Same-kind adjacent statements never
- * get a blank.
+ * children; between adjacent statements:
+ *   - `view:` definitions always get a blank line before them (and after
+ *     the previous one), regardless of whether the source had a blank or
+ *     what kind preceded — view definitions read as their own sections.
+ *   - For other kinds: preserve a single user-supplied blank line only if
+ *     the kinds differ. Same-kind adjacent statements (consecutive
+ *     dimensions, measures, etc.) never get a blank.
  *
  * Also: top-level body — forces a blank line before each statement after the
  * first, regardless of source spacing (top-level statements should breathe).
@@ -58,8 +62,17 @@ export function formatBlockBody(f: Formatter, ctx: ParserRuleContext): void {
     if (c instanceof ParserRuleContext) {
       if (lastChild !== null) {
         const userHadBlank = c._start.line - lastChildEndLine > 1;
-        const sameKind = statementKind(lastChild) === statementKind(c);
-        if (userHadBlank && !sameKind) f.o.blank();
+        const lastKind = statementKind(lastChild);
+        const curKind = statementKind(c);
+        const sameKind = lastKind === curKind;
+        // `view:` definitions always breathe — blank line above each one
+        // (and after the previous one) regardless of the user's source
+        // spacing or what kind preceded.
+        if (curKind === 'view' || lastKind === 'view') {
+          f.o.blank();
+        } else if (userHadBlank && !sameKind) {
+          f.o.blank();
+        }
       }
       f.format(c);
       lastChild = c;

--- a/packages/malloy/src/lang/prettify/formatter.ts
+++ b/packages/malloy/src/lang/prettify/formatter.ts
@@ -31,6 +31,7 @@ import {
   formatPickStatement,
 } from './pick-case';
 import {formatBinaryChain} from './binary-chain';
+import {formatImportSelect} from './import-select';
 
 export class Formatter {
   o = new Out();
@@ -105,6 +106,11 @@ export class Formatter {
       if (node instanceof rule.ctxClass) {
         return formatSectionStatement(this, node, rule);
       }
+    }
+
+    // RULE: IMPORT SELECT — `import {a, b} from 'x'` stays compact.
+    if (node instanceof parser.ImportSelectContext) {
+      return formatImportSelect(this, node);
     }
 
     // RULE: PICK / CASE / BINARY CHAIN.

--- a/packages/malloy/src/lang/prettify/import-select.ts
+++ b/packages/malloy/src/lang/prettify/import-select.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright Contributors to the Malloy project
+ * SPDX-License-Identifier: MIT
+ *
+ * RULE: IMPORT SELECT — `import {a, b, c} from 'url'`
+ *
+ * The selection list is `{ id (IS id)? (, id (IS id)?)* }`. Inline if the
+ * whole brace-and-contents fits on the current line. Otherwise wrap with
+ * each item on its own line at +1 indent.
+ */
+
+import type * as parser from '../lib/Malloy/MalloyParser';
+import type {Formatter} from './formatter';
+import {L, LINE_BUDGET} from './tokens';
+import {note} from './leaf';
+import {renderItemInline} from './inline-renderer';
+
+export function formatImportSelect(
+  f: Formatter,
+  ctx: parser.ImportSelectContext
+): void {
+  const items = ctx.importItem();
+  // Grammar puts FROM as the last token of importSelect: emit it ourselves
+  // so the trailing space and lastEmittedIdx land correctly.
+  const fromTok = ctx.FROM().symbol;
+  const fromIdx = fromTok.tokenIndex;
+  if (items.length === 0) {
+    f.o.space();
+    f.o.text('{} from');
+    note(f, L.FROM, fromIdx, fromTok);
+    return;
+  }
+  const itemStrs = items.map(it => renderItemInline(f, it));
+  const inlineBody = '{' + itemStrs.join(', ') + '} from';
+  if (f.o.lineLengthSoFar() + 1 + inlineBody.length <= LINE_BUDGET) {
+    f.o.space();
+    f.o.text(inlineBody);
+    note(f, L.FROM, fromIdx, fromTok);
+    return;
+  }
+  // Wrap form: one item per line at +1 indent.
+  f.o.space();
+  f.o.text('{');
+  f.o.indent++;
+  for (let i = 0; i < itemStrs.length; i++) {
+    f.o.nl();
+    f.o.text(itemStrs[i]);
+    if (i < itemStrs.length - 1) f.o.text(',');
+  }
+  f.o.indent--;
+  f.o.nl();
+  f.o.text('} from');
+  note(f, L.FROM, fromIdx, fromTok);
+}

--- a/packages/malloy/src/lang/prettify/import-select.ts
+++ b/packages/malloy/src/lang/prettify/import-select.ts
@@ -12,13 +12,17 @@
 import type * as parser from '../lib/Malloy/MalloyParser';
 import type {Formatter} from './formatter';
 import {L, LINE_BUDGET} from './tokens';
-import {note} from './leaf';
+import {flushHiddenBefore, hasCommentsInRange, note} from './leaf';
 import {renderItemInline} from './inline-renderer';
 
 export function formatImportSelect(
   f: Formatter,
   ctx: parser.ImportSelectContext
 ): void {
+  // Flush hidden tokens between the previous emit (IMPORT) and our opener
+  // so a comment like `import /* tag */ {a} from 'x'` is preserved.
+  flushHiddenBefore(f, ctx._start.tokenIndex);
+
   const items = ctx.importItem();
   // Grammar puts FROM as the last token of importSelect: emit it ourselves
   // so the trailing space and lastEmittedIdx land correctly.
@@ -30,23 +34,62 @@ export function formatImportSelect(
     note(f, L.FROM, fromIdx, fromTok);
     return;
   }
-  const itemStrs = items.map(it => renderItemInline(f, it));
-  const inlineBody = '{' + itemStrs.join(', ') + '} from';
-  if (f.o.lineLengthSoFar() + 1 + inlineBody.length <= LINE_BUDGET) {
+
+  const firstItem = items[0];
+  const lastItem = items[items.length - 1];
+  // Comments anywhere in the items' span (between items, inside an `as is`
+  // form, etc.) get stripped by renderItemInline. Fall back to a comment-
+  // safe wrap that emits each item via f.format — the leaf walker handles
+  // hidden-channel placement.
+  const itemsHaveComments = hasCommentsInRange(
+    f,
+    firstItem._start.tokenIndex,
+    lastItem._stop!.tokenIndex
+  );
+
+  if (!itemsHaveComments) {
+    const itemStrs = items.map(it => renderItemInline(f, it));
+    const inlineBody = '{' + itemStrs.join(', ') + '} from';
+    if (f.o.lineLengthSoFar() + 1 + inlineBody.length <= LINE_BUDGET) {
+      f.o.space();
+      f.o.text(inlineBody);
+      note(f, L.FROM, fromIdx, fromTok);
+      return;
+    }
+    // Wrap form (no comments): one item per line at +1 indent. Pre-rendered
+    // text is fine because renderItemInline saw no comments to drop.
     f.o.space();
-    f.o.text(inlineBody);
+    f.o.text('{');
+    f.o.indent++;
+    for (let i = 0; i < itemStrs.length; i++) {
+      f.o.nl();
+      f.o.text(itemStrs[i]);
+      if (i < itemStrs.length - 1) f.o.text(',');
+    }
+    f.o.indent--;
+    f.o.nl();
+    f.o.text('} from');
     note(f, L.FROM, fromIdx, fromTok);
     return;
   }
-  // Wrap form: one item per line at +1 indent.
+
+  // Comment-safe wrap: each item emits via f.format so flushHiddenBefore
+  // can place its leading/inter-item comments correctly. Trailing `,` after
+  // each non-last item, leaf walker turns it into a newline at indent.
   f.o.space();
   f.o.text('{');
   f.o.indent++;
-  for (let i = 0; i < itemStrs.length; i++) {
+  // Advance past the OCURLY we just emitted manually so the first item's
+  // flushHiddenBefore doesn't try to re-emit it.
+  f.lastEmittedIdx = ctx._start.tokenIndex;
+  for (let i = 0; i < items.length; i++) {
+    flushHiddenBefore(f, items[i]._start.tokenIndex);
     f.o.nl();
-    f.o.text(itemStrs[i]);
-    if (i < itemStrs.length - 1) f.o.text(',');
+    f.format(items[i]);
+    if (i < items.length - 1) f.o.text(',');
   }
+  // Catch any tail comments between the last item and the closing `}`.
+  flushHiddenBefore(f, fromIdx);
   f.o.indent--;
   f.o.nl();
   f.o.text('} from');

--- a/packages/malloy/src/lang/prettify/index.ts
+++ b/packages/malloy/src/lang/prettify/index.ts
@@ -56,6 +56,30 @@
  *   - Single-arg function calls don't wrap (no point — nowhere useful to break).
  *   - `(` hugs only after a known-callable token (CALL_HUG_AFTER); after `is`,
  *     `as`, `extend`, `on`, `when`, etc. the `(` is grouping and gets a space.
+ *     CALL_HUG_AFTER includes the keyword-named built-ins that are commonly
+ *     used as functions: ALL, EXCLUDE, the timeframe truncation keywords
+ *     (YEAR/MONTH/DAY/…), and the cast-target type names
+ *     (TIMESTAMP/DATE/NUMBER/STRING/BOOLEAN/JSON).
+ *   - `!` is the cast operator (`epoch_ms!timestamp(x)`); it glues to both
+ *     sides like `.` does.
+ *   - Empty `{}` collapses inline (`extend {}`, not `extend {\n}`).
+ *   - `import {a, b, c} from 'x'` formats as a flat list when it fits on the
+ *     line; otherwise one item per line at +1 indent.
+ *   - `view:` definitions in a block body always have a blank line before
+ *     each one (after the first), even when no blank was in the source. The
+ *     same-kind-no-blank rule still applies to other statement kinds.
+ *   - `{...}` bodies that contain more than one section statement never
+ *     collapse onto a single line, even when they would fit. Reading two
+ *     `group_by:` clauses jammed on one line is hostile.
+ *   - Single is-item section lists keep the keyword and item on the same
+ *     line (`nest: name is { … }`), so the body wraps naturally instead of
+ *     forcing a `nest:\n  name is {` opener split.
+ *   - join_one / join_many / join_cross multi-item lists always wrap one
+ *     item per line — items use `with`/`on` instead of `is` but are
+ *     structurally is-like.
+ *   - Trailing comments between the last item of a section list and the
+ *     enclosing `}` are emitted at the section's inner indent, so they
+ *     stay associated with the section the user wrote them in.
  *
  * Adding a new section-statement
  * ------------------------------

--- a/packages/malloy/src/lang/prettify/leaf.ts
+++ b/packages/malloy/src/lang/prettify/leaf.ts
@@ -134,6 +134,17 @@ export function hasCommentsInRange(
   return false;
 }
 
+// Index of the next non-hidden, non-EOF token strictly after `idx`, or -1.
+function nextVisibleAfter(f: Formatter, idx: number): number {
+  for (let j = idx + 1; j < f.tokens.length; j++) {
+    const t = f.tokens[j];
+    if (t.channel === Token.HIDDEN_CHANNEL) continue;
+    if (t.type === Token.EOF) return -1;
+    return j;
+  }
+  return -1;
+}
+
 // Does the paren-pair at [openIdx, closeIdx] have any COMMA at its own depth?
 // (Used to distinguish "function call with multiple args" from "single-arg
 // call" / "empty parens".)
@@ -199,6 +210,15 @@ export function emitVisibleToken(f: Formatter, t: Token, idx: number): void {
   if (t.type === L.OCURLY) {
     f.o.space();
     f.o.text('{');
+    // Empty `{}`: peek the next visible token. If it's the matching close,
+    // emit it inline so we get `extend {}` not `extend {\n}`.
+    const nextVisible = nextVisibleAfter(f, idx);
+    if (nextVisible !== -1 && f.tokens[nextVisible].type === L.CCURLY) {
+      f.o.text('}');
+      if (f.o.indent === 0) f.needBlank = true;
+      note(f, L.CCURLY, nextVisible, f.tokens[nextVisible]);
+      return;
+    }
     f.o.indent++;
     f.o.nl();
     note(f, t.type, idx, t);

--- a/packages/malloy/src/lang/prettify/leaf.ts
+++ b/packages/malloy/src/lang/prettify/leaf.ts
@@ -210,10 +210,17 @@ export function emitVisibleToken(f: Formatter, t: Token, idx: number): void {
   if (t.type === L.OCURLY) {
     f.o.space();
     f.o.text('{');
-    // Empty `{}`: peek the next visible token. If it's the matching close,
-    // emit it inline so we get `extend {}` not `extend {\n}`.
+    // Empty `{}`: peek the next visible token. If it's the matching close
+    // AND nothing hidden sits between them (no comments to preserve), emit
+    // inline so we get `extend {}` not `extend {\n}`. With a comment in the
+    // gap (`extend { /* keep */ }`), fall through to the wrapping form so
+    // the leaf walker's comment placement runs.
     const nextVisible = nextVisibleAfter(f, idx);
-    if (nextVisible !== -1 && f.tokens[nextVisible].type === L.CCURLY) {
+    if (
+      nextVisible !== -1 &&
+      f.tokens[nextVisible].type === L.CCURLY &&
+      !hasCommentsInRange(f, idx + 1, nextVisible - 1)
+    ) {
       f.o.text('}');
       if (f.o.indent === 0) f.needBlank = true;
       note(f, L.CCURLY, nextVisible, f.tokens[nextVisible]);

--- a/packages/malloy/src/lang/prettify/rules.ts
+++ b/packages/malloy/src/lang/prettify/rules.ts
@@ -28,7 +28,10 @@ export type ItemKind =
   | 'fieldName'
   | 'collectionMember'
   | 'orderBySpec'
-  | 'fieldExpr';
+  | 'fieldExpr'
+  | 'joinDef'
+  | 'includeField'
+  | 'indexElement';
 
 // One row per `keyword: items` rule we handle. The `list` accessor returns
 // the list-context child; the `keywordTypes` are the lexer token types that
@@ -126,6 +129,29 @@ export const SECTION_STATEMENT_RULES: SectionRule[] = [
     [L.HAVING],
     c => c.filterClauseList(),
     'fieldExpr'
+  ),
+  rule(parser.DefJoinOneContext, [L.JOIN_ONE], c => c.joinList(), 'joinDef'),
+  rule(parser.DefJoinManyContext, [L.JOIN_MANY], c => c.joinList(), 'joinDef'),
+  rule(
+    parser.DefJoinCrossContext,
+    [L.JOIN_CROSS],
+    c => c.joinList(),
+    'joinDef'
+  ),
+  // include block items: `public: a, b`, `internal: x, y, z`. The keyword
+  // (PUBLIC/PRIVATE/INTERNAL) lives one level down inside accessLabelProp;
+  // findKeyword in ./sections handles that nested case.
+  rule(
+    parser.IncludeItemContext,
+    [L.PUBLIC, L.PRIVATE, L.INTERNAL],
+    c => c.includeList(),
+    'includeField'
+  ),
+  rule(
+    parser.IndexStatementContext,
+    [L.INDEX],
+    c => c.indexFields(),
+    'indexElement'
   ),
 ];
 

--- a/packages/malloy/src/lang/prettify/sections.ts
+++ b/packages/malloy/src/lang/prettify/sections.ts
@@ -12,11 +12,21 @@
  *
  * formatSectionList rule (locked in with the user):
  *   - All bare items + total fits ≤ LINE_BUDGET → inline `kw: a, b, c`.
- *   - Single item that fits (even if it has `is`) → inline.
+ *   - Single item that fits (even if it has `is`) → inline. Items containing
+ *     a `{...}` body with more than one section statement are excluded —
+ *     view bodies don't read on one line regardless of length.
+ *   - Single is-item that doesn't fit inline → keep keyword and item on the
+ *     same line (`nest: name is { …wrapped body… }`); the body's `{...}`
+ *     wraps internally. Annotated items still take the keyword-on-own-line
+ *     form so the annotation lands above its item.
  *   - Otherwise → wrapped: keyword on its own line; items at +1 indent;
  *       bare items flow-fill ≤ LINE_BUDGET, comma-separated intra-line,
  *       no trailing commas; `is` items each on own line; annotated items
  *       each on own line, annotation on the line above.
+ *
+ * After the last item, trailing comments that sit between the section and
+ * the enclosing `}` are also emitted at the inner indent — they belong to
+ * the section the user just wrote, not the parent block.
  */
 
 import {ParserRuleContext, Token} from 'antlr4ts';
@@ -25,7 +35,14 @@ import {TerminalNode} from 'antlr4ts/tree';
 import * as parser from '../lib/Malloy/MalloyParser';
 import type {Formatter} from './formatter';
 import type {ItemKind, SectionRule} from './rules';
-import {INDENT_STR, L, LINE_BUDGET, endLineOf} from './tokens';
+import {
+  INDENT_STR,
+  L,
+  LINE_BUDGET,
+  SECTION_TOKENS,
+  endLineOf,
+  findMatching,
+} from './tokens';
 import {
   flushHiddenBefore,
   formatTokenRange,
@@ -48,7 +65,10 @@ export function formatSectionStatement(
   }
   for (let i = 0; i < stmt.childCount; i++) {
     const c = stmt.getChild(i);
-    if (c instanceof TerminalNode && c.symbol === keywordTok) {
+    const isKeywordChild =
+      (c instanceof TerminalNode && c.symbol === keywordTok) ||
+      (c instanceof ParserRuleContext && childContainsToken(c, keywordTok));
+    if (isKeywordChild) {
       flushHiddenBefore(f, keywordTok.tokenIndex);
       if (f.o.indent > 0) f.o.nl();
       else startStatementLine(f);
@@ -58,21 +78,42 @@ export function formatSectionStatement(
     }
     if (c === listCtx) {
       const items = listItems(listCtx, rule.itemKind);
-      if (items.length > 0) formatSectionList(f, items);
+      if (items.length > 0) formatSectionList(f, items, rule.itemKind);
       continue;
     }
     f.format(c);
   }
 }
 
+function childContainsToken(node: ParserRuleContext, tok: Token): boolean {
+  for (let i = 0; i < node.childCount; i++) {
+    const c = node.getChild(i);
+    if (c instanceof TerminalNode && c.symbol === tok) return true;
+  }
+  return false;
+}
+
 function findKeyword(
   node: ParserRuleContext,
   types: number[]
 ): Token | undefined {
+  // Direct terminal children — fast path, the common case.
   for (let i = 0; i < node.childCount; i++) {
     const c = node.getChild(i);
     if (c instanceof TerminalNode && types.includes(c.symbol.type))
       return c.symbol;
+  }
+  // Fallback: descend one level. Some rules wrap the keyword in a small
+  // nested rule (e.g. includeItem → accessLabelProp → INTERNAL).
+  for (let i = 0; i < node.childCount; i++) {
+    const c = node.getChild(i);
+    if (c instanceof ParserRuleContext) {
+      for (let j = 0; j < c.childCount; j++) {
+        const g = c.getChild(j);
+        if (g instanceof TerminalNode && types.includes(g.symbol.type))
+          return g.symbol;
+      }
+    }
   }
   return undefined;
 }
@@ -99,6 +140,12 @@ function listItems(
         return c instanceof parser.OrderBySpecContext;
       case 'fieldExpr':
         return c instanceof parser.FieldExprContext;
+      case 'joinDef':
+        return c instanceof parser.JoinDefContext;
+      case 'includeField':
+        return c instanceof parser.IncludeFieldContext;
+      case 'indexElement':
+        return c instanceof parser.IndexElementContext;
     }
   };
   const out: ParserRuleContext[] = [];
@@ -111,9 +158,12 @@ function listItems(
 
 function classifyItem(
   f: Formatter,
-  ctx: ParserRuleContext
+  ctx: ParserRuleContext,
+  itemKind: ItemKind
 ): {ctx: ParserRuleContext; hasIs: boolean; hasAnnotation: boolean} {
-  let hasIs = false;
+  // joinDef items always wrap onto their own line. They use `with` / `on`
+  // instead of `is`, but they're structurally one-per-line like is-items.
+  let hasIs = itemKind === 'joinDef';
   let hasAnnotation = false;
   for (let i = ctx._start.tokenIndex; i <= ctx._stop!.tokenIndex; i++) {
     const t = f.tokens[i];
@@ -129,8 +179,12 @@ function classifyItem(
   return {ctx, hasIs, hasAnnotation};
 }
 
-function formatSectionList(f: Formatter, items: ParserRuleContext[]): void {
-  const itemInfos = items.map(it => classifyItem(f, it));
+function formatSectionList(
+  f: Formatter,
+  items: ParserRuleContext[],
+  itemKind: ItemKind
+): void {
+  const itemInfos = items.map(it => classifyItem(f, it, itemKind));
   const noAnnotations = itemInfos.every(info => !info.hasAnnotation);
   const allBare = itemInfos.every(info => !info.hasIs && !info.hasAnnotation);
   const firstItem = items[0];
@@ -138,14 +192,22 @@ function formatSectionList(f: Formatter, items: ParserRuleContext[]): void {
 
   // Inline candidate: no annotations, no hidden-channel comments anywhere in
   // the items' span (renderItemInline drops them), AND either all bare or
-  // exactly one item.
+  // exactly one item. Items containing a `{...}` body with multiple inner
+  // statements are also excluded — collapsing a view body onto one line is
+  // hostile to read regardless of length.
   const itemsHaveComments = hasCommentsInRange(
     f,
     firstItem._start.tokenIndex,
     lastItem._stop!.tokenIndex
   );
+  const itemsHaveMultiStatementBody = itemInfos.some(info =>
+    hasMultiStatementCurlyBody(f, info.ctx)
+  );
   const inlineEligible =
-    noAnnotations && !itemsHaveComments && (allBare || items.length === 1);
+    noAnnotations &&
+    !itemsHaveComments &&
+    !itemsHaveMultiStatementBody &&
+    (allBare || items.length === 1);
 
   if (inlineEligible) {
     const renderedItems = itemInfos.map(info => renderItemInline(f, info.ctx));
@@ -163,6 +225,23 @@ function formatSectionList(f: Formatter, items: ParserRuleContext[]): void {
       );
       return;
     }
+  }
+
+  // Single is-item that doesn't fit inline: keep the keyword on the same
+  // line as the item (`nest: name is { …wrapped body… }`) instead of
+  // breaking before the name. The body's `{...}` will wrap on its own.
+  // Annotated items still need the keyword-on-own-line form so the
+  // annotation can land between them.
+  if (
+    items.length === 1 &&
+    itemInfos[0].hasIs &&
+    !itemInfos[0].hasAnnotation &&
+    !itemsHaveComments
+  ) {
+    f.o.text(' ');
+    f.format(itemInfos[0].ctx);
+    f.lastEmittedType = lastItem._stop!.type;
+    return;
   }
 
   // Wrapped form. Two paths:
@@ -232,14 +311,58 @@ function formatSectionList(f: Formatter, items: ParserRuleContext[]): void {
   f.lastEmittedType = lastItem._stop!.type;
 }
 
-// After the last item of a wrapped section list, flush any trailing comments
-// on the SAME source line as the last item — those are tail comments belong-
-// ing to the last item and should emit at the section's inner indent.
-// Different-line comments are leading comments for the next statement; leave
-// them for the parent context to emit at the outer indent.
+// Does any `{...}` block inside this item contain more than one section
+// keyword (group_by:, aggregate:, where:, …) at its top level? Used to gate
+// the section-list inline form: a view body with multiple statements never
+// reads well on a single line, even when it fits. Single-statement bodies
+// like `{ where: x = 1 }` may still inline.
+function hasMultiStatementCurlyBody(
+  f: Formatter,
+  ctx: ParserRuleContext
+): boolean {
+  const fromIdx = ctx._start.tokenIndex;
+  const toIdx = ctx._stop!.tokenIndex;
+  for (let i = fromIdx; i <= toIdx; i++) {
+    if (f.tokens[i].type !== L.OCURLY) continue;
+    const close = findMatching(f.tokens, i, L.OCURLY, L.CCURLY);
+    let count = 0;
+    let depth = 0;
+    for (let j = i + 1; j < close; j++) {
+      const t = f.tokens[j];
+      if (t.type === L.OCURLY || t.type === L.OPAREN || t.type === L.OBRACK) {
+        depth++;
+      } else if (
+        t.type === L.CCURLY ||
+        t.type === L.CPAREN ||
+        t.type === L.CBRACK
+      ) {
+        depth--;
+      } else if (depth === 0 && SECTION_TOKENS.has(t.type)) {
+        count++;
+        if (count > 1) return true;
+      }
+    }
+    i = close;
+  }
+  return false;
+}
+
+// After the last item of a wrapped section list, flush trailing comments
+// belonging to the section. There are two cases:
+//
+//   1. Same-line tail: a comment on the SAME source line as the last item.
+//      Always belongs to the last item; emit at the section's inner indent.
+//
+//   2. Different-line trailing comments that sit between the last item and
+//      the closing `}` of the enclosing block (no other statement follows).
+//      These visually belong to the section the user just wrote, not the
+//      block. Emit them at the inner indent so they stay associated with
+//      the section. If a real statement follows the comments, leave them
+//      for the parent — they're leading comments for that statement.
 function flushSameLineTail(f: Formatter, lastTok: Token): void {
   const lastEndLine = endLineOf(lastTok);
   let j = lastTok.tokenIndex + 1;
+  // Phase 1: same-line tail comments.
   while (j < f.tokens.length) {
     const t = f.tokens[j];
     if (t.channel !== Token.HIDDEN_CHANNEL) break;
@@ -247,14 +370,29 @@ function flushSameLineTail(f: Formatter, lastTok: Token): void {
     j++;
   }
   if (j > lastTok.tokenIndex + 1) {
-    // The wrapping loop emitted a per-item newline after the last item, but
-    // a same-line tail comment should attach to that item's line — not float
-    // on a fresh one. Drop the trailing newline so emitHiddenToken's
-    // same-line branch reattaches the comment correctly (and adds a trailing
-    // newline back for EOL comments). Without this, the comment lands on a
-    // new line, and a re-parse sees it as a different-line comment, breaking
-    // idempotence.
+    // Same-line comments: drop the wrapping loop's per-item newline so
+    // emitHiddenToken's same-line branch reattaches the comment correctly
+    // (and adds a trailing newline back for EOL comments). Otherwise a
+    // re-parse sees a different-line comment, breaking idempotence.
     f.o.trimTrailingNewlines();
     flushHiddenBefore(f, j);
+  }
+  // Phase 2: own-line comments before the next visible token. If the next
+  // visible token is a closing `}`, the comments visually belong to this
+  // section — emit them at the inner indent. Otherwise leave them for the
+  // parent (they're leading comments for whatever follows).
+  let k = j;
+  let trailingHidden = 0;
+  while (k < f.tokens.length) {
+    const t = f.tokens[k];
+    if (t.channel !== Token.HIDDEN_CHANNEL) break;
+    trailingHidden++;
+    k++;
+  }
+  if (trailingHidden > 0 && k < f.tokens.length) {
+    const next = f.tokens[k];
+    if (next.type === L.CCURLY) {
+      flushHiddenBefore(f, k);
+    }
   }
 }

--- a/packages/malloy/src/lang/prettify/tokens.ts
+++ b/packages/malloy/src/lang/prettify/tokens.ts
@@ -90,6 +90,26 @@ export const CALL_HUG_AFTER = new Set<number>([
   L.CAST,
   L.NOW,
   L.LAST,
+  // Ungrouped / level-modifier function-style calls.
+  L.ALL,
+  L.EXCLUDE,
+  // Timeframe truncation keywords used as functions: year(x), month(x), …
+  L.YEAR,
+  L.QUARTER,
+  L.MONTH,
+  L.WEEK,
+  L.DAY,
+  L.HOUR,
+  L.MINUTE,
+  L.SECOND,
+  // Type-cast keyword names: timestamp(x), date(x), number(x), string(x), …
+  L.TIMESTAMP,
+  L.TIMESTAMPTZ,
+  L.DATE,
+  L.NUMBER,
+  L.STRING,
+  L.BOOLEAN,
+  L.JSON,
 ]);
 
 // Binary operators that get spaces on both sides at the leaf level.
@@ -147,11 +167,15 @@ export function leadingAction(
     nextType === L.SEMI ||
     nextType === L.COLON ||
     nextType === L.TRIPLECOLON ||
+    nextType === L.EXCLAM ||
     nextType === L.CPAREN ||
     nextType === L.CBRACK
   ) {
     return 'glue';
   }
+  // After the `!` cast operator (`epoch_ms!timestamp(x)`), the next token
+  // glues to it like the `.` operator does.
+  if (prevType === L.EXCLAM) return 'glue';
   if (
     (nextType === L.OPAREN || nextType === L.OBRACK) &&
     prevType !== null &&

--- a/packages/malloy/src/lang/test/prettifier.spec.ts
+++ b/packages/malloy/src/lang/test/prettifier.spec.ts
@@ -646,6 +646,12 @@ describe('prettify — empty {} stays one line', () => {
         '}'
     );
   });
+  test('comment inside otherwise-empty {} is preserved (does not collapse)', () => {
+    // Empty-body inline collapse drops the comment if applied here, so the
+    // inline shortcut must be skipped when hidden tokens sit in the gap.
+    const out = pp('source: x is users extend { /* keep */ }');
+    expect(out).toContain('/* keep */');
+  });
 });
 
 describe('prettify — import select', () => {
@@ -665,6 +671,17 @@ describe('prettify — import select', () => {
     const out = pp(`import {${names}} from 'x.malloy'`);
     expect(out).toMatch(/^import \{\n/);
     expect(out).toMatch(/\n\} from 'x\.malloy'/);
+  });
+  test('block comment between import and select brace is preserved', () => {
+    const out = pp("import /* tag */ {a} from 'x.malloy'");
+    expect(out).toContain('/* tag */');
+  });
+  test('block comment between import items is preserved', () => {
+    // The inline form would drop the comment (renderItemInline strips
+    // hidden tokens). When any comment is present in the items' span the
+    // formatter must fall back to a comment-safe wrapped form.
+    const out = pp("import {a, /* keep */ b} from 'x.malloy'");
+    expect(out).toContain('/* keep */');
   });
 });
 

--- a/packages/malloy/src/lang/test/prettifier.spec.ts
+++ b/packages/malloy/src/lang/test/prettifier.spec.ts
@@ -474,6 +474,230 @@ describe('prettify — invariants', () => {
   });
 });
 
+describe('prettify — keyword-named function calls hug `(`', () => {
+  // Names that lex as keywords (ALL, EXCLUDE, YEAR, MONTH, …) but are
+  // commonly used as function calls. Without the explicit hug rule the
+  // prettifier inserts a space — `all (x)`, `year (created_at)` — which
+  // neither idiomatic Malloy nor the lexer expects.
+  const callableKeywords = [
+    ['all', 'all(population)'],
+    ['exclude', 'exclude(population, name)'],
+    ['year', 'year(created_at)'],
+    ['month', 'month(created_at)'],
+    ['day', 'day(created_at)'],
+    ['hour', 'hour(created_at)'],
+    ['minute', 'minute(created_at)'],
+    ['second', 'second(created_at)'],
+    ['week', 'week(created_at)'],
+    ['quarter', 'quarter(created_at)'],
+  ];
+  test.each(callableKeywords)('%s hugs its (', (_name, call) => {
+    const out = pp(
+      `source: x is duckdb.table('t') extend { measure: r is ${call} }`
+    );
+    expect(out).toContain(call);
+    // No space inserted before the open paren — the call hugs.
+    expect(out).not.toMatch(/\b\w+ \(/);
+  });
+
+  // Type names (TIMESTAMP, DATE, NUMBER, STRING, BOOLEAN, JSON) appear as
+  // function-call targets only via the `!` cast operator (`epoch_ms!timestamp(x)`).
+  // Confirm that form hugs.
+  const castTypes = ['timestamp', 'date', 'number', 'string', 'boolean'];
+  test.each(castTypes)('event_ms!%s(x) hugs', typeName => {
+    const out = pp(
+      `source: x is duckdb.table('t') extend { dimension: t is event_ms!${typeName}(x) }`
+    );
+    expect(out).toContain(`event_ms!${typeName}(x)`);
+  });
+
+  test('`!` cast operator with a 0-arg call form glues both sides', () => {
+    eq(
+      "source: x is duckdb.table('t') extend { dimension: t is event_ms!timestamp(x) }",
+      "source: x is duckdb.table('t') extend {\n" +
+        '  dimension: t is event_ms!timestamp(x)\n' +
+        '}'
+    );
+  });
+});
+
+describe('prettify — join_one / index / include sections', () => {
+  test('multi-item join_one wraps one per line', () => {
+    eq(
+      'source: x is users extend {\n' +
+        '  join_one: orders with user_id, profiles with id, prefs with id\n' +
+        '}',
+      'source: x is users extend {\n' +
+        '  join_one:\n' +
+        '    orders with user_id\n' +
+        '    profiles with id\n' +
+        '    prefs with id\n' +
+        '}'
+    );
+  });
+
+  test('single join_one stays inline if short', () => {
+    eq(
+      'source: x is users extend { join_one: orders with user_id }',
+      'source: x is users extend {\n  join_one: orders with user_id\n}'
+    );
+  });
+
+  test('long index list wraps with continuation indented past keyword', () => {
+    const fields = Array.from({length: 20}, (_, i) => `field_${i}`).join(', ');
+    const out = pp(
+      `source: x is duckdb.table('t') extend { view: i is { index: ${fields} } }`
+    );
+    // Wrapped index list lines must be indented further than the `index:`
+    // keyword itself.
+    const lines = out.split('\n');
+    const indexLine = lines.find(l => l.match(/^\s*index:\s*$/));
+    expect(indexLine).toBeDefined();
+    const indexCol = indexLine!.length - indexLine!.trimStart().length;
+    const fieldLines = lines.filter(l => l.match(/^\s+field_\d+/));
+    expect(fieldLines.length).toBeGreaterThan(0);
+    for (const line of fieldLines) {
+      const col = line.length - line.trimStart().length;
+      expect(col).toBeGreaterThan(indexCol);
+    }
+  });
+
+  test('include block items wrap with continuation indented past keyword', () => {
+    const fields = Array.from({length: 12}, (_, i) => `_field_${i}`).join(', ');
+    const out = pp(
+      'source: x is base include {\n' + `  internal: ${fields}\n` + '}'
+    );
+    const lines = out.split('\n');
+    const internalLine = lines.find(l => l.match(/^\s*internal:\s*$/));
+    expect(internalLine).toBeDefined();
+    const internalCol = internalLine!.length - internalLine!.trimStart().length;
+    const itemLines = lines.filter(l => l.match(/^\s+_field_/));
+    expect(itemLines.length).toBeGreaterThan(0);
+    for (const line of itemLines) {
+      const col = line.length - line.trimStart().length;
+      expect(col).toBeGreaterThan(internalCol);
+    }
+  });
+});
+
+describe('prettify — view: blank-line policy', () => {
+  test('forces blank between two view: definitions even without user blank', () => {
+    const out = pp(
+      "source: x is duckdb.table('t') extend {\n" +
+        '  view: a is { aggregate: c is count() }\n' +
+        '  view: b is { aggregate: c is count() }\n' +
+        '}'
+    );
+    // A blank line must sit between the two `view:` definitions. The body
+    // shape itself is the block-body rule's call — only the inter-view
+    // blank is what this test asserts.
+    expect(out).toMatch(/^ {2}}\n\n {2}view: b is/m);
+  });
+
+  test('inserts blank between non-view and following view: even without user blank', () => {
+    const out = pp(
+      "source: x is duckdb.table('t') extend {\n" +
+        '  measure: c is count()\n' +
+        '  view: a is { aggregate: c }\n' +
+        '}'
+    );
+    expect(out).toMatch(/measure: c is count\(\)\n\n {2}view: a is/);
+  });
+});
+
+describe('prettify — multi-statement {…} bodies do not collapse inline', () => {
+  test('nest with multi-statement body wraps even when it fits', () => {
+    const out = pp(
+      'source: x is t -> { nest: by_y is { group_by: y aggregate: c is count() } }'
+    );
+    // The body has two statements (group_by + aggregate); even if it would
+    // fit on one line, force the wrapped form.
+    expect(out).toMatch(
+      /nest: by_y is \{\n\s+group_by: y\n\s+aggregate: c is count\(\)\n\s+\}/
+    );
+  });
+
+  test('nest with single-statement body still inlines if it fits', () => {
+    const out = pp('source: x is t -> { nest: by_y is { group_by: y } }');
+    expect(out).toContain('nest: by_y is { group_by: y }');
+  });
+});
+
+describe('prettify — single-item nest: NAME stays on same line as nest:', () => {
+  test('single nest with multi-line body opens with `nest: name is {`', () => {
+    const out = pp(
+      'source: x is t -> { nest: dash is { group_by: y aggregate: c is count() } }'
+    );
+    // Opener is on one line — name is NOT broken onto its own line.
+    expect(out).not.toMatch(/nest:\s*\n\s+dash is \{/);
+    expect(out).toMatch(/nest: dash is \{/);
+  });
+});
+
+describe('prettify — empty {} stays one line', () => {
+  test('empty extend block', () => {
+    eq('source: x is users extend {}', 'source: x is users extend {}');
+  });
+  test('empty body in a join target', () => {
+    eq(
+      'source: x is users extend { join_one: o is orders extend {} on user_id = o.user_id }',
+      'source: x is users extend {\n' +
+        '  join_one: o is orders extend {} on user_id = o.user_id\n' +
+        '}'
+    );
+  });
+});
+
+describe('prettify — import select', () => {
+  test('single-name import stays on one line', () => {
+    eq(
+      "import {flights_cube_base} from 'flights_cube.malloy'",
+      "import {flights_cube_base} from 'flights_cube.malloy'"
+    );
+  });
+  test('few-name import stays on one line', () => {
+    eq("import {a, b, c} from 'x.malloy'", "import {a, b, c} from 'x.malloy'");
+  });
+  test('long import wraps each item on its own line', () => {
+    const names = Array.from({length: 12}, (_, i) => `name_number_${i}`).join(
+      ', '
+    );
+    const out = pp(`import {${names}} from 'x.malloy'`);
+    expect(out).toMatch(/^import \{\n/);
+    expect(out).toMatch(/\n\} from 'x\.malloy'/);
+  });
+});
+
+describe('prettify — comment placement inside aggregate/measure blocks', () => {
+  test('trailing comment inside aggregate stays at item indent (not hoisted out)', () => {
+    const out = pp(
+      'source: x is t -> { aggregate: a is count() // keep here\n}'
+    );
+    // The comment should sit on the line of `a is count()` (same-line tail).
+    expect(out).toContain('a is count() // keep here');
+  });
+
+  test('own-line comment between last aggregate item and `}` stays inside aggregate', () => {
+    const out = pp(
+      'source: x is t extend {\n' +
+        '  measure:\n' +
+        '    a is count()\n' +
+        '    b is sum(a)\n' +
+        '    // belongs to the measure block\n' +
+        '}'
+    );
+    // The comment line should be indented at the measure items level (4
+    // spaces under the source body), not flush with the closing `}`.
+    const lines = out.split('\n');
+    const commentLine = lines.find(l => l.includes('// belongs to'));
+    expect(commentLine).toBeDefined();
+    const itemLine = lines.find(l => l.includes('a is count()'));
+    const itemIndent = itemLine!.length - itemLine!.trimStart().length;
+    const commentIndent = commentLine!.length - commentLine!.trimStart().length;
+    expect(commentIndent).toBe(itemIndent);
+  });
+});
+
 // Regressions caught by external review. Each was a comment-handling bug:
 // dropped, duplicated, or landing at the wrong indent. Idempotence (asserted
 // inside `pp()`) is the load-bearing property here — these all originally


### PR DESCRIPTION
## Summary

Reviewed the experimental prettifier (#2787) against `~/malloy-samples` and found a list of disagreements with hand-written style. This PR addresses ten of them. Line budget stays at 100 (no change).

### Fixes

1. **Built-in keyword names hug `(`.** `all`, `exclude`, the timeframe truncation keywords (`year`/`month`/`day`/…), and the cast-target type names (`timestamp`/`date`/`number`/`string`/`boolean`/`json`) no longer produce `all (x)` / `year (created_at)`.
2. **`!` cast operator** (`epoch_ms!timestamp(x)`) glues to both sides like `.` does.
3. **Empty `{}`** stays one line (`extend {}` not `extend {\n}`).
4. **`import {…} from 'url'`** stays on one line when it fits, otherwise wraps one item per line at +1 indent. New `import-select.ts` rule.
5. **`view:` definitions always get a blank line before each one** in a block body, even when the source had no blank. Other statement kinds keep the existing same-kind-no-blank rule.
6. **`{...}` bodies with multiple section statements never collapse inline** (`nest: by_y is { group_by: y aggregate: c is count() }` reads badly regardless of length).
7. **Single is-item section lists keep keyword and item on same line** (`nest: name is { … }`); body wraps internally instead of forcing a `nest:\n  name is {` split.
8. **`join_one` / `join_many` / `join_cross` multi-item lists wrap one per line.** New section rules with `'joinDef'` item kind that's structurally is-like.
9. **`index:` and `public:` / `private:` / `internal:` items in `include {…}` blocks now indent continuation lines past their keyword.** New section rules; `findKeyword` descends one level to find the keyword nested in `accessLabelProp` for include items.
10. **Trailing comments between the last item of a section list and the enclosing `}`** stay at the section's inner indent so they remain associated with the section the user wrote them in.

### Test plan
- [x] 32 new test cases (one or more per fix), 58 pre-existing tests still pass — 90 total
- [x] `npm run lint` clean
- [x] `npx jest packages/malloy/src/lang` — 1358 tests pass (no regressions in the wider lang suite)
- [x] Corpus sweep over `~/malloy-samples` (17 files) — every file parses cleanly and is idempotent (`scripts/prettify-corpus-test.ts`)