### PR TITLE
test(db-duckdb): assert shareable CREATE TABLE writes land in the attached file

### DIFF
--- a/packages/malloy-db-duckdb/src/duckdb.spec.ts
+++ b/packages/malloy-db-duckdb/src/duckdb.spec.ts
@@ -366,6 +366,61 @@ describe('DuckDBConnection', () => {
       }
     });
 
+    it('shareable: CREATE TABLE on a fresh connection lands in the attached file, not :memory:', async () => {
+      // The cli build path: lookupConnection → conn.runSQL('CREATE TABLE …').
+      // No prior runSQL, no idle. The persistence builder expects the table
+      // to be written to the attached file so that another process can read
+      // it from the file. If `attachIfShareable` were skipped (or somehow the
+      // session still had `memory.main` as default), the unqualified CREATE
+      // would land in the in-memory primary and the file would stay empty.
+      const dbPath = path.join(
+        tempRoot,
+        'shareable-create-lands-in-file.duckdb'
+      );
+      const conn = new DuckDBConnection({
+        name: 'duckdb_shareable_persist',
+        databasePath: dbPath,
+        shareable: true,
+      });
+      try {
+        // Mirror cli/build.ts createTableFromSelect: DROP IF EXISTS then CREATE.
+        await conn.runSQL('DROP TABLE IF EXISTS persisted');
+        await conn.runSQL('CREATE TABLE persisted AS SELECT 42 AS v');
+
+        // Assert on the catalog the table actually lives in. `duckdb_tables()`
+        // exposes the database (catalog) name, which is what would distinguish
+        // memory.main.persisted from malloy_db.main.persisted.
+        const where = await conn.runSQL(
+          "SELECT database_name FROM duckdb_tables() WHERE table_name='persisted'"
+        );
+        expect(where.rows).toEqual([{database_name: 'malloy_db'}]);
+
+        // And: after DETACH, the data must actually be in the file. Idle to
+        // release the lock, then open the file from a child process and
+        // count the rows. If CREATE went to :memory:, the file is empty and
+        // this read returns no rows / the table doesn't exist.
+        await conn.idle();
+        const probe = spawnSync(
+          process.execPath,
+          [
+            '-e',
+            `(async () => {
+              const {DuckDBInstance} = require('@duckdb/node-api');
+              const inst = await DuckDBInstance.create(${JSON.stringify(dbPath)});
+              const c = await inst.connect();
+              const r = await (await c.run("SELECT v FROM persisted")).getRowObjectsJson();
+              process.stdout.write(JSON.stringify(r));
+              inst.closeSync();
+            })().catch(e => { process.stdout.write('ERR:' + (e && e.message ? e.message.split('\\n')[0] : String(e))); });`,
+          ],
+          {encoding: 'utf8', timeout: 10000}
+        );
+        expect(probe.stdout).toBe('[{"v":42}]');
+      } finally {
+        await conn.close();
+      }
+    });
+
     it('setupSQL replays after idle reattach', async () => {
       const dbPath = path.join(tempRoot, 'idle-setupsql.duckdb');
       const conn = new DuckDBConnection({


### PR DESCRIPTION
## Summary

Adds a single test in `packages/malloy-db-duckdb/src/duckdb.spec.ts` covering a coverage gap in the shareable connection path. No behavior change.

## Background

The shareable mode test cases today cover:
- `idle releases the OS file lock cross-process` — confirms DETACH releases the fcntl lock
- `setupSQL does NOT replay on wake` — confirms in-memory primary state survives idle
- per-connection sharing rules and reattach flow

None of them assert *which catalog* a CREATE actually lands in, or that the data made it to the file as opposed to surviving in the in-memory primary. The failure mode if `attachIfShareable` were ever skipped (or `USE malloy_db.main` failed silently) is invisible at the API level — `runSQL('CREATE TABLE …')` succeeds either way; the table just goes to `memory.main` instead of `malloy_db.main`, the file stays empty, and no error is raised.

This came up while diagnosing a user-reported "build with checkmarks but no data on disk" symptom (turned out to be an unrelated cli manifest-trust bug, fixed in malloydata/malloy-cli#186). The investigation needed exactly this assertion and there was no test for it.

## What the test does

1. Construct a `DuckDBConnection` with `shareable: true` and a real local-file `databasePath`.
2. Run `DROP TABLE IF EXISTS persisted` then `CREATE TABLE persisted AS SELECT 42 AS v` — same shape as `malloy-cli/src/malloy/build.ts:createTableFromSelect`.
3. Assert `SELECT database_name FROM duckdb_tables() WHERE table_name='persisted'` returns `[{database_name: 'malloy_db'}]`. This catches "table went to memory.main" directly.
4. `await conn.idle()` to release the lock, then spawn a child Node process, open the file, and read back the row. Assert the child sees `[{"v":42}]`. This catches "data lived in the in-memory primary and never reached disk."

The child-process probe matches the pattern of the existing `idle does NOT release the file lock cross-process` test at line 166 of the same file.
