### PR TITLE
fix(db-duckdb,db-mysql): quote table paths that aren't bare identifiers

### DIFF
--- a/packages/malloy-db-duckdb/src/duckdb.spec.ts
+++ b/packages/malloy-db-duckdb/src/duckdb.spec.ts
@@ -102,6 +102,35 @@ describe('DuckDBConnection', () => {
       });
       expect(runRawSQL).toHaveBeenCalledTimes(2);
     });
+
+    it('quotes file-path table names containing dashes', async () => {
+      // Bug repro: `duckdb.table('arrests-latest.parquet')` failed because
+      // the dash made DuckDB parse `arrests-latest.parquet` as subtraction.
+      await connection.fetchSchemaForTables(
+        {'dashed': 'arrests-latest.parquet'},
+        {}
+      );
+      expect(runRawSQL).toHaveBeenCalledWith(
+        "DESCRIBE SELECT * FROM 'arrests-latest.parquet'"
+      );
+    });
+
+    it('leaves bare table identifiers unquoted', async () => {
+      await connection.fetchSchemaForTables({'plain': 'plain_table'}, {});
+      expect(runRawSQL).toHaveBeenCalledWith(
+        'DESCRIBE SELECT * FROM plain_table'
+      );
+    });
+
+    it('leaves schema-qualified identifiers unquoted', async () => {
+      await connection.fetchSchemaForTables(
+        {'qualified': 'main.qualified_table'},
+        {}
+      );
+      expect(runRawSQL).toHaveBeenCalledWith(
+        'DESCRIBE SELECT * FROM main.qualified_table'
+      );
+    });
   });
 
   describe('multiple connections', () => {

--- a/packages/malloy-db-duckdb/src/duckdb_common.ts
+++ b/packages/malloy-db-duckdb/src/duckdb_common.ts
@@ -56,6 +56,16 @@ const unquoteName = (name: string) => {
   return name;
 };
 
+/**
+ * A bare or schema-qualified SQL identifier — `name` or `schema.name`. Anything
+ * else (file paths with dashes, dots-as-extensions, slashes, URL schemes,
+ * globs) is treated as a file-path string by `fetchTableSchema` and wrapped
+ * in single quotes so DuckDB sees it as a string literal rather than parsing
+ * it as a SQL identifier.
+ */
+const SQL_IDENTIFIER_CHAIN =
+  /^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)*$/;
+
 export abstract class DuckDBCommon
   extends BaseConnection
   implements TestableConnection, PersistSQLResults, StreamingConnection
@@ -202,9 +212,9 @@ export abstract class DuckDBCommon
       fields: [],
     };
 
-    const quotedTablePath = tablePath.match(/[:*/]/)
-      ? `'${tablePath}'`
-      : tablePath;
+    const quotedTablePath = SQL_IDENTIFIER_CHAIN.test(tablePath)
+      ? tablePath
+      : `'${tablePath}'`;
     const infoQuery = `DESCRIBE SELECT * FROM ${quotedTablePath}`;
     await this.schemaFromQuery(infoQuery, structDef);
     return structDef;

--- a/packages/malloy-db-mysql/src/mysql_connection.spec.ts
+++ b/packages/malloy-db-mysql/src/mysql_connection.spec.ts
@@ -55,6 +55,26 @@ describeMySQL('db:MySQL', () => {
       numberType: 'bigint',
     });
   });
+
+  it('fetches schema for tables whose names contain dashes', async () => {
+    // Bug repro: `mysql.table('arrests-latest')` failed because the dash
+    // made MySQL parse `DESCRIBE arrests-latest` as subtraction.
+    await connection.runRawSQL('DROP TABLE IF EXISTS `arrests-latest`');
+    await connection.runRawSQL(
+      'CREATE TABLE `arrests-latest` (id INT, name VARCHAR(50))'
+    );
+    try {
+      const res = await connection.fetchSchemaForTables(
+        {dashed: 'arrests-latest'},
+        {}
+      );
+      expect(res.errors).toEqual({});
+      const fields = res.schemas['dashed']?.fields ?? [];
+      expect(fields.map(f => f.name).sort()).toEqual(['id', 'name']);
+    } finally {
+      await connection.runRawSQL('DROP TABLE `arrests-latest`');
+    }
+  });
 });
 
 /**

--- a/packages/malloy-db-mysql/src/mysql_connection.ts
+++ b/packages/malloy-db-mysql/src/mysql_connection.ts
@@ -25,6 +25,15 @@ import {BaseConnection} from '@malloydata/malloy/connection';
 import {randomUUID} from 'crypto';
 import * as MYSQL from 'mysql2/promise';
 
+/**
+ * A bare or schema-qualified SQL identifier — `name` or `db.name`. Anything
+ * else (dashes, dots-as-extensions, slashes, special characters) needs to be
+ * wrapped in backticks for `DESCRIBE` to parse it as one identifier rather
+ * than e.g. parsing `my-table` as subtraction.
+ */
+const SQL_IDENTIFIER_CHAIN =
+  /^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)*$/;
+
 export interface MySQLConfiguration {
   host?: string;
   port?: number;
@@ -185,9 +194,9 @@ export class MySQLConnection
       fields: [],
     };
 
-    const quotedTablePath = tablePath.match(/[:*/]/)
-      ? `\`${tablePath}\``
-      : tablePath;
+    const quotedTablePath = SQL_IDENTIFIER_CHAIN.test(tablePath)
+      ? tablePath
+      : `\`${tablePath}\``;
     const infoQuery = `DESCRIBE ${quotedTablePath}`;
     const result = await this.runRawSQL(infoQuery);
     await this.schemaFromResult(result, structDef);


### PR DESCRIPTION
## Summary

HT @mrtimo for finding this!

`duckdb.table('arrests-latest.parquet')` failed with:

```
Parser Error: syntax error at or near \"-\"
LINE 1: DESCRIBE SELECT * FROM arrests-latest.parquet
                                      ^
```

`duckdb_common.fetchTableSchema` was using a heuristic that only quoted the table path when it contained `:`, `*`, or `/`. A bare filename whose only special characters were `.` and `-` slipped through unquoted, and DuckDB parsed `arrests-latest.parquet` inside `DESCRIBE SELECT * FROM ...` as the subtraction `arrests - latest.parquet`.

`db-mysql` had identical code with the same bug — the file-path use case doesn't really apply to MySQL, but a real MySQL table whose name contains a dash (`mysql.table('arrests-latest')`) hit the same parse error. Same fix, with backticks instead of single quotes.

## Audit of other dialects

| Dialect | Same bug? | Notes |
|---|---|---|
| **duckdb** | yes — fixed | |
| **mysql** | **yes — fixed** | identical regex, same shape |
| databricks | no | `dialect.quoteTablePath` already does correct per-segment quoting |
| bigquery | no | uses BQ metadata API, not SQL |
| postgres | no | looks up via `information_schema` |
| publisher | no | REST API |
| snowflake | no — but unquoted | Raw `DESCRIBE TABLE \${tablePath}`. Different shape; separate fix. |
| trino | no — but unquoted | Raw `DESCRIBE \${tablePath}`. Different shape; separate fix. |
