### PR TITLE
feat(config): allow overlay references for top-level string settings

### DIFF
--- a/packages/malloy/src/api/foundation/CONTEXT.md
+++ b/packages/malloy/src/api/foundation/CONTEXT.md
@@ -11,7 +11,7 @@ This file is about the parts that are fragile and easy to break.
 | `config.ts` | `MalloyConfig` class (constructor pipeline, `wrapConnections`, `shutdown`, `readOverlay`) and standalone `Manifest` |
 | `config_overlays.ts` | `Overlay` (sync-or-async), `ConfigOverlays`, `envOverlay()`, `contextOverlay()`, `defaultConfigOverlays()` |
 | `config_compile.ts` | Schema-directed POJO → typed tree. Section compilers. The **security boundary**. |
-| `config_resolve.ts` | `prepareConfig()` — synchronous extraction of top-level sections; fabricates default-connection entries. No overlay IO. |
+| `config_resolve.ts` | `prepareConfig()` — synchronous extraction of top-level sections; fabricates default-connection entries. Sync-peeks overlays for top-level string references (e.g. `manifestPath: {env: "X"}`); async overlays warn + drop. |
 | `config_lookup.ts` | `buildManagedLookup()` — async, per-lookup reference resolution + property defaults + factory invocation. Where overlay calls actually happen. |
 | `config_discover.ts` | `discoverConfig()` URL walk; returns a fully-built `MalloyConfig` or `null` |
 | `runtime.ts` | `Runtime`, materializers, lazy manifest read |
@@ -33,6 +33,8 @@ compiled (typed tree: ConfigDict | ConfigLiteral | ConfigReference)
    │  3. merge overlays onto defaults ({...defaultConfigOverlays(), ...passed})
    │  4. prepareConfig: extract non-connection sections (manifestPath,
    │     virtualMap); pull out compiled connection subtrees untouched.
+   │     Sync-peek overlays for top-level string references (manifestPath
+   │     can be {env: "X"} etc.); async returns warn + drop.
    │     If includeDefaultConnections: fabricate bare {is: typeName}
    │     compiled entries for registered types not already present.
    │  5. buildManagedLookup: package compiled connection subtrees + overlays
@@ -59,9 +61,14 @@ The compiled tree exists from step 2 onward and is held by `ManagedConnectionLoo
 
 - An `Overlay` is `(path: string[]) => unknown | Promise<unknown>`. The resolver `await`s every overlay result, so sync and async overlays are interchangeable from the caller's perspective.
 - `readOverlay()` on `MalloyConfig` is async for the same reason.
-- `computeManifestURL` is the one construction-time exception — it sync-peeks the `config` overlay for `configURL`. **The `config` overlay MUST resolve `configURL` synchronously**; other keys (`rootDirectory`, etc.) may be async. If the peek sees a Promise, `computeManifestURL` pushes a loud warning to `config.log` and sets `manifestURL = undefined` — failing audibly instead of silently dropping persistence. Hosts that build a `config` overlay from mixed sync/async sources should branch on the key.
+- Construction-time overlay peeks are the exception to the deferred-resolution rule. Two cases peek synchronously: (1) `computeManifestURL` reads `configURL` from the `config` overlay; (2) `prepareConfig`'s `resolveSyncStringSetting` resolves top-level string references like `manifestPath: {env: "X"}`. **All sync-peek overlays MUST return synchronously**; if any returns a Promise, the resolver pushes a loud warning to `config.log` and drops the value — failing audibly instead of silently breaking persistence or losing the setting. Inside the `config` overlay, only `configURL` is sync-only; other keys (`rootDirectory`, etc.) can still be async because they're consumed at lookup time. Hosts that build overlays from mixed sync/async sources should branch on the key.
 
-**Log timing.** Warnings about unknown overlay sources fire at lookup time, not construction time. The `log` array is mutable and shared — callers that read `config.log` before any connection lookup won't see resolution warnings; reading after a lookup will. This is an intentional consequence of deferred resolution: we don't pay for warnings on connections nobody asks about.
+**Log timing.** The `log` array is mutable and shared — entries arrive in waves matching the resolution timeline:
+
+1. *Construction* — compile-time validation warnings, plus resolution warnings for the two sync-only slots (top-level string references and `configURL`).
+2. *First lookup of each connection* — resolution warnings for that connection's property references and reference-shaped defaults.
+
+Callers that read `config.log` before any connection lookup see only the construction-time entries; warnings for a never-used connection never appear. This is an intentional consequence of deferred resolution — we don't pay for warnings on connections nobody asks about.
 
 Manifest reading happens lazily in the Runtime; discovery (which does IO) is a separate helper that *builds* a `MalloyConfig`, it's not part of the constructor.
 
@@ -80,7 +87,8 @@ const TOP_LEVEL_SECTIONS: Record<string, SectionCompiler> = {
 ```
 
 - `compileConnections` is the **only** dynamic section. For each entry, it looks up `is` in the connection registry, walks the declared properties, and at each *non-`json`* property (the reference slots) accepts either a literal or a single-key `{source: path}` reference. At each `json`-typed property it passes raw data through as `ConfigLiteral` — no reference interpretation.
