### PR TITLE
revert(db-duckdb): undo 0.0.389 disconnectSync — caused SIGSEGV in language server

### DIFF
--- a/packages/malloy-db-duckdb/src/duckdb.spec.ts
+++ b/packages/malloy-db-duckdb/src/duckdb.spec.ts
@@ -142,7 +142,15 @@ describe('DuckDBConnection', () => {
       fs.rmSync(tempRoot, {recursive: true, force: true});
     });
 
-    it('idle releases the file lock for an on-disk database', async () => {
+    it('idle does NOT release the file lock cross-process (TODO: fix without crashing)', async () => {
+      // 0.0.389 attempted this fix via `disconnectSync()` in
+      // `detachInstance()`; it caused SIGSEGV / `bad_weak_ptr` from
+      // malloy-internal caches retaining weak_ptrs to the destroyed
+      // C++ Connection. Reverted in 0.0.390. Proper fix needs cache
+      // invalidation coordination (manifest reader is the leading
+      // suspect). Until then this test asserts the current (buggy
+      // but stable) behavior: another process trying to open the
+      // same database path while we hold it idle gets HELD, not FREE.
       const dbPath = path.join(tempRoot, 'idle-release.duckdb');
       const conn = new DuckDBConnection({name: 'duckdb', databasePath: dbPath});
       try {
@@ -172,7 +180,7 @@ describe('DuckDBConnection', () => {
           ],
           {encoding: 'utf8', timeout: 10000}
         );
-        expect(result.stdout).toBe('FREE');
+        expect(result.stdout.startsWith('HELD')).toBe(true);
       } finally {
         await conn.close();
       }

--- a/packages/malloy-db-duckdb/src/duckdb_connection.ts
+++ b/packages/malloy-db-duckdb/src/duckdb_connection.ts
@@ -449,24 +449,36 @@ export class DuckDBConnection extends DuckDBCommon {
   }
 
   /**
-   * Dispose this connection's stake in the underlying `DuckDBInstance`:
-   *   1. Disconnect the per-connection C++ `Connection` so its
-   *      `ClientContext` stops pinning the `DatabaseInstance`.
-   *   2. Drop our entry from the shared `activeDBs` bookkeeping.
-   *   3. If we were the last sharer, close the instance — which releases
-   *      DuckDB's per-process file lock.
+   * Drop our entry from the shared `activeDBs` bookkeeping. If we were
+   * the last sharer, close the underlying `DuckDBInstance`.
    *
-   * Step 1 is required even though step 3 calls `instance.closeSync()`.
-   * The C-API `duckdb_close` only decrements the `shared_ptr<DatabaseInstance>`
-   * refcount; live `Connection` objects keep that refcount above zero via
-   * their `ClientContext`, so the file handle (and `fcntl` lock) survive
-   * the `closeSync` call. Disconnecting first guarantees the `closeSync`
-   * is the last ref and the lock is actually released.
+   * NOTE: this does NOT fully release the OS file lock when other
+   * processes try to open the same path. `duckdb_close` (= `closeSync`)
+   * is a refcount-decrement on `shared_ptr<DatabaseInstance>`; the
+   * `fcntl(F_SETLK)` lock on the storage manager's `UnixFileHandle`
+   * survives until the last `shared_ptr` ref is gone, and live C++
+   * `Connection` objects keep that refcount above zero via their
+   * `ClientContext`. To force the lock release we'd need to also
+   * `disconnectSync()` the per-connection node-api Connection — but
+   * doing so unconditionally (as 0.0.389 did) crashes the language
+   * server because malloy's translate/persistence layer retains
+   * weak_ptrs to the destroyed C++ Connection. See the commented-out
+   * code below and PR #2793 / the revert PR for context.
+   *
+   * Proper fix needs to coordinate disconnect with invalidation of
+   * whatever caches survive idle (manifest reader is the main suspect).
    */
   private detachInstance(): void {
-    if (this.connection) {
-      this.connection.disconnectSync();
-    }
+    // [PR #2793, reverted] Adding `this.connection?.disconnectSync()`
+    // here releases the OS file lock — but it also destroys C++ state
+    // that malloy-internal caches (manifest reader, etc.) hold
+    // weak_ptrs to. Result: SIGSEGV in the language server during
+    // translate, or `bad_weak_ptr` exceptions surfacing as model
+    // problems on next op. Left here as a marker for the proper fix.
+    //
+    // if (this.connection) {
+    //   this.connection.disconnectSync();
+    // }
     const activeDB = DuckDBConnection.activeDBs[this.shareKey];
     if (activeDB) {
       activeDB.connections = activeDB.connections.filter(

--- a/packages/malloy-db-duckdb/src/duckdb_connection.ts
+++ b/packages/malloy-db-duckdb/src/duckdb_connection.ts
@@ -476,14 +476,6 @@ export class DuckDBConnection extends DuckDBCommon {
     // translate, or `bad_weak_ptr` exceptions surfacing as model
     // problems on next op. Left here as a marker for the proper fix.
     //
-    // Note: no try/catch around disconnectSync is intentional. An
-    // earlier iteration wrapped it and warned on failure; that was
-    // removed in 0.0.389 (commit e012fa55e) because swallowing the
-    // error makes the subsequent `closeSync` silently fail to release
-    // the lock, surfacing later as a confusing "could not acquire
-    // lock" on the next op. If the proper fix re-enables this block,
-    // keep the bare call — let disconnect failures throw.
-    //
     // if (this.connection) {
     //   this.connection.disconnectSync();
     // }

--- a/packages/malloy-db-duckdb/src/duckdb_connection.ts
+++ b/packages/malloy-db-duckdb/src/duckdb_connection.ts
@@ -476,6 +476,14 @@ export class DuckDBConnection extends DuckDBCommon {
     // translate, or `bad_weak_ptr` exceptions surfacing as model
     // problems on next op. Left here as a marker for the proper fix.
     //
+    // Note: no try/catch around disconnectSync is intentional. An
+    // earlier iteration wrapped it and warned on failure; that was
+    // removed in 0.0.389 (commit e012fa55e) because swallowing the
+    // error makes the subsequent `closeSync` silently fail to release
+    // the lock, surfacing later as a confusing "could not acquire
+    // lock" on the next op. If the proper fix re-enables this block,
+    // keep the bare call — let disconnect failures throw.
+    //
     // if (this.connection) {
     //   this.connection.disconnectSync();
     // }


### PR DESCRIPTION
## Summary

0.0.389 added `this.connection.disconnectSync()` at the top of
`DuckDBConnection.detachInstance()` to make `idle()`/`close()` actually
release the OS file lock cross-process. The intent was correct (the
reproducer in `duckdb.spec.ts` confirmed lock release with the patch).

In real workloads it's fatal:

- SIGSEGV crashes the language server process during translate-then-idle
  in `malloy-vscode-extension` notebooks (~23s multi-cell translate
  followed by `runtime.shutdown('idle')` reliably reproduces).
- `bad_weak_ptr` C++ exceptions surface as "Invalid SQL, Invalid Error:
  bad_weak_ptr" model problems on subsequent operations.

Both come from the same root cause: something in malloy's runtime /
translate / persistence layer holds a `weak_ptr` to the C++ Connection
past `idle`. When the patch destroys that Connection via
`disconnectSync`, those retained references either throw on `lock()`
or dereference freed memory.

The proper fix needs to coordinate `disconnectSync` with invalidation
of the surviving caches (manifest reader is the leading suspect, not
confirmed). That's not a one-line patch and needs proper design.

This revert returns malloy to the pre-0.0.389 behavior: the OS file
lock is held until V8 GC eventually finalizes the node-api Connection,
which is the original known limitation but does not crash.

The disconnectSync block is left in place as a comment block with
context, so the next person picking up the proper fix doesn't have to
re-derive the diagnosis.

The cross-process lock-release test in duckdb.spec.ts is kept and its
expectation flipped (HELD instead of FREE) with a TODO. The test
continues to document the real cross-process behavior.

## Caveats / follow-ups
- The original lock-release problem (CLI cannot acquire the file while VS Code holds it) is back. This is a pre-0.0.389 known limitation, not a regression from this PR.
- PR #2793 should not be re-applied without first invalidating malloy's manifest-reader cache (and any other connection-bound state) on idle. Without that, the same SIGSEGV / bad_weak_ptr return.