### PR TITLE
build: add dev script to db-* and malloy-connections packages

### DIFF
--- a/packages/malloy-connections/package.json
+++ b/packages/malloy-connections/package.json
@@ -29,6 +29,7 @@
   },
   "scripts": {
     "build": "tsc --build",
+    "dev": "tsc --build",
     "clean": "tsc --build --clean && rm -f tsconfig.tsbuildinfo"
   },
   "dependencies": {

--- a/packages/malloy-db-bigquery/package.json
+++ b/packages/malloy-db-bigquery/package.json
@@ -17,6 +17,7 @@
     "lint-fix": "eslint '**/*.ts{,x}' --fix",
     "test": "jest --config=../../jest.config.js",
     "build": "tsc --build",
+    "dev": "tsc --build",
     "clean": "tsc --build --clean && rm -f tsconfig.tsbuildinfo",
     "malloyc": "ts-node ../../scripts/malloy-to-json",
     "prepublishOnly": "npm run build"

--- a/packages/malloy-db-databricks/package.json
+++ b/packages/malloy-db-databricks/package.json
@@ -17,6 +17,7 @@
     "lint-fix": "eslint '**/*.ts{,x}' --fix",
     "test": "jest --config=../../jest.config.js",
     "build": "tsc --build",
+    "dev": "tsc --build",
     "clean": "tsc --build --clean && rm -f tsconfig.tsbuildinfo",
     "prepublishOnly": "npm run build"
   },

--- a/packages/malloy-db-duckdb/package.json
+++ b/packages/malloy-db-duckdb/package.json
@@ -53,6 +53,7 @@
     "lint-fix": "eslint '**/*.ts{,x}' --fix",
     "test": "jest --config=../../jest.config.js",
     "build": "tsc --build",
+    "dev": "tsc --build",
     "clean": "tsc --build --clean && rm -f tsconfig.tsbuildinfo",
     "malloyc": "ts-node ../../scripts/malloy-to-json",
     "prepublishOnly": "npm run build"

--- a/packages/malloy-db-mysql/package.json
+++ b/packages/malloy-db-mysql/package.json
@@ -17,6 +17,7 @@
     "lint-fix": "eslint '**/*.ts{,x}' --fix",
     "test": "jest --config=../../jest.config.js",
     "build": "tsc --build",
+    "dev": "tsc --build",
     "clean": "tsc --build --clean && rm -f tsconfig.tsbuildinfo",
     "malloyc": "ts-node ../../scripts/malloy-to-json",
     "prepublishOnly": "npm run build"

--- a/packages/malloy-db-postgres/package.json
+++ b/packages/malloy-db-postgres/package.json
@@ -17,6 +17,7 @@
     "lint-fix": "eslint '**/*.ts{,x}' --fix",
     "test": "jest --config=../../jest.config.js",
     "build": "tsc --build",
+    "dev": "tsc --build",
     "clean": "tsc --build --clean && rm -f tsconfig.tsbuildinfo",
     "malloyc": "ts-node ../../scripts/malloy-to-json",
     "prepublishOnly": "npm run build"

--- a/packages/malloy-db-publisher/package.json
+++ b/packages/malloy-db-publisher/package.json
@@ -17,6 +17,7 @@
     "lint-fix": "eslint '**/*.ts{,x}' --fix",
     "test": "jest --config=../../jest.config.js",
     "build": "tsc --build",
+    "dev": "tsc --build",
     "clean": "tsc --build --clean && rm -f tsconfig.tsbuildinfo",
     "malloyc": "ts-node ../../scripts/malloy-to-json",
     "prepublishOnly": "npm run build",

--- a/packages/malloy-db-snowflake/package.json
+++ b/packages/malloy-db-snowflake/package.json
@@ -17,6 +17,7 @@
     "lint-fix": "eslint '**/*.ts{,x}' --fix",
     "test": "jest --config=../../jest.config.js",
     "build": "tsc --build",
+    "dev": "tsc --build",
     "clean": "tsc --build --clean && rm -f tsconfig.tsbuildinfo",
     "malloyc": "ts-node ../../scripts/malloy-to-json",
     "prepublishOnly": "npm run build"

--- a/packages/malloy-db-trino/package.json
+++ b/packages/malloy-db-trino/package.json
@@ -17,6 +17,7 @@
     "lint-fix": "eslint '**/*.ts{,x}' --fix",
     "test": "jest --config=../../jest.config.js",
     "build": "tsc --build",
+    "dev": "tsc --build",
     "clean": "tsc --build --clean && rm -f tsconfig.tsbuildinfo",
     "malloyc": "ts-node ../../scripts/malloy-to-json",
     "prepublishOnly": "npm run build"


### PR DESCRIPTION
## Summary

`npm run dev` at the repo root is `npm run -ws --if-present dev`. The `--if-present` flag silently skips workspaces with no `dev` script — and every `db-*` adapter plus `malloy-connections` only defined `build`, not `dev`. As a result, `npm run dev` never rebuilt those packages.

Concrete impact: edit `packages/malloy-db-duckdb/src/native.ts`, run `npm run dev`, see "BUILD OK", but `dist/native.js` is unchanged. Any consumer that loads the dist file (a globally installed `malloy-cli` symlinked into the workspace, the VS Code extension's bundle, etc.) silently reads stale code. We hit this on the shareable PR (#2795) — the new property registration was in source but invisible to a CLI that loads from this workspace, and we got "unknown property `shareable` for connection type `duckdb`" until `tsc --build` was run by hand.

This adds `"dev": "tsc --build"` to each affected package.json — same as the existing `build` since none of them have a render-style heavy step. `malloy-render` remains the only intentional opt-out, as documented in `CONTEXT.md`:

> `npm run dev` — Runs codegen (ANTLR, peggy) then `tsc --build` for each package. (...) It skips the vite render build since tests don't need it.

After this PR, that statement is accurate.

## Files

9 `package.json` files: each db-* adapter (bigquery, databricks, duckdb, mysql, postgres, publisher, snowflake, trino) and `malloy-connections`. One added line per file.