-- `compileVirtualMap`, `compileManifestPath`, `compileIncludeDefaultConnections` are pass-through. `{env: "X"}` *inside* `virtualMap` is literal JSON, not a reference.
+- `compileManifestPath` accepts either a literal string or a reference shape. Resolution happens synchronously in `prepareConfig` — see the sync-peek discussion under [Sync/async boundary](#the-pipeline) above.
+- `compileVirtualMap`, `compileIncludeDefaultConnections` are pass-through. `{env: "X"}` *inside* `virtualMap` is literal JSON, not a reference.
 
 Consequences:
 
@@ -116,7 +124,7 @@ Plain spread. This gives callers three moves without any extra API:
 - **Replace** — passing an existing key clobbers the default (`config` → discovery-populated or Publisher's).
 - **Disable** — omit; the default is already a no-op for `config`.
 
-### Three Failure Modes
+### Four Failure Modes
 
 Cases and observed behavior: [configuration.md → Failure Modes](../../doc/configuration.md#failure-modes). Why each behaves the way it does — the rationale that matters when you're tempted to "improve" them in code:
 
@@ -125,8 +133,11 @@ Cases and observed behavior: [configuration.md → Failure Modes](../../doc/conf
 | Unknown overlay source → warning + drop | Almost always a typo or host/config mismatch. Silent-dropping would hide real bugs; throwing would punish a host that hasn't yet registered an optional overlay. The `config.log` warning splits the difference. |
 | Known overlay returns `undefined` → silent drop | Legitimate "value not present" state, matching env-var semantics. A required-field violation surfaces at connection-build time (lazy, at lookup), not here — keeping the resolver out of policy decisions about what's required. |
 | Unresolved reference in a `default` → silent drop | A default is a hint, not a requirement. "No default applicable" is a normal terminal state, not a failure. |
+| Async overlay used in a sync-only slot → loud warning + drop | A construction-time peek can't `await`. This is misuse rather than absence, so silent drop would hide a wiring bug; throwing would brittly couple to a stack the host might still be assembling. The loud warning gets the host's attention while keeping construction infallible. Applies to `configURL` and to top-level string references like `manifestPath`. |
 
 Consequence: cases 2 and 3 make "typo'd env var" and "legitimately unset env var" indistinguishable. Matches today's behavior. Typo detection would need the resolver to know which properties are required by which factory — not worth crossing that line.
+
+Case 1 fires at *construction time* for top-level references (resolved in `prepareConfig`) and at *first lookup* for connection-property references (resolved in `buildManagedLookup`). This is a consequence of when each kind is consumed — not a behavior to "unify."
 
 ## Property Defaults vs. `includeDefaultConnections`
 
@@ -242,5 +253,5 @@ URL-based (not filesystem-based) so the helper works in browser-safe environment
 - **A single-key object isn't always a reference.** In `json`-typed slots and in `virtualMap`, it's literal data. The section-compiler boundary is what makes this safe.
 - **`manifestURL` computation uses `configURL`, not `rootDirectory`.** The manifest hangs off the config file's directory, not the project root. These are different URLs when the config file lives in a subdirectory.
 - **Property defaults run *after* overlay resolution of explicit values**, so a user who sets a property to a reference that resolves to `undefined` gets the same silent-drop as if they'd omitted the property — and then the default fills in. This is intentional and composes cleanly; don't "fix" it by conflating the phases.
-- **Reference resolution is deferred to `lookupConnection`.** `MalloyConfig`'s constructor stays sync and zero-IO so it's safe to build anywhere. Overlays with async dependencies (secret stores, session reads) get a natural async seam at lookup. A consequence: `config.log` is populated incrementally as connections are looked up — warnings for a never-used connection never appear.
+- **Connection-property reference resolution is deferred to `lookupConnection`.** `MalloyConfig`'s constructor stays sync and does no overlay IO for connection properties, so it's safe to build anywhere. Overlays with async dependencies (secret stores, session reads) get a natural async seam at lookup. A consequence: warnings about connection-property references arrive in `config.log` incrementally as connections are looked up — warnings for a never-used connection never appear. Top-level string references and `configURL` are the exceptions: they resolve synchronously at construction time and any warnings about them appear immediately.
 - **`wrapConnections` can be called multiple times.** Each wrap sees the previous wrap's result as `base`. Hosts that need ordered layering (VS Code's three-level resolution) rely on this.

--- a/packages/malloy/src/api/foundation/config.spec.ts
+++ b/packages/malloy/src/api/foundation/config.spec.ts
@@ -352,6 +352,67 @@ describe('MalloyConfig manifestURL resolution', () => {
   });
 });
 
+describe('MalloyConfig top-level string references', () => {
+  const configURL = 'file:///home/user/project/malloy-config.json';
+
+  it('resolves an env reference for manifestPath', () => {
+    process.env['TEST_MANIFEST_PATH'] = 'custom/build';
+    try {
+      const config = new MalloyConfig(
+        {manifestPath: {env: 'TEST_MANIFEST_PATH'}},
+        {config: contextOverlay({configURL})}
+      );
+      expect(config.log).toEqual([]);
+      expect(config.manifestPath).toBe('custom/build');
+      expect(config.manifestURL?.toString()).toBe(
+        'file:///home/user/project/custom/build/malloy-manifest.json'
+      );
+    } finally {
+      delete process.env['TEST_MANIFEST_PATH'];
+    }
+  });
+
+  it('falls back to the default when the env reference is unset', () => {
+    delete process.env['DEFINITELY_NOT_SET_98765'];
+    const config = new MalloyConfig(
+      {manifestPath: {env: 'DEFINITELY_NOT_SET_98765'}},
+      {config: contextOverlay({configURL})}
+    );
+    expect(config.log).toEqual([]);
+    expect(config.manifestPath).toBeUndefined();
+    expect(config.manifestURL?.toString()).toBe(
+      'file:///home/user/project/MANIFESTS/malloy-manifest.json'
+    );
+  });
+
+  it('warns and drops on unknown overlay source', () => {
+    const config = new MalloyConfig(
+      {manifestPath: {nosuch: 'whatever'}},
+      {config: contextOverlay({configURL})}
+    );
+    const warnings = config.log.filter(l => l.code === 'config-overlay');
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].message).toContain('unknown overlay source "nosuch"');
+    expect(warnings[0].message).toContain('manifestPath');
+    expect(config.manifestPath).toBeUndefined();
+  });
+
+  it('warns and drops when the overlay returns a Promise', () => {
+    const config = new MalloyConfig(
+      {manifestPath: {async: 'manifestPath'}},
+      {
+        config: contextOverlay({configURL}),
+        async: async () => 'something',
+      }
+    );
+    const warnings = config.log.filter(l => l.code === 'config-overlay');
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].message).toContain('Promise');
+    expect(warnings[0].message).toContain('manifestPath');
+    expect(config.manifestPath).toBeUndefined();
+  });
+});
+
 describe('MalloyConfig overlay resolution', () => {
   it('resolves env references via the default stack', async () => {
     process.env['TEST_DB_PATH_ENV'] = '/tmp/test.db';

--- a/packages/malloy/src/api/foundation/config.ts
+++ b/packages/malloy/src/api/foundation/config.ts
@@ -15,7 +15,7 @@ import type {
 import {compileConfig} from './config_compile';
 import {prepareConfig} from './config_resolve';
 import {buildManagedLookup} from './config_lookup';
-import {defaultConfigOverlays} from './config_overlays';
+import {defaultConfigOverlays, isThenable} from './config_overlays';
 import type {ConfigOverlays} from './config_overlays';
 
 /**
@@ -222,7 +222,7 @@ export class MalloyConfig {
     // Reference resolution for connection properties is *not* done here —
     // it happens async at `lookupConnection` time, so overlays that touch
     // IO (secret stores, session reads) have a natural async seam.
-    const prepared = prepareConfig(compiled.compiled, log);
+    const prepared = prepareConfig(compiled.compiled, mergedOverlays, log);
 
     this._managedLookup = buildManagedLookup(
       prepared.compiledConnections,
@@ -435,14 +435,6 @@ function toVirtualMap(raw: unknown): VirtualMap | undefined {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
-
-function isThenable(value: unknown): value is PromiseLike<unknown> {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    typeof (value as {then?: unknown}).then === 'function'
-  );
 }
 
 function isBuildManifestEntry(value: unknown): value is BuildManifestEntry {

--- a/packages/malloy/src/api/foundation/config_compile.ts
+++ b/packages/malloy/src/api/foundation/config_compile.ts
@@ -263,8 +263,15 @@ function compileManifestPath(
   value: unknown,
   log: LogMessage[]
 ): ConfigNode | undefined {
+  const ref = asReferenceShape(value);
+  if (ref !== undefined) return ref;
   if (typeof value !== 'string') {
-    log.push(makeWarning('manifestPath', '"manifestPath" should be a string'));
+    log.push(
+      makeWarning(
+        'manifestPath',
+        '"manifestPath" should be a string or an overlay reference'
+      )
+    );
     return undefined;
   }
   return {kind: 'value', value};

--- a/packages/malloy/src/api/foundation/config_overlays.ts
+++ b/packages/malloy/src/api/foundation/config_overlays.ts
@@ -80,3 +80,17 @@ export function defaultConfigOverlays(): ConfigOverlays {
     config: () => undefined,
   };
 }
+
+/**
+ * Type guard for "looks like a Promise." Used by sync-peek call sites
+ * (`computeManifestURL`, `resolveSyncStringSetting`) to detect when a host
+ * mistakenly wired an async overlay into a slot that's read synchronously.
+ */
+export function isThenable(value: unknown): value is PromiseLike<unknown> {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'then' in value &&
+    typeof value.then === 'function'
+  );
+}

--- a/packages/malloy/src/api/foundation/config_resolve.ts
+++ b/packages/malloy/src/api/foundation/config_resolve.ts
@@ -5,7 +5,9 @@
 
 import type {LogMessage} from '../../lang/parse-log';
 import {getRegisteredConnectionTypes} from '../../connection/registry';
-import type {ConfigDict} from './config_compile';
+import type {ConfigDict, ConfigNode} from './config_compile';
+import {isThenable} from './config_overlays';
+import type {ConfigOverlays} from './config_overlays';
 
 /**
  * The synchronous slice of config preparation. What the `MalloyConfig`
@@ -46,7 +48,8 @@ export interface PreparedConfig {
  */
 export function prepareConfig(
   compiled: ConfigDict,
-  _log: LogMessage[]
+  overlays: ConfigOverlays,
+  log: LogMessage[]
 ): PreparedConfig {
   let compiledConnections: Record<string, ConfigDict> = {};
   let manifestPath: string | undefined;
@@ -61,9 +64,12 @@ export function prepareConfig(
         break;
       }
       case 'manifestPath': {
-        if (node.kind === 'value' && typeof node.value === 'string') {
-          manifestPath = node.value;
-        }
+        manifestPath = resolveSyncStringSetting(
+          node,
+          overlays,
+          log,
+          'manifestPath'
+        );
         break;
       }
       case 'virtualMap': {
@@ -134,4 +140,50 @@ function fabricateMissingConnections(
       },
     };
   }
+}
+
+/**
+ * Resolve a top-level string setting that may be a literal or an overlay
+ * reference. Top-level scalars are read at construction time, so the overlay
+ * MUST resolve synchronously — same rule that applies to `configURL`. An
+ * overlay returning a Promise is a hard misuse: warn loudly and drop, so the
+ * application notices instead of silently losing the setting.
+ *
+ * Failure modes mirror connection-property resolution otherwise:
+ *   - unknown overlay source → warn + drop (case 1)
+ *   - overlay returns undefined → silent drop (case 2; falls back to default)
+ *   - non-string literal node → returns undefined (compile-time validation
+ *     already warned)
+ */
+function resolveSyncStringSetting(
+  node: ConfigNode,
+  overlays: ConfigOverlays,
+  log: LogMessage[],
+  settingName: string
+): string | undefined {
+  if (node.kind === 'value') {
+    return typeof node.value === 'string' ? node.value : undefined;
+  }
+  if (node.kind === 'reference') {
+    const overlay = overlays[node.source];
+    if (!overlay) {
+      log.push({
+        message: `unknown overlay source "${node.source}" for "${settingName}"`,
+        severity: 'warn',
+        code: 'config-overlay',
+      });
+      return undefined;
+    }
+    const v = overlay(node.path);
+    if (isThenable(v)) {
+      log.push({
+        message: `the \`${node.source}\` overlay returned a Promise for "${settingName}"; top-level string settings must resolve synchronously`,
+        severity: 'warn',
+        code: 'config-overlay',
+      });
+      return undefined;
+    }
+    return typeof v === 'string' ? v : undefined;
+  }
+  return undefined;
 }

--- a/packages/malloy/src/doc/configuration.md
+++ b/packages/malloy/src/doc/configuration.md
@@ -40,11 +40,11 @@ Top-level keys:
 | Key | Purpose |
 |---|---|
 | `connections` | Named connection entries. Each has an `is` field naming a registered backend, plus backend-specific properties. |
-| `manifestPath` | Directory where the build manifest lives, relative to the config file. Defaults to `MANIFESTS`. |
+| `manifestPath` | Directory where the build manifest lives, relative to the config file. Defaults to `MANIFESTS`. May be a string literal or a sync-resolving overlay reference (e.g. `{"env": "MALLOY_MANIFEST_PATH"}`). |
 | `virtualMap` | URL rewrite rules for sources that reference virtual locations. Literal — no overlay expansion. |
 | `includeDefaultConnections` | If `true`, fabricate one entry per registered backend type not already listed. See below. |
 
-Any non-`json`-typed property value may be a reference instead of a literal (see [Overlay References](#overlay-references)).
+Any non-`json`-typed property value — both inside `connections` and at the top level (currently just `manifestPath`) — may be a reference instead of a literal. See [Overlay References](#overlay-references). Top-level references carry one extra constraint: the overlay must resolve synchronously, because these values are read at construction time.
 
 ## Overlay References
 
@@ -67,17 +67,25 @@ Hosts can register additional overlays — VS Code adds a `secret` overlay backe
 
 Overlays may be synchronous or asynchronous — an overlay's return type is `unknown | Promise<unknown>`. Use sync for purely in-memory sources (env vars, context dicts); use async for anything that touches IO (secret stores, session fetches, enterprise-injected values). Reference resolution is deferred to connection-lookup time (already async), so async overlays don't force the host to change anything else.
 
-**One exception.** The `config` overlay must resolve the `configURL` key synchronously. `manifestURL` is computed once in the `MalloyConfig` constructor from `configURL` + `manifestPath`, and that single peek is the one place overlay IO can't be awaited. If a host's `config` overlay returns a Promise for `configURL`, `MalloyConfig` pushes a warning to `config.log` and leaves `manifestURL` undefined (persistence silently stops working otherwise). Other keys in the `config` overlay — `rootDirectory`, host-specific context — can still be async; only `configURL` is sync-only.
+**Sync-only at the top level.** Two construction-time peeks are exempt from the deferred-resolution rule and must resolve synchronously:
+
+- Any top-level string setting written as a reference (currently `manifestPath: {env: "..."}` or similar).
+- The `configURL` key on the `config` overlay (set by the host, not by the user — see [`rootDirectory` vs. `configURL`](#rootdirectory-vs-configurl)).
+
+Both feed into `manifestURL`, which is computed once in the `MalloyConfig` constructor — and constructors can't `await`. If an overlay returns a Promise for one of these, `MalloyConfig` pushes a loud warning to `config.log` and drops the value; without the warning, persistence would silently stop working. Inside the `config` overlay, only `configURL` is sync-only — other keys (`rootDirectory`, host-specific context) can still be async because they're consumed at lookup time.
 
 ### Failure Modes
 
-References fail in three distinguishable ways, each handled differently:
+References fail in four distinguishable ways, each handled differently:
 
-1. **Unknown overlay source** (`{zzz: "foo"}` when no `zzz` overlay is registered) — logged as a warning to `config.log` when the affected connection is looked up (not at construction time); the property is dropped. Almost always a typo or host/config mismatch.
+1. **Unknown overlay source** (`{zzz: "foo"}` when no `zzz` overlay is registered) — logged as a warning to `config.log`; the property is dropped. Almost always a typo or host/config mismatch.
 2. **Known overlay returns `undefined`** (`{env: "MISSING_VAR"}` — env var unset) — silently dropped. Legitimate "value not present" state. If the dropped property was required, the connection factory complains when the connection is built (lazy, at lookup time), not at config-build time.
 3. **Unresolved reference inside a default** — silently dropped. Defaults are hints, not requirements.
+4. **Async overlay used in a sync-only slot** (e.g. `manifestPath: {secret: "X"}` when `secret` returns a Promise) — logged as a loud warning to `config.log` and dropped. Top-level string settings are read at construction time and can't `await`; this is misuse, not a missing value. The same rule applies to `configURL` on the host-supplied `config` overlay.
 
 A consequence: a typo'd env var and an unset env var are indistinguishable. This matches established behavior.
+
+Mode 1 fires at construction time for top-level references and at first lookup for connection-property references — a consequence of when each is resolved. Mode 4 only fires at construction time, since it's specific to the sync-only slots. Modes 2 and 3 are silent in both cases.
 
 ### The `json` Property Type
 


### PR DESCRIPTION
## Summary

- Top-level string settings (currently just `manifestPath`) now accept overlay references like `{"env": "MALLOY_MANIFEST_PATH"}`, mirroring what's already allowed for connection properties. Closes the gap noted at the top of the user-facing config doc.
- Resolution at the top level is **sync-only** — these values are consumed in the `MalloyConfig` constructor, which can't `await`. An overlay that returns a Promise for one of these slots (or for `configURL`) gets a loud warning in `config.log` and the value is dropped, so misuse fails audibly instead of silently breaking persistence. This is the same rule that already applied to `configURL`; this PR generalizes it and documents it as one rule.
- Refactor: deduplicates the `isThenable` helper into `config_overlays.ts` (was copy-pasted between `config.ts` and `config_resolve.ts`) and replaces the `as` cast with `'then' in value` narrowing.

## Behavior

| User writes | Result |
|---|---|
| `"manifestPath": "MANIFESTS"` | unchanged — literal string |
| `"manifestPath": {"env": "MALLOY_MANIFEST_PATH"}` | resolves via env overlay |
| `"manifestPath": {"env": "UNSET"}` | silently drops, falls back to default `MANIFESTS` |
| `"manifestPath": {"nosuch": "x"}` | warns to `config.log`, falls back |
| `"manifestPath": {"asyncOverlay": "x"}` (overlay returns Promise) | loud warning, falls back |

Existing literal-string `manifestPath` configs are unaffected.
