### PR TITLE
fix(givens): accept date literal as default for timestamp-typed given

### DIFF
--- a/packages/malloy/src/lang/ast/statements/define-given.ts
+++ b/packages/malloy/src/lang/ast/statements/define-given.ts
@@ -13,20 +13,18 @@ import {givenUsageFrom, TD} from '../../../model/malloy_types';
 import {mkGivenID} from '../../../model/source_def_utils';
 import {typeDefToString} from '../../../model/utils';
 import type {ConstantExpression} from '../expressions/constant-expression';
-import {checkFilterExpression} from '../types/expression-def';
+import {checkFilterExpression, getMorphicValue} from '../types/expression-def';
 import type {ExprValue} from '../types/expr-value';
 import type {DocStatement, Document} from '../types/malloy-element';
 import {DocStatementList, MalloyElement} from '../types/malloy-element';
 import type {Noteable} from '../types/noteable';
 import {extendNoteMethod} from '../types/noteable';
 
-/**
- * True when exactly one of `declared` and `constVal` is filter-typed.
- * Catches `filter<T>` declared with a non-filter default (and vice versa)
- * at definition time. Inner-content validation of `filter<T>` defaults
- * (syntax + compatibility with `T`) is the filter machinery's job at the
- * use site; we don't try to do it here.
- */
+// `filter<T>` defaults can't be type-checked via TD.eq — the filter
+// expression value shape doesn't match an atomic typeDef. Catch only
+// the gross kind mismatch here; inner-content validation (filter
+// syntax + T compatibility) belongs to the filter machinery at use
+// site.
 function filterTypeMismatch(
   declared: GivenTypeDef,
   constVal: ExprValue
@@ -37,9 +35,6 @@ function filterTypeMismatch(
   );
 }
 
-/**
- * One named given declaration: `NAME :: TYPE [is EXPR]`.
- */
 export class GivenDeclaration
   extends MalloyElement
   implements DocStatement, Noteable
@@ -88,12 +83,21 @@ export class GivenDeclaration
     if (this.default) {
       const constVal = this.default.constantValue();
       if (constVal.type !== 'error') {
+        // `X :: timestamp is @2024-01-01` works because date literals
+        // carry a morphic.timestamp. Date/timestamp are the only
+        // MorphicType targets — other declared types fall through to
+        // the TD.eq check below.
+        const morphed =
+          this.typeDef.type === 'date' || this.typeDef.type === 'timestamp'
+            ? getMorphicValue(constVal, this.typeDef.type)
+            : undefined;
         // `filter<T>` defaults are filter-expression literals — their
         // shape doesn't match an atomic typeDef, so type-check there is
         // owned by the filter machinery, not us. `null` is implicitly
         // accepted for any declared type.
         if (
           constVal.type !== 'null' &&
+          morphed === undefined &&
           (filterTypeMismatch(this.typeDef, constVal) ||
             !TD.eq(this.typeDef, constVal))
         ) {
@@ -117,7 +121,7 @@ export class GivenDeclaration
             constVal.value
           );
         }
-        defaultExpr = constVal.value;
+        defaultExpr = morphed?.value ?? constVal.value;
         // Build the transitive closure of givens reachable through this
         // default's expression. We only include direct refs PLUS each
         // referenced given's already-precomputed transitive (which is
@@ -189,9 +193,6 @@ export class GivenDeclaration
   }
 }
 
-/**
- * Top-level `given:` block — a sequence of given declarations.
- */
 export class DefineGivens extends DocStatementList {
   elementType = 'defineGivens';
   readonly givens: GivenDeclaration[];

--- a/packages/malloy/src/lang/test/givens.spec.ts
+++ b/packages/malloy/src/lang/test/givens.spec.ts
@@ -471,6 +471,24 @@ describe('given: IR generation', () => {
     );
   });
 
+  test('date literal accepted for declared timestamp (morphic)', () => {
+    expect(`
+      ##! experimental.givens
+      given: X :: timestamp is @2001-02-02
+    `).toTranslate();
+  });
+
+  test('timestamp literal not accepted for declared date (no reverse morph)', () => {
+    expect(`
+      ##! experimental.givens
+      given: BAD :: date is @2001-02-02 12:00:00
+    `).toLog(
+      errorMessage(
+        'Default value of type `timestamp` does not match declared type `date`'
+      )
+    );
+  });
+
   test('compound declared type echoes back in type-mismatch error', () => {
     expect(`
       ##! experimental.givens

--- a/test/src/core/givens.spec.ts
+++ b/test/src/core/givens.spec.ts
@@ -209,6 +209,33 @@ describe('givens — runtime supply path (Stage 4)', () => {
     expect(rSp.data.path(0, 'ct').value).toBe(1);
   });
 
+  test('date-literal default morphs to timestamp and filters flights.dep_time', async () => {
+    // Exercises the morphic default path in define-given: the declared
+    // type is `timestamp`, the default `@2003-01-01` is a date literal,
+    // and the AST converts it to a timestamp expression so the default
+    // can drive a timestamp-column comparison at runtime.
+    const model = runtime.loadModel(`
+      ##! experimental.givens
+      given: BEFORE :: timestamp is @2003-01-01
+      query: q is duckdb.table('malloytest.flights') -> {
+        where: dep_time < $BEFORE
+        aggregate: ct is count()
+      }
+    `);
+    // No caller supply — the morphed default drives the cutoff.
+    const def = await model.loadQueryByName('q').run();
+    const defaultCt = def.data.path(0, 'ct').value;
+    expect(typeof defaultCt).toBe('number');
+    expect(defaultCt).toBeGreaterThan(0);
+    // Override with a tighter cutoff — count must drop.
+    const tight = await model
+      .loadQueryByName('q')
+      .run({givens: {BEFORE: '2002-01-01 00:00:00'}});
+    expect(Number(tight.data.path(0, 'ct').value)).toBeLessThan(
+      Number(defaultCt)
+    );
+  });
+
   test('naive timestamp given rejects offset-bearing strings', async () => {
     const model = runtime.loadModel(`
       ##! experimental.givens


### PR DESCRIPTION
## Summary

- `given: X :: timestamp is @2024-01-01` now translates: the date literal's `morphic.timestamp` form is used as the default expression, same pattern as `expr-time-extract.ts` and `for-range.ts`.
- Reverse direction (`given: X :: date is @2024-01-01 12:00:00`) still rejected — timestamps don't morph back to date.
- Surfaced through end-to-end test that runs a query against `malloytest.flights`, filtering `dep_time < $BEFORE` with a date-literal default.
