### PR TITLE
build(deps): bump axios, ip-address, and socks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12038,12 +12038,12 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
         "proxy-from-env": "^2.1.0"
       }
@@ -18144,21 +18144,13 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
-      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
-      "dependencies": {
-        "jsbn": "1.1.0",
-        "sprintf-js": "^1.1.3"
-      },
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
       "engines": {
         "node": ">= 12"
       }
-    },
-    "node_modules/ip-address/node_modules/sprintf-js": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="
     },
     "node_modules/is": {
       "version": "3.3.0",
@@ -20511,11 +20503,6 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
-    },
-    "node_modules/jsbn": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
-      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A=="
     },
     "node_modules/jsdoc-type-pratt-parser": {
       "version": "4.8.0",
@@ -25823,11 +25810,12 @@
       }
     },
     "node_modules/socks": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
-      "integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.8.tgz",
+      "integrity": "sha512-NlGELfPrgX2f1TAAcz0WawlLn+0r3FyhhCRpFFK2CemXenPYvzMWWZINv3eDNo9ucdwme7oCHRY0Jnbs4aIkog==",
+      "license": "MIT",
       "dependencies": {
-        "ip-address": "^9.0.5",
+        "ip-address": "^10.1.1",
         "smart-buffer": "^4.2.0"
       },
       "engines": {


### PR DESCRIPTION
## Summary

Combines three open dependabot PRs into one lockfile-only bump:

- #2799 — axios 1.15.0 → **1.16.0** (dependabot asked for 1.15.2; `npm update` picks the latest within the existing `^1.12.0` range, which is now 1.16.0)
- #2801 — ip-address 9.0.5 → 10.2.0 + socks 2.8.3 → 2.8.8 (grouped transitive bump)

`ip-address@10` drops its bundled `jsbn` and `sprintf-js` transitives, so the lockfile diff is +13/−25.

## Why one PR

All three are pure `package-lock.json` changes with no source-code impact, so bundling saves a CI run and a merge each. The third open dependabot PR (#2779, uuid 8 → 14) is **not** included here — it's a 6-major-version jump that includes a CommonJS removal and currently fails CI; it needs a deliberate look, not a routine bump.

## Audit delta

| Severity | main | this branch | Δ |
|---|---:|---:|---:|
| critical | 3 | 3 | — |
| high | 31 | 31 | — |
| moderate | 11 | 9 | **−2** |
| low | 14 | 14 | — |
| **total** | 59 | 57 | **−2** |

Two moderate vulnerabilities clear (the `ip-address`/`socks` advisories that #2801 was issued for). Critical/high counts are unchanged — those live in `snowflake-sdk` and `@databricks/sql` transitive chains (`fast-xml-parser`, `@aws-sdk/xml-builder`, `basic-ftp`) and won't move until those direct deps refresh.

## Test plan

- [x] `npm install` clean
- [x] `npm run build` clean (full workspace)
- [x] `npm run test-duckdb` passes (3052 tests, 89 suites)
- [x] No `package.json` changes needed — existing semver ranges already accept the new versions

## Closes

Closes #2799 and #2801. Leaves #2779 (uuid major bump) for separate handling.