### PR TITLE
fix(dialect): safe identifier and literal quoting across all dialects

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -262,6 +262,8 @@ For new files, this is the current correct copyright text (here in C/Java/Javasc
  */
 ```
 
+**Do not copy the header from a neighboring file.** Most existing files were created when the project used a longer Google MIT header; the short SPDX form above is what every *new* file must use. The neighboring-file pattern is the most common way to end up with the wrong header by accident. Always use the exact block above for new files, regardless of what the rest of the directory looks like.
+
 ## Commit and PR Guidelines
 
 Do not include AI attribution (e.g., "Generated with Claude Code", "Co-Authored-By: Claude") in commits or pull requests.

--- a/packages/malloy-db-duckdb/src/duckdb.spec.ts
+++ b/packages/malloy-db-duckdb/src/duckdb.spec.ts
@@ -115,20 +115,20 @@ describe('DuckDBConnection', () => {
       );
     });
 
-    it('leaves bare table identifiers unquoted', async () => {
+    it('quotes bare table identifiers', async () => {
       await connection.fetchSchemaForTables({'plain': 'plain_table'}, {});
       expect(runRawSQL).toHaveBeenCalledWith(
-        'DESCRIBE SELECT * FROM plain_table'
+        'DESCRIBE SELECT * FROM "plain_table"'
       );
     });
 
-    it('leaves schema-qualified identifiers unquoted', async () => {
+    it('quotes each segment of schema-qualified identifiers', async () => {
       await connection.fetchSchemaForTables(
         {'qualified': 'main.qualified_table'},
         {}
       );
       expect(runRawSQL).toHaveBeenCalledWith(
-        'DESCRIBE SELECT * FROM main.qualified_table'
+        'DESCRIBE SELECT * FROM "main"."qualified_table"'
       );
     });
   });

--- a/packages/malloy-db-duckdb/src/duckdb_common.ts
+++ b/packages/malloy-db-duckdb/src/duckdb_common.ts
@@ -56,16 +56,6 @@ const unquoteName = (name: string) => {
   return name;
 };
 
-/**
- * A bare or schema-qualified SQL identifier — `name` or `schema.name`. Anything
- * else (file paths with dashes, dots-as-extensions, slashes, URL schemes,
- * globs) is treated as a file-path string by `fetchTableSchema` and wrapped
- * in single quotes so DuckDB sees it as a string literal rather than parsing
- * it as a SQL identifier.
- */
-const SQL_IDENTIFIER_CHAIN =
-  /^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)*$/;
-
 export abstract class DuckDBCommon
   extends BaseConnection
   implements TestableConnection, PersistSQLResults, StreamingConnection
@@ -212,10 +202,7 @@ export abstract class DuckDBCommon
       fields: [],
     };
 
-    const quotedTablePath = SQL_IDENTIFIER_CHAIN.test(tablePath)
-      ? tablePath
-      : `'${tablePath}'`;
-    const infoQuery = `DESCRIBE SELECT * FROM ${quotedTablePath}`;
+    const infoQuery = `DESCRIBE SELECT * FROM ${this.dialect.quoteTablePath(tablePath)}`;
     await this.schemaFromQuery(infoQuery, structDef);
     return structDef;
   }

--- a/packages/malloy-db-mysql/src/mysql_connection.ts
+++ b/packages/malloy-db-mysql/src/mysql_connection.ts
@@ -25,15 +25,6 @@ import {BaseConnection} from '@malloydata/malloy/connection';
 import {randomUUID} from 'crypto';
 import * as MYSQL from 'mysql2/promise';
 
-/**
- * A bare or schema-qualified SQL identifier — `name` or `db.name`. Anything
- * else (dashes, dots-as-extensions, slashes, special characters) needs to be
- * wrapped in backticks for `DESCRIBE` to parse it as one identifier rather
- * than e.g. parsing `my-table` as subtraction.
- */
-const SQL_IDENTIFIER_CHAIN =
-  /^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)*$/;
-
 export interface MySQLConfiguration {
   host?: string;
   port?: number;
@@ -194,10 +185,7 @@ export class MySQLConnection
       fields: [],
     };
 
-    const quotedTablePath = SQL_IDENTIFIER_CHAIN.test(tablePath)
-      ? tablePath
-      : `\`${tablePath}\``;
-    const infoQuery = `DESCRIBE ${quotedTablePath}`;
+    const infoQuery = `DESCRIBE ${this.dialect.quoteTablePath(tablePath)}`;
     const result = await this.runRawSQL(infoQuery);
     await this.schemaFromResult(result, structDef);
     return structDef;

--- a/packages/malloy/src/api/asynchronous.spec.ts
+++ b/packages/malloy/src/api/asynchronous.spec.ts
@@ -134,7 +134,7 @@ describe('api', () => {
           connection_name: 'connection',
           sql: `SELECT \n\
    base."carrier" as "carrier"
-FROM flights as base
+FROM "flights" as base
 GROUP BY 1
 ORDER BY 1 asc NULLS LAST
 `,
@@ -229,7 +229,7 @@ ORDER BY 1 asc NULLS LAST
           connection_name: 'connection',
           sql: `SELECT \n\
    base."carrier" as "carrier"
-FROM flights as base
+FROM "flights" as base
 GROUP BY 1
 ORDER BY 1 asc NULLS LAST
 `,

--- a/packages/malloy/src/api/foundation/runtime.ts
+++ b/packages/malloy/src/api/foundation/runtime.ts
@@ -696,9 +696,7 @@ export class SingleConnectionRuntime<
 
   // quote a column name
   quote(column: string): string {
-    return getDialect(this.connection.dialectName).sqlMaybeQuoteIdentifier(
-      column
-    );
+    return getDialect(this.connection.dialectName).sqlQuoteIdentifier(column);
   }
 
   get dialect(): Dialect {

--- a/packages/malloy/src/api/sessioned.spec.ts
+++ b/packages/malloy/src/api/sessioned.spec.ts
@@ -278,7 +278,7 @@ describe('api', () => {
           connection_name: 'connection',
           sql: `SELECT \n\
    base."carrier" as "carrier"
-FROM flights as base
+FROM "flights" as base
 GROUP BY 1
 ORDER BY 1 asc NULLS LAST
 `,

--- a/packages/malloy/src/api/stateless.spec.ts
+++ b/packages/malloy/src/api/stateless.spec.ts
@@ -469,7 +469,7 @@ describe('api', () => {
   });
   test('compile model with turducken sql dependency', () => {
     const sql =
-      '\n                SELECT carrier FROM (SELECT \n   base."carrier" as "carrier"\nFROM flights as base\nGROUP BY 1\nORDER BY 1 asc NULLS LAST\n)\n              ';
+      '\n                SELECT carrier FROM (SELECT \n   base."carrier" as "carrier"\nFROM "flights" as base\nGROUP BY 1\nORDER BY 1 asc NULLS LAST\n)\n              ';
     const result = compileModel({
       model_url: 'file://test.malloy',
       compiler_needs: {
@@ -611,7 +611,7 @@ describe('api', () => {
           ],
           sql: `SELECT \n\
    base."carrier" as "carrier"
-FROM flights as base
+FROM "flights" as base
 GROUP BY 1
 ORDER BY 1 asc NULLS LAST
 `,
@@ -729,7 +729,7 @@ ORDER BY 1 asc NULLS LAST
           ],
           sql: `SELECT \n\
    base."carrier" as "carrier"
-FROM flights as base
+FROM "flights" as base
 GROUP BY 1
 ORDER BY 1 asc NULLS LAST
 LIMIT 100
@@ -810,7 +810,7 @@ LIMIT 100
           ],
           sql: `SELECT \n\
    base."carrier" as "carrier"
-FROM flights as base
+FROM "flights" as base
 GROUP BY 1
 ORDER BY 1 asc NULLS LAST
 LIMIT 101
@@ -1193,8 +1193,8 @@ LIMIT 101
       expect(result.result).toBeDefined();
       expect(result.result?.sql).toBeDefined();
       expect(result.result?.connection_name).toBe('duckdb');
-      expect(result.result?.sql).toContain('LEFT JOIN malloytest.airports');
-      expect(result.result?.sql).toContain('LEFT JOIN malloytest.carriers');
+      expect(result.result?.sql).toContain('LEFT JOIN "malloytest"."airports"');
+      expect(result.result?.sql).toContain('LEFT JOIN "malloytest"."carriers"');
       expect(result.result?.sql).toContain(
         'COALESCE((COALESCE((base."id2"),airports_0."city")),carriers_0."name")'
       );
@@ -1277,7 +1277,7 @@ LIMIT 101
       expect(result.result).toBeDefined();
       expect(result.result?.sql).toBeDefined();
       expect(result.result?.connection_name).toBe('duckdb');
-      expect(result.result?.sql).toContain('LEFT JOIN malloytest.airports');
+      expect(result.result?.sql).toContain('LEFT JOIN "malloytest"."airports"');
       expect(result.result?.sql).toContain('airports_0."city"');
     });
     test('coalesce with parameter and constant', () => {

--- a/packages/malloy/src/dialect/CONTEXT.md
+++ b/packages/malloy/src/dialect/CONTEXT.md
@@ -250,6 +250,22 @@ When creating a new dialect, prefer `def()` and the `T` convention for simple fu
 
 See [adding-a-new-database.md](../doc/adding-a-new-database.md) for a complete step-by-step guide covering both the Dialect and Connection sides, test data setup, and CI configuration.
 
+### Escape-function contract
+
+Every dialect must declare three fields that drive identifier and string-literal escaping:
+
+- `identifierQuoteChar` — the character used to quote identifiers, typically `"` or `` ` ``.
+- `identifierEscapeStyle` — `EscapeStyle.Doubled` (ANSI: doubling the quote char escapes it; every current dialect except BigQuery) or `EscapeStyle.Backslash` (BigQuery: quoted identifiers use string-literal escape sequences).
+- `stringLiteralStyle` — `EscapeStyle.Doubled` for ANSI `''` escaping (Postgres-family) or `EscapeStyle.Backslash` for `\'` escaping (BigQuery, Snowflake, MySQL, Databricks).
+
+`EscapeStyle` is exported from `dialect.ts`; importing it gives the literal-type narrowing for free, so dialect files do not need `as const`.
+
+The base class provides safe implementations of `sqlQuoteIdentifier`, `sqlLiteralString`, and `sqlLiteralRegexp` driven by these flags. Dialects normally do not override them. If a subclass forgets to set a flag, the base method throws at first use with a message naming the dialect and the missing flag — `escape.spec.ts` exercises this fail-fast path on every registered dialect, so a forgotten flag fails CI rather than producing wrong SQL silently.
+
+`quoteTablePath` is still per-dialect because table-path styles vary (per-part vs whole-path quoting, file-path string literals for DuckDB). Use the protected `quoteIdentifierPart(part, alwaysQuote)` helper rather than rolling your own string concatenation — it routes through `sqlQuoteIdentifier` and is correct by construction.
+
+The contract is verified by `packages/malloy/src/dialect/escape.spec.ts`, which iterates `getDialects()` and asserts that an adversarial input corpus round-trips through each escape function. A new dialect is covered automatically the moment it is registered in `dialect_map.ts`; you do not need to edit the spec file.
+
 ## Key Source Files
 
 | File | Purpose |

--- a/packages/malloy/src/dialect/databricks/databricks.ts
+++ b/packages/malloy/src/dialect/databricks/databricks.ts
@@ -33,7 +33,7 @@ import type {
   OrderByRequest,
   QueryInfo,
 } from '../dialect';
-import {Dialect, qtz} from '../dialect';
+import {Dialect, EscapeStyle, qtz} from '../dialect';
 import type {DialectFunctionOverloadDef} from '../functions';
 import {expandBlueprintMap, expandOverrideMap} from '../functions';
 import {DATABRICKS_DIALECT_FUNCTIONS} from './dialect_functions';
@@ -72,6 +72,9 @@ const databricksToMalloyTypes: {[key: string]: BasicAtomicTypeDef} = {
 
 export class DatabricksDialect extends Dialect {
   name = 'databricks';
+  stringLiteralStyle = EscapeStyle.Backslash;
+  identifierEscapeStyle = EscapeStyle.Doubled;
+  identifierQuoteChar = '`';
   defaultNumberType = 'DOUBLE';
   defaultDecimalType = 'DECIMAL';
   udfPrefix = '__udf';
@@ -123,7 +126,7 @@ export class DatabricksDialect extends Dialect {
         for (const f of malloyType.fields) {
           if (isAtomic(f)) {
             fields.push(
-              `${this.sqlMaybeQuoteIdentifier(f.name)}: ${this.malloyTypeToSQLType(f)}`
+              `${this.sqlQuoteIdentifier(f.name)}: ${this.malloyTypeToSQLType(f)}`
             );
           }
         }
@@ -135,7 +138,7 @@ export class DatabricksDialect extends Dialect {
           for (const f of malloyType.fields) {
             if (isAtomic(f)) {
               fields.push(
-                `${this.sqlMaybeQuoteIdentifier(f.name)}: ${this.malloyTypeToSQLType(f)}`
+                `${this.sqlQuoteIdentifier(f.name)}: ${this.malloyTypeToSQLType(f)}`
               );
             }
           }
@@ -163,9 +166,12 @@ export class DatabricksDialect extends Dialect {
   }
 
   quoteTablePath(tablePath: string): string {
+    // Always quote each segment so reserved words can be used as table
+    // names. Databricks is case-insensitive for identifiers, so quoting
+    // has no backward-compat cost.
     return tablePath
       .split('.')
-      .map(part => (/^[a-zA-Z_]\w*$/.test(part) ? part : `\`${part}\``))
+      .map(part => this.quoteIdentifierPart(part, true))
       .join('.');
   }
 
@@ -203,7 +209,9 @@ export class DatabricksDialect extends Dialect {
   private buildNamedStructExpression(fieldList: DialectFieldList): string {
     return (
       'named_struct(' +
-      fieldList.map(f => `'${f.rawName}', ${f.sqlExpression}`).join(', ') +
+      fieldList
+        .map(f => `${this.sqlLiteralString(f.rawName)}, ${f.sqlExpression}`)
+        .join(', ') +
       ')'
     );
   }
@@ -265,7 +273,9 @@ export class DatabricksDialect extends Dialect {
     const namedStruct = this.buildNamedStructExpression(fieldList);
     const nullStruct =
       'named_struct(' +
-      fieldList.map(f => `'${f.rawName}', NULL`).join(', ') +
+      fieldList
+        .map(f => `${this.sqlLiteralString(f.rawName)}, NULL`)
+        .join(', ') +
       ')';
     return `COALESCE(FIRST(CASE WHEN group_set=${groupSet} THEN ${namedStruct} END) IGNORE NULLS, ${nullStruct})`;
   }
@@ -352,7 +362,7 @@ export class DatabricksDialect extends Dialect {
     if (childName === '__row_id') {
       return `__row_id_from_${parentAlias}`;
     }
-    return `${parentAlias}.${this.sqlMaybeQuoteIdentifier(childName)}`;
+    return `${parentAlias}.${this.sqlQuoteIdentifier(childName)}`;
   }
 
   sqlCreateFunction(id: string, funcText: string): string {
@@ -371,13 +381,9 @@ export class DatabricksDialect extends Dialect {
 
   sqlSelectAliasAsStruct(alias: string, fieldList: DialectFieldList) {
     const fields = fieldList
-      .map(f => `${alias}.${this.sqlMaybeQuoteIdentifier(f.rawName)}`)
+      .map(f => `${alias}.${this.sqlQuoteIdentifier(f.rawName)}`)
       .join(', ');
     return `STRUCT(${fields})`;
-  }
-
-  sqlMaybeQuoteIdentifier(identifier: string): string {
-    return '`' + identifier.replace(/`/g, '``') + '`';
   }
 
   sqlCreateTableAsSelect(tableName: string, sql: string): string {
@@ -540,15 +546,6 @@ export class DatabricksDialect extends Dialect {
       }
     }
     return tableSQL;
-  }
-
-  sqlLiteralString(literal: string): string {
-    const noVirgule = literal.replace(/\\/g, '\\\\');
-    return "'" + noVirgule.replace(/'/g, "\\'") + "'";
-  }
-
-  sqlLiteralRegexp(literal: string): string {
-    return "'" + literal.replace(/'/g, "''") + "'";
   }
 
   getDialectFunctionOverrides(): {

--- a/packages/malloy/src/dialect/dialect.ts
+++ b/packages/malloy/src/dialect/dialect.ts
@@ -69,7 +69,7 @@ export interface CompiledOrderBy {
  */
 export interface LateralJoinExpression {
   sql: string;
-  name: string; // already quoted by sqlMaybeQuoteIdentifier
+  name: string; // already quoted by sqlQuoteIdentifier
 }
 
 /*
@@ -92,6 +92,19 @@ export const MAX_INT128 = BigInt('170141183460469231731687303715884105727'); // 
 // Decimal(38,0) limits (for Snowflake NUMBER(38,0))
 export const MIN_DECIMAL38 = BigInt('-99999999999999999999999999999999999999'); // -(10^38 - 1)
 export const MAX_DECIMAL38 = BigInt('99999999999999999999999999999999999999'); // 10^38 - 1
+
+/**
+ * Allowed values for `Dialect.stringLiteralStyle` and
+ * `Dialect.identifierEscapeStyle`. Subclasses set their style with
+ * e.g. `stringLiteralStyle = EscapeStyle.Backslash`; the `as const`
+ * is centralized here so dialect files stay free of it.
+ */
+export const EscapeStyle = {
+  Doubled: 'doubled',
+  Backslash: 'backslash',
+  Unset: 'unset',
+} as const;
+export type EscapeStyleValue = (typeof EscapeStyle)[keyof typeof EscapeStyle];
 
 /**
  * Data which dialect methods need in order to correctly generate SQL.
@@ -466,7 +479,94 @@ export abstract class Dialect {
   sqlDateToString(sqlDateExp: string): string {
     return this.castToString(`DATE(${sqlDateExp})`);
   }
-  abstract sqlMaybeQuoteIdentifier(identifier: string): string;
+  /**
+   * The character the dialect uses to quote identifiers. Most dialects
+   * use ANSI double-quote `"`; MySQL, BigQuery and Databricks use the
+   * backtick `` ` ``. The dialect must escape this character by doubling
+   * inside a quoted identifier.
+   *
+   * Defaults to the empty string sentinel — concrete dialects must set
+   * a real value (or override `sqlQuoteIdentifier`), otherwise the
+   * base method throws to surface the omission immediately.
+   */
+  identifierQuoteChar = '';
+
+  /**
+   * How the dialect escapes the closing quote inside a string literal.
+   * Set via `EscapeStyle` from this module:
+   *
+   * - `EscapeStyle.Doubled`: `''` escapes `'`. Backslash is a literal
+   *   character. (ANSI standard; Postgres, DuckDB, Trino, Presto.)
+   * - `EscapeStyle.Backslash`: `\'` escapes `'`, `\\` escapes `\`.
+   *   (BigQuery, Snowflake, MySQL default mode, Databricks.)
+   * - `EscapeStyle.Unset` (default): base methods throw if reached. A
+   *   new dialect must set this (or override the literal methods).
+   *
+   * `sqlLiteralString` and `sqlLiteralRegexp` share this style — the
+   * regex engine receives whatever the SQL parser decodes, and the two
+   * must agree or regex patterns containing backslashes silently break.
+   */
+  stringLiteralStyle: EscapeStyleValue = EscapeStyle.Unset;
+
+  /**
+   * How the dialect escapes the quote character inside a quoted
+   * identifier. Mirrors `stringLiteralStyle`:
+   *
+   * - `EscapeStyle.Doubled`: doubling the quote char escapes it (ANSI
+   *   standard; most dialects).
+   * - `EscapeStyle.Backslash`: backslash-style escape, with `\\` for
+   *   backslash and `\<quote>` for the quote char. (BigQuery — quoted
+   *   identifiers use string-literal escape sequences.)
+   * - `EscapeStyle.Unset` (default): base method throws if reached.
+   */
+  identifierEscapeStyle: EscapeStyleValue = EscapeStyle.Unset;
+
+  /**
+   * Wrap an identifier in the dialect's quote character, escaping any
+   * embedded quote characters per the dialect's `identifierEscapeStyle`.
+   * This is the only safe way to render a user-controlled identifier
+   * in SQL.
+   */
+  sqlQuoteIdentifier(identifier: string): string {
+    const q = this.identifierQuoteChar;
+    if (!q) {
+      throw new Error(
+        `${this.name}: identifierQuoteChar is not set. ` +
+          'Set it on the dialect (e.g. \'"\' or "`"), ' +
+          'or override sqlQuoteIdentifier.'
+      );
+    }
+    if (this.identifierEscapeStyle === EscapeStyle.Doubled) {
+      return q + identifier.split(q).join(q + q) + q;
+    }
+    if (this.identifierEscapeStyle === EscapeStyle.Backslash) {
+      const escaped = identifier
+        .replace(/\\/g, '\\\\')
+        .split(q)
+        .join('\\' + q);
+      return q + escaped + q;
+    }
+    throw new Error(
+      `${this.name}: identifierEscapeStyle is not set. ` +
+        'Set it to EscapeStyle.Doubled or EscapeStyle.Backslash on the dialect, ' +
+        'or override sqlQuoteIdentifier.'
+    );
+  }
+
+  /**
+   * Quote a single segment of a table path. When `alwaysQuote` is false,
+   * a segment that already looks like a bare SQL identifier is returned
+   * unquoted, which produces tidier SQL for the common case. When true,
+   * the segment is always wrapped and escaped.
+   *
+   * Dialects compose this in their `quoteTablePath` implementations.
+   */
+  protected quoteIdentifierPart(part: string, alwaysQuote: boolean): string {
+    if (!alwaysQuote && /^[A-Za-z_][A-Za-z0-9_]*$/.test(part)) {
+      return part;
+    }
+    return this.sqlQuoteIdentifier(part);
+  }
 
   abstract castToString(expression: string): string;
 
@@ -803,8 +903,35 @@ export abstract class Dialect {
     literal: string,
     timezone: string
   ): string;
-  abstract sqlLiteralString(literal: string): string;
-  abstract sqlLiteralRegexp(literal: string): string;
+  /**
+   * Render a Malloy string as a SQL string literal. The escape style is
+   * driven by `stringLiteralStyle`; dialects normally do not override
+   * this method.
+   */
+  sqlLiteralString(literal: string): string {
+    if (this.stringLiteralStyle === 'doubled') {
+      return "'" + literal.split("'").join("''") + "'";
+    }
+    if (this.stringLiteralStyle === 'backslash') {
+      const escaped = literal.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+      return "'" + escaped + "'";
+    }
+    throw new Error(
+      `${this.name}: stringLiteralStyle is not set. ` +
+        'Set it to EscapeStyle.Doubled or EscapeStyle.Backslash on the dialect, ' +
+        'or override sqlLiteralString.'
+    );
+  }
+
+  /**
+   * Render a Malloy regex literal as a SQL string literal. Defaults to
+   * `sqlLiteralString` — the regex engine receives whatever bytes the
+   * SQL parser decodes, and `sqlLiteralString` already produces a
+   * correctly decoding literal for both escape styles.
+   */
+  sqlLiteralRegexp(literal: string): string {
+    return this.sqlLiteralString(literal);
+  }
   abstract sqlLiteralArray(lit: ArrayLiteralNode): string;
   abstract sqlLiteralRecord(lit: RecordLiteralNode): string;
 

--- a/packages/malloy/src/dialect/duckdb/duckdb.ts
+++ b/packages/malloy/src/dialect/duckdb/duckdb.ts
@@ -114,8 +114,20 @@ export class DuckDBDialect extends PostgresBase {
   }
 
   quoteTablePath(tableName: string): string {
-    // Quote if contains special chars that could be SQL injection or need quoting
-    return tableName.match(/[/*:;-]/) ? `'${tableName}'` : tableName;
+    // DuckDB accepts either a SQL identifier path (schema.table) or a
+    // file path as a string literal (FROM 'foo.parquet'). Detect which
+    // shape the input is.
+    if (/^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)*$/.test(tableName)) {
+      // Identifier path. Always quote each segment so that reserved
+      // words (`select`, `from`, ...) can be used as table names.
+      // DuckDB is case-insensitive for both bare and quoted identifiers,
+      // so there is no backward-compat cost to quoting.
+      return tableName
+        .split('.')
+        .map(part => this.quoteIdentifierPart(part, true))
+        .join('.');
+    }
+    return this.sqlLiteralString(tableName);
   }
 
   sqlGroupSetTable(groupSetCount: number): string {
@@ -238,7 +250,7 @@ export class DuckDBDialect extends PostgresBase {
     } else if (parentType === 'array[scalar]') {
       return parentAlias;
     } else {
-      return `${parentAlias}.${this.sqlMaybeQuoteIdentifier(childName)}`;
+      return `${parentAlias}.${this.sqlQuoteIdentifier(childName)}`;
     }
   }
 
@@ -281,7 +293,7 @@ export class DuckDBDialect extends PostgresBase {
       }
     }
     return `SELECT LIST(STRUCT_PACK(${dialectFieldList
-      .map(d => this.sqlMaybeQuoteIdentifier(d.sqlOutputName))
+      .map(d => this.sqlQuoteIdentifier(d.sqlOutputName))
       .join(',')})${o}) FROM ${lastStageName}\n`;
   }
 
@@ -354,14 +366,6 @@ export class DuckDBDialect extends PostgresBase {
     return `ORDER BY ${orderTerms.map(t => `${t} NULLS LAST`).join(',')}`;
   }
 
-  sqlLiteralString(literal: string): string {
-    return "'" + literal.replace(/'/g, "''") + "'";
-  }
-
-  sqlLiteralRegexp(literal: string): string {
-    return "'" + literal.replace(/'/g, "''") + "'";
-  }
-
   getDialectFunctionOverrides(): {
     [name: string]: DialectFunctionOverloadDef[];
   } {
@@ -390,7 +394,7 @@ export class DuckDBDialect extends PostgresBase {
       for (const f of malloyType.fields) {
         if (isAtomic(f)) {
           typeSpec.push(
-            `${this.sqlMaybeQuoteIdentifier(f.name)} ${this.malloyTypeToSQLType(f)}`
+            `${this.sqlQuoteIdentifier(f.name)} ${this.malloyTypeToSQLType(f)}`
           );
         }
       }
@@ -401,7 +405,7 @@ export class DuckDBDialect extends PostgresBase {
         for (const f of malloyType.fields) {
           if (isAtomic(f)) {
             typeSpec.push(
-              `${this.sqlMaybeQuoteIdentifier(f.name)} ${this.malloyTypeToSQLType(f)}`
+              `${this.sqlQuoteIdentifier(f.name)} ${this.malloyTypeToSQLType(f)}`
             );
           }
         }
@@ -503,7 +507,7 @@ export class DuckDBDialect extends PostgresBase {
   sqlLiteralRecord(lit: RecordLiteralNode): string {
     const pairs = Object.entries(lit.kids).map(
       ([propName, propVal]) =>
-        `${this.sqlMaybeQuoteIdentifier(propName)}:${propVal.sql}`
+        `${this.sqlQuoteIdentifier(propName)}:${propVal.sql}`
     );
     return '{' + pairs.join(',') + '}';
   }

--- a/packages/malloy/src/dialect/escape.spec.ts
+++ b/packages/malloy/src/dialect/escape.spec.ts
@@ -1,0 +1,484 @@
+/*
+ * Copyright Contributors to the Malloy project
+ * SPDX-License-Identifier: MIT
+ */
+
+import {getDialects} from './dialect_map';
+import {Dialect} from './dialect';
+import type {RecordLiteralNode} from '../model/malloy_types';
+
+// ---------------------------------------------------------------------------
+// Adversarial input corpus
+// ---------------------------------------------------------------------------
+
+// Strings to pass through string/regex/identifier escape functions. Each
+// entry is something that, if mishandled, allows SQL injection or breaks
+// query parsing.
+const ADVERSARIAL_STRINGS: {name: string; value: string}[] = [
+  {name: 'empty', value: ''},
+  {name: 'bare', value: 'foo'},
+  {name: 'bare_underscore', value: 'foo_bar'},
+  {name: 'single_quote', value: "o'brien"},
+  {name: 'double_quote', value: 'say "hi"'},
+  {name: 'backtick', value: 'foo`bar'},
+  {name: 'backslash', value: 'foo\\bar'},
+  {name: 'lone_single_quote', value: "'"},
+  {name: 'lone_double_quote', value: '"'},
+  {name: 'lone_backtick', value: '`'},
+  {name: 'lone_backslash', value: '\\'},
+  {name: 'doubled_single_quote', value: "''"},
+  {name: 'doubled_double_quote', value: '""'},
+  {name: 'doubled_backtick', value: '``'},
+  {name: 'injection_classic', value: "';DROP TABLE x;--"},
+  {name: 'injection_or_1_1', value: "' OR 1=1 --"},
+  {name: 'block_comment', value: '/* injected */'},
+  {name: 'line_comment', value: '-- injected'},
+  {name: 'all_delims', value: '\'`"\\'},
+  {name: 'newline', value: 'line1\nline2'},
+  {name: 'tab', value: 'col\tval'},
+];
+
+// Additional inputs for table paths, which may legitimately contain dots
+// and other path-like characters.
+const ADVERSARIAL_TABLE_PATHS: {name: string; value: string}[] = [
+  ...ADVERSARIAL_STRINGS,
+  {name: 'dotted_schema', value: 'schema.table'},
+  {name: 'three_part_path', value: 'project.dataset.table'},
+  {name: 'dashed_filename', value: 'arrests-latest.parquet'},
+  {name: 'slash_path', value: 'path/to/file.parquet'},
+  {name: 'space_in_name', value: 'my table'},
+];
+
+// ---------------------------------------------------------------------------
+// SQL parsers — minimal but accurate enough to detect smuggling.
+//
+// Each parser returns the decoded value and the position after it consumed.
+// If the parser cannot consume the full input as the expected SQL form,
+// the test reports the failure with the actual output for diagnosis.
+// ---------------------------------------------------------------------------
+
+type ParseResult = {value: string; end: number} | null;
+
+// Parse a SQL string literal of the form 'body', where body uses either
+// '' (doubled) or \' (backslash) to escape the closing quote. Backslash
+// also escapes itself when in backslash mode.
+function parseStringLiteral(
+  sql: string,
+  mode: 'doubled' | 'backslash'
+): ParseResult {
+  if (sql[0] !== "'") return null;
+  let i = 1;
+  let value = '';
+  while (i < sql.length) {
+    const c = sql[i];
+    if (c === "'") {
+      if (sql[i + 1] === "'") {
+        value += "'";
+        i += 2;
+        continue;
+      }
+      return {value, end: i + 1};
+    }
+    if (mode === 'backslash' && c === '\\') {
+      if (i + 1 >= sql.length) return null;
+      const next = sql[i + 1];
+      // Decode the escape sequence. We are deliberately permissive: any
+      // dialect-specific backslash sequence is accepted, but we only
+      // decode the ones we recognize. The crucial point is that \' does
+      // not close the literal.
+      if (next === "'") value += "'";
+      else if (next === '\\') value += '\\';
+      else if (next === 'n') value += '\n';
+      else if (next === 't') value += '\t';
+      else if (next === 'r') value += '\r';
+      else value += next;
+      i += 2;
+      continue;
+    }
+    value += c;
+    i++;
+  }
+  return null; // unterminated
+}
+
+// Parse a quoted identifier delimited by `q`.
+//
+// - `doubled` mode treats `qq` as the escape for q (ANSI SQL).
+// - `backslash` mode treats `\q`, `\\`, and other `\X` sequences as
+//   string-literal-style escapes (BigQuery quoted identifiers).
+function parseQuotedIdent(
+  sql: string,
+  q: string,
+  mode: 'doubled' | 'backslash',
+  start = 0
+): ParseResult {
+  if (sql[start] !== q) return null;
+  let i = start + 1;
+  let value = '';
+  while (i < sql.length) {
+    const c = sql[i];
+    if (mode === 'backslash' && c === '\\') {
+      if (i + 1 >= sql.length) return null;
+      const next = sql[i + 1];
+      if (next === q) value += q;
+      else if (next === '\\') value += '\\';
+      else if (next === 'n') value += '\n';
+      else if (next === 't') value += '\t';
+      else if (next === 'r') value += '\r';
+      else value += next;
+      i += 2;
+      continue;
+    }
+    if (c === q) {
+      if (mode === 'doubled' && sql[i + 1] === q) {
+        value += q;
+        i += 2;
+        continue;
+      }
+      return {value, end: i + 1};
+    }
+    value += c;
+    i++;
+  }
+  return null;
+}
+
+// Parse a bare SQL identifier starting at offset.
+function parseBareIdent(sql: string, start = 0): ParseResult {
+  const m = sql.slice(start).match(/^[A-Za-z_][A-Za-z0-9_$]*/);
+  if (!m) return null;
+  return {value: m[0], end: start + m[0].length};
+}
+
+// Parse a dotted path of [bare | quoted] segments. Accepts a single
+// identifier quote character. Returns the joined parts and total length
+// consumed, or null if malformed.
+function parseDottedPath(
+  sql: string,
+  identQuote: string,
+  identMode: 'doubled' | 'backslash'
+): {value: string; end: number} | null {
+  let i = 0;
+  const parts: string[] = [];
+  while (i < sql.length) {
+    let seg: ParseResult;
+    if (sql[i] === identQuote) {
+      seg = parseQuotedIdent(sql, identQuote, identMode, i);
+    } else {
+      seg = parseBareIdent(sql, i);
+    }
+    if (!seg) return null;
+    parts.push(seg.value);
+    i = seg.end;
+    if (i >= sql.length) break;
+    if (sql[i] !== '.') return null;
+    i++;
+  }
+  return {value: parts.join('.'), end: i};
+}
+
+// ---------------------------------------------------------------------------
+// Per-dialect probes — detect escape style and identifier quote char.
+// We probe rather than hard-code so a new dialect is automatically handled.
+// ---------------------------------------------------------------------------
+
+function probeStringEscapeStyle(
+  fn: (s: string) => string,
+  context: string
+): 'doubled' | 'backslash' {
+  const out = fn("'");
+  if (out === "''''") return 'doubled';
+  if (out === "'\\''") return 'backslash';
+  throw new Error(
+    `${context}: cannot determine escape style. ` +
+      `Expected one of '''' (doubled) or '\\'' (backslash), got ${JSON.stringify(out)}. ` +
+      'If your dialect uses a different escape style, extend probeStringEscapeStyle.'
+  );
+}
+
+function probeIdentifierQuote(d: Dialect): string {
+  const out = d.sqlQuoteIdentifier('a');
+  if (out.length < 2) {
+    throw new Error(
+      `${d.name}: sqlQuoteIdentifier('a') returned ${JSON.stringify(out)}; ` +
+        'expected a quoted identifier of at least three characters.'
+    );
+  }
+  const first = out[0];
+  const last = out[out.length - 1];
+  if (first !== last) {
+    throw new Error(
+      `${d.name}: sqlQuoteIdentifier('a') returned ${JSON.stringify(out)}; ` +
+        'expected matching opening and closing quote characters.'
+    );
+  }
+  return first;
+}
+
+// Detect whether the dialect's identifier quoting uses ANSI doubled-
+// quote escapes (e.g. Postgres "a""b") or string-literal-style
+// backslash escapes (BigQuery `a\\b`). Probe by feeding a single
+// backslash: doubled-mode produces 3 chars (quote + \ + quote);
+// backslash-mode produces 4 chars (quote + \ + \ + quote).
+function probeIdentifierEscapeStyle(d: Dialect): 'doubled' | 'backslash' {
+  const out = d.sqlQuoteIdentifier('\\');
+  if (out.length === 3) return 'doubled';
+  if (out.length === 4) return 'backslash';
+  throw new Error(
+    `${d.name}: sqlQuoteIdentifier('\\\\') returned ${JSON.stringify(out)}; ` +
+      'expected either 3 chars (doubled) or 4 chars (backslash).'
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+for (const dialect of getDialects()) {
+  describe(`${dialect.name} dialect escape invariants`, () => {
+    const identQuote = probeIdentifierQuote(dialect);
+    const identStyle = probeIdentifierEscapeStyle(dialect);
+    const stringStyle = probeStringEscapeStyle(
+      s => dialect.sqlLiteralString(s),
+      `${dialect.name}.sqlLiteralString`
+    );
+    const regexpStyle = probeStringEscapeStyle(
+      s => dialect.sqlLiteralRegexp(s),
+      `${dialect.name}.sqlLiteralRegexp`
+    );
+
+    describe('sqlLiteralString round-trip', () => {
+      for (const {name, value} of ADVERSARIAL_STRINGS) {
+        it(name, () => {
+          const out = dialect.sqlLiteralString(value);
+          const parsed = parseStringLiteral(out, stringStyle);
+          expect(parsed).not.toBeNull();
+          expect(parsed!.end).toBe(out.length);
+          expect(parsed!.value).toBe(value);
+        });
+      }
+    });
+
+    describe('sqlLiteralRegexp round-trip', () => {
+      for (const {name, value} of ADVERSARIAL_STRINGS) {
+        it(name, () => {
+          const out = dialect.sqlLiteralRegexp(value);
+          const parsed = parseStringLiteral(out, regexpStyle);
+          expect(parsed).not.toBeNull();
+          expect(parsed!.end).toBe(out.length);
+          expect(parsed!.value).toBe(value);
+        });
+      }
+    });
+
+    describe('sqlQuoteIdentifier round-trip', () => {
+      for (const {name, value} of ADVERSARIAL_STRINGS) {
+        it(name, () => {
+          // A dialect may refuse inputs it has no way to encode safely
+          // (e.g. BigQuery cannot escape a backtick inside a backtick-
+          // quoted identifier). Throwing is a safe outcome — better a
+          // compile-time error than malformed or injecting SQL.
+          let out: string;
+          try {
+            out = dialect.sqlQuoteIdentifier(value);
+          } catch (e) {
+            return;
+          }
+          const parsed = parseQuotedIdent(out, identQuote, identStyle);
+          expect(parsed).not.toBeNull();
+          expect(parsed!.end).toBe(out.length);
+          expect(parsed!.value).toBe(value);
+        });
+      }
+    });
+
+    describe('quoteTablePath round-trip', () => {
+      for (const {name, value} of ADVERSARIAL_TABLE_PATHS) {
+        it(name, () => {
+          // A dialect may refuse to encode an input (e.g. BigQuery cannot
+          // represent a backtick inside a backtick-quoted identifier).
+          // Throwing is a safe outcome — better a compile-time error than
+          // SQL that the dialect cannot represent unambiguously.
+          let out: string;
+          try {
+            out = dialect.quoteTablePath(value);
+          } catch (e) {
+            return;
+          }
+          // A dialect may produce either:
+          //   (a) one quoted identifier containing the whole path including dots
+          //       (e.g. BigQuery: `proj.dataset.table`)
+          //   (b) a dot-separated sequence of bare/quoted identifier parts
+          //       (e.g. Postgres: "proj"."dataset"."table")
+          //   (c) a single string literal — only used by DuckDB for paths
+          //       which are actually file references rather than identifiers.
+          // Round-trip succeeds if any of these interpretations decodes
+          // exactly to the input.
+          const candidates: (() => string | null)[] = [
+            // (a) Whole path as one quoted identifier.
+            () => {
+              const r = parseQuotedIdent(out, identQuote, identStyle);
+              if (r && r.end === out.length) return r.value;
+              return null;
+            },
+            // (b) Dotted sequence of identifier segments.
+            () => {
+              const r = parseDottedPath(out, identQuote, identStyle);
+              if (r && r.end === out.length) return r.value;
+              return null;
+            },
+            // (c) Single-quoted string literal (DuckDB file paths).
+            () => {
+              const r = parseStringLiteral(out, stringStyle);
+              if (r && r.end === out.length) return r.value;
+              return null;
+            },
+          ];
+
+          let decoded: string | null = null;
+          for (const tryParse of candidates) {
+            const v = tryParse();
+            if (v === value) {
+              decoded = v;
+              break;
+            }
+          }
+
+          expect(decoded).toBe(value);
+        });
+      }
+    });
+  });
+}
+
+// Record-literal and field-reference smuggling tests.
+//
+// `sqlLiteralRecord` and `sqlFieldReference` render user-controlled
+// field names into per-dialect SQL fragments (JSON paths, record
+// constructors, JSONB extract calls). Historical bugs interpolated
+// names raw into `'${name}'`, letting a single quote inside the name
+// escape the SQL string literal.
+//
+// Test strategy: strip everything that's inside a quoted region
+// (single-quoted literals, double-quoted identifiers, backtick
+// identifiers), then assert the attack keyword does not appear in
+// what remains. If escaping is correct, the attack chars stay inside
+// the quoted region; if broken, they leak into bare SQL.
+
+const FIELD_NAME_INJECTION = "';DROP TABLE x;--";
+
+// Walk the SQL string, skipping anything between matching quote
+// characters. Both doubled-escape (`''`) and backslash-escape (`\'`)
+// styles are handled — the dialect-agnostic stripping treats both as
+// "still inside a quoted region."
+function stripQuotedRegions(sql: string): string {
+  let out = '';
+  let i = 0;
+  while (i < sql.length) {
+    const c = sql[i];
+    if (c === "'" || c === '"' || c === '`') {
+      i++;
+      while (i < sql.length && sql[i] !== c) {
+        if (sql[i] === '\\' && i + 1 < sql.length) {
+          i += 2;
+        } else {
+          i++;
+        }
+      }
+      if (i < sql.length) i++; // consume the closing quote
+      continue;
+    }
+    out += c;
+    i++;
+  }
+  return out;
+}
+
+function makeRecordLit(fieldName: string): RecordLiteralNode {
+  return {
+    node: 'recordLiteral',
+    kids: {
+      [fieldName]: {
+        node: 'numberLiteral',
+        literal: '42',
+        sql: '42',
+        typeDef: {type: 'number', numberType: 'integer'},
+      },
+    },
+    typeDef: {
+      type: 'record',
+      fields: [{name: fieldName, type: 'number', numberType: 'integer'}],
+    },
+  };
+}
+
+for (const dialect of getDialects()) {
+  describe(`${dialect.name} field-name smuggling`, () => {
+    it('sqlFieldReference keeps attack payload inside quoted regions', () => {
+      let out: string;
+      try {
+        out = dialect.sqlFieldReference(
+          'base',
+          'record',
+          FIELD_NAME_INJECTION,
+          'string'
+        );
+      } catch {
+        return; // refusing to encode is also a safe outcome
+      }
+      expect(stripQuotedRegions(out)).not.toMatch(/DROP\s+TABLE/i);
+    });
+
+    it('sqlLiteralRecord keeps attack payload inside quoted regions', () => {
+      let out: string;
+      try {
+        out = dialect.sqlLiteralRecord(makeRecordLit(FIELD_NAME_INJECTION));
+      } catch {
+        return;
+      }
+      expect(stripQuotedRegions(out)).not.toMatch(/DROP\s+TABLE/i);
+    });
+  });
+}
+
+// Meta-test: the base Dialect's literal/identifier methods must fail
+// loudly when a subclass forgets to set `stringLiteralStyle` or
+// `identifierQuoteChar`. Without this guarantee a new dialect could
+// silently emit SQL that looks structurally well-formed in the
+// round-trip tests above but is wrong against a real database.
+describe('base Dialect fail-fast on missing config', () => {
+  // Construct a Dialect-prototype instance without running the
+  // constructor (which would require implementing every abstract
+  // method). The base methods under test only read instance fields, so
+  // a prototype-only object reaches the same code path that a real
+  // subclass would.
+  const stub = Object.create(Dialect.prototype) as Dialect;
+  stub.name = 'stub-no-config';
+
+  it('sqlLiteralString throws naming the missing flag', () => {
+    expect(() => stub.sqlLiteralString('x')).toThrow(
+      /stub-no-config.*stringLiteralStyle is not set/
+    );
+  });
+
+  it('sqlLiteralRegexp throws naming the missing flag', () => {
+    expect(() => stub.sqlLiteralRegexp('x')).toThrow(
+      /stub-no-config.*stringLiteralStyle is not set/
+    );
+  });
+
+  it('sqlQuoteIdentifier throws when identifierQuoteChar is unset', () => {
+    expect(() => stub.sqlQuoteIdentifier('x')).toThrow(
+      /stub-no-config.*identifierQuoteChar is not set/
+    );
+  });
+
+  it('sqlQuoteIdentifier throws when identifierEscapeStyle is unset', () => {
+    const partial = Object.create(Dialect.prototype) as Dialect;
+    partial.name = 'stub-no-escape-style';
+    partial.identifierQuoteChar = '"';
+    expect(() => partial.sqlQuoteIdentifier('x')).toThrow(
+      /stub-no-escape-style.*identifierEscapeStyle is not set/
+    );
+  });
+});

--- a/packages/malloy/src/dialect/mysql/mysql.ts
+++ b/packages/malloy/src/dialect/mysql/mysql.ts
@@ -55,7 +55,7 @@ import type {
   OrderByClauseType,
   QueryInfo,
 } from '../dialect';
-import {Dialect, qtz} from '../dialect';
+import {Dialect, EscapeStyle, qtz} from '../dialect';
 import type {DialectFunctionOverloadDef} from '../functions';
 import {expandBlueprintMap, expandOverrideMap} from '../functions';
 import {MYSQL_DIALECT_FUNCTIONS} from './dialect_functions';
@@ -126,6 +126,9 @@ function malloyTypeToJSONTableType(malloyType: AtomicTypeDef): string {
 
 export class MySQLDialect extends Dialect {
   name = 'mysql';
+  stringLiteralStyle = EscapeStyle.Backslash;
+  identifierEscapeStyle = EscapeStyle.Doubled;
+  identifierQuoteChar = '`';
   defaultNumberType = 'DOUBLE PRECISION';
   defaultDecimalType = 'DECIMAL';
   udfPrefix = 'ms_temp.__udf';
@@ -193,7 +196,7 @@ export class MySQLDialect extends Dialect {
   quoteTablePath(tablePath: string): string {
     return tablePath
       .split('.')
-      .map(part => `\`${part}\``)
+      .map(part => this.quoteIdentifierPart(part, true))
       .join('.');
   }
 
@@ -206,7 +209,11 @@ export class MySQLDialect extends Dialect {
   }
 
   private mapFields(fieldList: DialectFieldList): string {
-    return fieldList.map(f => `"${f.rawName}", ${f.sqlExpression}`).join(', ');
+    // JSON_OBJECT key is a string value. Routing rawName through
+    // sqlLiteralString also keeps the SQL valid under ANSI_QUOTES mode.
+    return fieldList
+      .map(f => `${this.sqlLiteralString(f.rawName)}, ${f.sqlExpression}`)
+      .join(', ');
   }
 
   sqlAggregateTurtle(
@@ -272,10 +279,13 @@ export class MySQLDialect extends Dialect {
       ) {
         fType = f.typeDef.rawType.toUpperCase();
       }
+      // JSON_TABLE PATH argument is a string literal containing a
+      // JSONPath. Render rawName through sqlLiteralString so a single
+      // quote in the user-controlled field name cannot close the SQL
+      // string literal.
+      const jsonPathLit = this.sqlLiteralString('$.' + f.rawName);
       fields.push(
-        `${this.sqlMaybeQuoteIdentifier(f.sqlOutputName)} ${fType}  PATH "$.${
-          f.rawName
-        }"`
+        `${this.sqlQuoteIdentifier(f.sqlOutputName)} ${fType}  PATH ${jsonPathLit}`
       );
     }
     return fields.join(',\n');
@@ -354,7 +364,11 @@ export class MySQLDialect extends Dialect {
     childType: string
   ): string {
     if (parentType === 'array[scalar]' || parentType === 'record') {
-      let ret = `JSON_UNQUOTE(JSON_EXTRACT(${parentAlias},'$.${childName}'))`;
+      // childName comes from user-controlled record field names; render
+      // the JSON path through sqlLiteralString so a single quote in the
+      // name cannot close the SQL string literal.
+      const jsonPathLit = this.sqlLiteralString('$.' + childName);
+      let ret = `JSON_UNQUOTE(JSON_EXTRACT(${parentAlias},${jsonPathLit}))`;
       if (parentType === 'array[scalar]') {
         ret = `JSON_UNQUOTE(${parentAlias}.\`value\`)`;
       }
@@ -368,7 +382,7 @@ export class MySQLDialect extends Dialect {
           return `CAST(${ret} as JSON)`;
       }
     }
-    const child = this.sqlMaybeQuoteIdentifier(childName);
+    const child = this.sqlQuoteIdentifier(childName);
     return `${parentAlias}.${child}`;
   }
 
@@ -389,10 +403,6 @@ export class MySQLDialect extends Dialect {
     // return `JSON_OBJECT(${physicalFieldNames
     //   .map(name => `'${name.replace(/`/g, '')}', \`${alias}\`.${name}`)
     //   .join(',')})`;
-  }
-
-  sqlMaybeQuoteIdentifier(identifier: string): string {
-    return '`' + identifier.replace(/`/g, '``') + '`';
   }
 
   // TODO: Check what this is.
@@ -584,15 +594,6 @@ export class MySQLDialect extends Dialect {
       }
     }
     return tableSQL;
-  }
-
-  sqlLiteralString(literal: string): string {
-    const noVirgule = literal.replace(/\\/g, '\\\\');
-    return "'" + noVirgule.replace(/'/g, "\\'") + "'";
-  }
-
-  sqlLiteralRegexp(literal: string): string {
-    return "'" + literal.replace(/'/g, "''") + "'";
   }
 
   getDialectFunctionOverrides(): {

--- a/packages/malloy/src/dialect/pg_impl.ts
+++ b/packages/malloy/src/dialect/pg_impl.ts
@@ -17,7 +17,7 @@ import type {
 } from '../model/malloy_types';
 import {TD} from '../model/malloy_types';
 import type {QueryInfo} from './dialect';
-import {Dialect, qtz} from './dialect';
+import {Dialect, EscapeStyle, qtz} from './dialect';
 
 export const timeExtractMap: Record<string, string> = {
   'day_of_week': 'dow',
@@ -32,6 +32,13 @@ export abstract class PostgresBase extends Dialect {
   hasTimestamptz = true;
   // Postgres-family dialects use JSON serialization which loses bigint precision
   supportsBigIntPrecision = false;
+
+  // All current Postgres-family dialects (Postgres, DuckDB, Trino, Presto)
+  // use ANSI doubled-quote literal escaping and ANSI double-quote identifiers.
+  // Subclasses may override.
+  stringLiteralStyle = EscapeStyle.Doubled;
+  identifierEscapeStyle = EscapeStyle.Doubled;
+  identifierQuoteChar = '"';
 
   sqlNowExpr(): string {
     return 'LOCALTIMESTAMP';
@@ -126,10 +133,6 @@ export abstract class PostgresBase extends Dialect {
   sqlLiteralArray(lit: ArrayLiteralNode): string {
     const array = lit.kids.values.map(val => val.sql);
     return 'ARRAY[' + array.join(',') + ']';
-  }
-
-  sqlMaybeQuoteIdentifier(identifier: string): string {
-    return '"' + identifier.replace(/"/g, '""') + '"';
   }
 
   sqlConvertToCivilTime(

--- a/packages/malloy/src/dialect/postgres/postgres.ts
+++ b/packages/malloy/src/dialect/postgres/postgres.ts
@@ -127,7 +127,7 @@ export class PostgresDialect extends PostgresBase {
   quoteTablePath(tablePath: string): string {
     return tablePath
       .split('.')
-      .map(part => `"${part}"`)
+      .map(part => this.quoteIdentifierPart(part, true))
       .join('.');
   }
 
@@ -224,7 +224,8 @@ export class PostgresDialect extends PostgresBase {
       return `(${parentAlias}->>'__row_id')`;
     }
     if (parentType !== 'table') {
-      let ret = `JSONB_EXTRACT_PATH_TEXT(${parentAlias},'${childName}')`;
+      const nameLit = this.sqlLiteralString(childName);
+      let ret = `JSONB_EXTRACT_PATH_TEXT(${parentAlias},${nameLit})`;
       switch (childType) {
         case 'string':
           break;
@@ -236,12 +237,12 @@ export class PostgresDialect extends PostgresBase {
         case 'record':
         case 'array[record]':
         case 'sql native':
-          ret = `JSONB_EXTRACT_PATH(${parentAlias},'${childName}')`;
+          ret = `JSONB_EXTRACT_PATH(${parentAlias},${nameLit})`;
           break;
       }
       return ret;
     } else {
-      const child = this.sqlMaybeQuoteIdentifier(childName);
+      const child = this.sqlQuoteIdentifier(childName);
       return `${parentAlias}.${child}`;
     }
   }
@@ -399,14 +400,6 @@ export class PostgresDialect extends PostgresBase {
     return `ORDER BY ${orderTerms.map(t => `${t} NULLS LAST`).join(',')}`;
   }
 
-  sqlLiteralString(literal: string): string {
-    return "'" + literal.replace(/'/g, "''") + "'";
-  }
-
-  sqlLiteralRegexp(literal: string): string {
-    return "'" + literal.replace(/'/g, "''") + "'";
-  }
-
   getDialectFunctionOverrides(): {
     [name: string]: DialectFunctionOverloadDef[];
   } {
@@ -471,7 +464,7 @@ export class PostgresDialect extends PostgresBase {
   sqlLiteralRecord(lit: RecordLiteralNode): string {
     const props: string[] = [];
     for (const [kName, kVal] of Object.entries(lit.kids)) {
-      props.push(`'${kName}',${kVal.sql}`);
+      props.push(`${this.sqlLiteralString(kName)},${kVal.sql}`);
     }
     return `JSONB_BUILD_OBJECT(${props.join(', ')})`;
   }

--- a/packages/malloy/src/dialect/snowflake/snowflake.ts
+++ b/packages/malloy/src/dialect/snowflake/snowflake.ts
@@ -54,7 +54,13 @@ import type {
   IntegerTypeMapping,
   QueryInfo,
 } from '../dialect';
-import {Dialect, qtz, MIN_DECIMAL38, MAX_DECIMAL38} from '../dialect';
+import {
+  Dialect,
+  EscapeStyle,
+  qtz,
+  MIN_DECIMAL38,
+  MAX_DECIMAL38,
+} from '../dialect';
 import {SNOWFLAKE_DIALECT_FUNCTIONS} from './dialect_functions';
 import {SNOWFLAKE_MALLOY_STANDARD_OVERLOADS} from './function_overrides';
 
@@ -106,6 +112,9 @@ export class SnowflakeDialect extends Dialect {
   name = 'snowflake';
   experimental = false;
   hasTimestamptz = true;
+  stringLiteralStyle = EscapeStyle.Backslash;
+  identifierEscapeStyle = EscapeStyle.Doubled;
+  identifierQuoteChar = '"';
   defaultNumberType = 'NUMBER';
   defaultDecimalType = 'NUMBER';
   udfPrefix = '__udf';
@@ -134,14 +143,16 @@ export class SnowflakeDialect extends Dialect {
   ];
 
   quoteTablePath(tablePath: string): string {
-    // Quote with double quotes if contains dangerous characters
-    if (tablePath.match(/[;-]/)) {
-      return tablePath
-        .split('.')
-        .map(part => `"${part}"`)
-        .join('.');
-    }
-    return tablePath;
+    // OPEN QUESTION: should this always-quote each segment so reserved
+    // words can be used as table names? Snowflake folds bare identifiers
+    // to UPPERCASE, while quoted identifiers preserve case. Switching to
+    // always-quote would break every existing user whose tables were
+    // created bare (so live as uppercase) and addressed from Malloy in
+    // mixed/lower case. Left as perPartMaybeQuoted pending a design call.
+    return tablePath
+      .split('.')
+      .map(part => this.quoteIdentifierPart(part, false))
+      .join('.');
   }
 
   sqlGroupSetTable(groupSetCount: number): string {
@@ -162,7 +173,7 @@ export class SnowflakeDialect extends Dialect {
 
   mapFieldsForObjectConstruct(fieldList: DialectFieldList): string {
     return fieldList
-      .map(f => `'${f.rawName}', (${f.sqlExpression})`)
+      .map(f => `${this.sqlLiteralString(f.rawName)}, (${f.sqlExpression})`)
       .join(', ');
   }
 
@@ -211,7 +222,7 @@ export class SnowflakeDialect extends Dialect {
     isArray: boolean,
     _isInNestedPipeline: boolean
   ): string {
-    const as = this.sqlMaybeQuoteIdentifier(alias);
+    const as = this.sqlQuoteIdentifier(alias);
     if (isArray) {
       return `LEFT JOIN lateral flatten(input => ${source}) as ${as}`;
     } else {
@@ -268,7 +279,7 @@ export class SnowflakeDialect extends Dialect {
     childName: string,
     childType: string
   ): string {
-    const sqlName = this.sqlMaybeQuoteIdentifier(childName);
+    const sqlName = this.sqlQuoteIdentifier(childName);
     if (childName === '__row_id') {
       return `"${parentAlias}".INDEX::varchar`;
     } else if (parentType.startsWith('array')) {
@@ -320,10 +331,6 @@ export class SnowflakeDialect extends Dialect {
 
   sqlSelectAliasAsStruct(alias: string): string {
     return `OBJECT_CONSTRUCT_KEEP_NULL(${alias}.*)`;
-  }
-
-  sqlMaybeQuoteIdentifier(identifier: string): string {
-    return '"' + identifier.replace(/"/g, '""') + '"';
   }
 
   sqlCreateTableAsSelect(tableName: string, sql: string): string {
@@ -560,16 +567,6 @@ ${indent(sql)}
     return `ORDER BY ${orderTerms.map(t => `${t} NULLS LAST`).join(',')}`;
   }
 
-  sqlLiteralString(literal: string): string {
-    const noVirgule = literal.replace(/\\/g, '\\\\');
-    return "'" + noVirgule.replace(/'/g, "\\'") + "'";
-  }
-
-  sqlLiteralRegexp(literal: string): string {
-    const noVirgule = literal.replace(/\\/g, '\\\\');
-    return "'" + noVirgule.replace(/'/g, "\\'") + "'";
-  }
-
   getDialectFunctionOverrides(): {
     [name: string]: DialectFunctionOverloadDef[];
   } {
@@ -596,7 +593,7 @@ ${indent(sql)}
       const sqlFields = malloyType.fields.reduce((ret, f) => {
         if (isAtomic(f)) {
           const name = f.as ?? f.name;
-          const oneSchema = `${this.sqlMaybeQuoteIdentifier(
+          const oneSchema = `${this.sqlQuoteIdentifier(
             name
           )} ${this.malloyTypeToSQLType(f)}`;
           ret.push(oneSchema);
@@ -665,10 +662,9 @@ ${indent(sql)}
     const rowVals: string[] = [];
     for (const f of lit.typeDef.fields) {
       const name = f.as ?? f.name;
-      const propName = `'${name}'`;
       const propVal =
         safeRecordGet(lit.kids, name)?.sql ?? 'internal-error-record-literal';
-      rowVals.push(`${propName},${propVal}`);
+      rowVals.push(`${this.sqlLiteralString(name)},${propVal}`);
     }
     return `OBJECT_CONSTRUCT_KEEP_NULL(${rowVals.join(',')})`;
   }

--- a/packages/malloy/src/dialect/standardsql/standardsql.ts
+++ b/packages/malloy/src/dialect/standardsql/standardsql.ts
@@ -54,6 +54,7 @@ import type {
 } from '../dialect';
 import {
   Dialect,
+  EscapeStyle,
   MIN_INT64,
   MAX_INT64,
   type LateralJoinExpression,
@@ -115,6 +116,9 @@ const bqToMalloyTypes: {[key: string]: BasicAtomicTypeDef} = {
 
 export class StandardSQLDialect extends Dialect {
   name = 'standardsql';
+  stringLiteralStyle = EscapeStyle.Backslash;
+  identifierEscapeStyle = EscapeStyle.Backslash;
+  identifierQuoteChar = '`';
   experimental = false;
   defaultNumberType = 'FLOAT64';
   defaultDecimalType = 'NUMERIC';
@@ -147,8 +151,28 @@ export class StandardSQLDialect extends Dialect {
     {min: MIN_INT64, max: MAX_INT64, numberType: 'bigint'},
   ];
 
+  // BigQuery's parser accepts `\`` as a backtick escape inside quoted
+  // identifiers, but BigQuery's schema layer rejects field/table names
+  // containing a literal backtick. Refuse here so the error names the
+  // dialect; the rest of the escape (backslash-doubling) is handled by
+  // the base via identifierEscapeStyle.
+  // Reference: https://cloud.google.com/bigquery/docs/reference/standard-sql/lexical
+  private bqRejectBacktick(name: string, kind: string): void {
+    if (name.includes('`')) {
+      throw new Error(
+        `BigQuery ${kind} cannot contain a backtick: ${JSON.stringify(name)}`
+      );
+    }
+  }
+
   quoteTablePath(tablePath: string): string {
-    return `\`${tablePath}\``;
+    this.bqRejectBacktick(tablePath, 'table path');
+    return '`' + tablePath.replace(/\\/g, '\\\\') + '`';
+  }
+
+  sqlQuoteIdentifier(identifier: string): string {
+    this.bqRejectBacktick(identifier, 'identifier');
+    return super.sqlQuoteIdentifier(identifier);
   }
 
   needsCivilTimeComputation(
@@ -280,7 +304,7 @@ export class StandardSQLDialect extends Dialect {
     childName: string,
     _childType: string
   ): string {
-    const child = this.sqlMaybeQuoteIdentifier(childName);
+    const child = this.sqlQuoteIdentifier(childName);
     return `${parentAlias}.${child}`;
   }
 
@@ -319,10 +343,6 @@ ${indent(sql)}
 
   sqlSelectAliasAsStruct(alias: string): string {
     return `(SELECT AS STRUCT ${alias}.*)`;
-  }
-
-  sqlMaybeQuoteIdentifier(identifier: string): string {
-    return '`' + identifier + '`';
   }
 
   sqlNowExpr(): string {
@@ -506,16 +526,6 @@ ${indent(sql)}
     return tableSQL;
   }
 
-  sqlLiteralString(literal: string): string {
-    const noVirgule = literal.replace(/\\/g, '\\\\');
-    return "'" + noVirgule.replace(/'/g, "\\'") + "'";
-  }
-
-  sqlLiteralRegexp(literal: string): string {
-    const noVirgule = literal.replace(/\\/g, '\\\\');
-    return "'" + noVirgule.replace(/'/g, "\\'") + "'";
-  }
-
   getDialectFunctionOverrides(): {
     [name: string]: DialectFunctionOverloadDef[];
   } {
@@ -591,7 +601,7 @@ ${indent(sql)}
     const ents: string[] = [];
     for (const [name, val] of Object.entries(lit.kids)) {
       const expr = val.sql || 'internal-error-literal-record';
-      ents.push(`${expr} AS ${this.sqlMaybeQuoteIdentifier(name)}`);
+      ents.push(`${expr} AS ${this.sqlQuoteIdentifier(name)}`);
     }
     return `STRUCT(${ents.join(',')})`;
   }

--- a/packages/malloy/src/dialect/trino/trino.ts
+++ b/packages/malloy/src/dialect/trino/trino.ts
@@ -140,14 +140,16 @@ export class TrinoDialect extends PostgresBase {
   supportsHyperLogLog = true;
 
   quoteTablePath(tablePath: string): string {
-    // Quote with double quotes if contains dangerous characters
-    if (tablePath.match(/[;-]/)) {
-      return tablePath
-        .split('.')
-        .map(part => `"${part}"`)
-        .join('.');
-    }
-    return tablePath;
+    // OPEN QUESTION: should this always-quote each segment so reserved
+    // words can be used as table names? Trino normalizes bare identifiers
+    // to lowercase (like Postgres), so switching to always-quote could
+    // break users whose Malloy uses mixed/upper case for tables that
+    // were created bare. Left as perPartMaybeQuoted pending a design
+    // call alongside Snowflake.
+    return tablePath
+      .split('.')
+      .map(part => this.quoteIdentifierPart(part, false))
+      .join('.');
   }
 
   sqlGroupSetTable(groupSetCount: number): string {
@@ -275,7 +277,7 @@ export class TrinoDialect extends PostgresBase {
     if (childName === '__row_id') {
       return `__row_id_from_${parentAlias}`;
     }
-    return `${parentAlias}.${this.sqlMaybeQuoteIdentifier(childName)}`;
+    return `${parentAlias}.${this.sqlQuoteIdentifier(childName)}`;
   }
 
   sqlUnnestPipelineHead(
@@ -594,14 +596,6 @@ ${indent(sql)}
     return tableSQL;
   }
 
-  sqlLiteralString(literal: string): string {
-    return "'" + literal.replace(/'/g, "''") + "'";
-  }
-
-  sqlLiteralRegexp(literal: string): string {
-    return "'" + literal.replace(/'/g, "''") + "'";
-  }
-
   getDialectFunctionOverrides(): {
     [name: string]: DialectFunctionOverloadDef[];
   } {
@@ -631,7 +625,7 @@ ${indent(sql)}
         for (const f of malloyType.fields) {
           if (isAtomic(f)) {
             typeSpec.push(
-              `${this.sqlMaybeQuoteIdentifier(
+              `${this.sqlQuoteIdentifier(
                 f.name
               )} ${this.malloyTypeToSQLType(f)}`
             );
@@ -647,7 +641,7 @@ ${indent(sql)}
           for (const f of malloyType.fields) {
             if (isAtomic(f)) {
               typeSpec.push(
-                `${this.sqlMaybeQuoteIdentifier(
+                `${this.sqlQuoteIdentifier(
                   f.name
                 )} ${this.malloyTypeToSQLType(f)}`
               );
@@ -766,7 +760,7 @@ ${indent(sql)}
           safeRecordGet(lit.kids, name)?.sql ?? 'internal-error-record-literal'
         );
         const elType = this.malloyTypeToSQLType(f);
-        rowTypes.push(`${this.sqlMaybeQuoteIdentifier(name)} ${elType}`);
+        rowTypes.push(`${this.sqlQuoteIdentifier(name)} ${elType}`);
       }
     }
     return `CAST(ROW(${rowVals.join(',')}) AS ROW(${rowTypes.join(',')}))`;

--- a/packages/malloy/src/lang/CONTEXT.md
+++ b/packages/malloy/src/lang/CONTEXT.md
@@ -35,6 +35,30 @@ When modifying grammar files, regenerate the parser:
 npm run build-parser  # In the malloy package directory
 ```
 
+### String literal forms
+
+Malloy has several quoted-literal forms with different escape rules. Knowing which is which matters when generating Malloy source programmatically (e.g. in tests with adversarial values) — they are NOT interchangeable. The authoritative source is `MalloyLexer.g4`.
+
+Two lexer rules drive the escape behavior:
+- `STR_CHAR` covers escape-processed bodies. `\'`, `\\`, `\n`, `\t`, `\uXXXX` are real escape sequences and produce a single character in the resulting string.
+- `RAW_CHAR` (and `RAW3_CHAR` for triple-delimited forms) covers raw bodies. Backslash is a literal character; `\'` is the only practical "escape" and it just lets the lexer keep scanning — both the `\` and the `'` end up in the string.
+
+| Form | Lexer token | Example | Body | Notes |
+|---|---|---|---|---|
+| Single-quoted string | `SQ_STRING` | `'hello'`, `'o\'brien'` | `STR_CHAR` | Standard string value — backslash escapes |
+| Double-quoted string | `DQ_STRING` | `"hello"` | `STR_CHAR` | Same; choice of delimiter is cosmetic |
+| Backtick-quoted identifier | `BQ_STRING` | `` `weird name` `` | `STR_CHAR` | An identifier (column/field name), not a string value |
+| Raw single-quoted string | `RAW_SQ` | `s'a\d'` | `RAW_CHAR` | Raw string value. `s` prefix |
+| Raw double-quoted string | `RAW_DQ` | `s"a\d"` | `RAW_CHAR` | Same, double-delimited |
+| Regex literal | `HACKY_REGEX` | `r'a\d'`, `R'a\d'`, `/a\d/` | `RAW_CHAR` | Regular expression; always raw |
+| Filter expression | `SQ_FILTER` / `DQ_FILTER` / `BQ_FILTER` | `f'...'`, `f"..."`, `` f`...` `` | `RAW_CHAR` | Filter syntax; always raw |
+| Multi-line filter | `SQ3_FILTER` / `DQ3_FILTER` / `BQ3_FILTER` | `f'''...'''`, `f"""..."""`, `` f```...``` `` | `RAW3_CHAR` | Triple-delimited filter; always raw |
+| Embedded SQL block | `SQL_BEGIN`/`SQL_END` | `"""SELECT * FROM ${%{...}}"""` | `SQL_CHAR` | Body is raw SQL with `%{ malloy }` interpolation; opens a lexer mode. Used in `db.sql("""...""")` and turducken patterns |
+
+A naming gotcha across languages: in BigQuery and Python, `r'...'` means *raw string*. In Malloy, `r'...'` means *regex literal*. Malloy's raw-string prefix is `s`.
+
+Practical implication when authoring Malloy source from JavaScript: for any of the raw forms above (regex, `s'...'`, filter, triple-quoted filter, embedded SQL), do not double backslashes in the JavaScript-side rendering — Malloy will not undouble them. The standard mistake is `"r'" + s.replace(/\\/g, '\\\\') + "'"`, which turns the JS string `a\d` into the 4-character Malloy string `a\\d`, and the regex engine sees a literal backslash where you expected a digit class.
+
 ### 2. AST (Abstract Syntax Tree) (ast/)
 
 The AST is a tree of `MalloyElement` objects that represents the semantic structure of Malloy code.

--- a/packages/malloy/src/model/filter_compilers.ts
+++ b/packages/malloy/src/model/filter_compilers.ts
@@ -161,7 +161,7 @@ export const FilterCompilers = {
     // For some databases checking NULL combined with a boolean check
     // is faster than a COALESCE, for now, just detect if the expression
     // is just a column reference, and if so, don't use COALECSE.
-    const quoteChar = d.sqlMaybeQuoteIdentifier('select')[0];
+    const quoteChar = d.sqlQuoteIdentifier('select')[0];
     const isColumn = x.match(`^[()${quoteChar}\\w.]+$`);
 
     if (isColumn) {

--- a/packages/malloy/src/model/query_model_impl.ts
+++ b/packages/malloy/src/model/query_model_impl.ts
@@ -163,12 +163,12 @@ export class QueryModelImpl implements QueryModel, ModelRootInterface {
       const fieldNames: string[] = [];
       for (const f of ret.outputStruct.fields) {
         if (isAtomic(f)) {
-          const quoted = q.parent.dialect.sqlMaybeQuoteIdentifier(f.name);
+          const quoted = q.parent.dialect.sqlQuoteIdentifier(f.name);
           fieldNames.push(quoted);
         }
       }
       // const fieldNames = getAtomicFields(ret.outputStruct).map(fieldDef =>
-      //   q.parent.dialect.sqlMaybeQuoteIdentifier(fieldDef.name)
+      //   q.parent.dialect.sqlQuoteIdentifier(fieldDef.name)
       // );
       ret.lastStageName = stageWriter.addStage(
         q.parent.dialect.sqlFinalStage(ret.lastStageName, fieldNames)
@@ -302,11 +302,11 @@ export class QueryModelImpl implements QueryModel, ModelRootInterface {
         },
       ],
     };
-    const fieldNameColumn = d.sqlMaybeQuoteIdentifier('fieldName');
-    const fieldPathColumn = d.sqlMaybeQuoteIdentifier('fieldPath');
-    const fieldValueColumn = d.sqlMaybeQuoteIdentifier('fieldValue');
-    const fieldTypeColumn = d.sqlMaybeQuoteIdentifier('fieldType');
-    const weightColumn = d.sqlMaybeQuoteIdentifier('weight');
+    const fieldNameColumn = d.sqlQuoteIdentifier('fieldName');
+    const fieldPathColumn = d.sqlQuoteIdentifier('fieldPath');
+    const fieldValueColumn = d.sqlQuoteIdentifier('fieldValue');
+    const fieldTypeColumn = d.sqlQuoteIdentifier('fieldType');
+    const weightColumn = d.sqlQuoteIdentifier('weight');
 
     // if we've compiled the SQL before use it otherwise
     let sqlPDT = this.exploreSearchSQLMap.get(explore);

--- a/packages/malloy/src/model/query_query.ts
+++ b/packages/malloy/src/model/query_query.ts
@@ -945,7 +945,7 @@ export class QueryQuery extends QueryField {
       }
       if (ji.makeUniqueKey) {
         const passKeys = this.generateSQLPassthroughKeys(qs);
-        structSQL = `(SELECT ${qs.dialect.sqlGenerateUUID()} as ${qs.dialect.sqlMaybeQuoteIdentifier(
+        structSQL = `(SELECT ${qs.dialect.sqlGenerateUUID()} as ${qs.dialect.sqlQuoteIdentifier(
           '__distinct_key'
         )}, x.* ${passKeys} FROM ${structSQL} as x)`;
       }
@@ -1118,7 +1118,7 @@ export class QueryQuery extends QueryField {
     if (isBaseTable(qs.structDef)) {
       if (ji.makeUniqueKey) {
         const passKeys = this.generateSQLPassthroughKeys(qs);
-        structSQL = `(SELECT ${qs.dialect.sqlGenerateUUID()} as ${qs.dialect.sqlMaybeQuoteIdentifier(
+        structSQL = `(SELECT ${qs.dialect.sqlGenerateUUID()} as ${qs.dialect.sqlQuoteIdentifier(
           '__distinct_key'
         )}, x.* ${passKeys} FROM ${structSQL} as x)`;
       }
@@ -1214,7 +1214,7 @@ export class QueryQuery extends QueryField {
             o.push(`${fi.fieldUsage.resultIndex} ${f.dir || 'ASC'}`);
           } else if (this.parent.dialect.orderByClause === 'output_name') {
             o.push(
-              `${this.parent.dialect.sqlMaybeQuoteIdentifier(f.field)} ${
+              `${this.parent.dialect.sqlQuoteIdentifier(f.field)} ${
                 f.dir || 'ASC'
               }`
             );
@@ -1231,7 +1231,7 @@ export class QueryQuery extends QueryField {
         } else if (this.parent.dialect.orderByClause === 'output_name') {
           const orderingField = resultStruct.getFieldByNumber(f.field);
           o.push(
-            `${this.parent.dialect.sqlMaybeQuoteIdentifier(
+            `${this.parent.dialect.sqlQuoteIdentifier(
               orderingField.name
             )} ${f.dir || 'ASC'}`
           );
@@ -1261,7 +1261,7 @@ export class QueryQuery extends QueryField {
 
     for (const [name, field] of this.rootResult.allFields) {
       const fi = field as FieldInstanceField;
-      const sqlName = this.parent.dialect.sqlMaybeQuoteIdentifier(name);
+      const sqlName = this.parent.dialect.sqlQuoteIdentifier(name);
       if (fi.fieldUsage.type === 'result') {
         fields.push(` ${fi.generateExpression()} as ${sqlName}`);
       }
@@ -1325,7 +1325,7 @@ export class QueryQuery extends QueryField {
         .join(',\n');
       const outputFields = outputPipelinedSQL.map(f => f.sqlFieldName);
       const allFields = Array.from(this.rootResult.allFields.keys()).map(f =>
-        this.parent.dialect.sqlMaybeQuoteIdentifier(f)
+        this.parent.dialect.sqlQuoteIdentifier(f)
       );
       const fields = allFields.filter(f => outputFields.indexOf(f) === -1);
       retSQL = `SELECT ${
@@ -1352,7 +1352,7 @@ export class QueryQuery extends QueryField {
     const orderedFields = [...scalarFields, ...otherFields];
 
     for (const [name, fi] of orderedFields) {
-      const outputName = this.parent.dialect.sqlMaybeQuoteIdentifier(
+      const outputName = this.parent.dialect.sqlQuoteIdentifier(
         `${name}__${resultSet.groupSet}`
       );
       if (fi instanceof FieldInstanceField) {
@@ -1375,10 +1375,9 @@ export class QueryQuery extends QueryField {
               });
               output.sql.push(outputFieldName);
               if (fi.f.fieldDef.type === 'number') {
-                const outputNameString =
-                  this.parent.dialect.sqlMaybeQuoteIdentifier(
-                    `${name}__${resultSet.groupSet}_string`
-                  );
+                const outputNameString = this.parent.dialect.sqlQuoteIdentifier(
+                  `${name}__${resultSet.groupSet}_string`
+                );
                 const outputFieldNameString = `__lateral_join_bag.${outputNameString}`;
                 output.sql.push(outputFieldNameString);
                 output.dimensionIndexes.push(output.fieldIndex++);
@@ -1519,9 +1518,7 @@ export class QueryQuery extends QueryField {
         while (r) {
           for (const name of r.fieldNames(fi => isScalarField(fi.f))) {
             dimensions.push(
-              this.parent.dialect.sqlMaybeQuoteIdentifier(
-                `${name}__${r.groupSet}`
-              )
+              this.parent.dialect.sqlQuoteIdentifier(`${name}__${r.groupSet}`)
             );
           }
           r = r.parent;
@@ -1560,7 +1557,7 @@ export class QueryQuery extends QueryField {
             }
             obSQL.push(
               ' ' +
-                this.parent.dialect.sqlMaybeQuoteIdentifier(
+                this.parent.dialect.sqlQuoteIdentifier(
                   `${orderingField.name}__${result.groupSet}`
                 ) +
                 ` ${ordering.dir || 'ASC'}`
@@ -1725,7 +1722,7 @@ export class QueryQuery extends QueryField {
   ) {
     const groupsToMap: number[] = [];
     for (const [name, fi] of resultSet.allFields) {
-      const sqlFieldName = this.parent.dialect.sqlMaybeQuoteIdentifier(
+      const sqlFieldName = this.parent.dialect.sqlQuoteIdentifier(
         `${name}__${resultSet.groupSet}`
       );
       if (fi instanceof FieldInstanceField) {
@@ -1860,12 +1857,12 @@ export class QueryQuery extends QueryField {
     const outputPipelinedSQL: OutputPipelinedSQL[] = [];
     const dimensionIndexes: number[] = [];
     for (const [name, fi] of this.rootResult.allFields) {
-      const sqlName = this.parent.dialect.sqlMaybeQuoteIdentifier(name);
+      const sqlName = this.parent.dialect.sqlQuoteIdentifier(name);
       if (fi instanceof FieldInstanceField) {
         if (fi.fieldUsage.type === 'result') {
           if (isScalarField(fi.f)) {
             fieldsSQL.push(
-              this.parent.dialect.sqlMaybeQuoteIdentifier(
+              this.parent.dialect.sqlQuoteIdentifier(
                 `${name}__${this.rootResult.groupSet}`
               ) + ` as ${sqlName}`
             );
@@ -1873,7 +1870,7 @@ export class QueryQuery extends QueryField {
           } else if (isBasicCalculation(fi.f)) {
             fieldsSQL.push(
               this.parent.dialect.sqlAnyValueLastTurtle(
-                this.parent.dialect.sqlMaybeQuoteIdentifier(
+                this.parent.dialect.sqlQuoteIdentifier(
                   `${name}__${this.rootResult.groupSet}`
                 ),
                 this.rootResult.groupSet,
@@ -1897,7 +1894,7 @@ export class QueryQuery extends QueryField {
         } else if (fi.firstSegment.type === 'project') {
           fieldsSQL.push(
             this.parent.dialect.sqlAnyValueLastTurtle(
-              this.parent.dialect.sqlMaybeQuoteIdentifier(
+              this.parent.dialect.sqlQuoteIdentifier(
                 `${name}__${this.rootResult.groupSet}`
               ),
               this.rootResult.groupSet,
@@ -1945,7 +1942,7 @@ export class QueryQuery extends QueryField {
     const dialectFieldList: DialectFieldList = [];
 
     for (const [name, field] of resultStruct.allFields) {
-      const sqlName = this.parent.dialect.sqlMaybeQuoteIdentifier(name);
+      const sqlName = this.parent.dialect.sqlQuoteIdentifier(name);
       //
       if (
         resultStruct.firstSegment.type === 'reduce' &&
@@ -1966,7 +1963,7 @@ export class QueryQuery extends QueryField {
           };
           dialectFieldList.push({
             typeDef: multiLineNest,
-            sqlExpression: this.parent.dialect.sqlMaybeQuoteIdentifier(
+            sqlExpression: this.parent.dialect.sqlQuoteIdentifier(
               `${name}__${resultStruct.groupSet}`
             ),
             rawName: name,
@@ -1981,7 +1978,7 @@ export class QueryQuery extends QueryField {
           };
           dialectFieldList.push({
             typeDef: oneLineNest,
-            sqlExpression: this.parent.dialect.sqlMaybeQuoteIdentifier(
+            sqlExpression: this.parent.dialect.sqlQuoteIdentifier(
               `${name}__${resultStruct.groupSet}`
             ),
             rawName: name,
@@ -1995,7 +1992,7 @@ export class QueryQuery extends QueryField {
       ) {
         pushDialectField(dialectFieldList, {
           fieldDef: field.f.fieldDef,
-          sqlExpression: this.parent.dialect.sqlMaybeQuoteIdentifier(
+          sqlExpression: this.parent.dialect.sqlQuoteIdentifier(
             `${name}__${resultStruct.groupSet}`
           ),
           rawName: name,
@@ -2038,12 +2035,12 @@ export class QueryQuery extends QueryField {
       } else {
         orderingField = resultStruct.getFieldByNumber(ordering.field);
       }
-      const structField = this.parent.dialect.sqlMaybeQuoteIdentifier(
+      const structField = this.parent.dialect.sqlQuoteIdentifier(
         orderingField.name
       );
       if (resultStruct.firstSegment.type === 'reduce') {
         compiledOrderBy.push({
-          field: this.parent.dialect.sqlMaybeQuoteIdentifier(
+          field: this.parent.dialect.sqlQuoteIdentifier(
             `${orderingField.name}__${resultStruct.groupSet}`
           ),
           structField,
@@ -2311,12 +2308,12 @@ class QueryQueryIndexStage extends QueryQuery {
   generateSQL(stageWriter: StageWriter): string {
     let measureSQL = 'COUNT(*)';
     const dialect = this.parent.dialect;
-    const fieldNameColumn = dialect.sqlMaybeQuoteIdentifier('fieldName');
-    const fieldPathColumn = dialect.sqlMaybeQuoteIdentifier('fieldPath');
-    const fieldValueColumn = dialect.sqlMaybeQuoteIdentifier('fieldValue');
-    const fieldTypeColumn = dialect.sqlMaybeQuoteIdentifier('fieldType');
-    const fieldRangeColumn = dialect.sqlMaybeQuoteIdentifier('fieldRange');
-    const weightColumn = dialect.sqlMaybeQuoteIdentifier('weight');
+    const fieldNameColumn = dialect.sqlQuoteIdentifier('fieldName');
+    const fieldPathColumn = dialect.sqlQuoteIdentifier('fieldPath');
+    const fieldValueColumn = dialect.sqlQuoteIdentifier('fieldValue');
+    const fieldTypeColumn = dialect.sqlQuoteIdentifier('fieldType');
+    const fieldRangeColumn = dialect.sqlQuoteIdentifier('fieldRange');
+    const weightColumn = dialect.sqlQuoteIdentifier('weight');
     const measureName = (this.firstSegment as IndexSegment).weightMeasure;
     if (measureName) {
       measureSQL = this.rootResult.getField(measureName).generateExpression();

--- a/packages/malloy/src/test/test-models.ts
+++ b/packages/malloy/src/test/test-models.ts
@@ -261,7 +261,7 @@ function generateSQL(dialect: Dialect, rows: TestDataRow[]): string {
 
       if (idx === 0) {
         // First row: include column aliases and explicit casts if needed
-        const quotedName = dialect.sqlMaybeQuoteIdentifier(colName);
+        const quotedName = dialect.sqlQuoteIdentifier(colName);
         if (typedValue.needsCast) {
           const sqlType = dialect.malloyTypeToSQLType(typedValue.malloyType);
           fields.push(`CAST(${sql} AS ${sqlType}) AS ${quotedName}`);
@@ -293,7 +293,7 @@ function generateSQL(dialect: Dialect, rows: TestDataRow[]): string {
 
   // Multiple rows: wrap for sorting
   const quotedColumns = columnList
-    .map(col => dialect.sqlMaybeQuoteIdentifier(col))
+    .map(col => dialect.sqlQuoteIdentifier(col))
     .join(', ');
   const innerQuery = selects.join('\nUNION ALL ');
 

--- a/test/CONTEXT.md
+++ b/test/CONTEXT.md
@@ -163,6 +163,12 @@ Cloud SQL warehouses (BigQuery, Snowflake, Databricks) can't read local files vi
 
 An ideal future state would be publishing the parquets to a well-known cloud storage location that all warehouses could read from, but the hosting/cost question is still open.
 
+## Authoring Malloy source from JavaScript
+
+When a test programmatically constructs Malloy source (e.g. injecting adversarial values for escape testing), be aware that Malloy has several string-literal forms with different escape rules. The `r'...'` and `/.../` regex forms — and all triple-quoted strings — are *raw*: backslash is preserved verbatim, no escape processing. Doubling backslashes on the JavaScript side will produce a different string than intended.
+
+The full table is in [`../packages/malloy/src/lang/CONTEXT.md`](../packages/malloy/src/lang/CONTEXT.md) under "String literal forms". `test/src/databases/all/escape.spec.ts` is a worked example.
+
 ## Important Notes
 
 - Cross-database tests are critical for verifying Malloy's dialect abstraction

--- a/test/src/core/persist.spec.ts
+++ b/test/src/core/persist.spec.ts
@@ -273,7 +273,7 @@ describe('source persistence', () => {
           connectionDigests: {[tstDB]: connectionDigest},
         });
 
-        expect(sql).toContain('my_schema.persisted_carrier_stats');
+        expect(sql).toContain('"my_schema"."persisted_carrier_stats"');
         expect(sql).not.toContain('COUNT(');
       });
 
@@ -365,7 +365,7 @@ describe('source persistence', () => {
           connectionDigests: {[tstDB]: connectionDigest},
         });
 
-        expect(sql).toContain('cached.carrier_stats_table');
+        expect(sql).toContain('"cached"."carrier_stats_table"');
         expect(sql).not.toContain('COUNT(');
       });
     });
@@ -1144,7 +1144,7 @@ describe('source persistence', () => {
         connectionDigests: {[tstDB]: connectionDigest},
       });
 
-      expect(sql).toContain('cache.carrier_stats_built');
+      expect(sql).toContain('"cache"."carrier_stats_built"');
       expect(sql).not.toContain('COUNT(');
     });
   });
@@ -1222,7 +1222,7 @@ describe('source persistence', () => {
         connectionDigests: {[tstDB]: connectionDigest},
       });
 
-      expect(wrapperSQL).toContain('build_cache.carrier_stats_v1');
+      expect(wrapperSQL).toContain('"build_cache"."carrier_stats_v1"');
       expect(wrapperSQL).toContain('flight_count > 100');
 
       const wrapperBuildId = wrapper.makeBuildId(connectionDigest, wrapperSQL);
@@ -1460,7 +1460,7 @@ describe('source persistence', () => {
       );
 
       const sql = await getModel2SQL(manifest);
-      expect(sql).toContain('cached.carrier_stats_table');
+      expect(sql).toContain('"cached"."carrier_stats_table"');
       expect(sql).not.toContain('COUNT(');
     });
 
@@ -1499,7 +1499,7 @@ describe('source persistence', () => {
       );
 
       const sql = await getModel2SQL(manifest);
-      expect(sql).toContain('cached.carrier_stats_table');
+      expect(sql).toContain('"cached"."carrier_stats_table"');
       expect(sql).not.toContain('COUNT(');
     });
 
@@ -1519,7 +1519,7 @@ describe('source persistence', () => {
       );
 
       const sql = await getModel2SQL(manifest);
-      expect(sql).toContain('cached.carrier_stats_table');
+      expect(sql).toContain('"cached"."carrier_stats_table"');
       expect(sql).not.toContain('COUNT(');
     });
 
@@ -1784,7 +1784,7 @@ describe('source persistence', () => {
       const sqlWithManifest = await rt
         .loadQuery(BY_CARRIER_QUERY_MODEL)
         .getSQL();
-      expect(sqlWithManifest).toMatch(/FROM\s+by_carrier\s/);
+      expect(sqlWithManifest).toMatch(/FROM\s+"by_carrier"\s/);
 
       // Override with empty manifest — SQL should NOT reference the table
       const sqlWithoutManifest = await rt
@@ -1792,7 +1792,7 @@ describe('source persistence', () => {
           buildManifest: EMPTY_BUILD_MANIFEST,
         })
         .getSQL();
-      expect(sqlWithoutManifest).not.toMatch(/FROM\s+by_carrier\s/);
+      expect(sqlWithoutManifest).not.toMatch(/FROM\s+"by_carrier"\s/);
     });
 
     it('query results match with and without manifest', async () => {
@@ -1988,14 +1988,14 @@ describe('source persistence', () => {
       const sqlBefore = await runtime
         .loadQuery(BY_CARRIER_QUERY_MODEL)
         .getSQL();
-      expect(sqlBefore).not.toMatch(/FROM\s+by_carrier\s/);
+      expect(sqlBefore).not.toMatch(/FROM\s+"by_carrier"\s/);
 
       // Set manifest via setter
       runtime.buildManifest = manifest;
 
       // Now SQL SHOULD reference the table
       const sqlAfter = await runtime.loadQuery(BY_CARRIER_QUERY_MODEL).getSQL();
-      expect(sqlAfter).toMatch(/FROM\s+by_carrier\s/);
+      expect(sqlAfter).toMatch(/FROM\s+"by_carrier"\s/);
     });
   });
 
@@ -2057,7 +2057,7 @@ describe('source persistence', () => {
       const resultSQL = await runtimeWithManifest(manifest)
         .loadQuery(strictModelCode)
         .getSQL();
-      expect(resultSQL).toContain('cached.by_carrier');
+      expect(resultSQL).toContain('"cached"."by_carrier"');
     });
 
     it('non-strict manifest falls through when persist source is missing', async () => {
@@ -2111,7 +2111,7 @@ describe('source persistence', () => {
       const sql = await runtimeWithManifest(manifest)
         .loadQuery(modelCode)
         .getSQL();
-      expect(sql).toContain('cached.by_carrier');
+      expect(sql).toContain('"cached"."by_carrier"');
     });
 
     it('strict manifest ignores named non-persistent source used as join', async () => {
@@ -2157,7 +2157,7 @@ describe('source persistence', () => {
       const sql = await runtimeWithManifest(manifest)
         .loadQuery(modelCode)
         .getSQL();
-      expect(sql).toContain('cached.by_carrier');
+      expect(sql).toContain('"cached"."by_carrier"');
     });
   });
 });

--- a/test/src/databases/all/closeall.spec.ts
+++ b/test/src/databases/all/closeall.spec.ts
@@ -8,7 +8,7 @@ const runtimes = new RuntimeList(databasesFromEnvironmentOr(allDatabases));
 describe.each(runtimes.runtimeList)(
   'connection close test %s',
   (conName, runtime) => {
-    const n = runtime.dialect.sqlMaybeQuoteIdentifier('n');
+    const n = runtime.dialect.sqlQuoteIdentifier('n');
     const testModel = wrapTestModel(runtime, '');
     test.each(Array.from({length: 50}, (_, i) => i + 1))(
       'run SELECT %i',

--- a/test/src/databases/all/compound-atomic.spec.ts
+++ b/test/src/databases/all/compound-atomic.spec.ts
@@ -37,7 +37,7 @@ describe.each(runtimes.runtimeList)(
   (conName, runtime) => {
     const testModel = wrapTestModel(runtime, '');
     const supportsNestedArrays = runtime.dialect.nestedArrays;
-    const quote = runtime.dialect.sqlMaybeQuoteIdentifier;
+    const quote = (s: string) => runtime.dialect.sqlQuoteIdentifier(s);
 
     const empty = `${conName}.sql("SELECT 0 as z")`;
     function arraySelectVal(...val: number[]): string {

--- a/test/src/databases/all/escape.spec.ts
+++ b/test/src/databases/all/escape.spec.ts
@@ -59,17 +59,37 @@ function toMalloyString(s: string): string {
   return "'" + s.replace(/\\/g, '\\\\').replace(/'/g, "\\'") + "'";
 }
 
-// Malloy r'...' is a raw string: backslash is literal, no escape
-// processing inside the body. As a consequence the body cannot
-// contain a single quote — `\'` in r'...' is parsed as two raw chars
-// (backslash + quote), not as an escape that vanishes the quote, so
-// there is no syntax that produces a regex literal containing a `'`.
-// Assert the precondition rather than fake an escape that wouldn't
-// round-trip.
+// Render a JS string as a Malloy regex literal (r'...').
+//
+// The lexer rules (MalloyLexer.g4) are:
+//   HACKY_REGEX: ('/' | [rR]) SQ RAW_CHAR*? SQ;
+//   RAW_CHAR:    ('\\' ~[\n]) | ~[\\\n];
+//
+// r'...' is a raw string: there is no escape character. The `\X`
+// alternative of RAW_CHAR exists only so the lexer can scan past
+// a quote without terminating — both the backslash and X end up
+// in the resulting string. Consequences:
+//
+//   * A single quote in the desired body has no lossless encoding.
+//     `\'` puts a `'` in the body but leaves an extra `\` next to
+//     it, which changes the regex pattern.
+//   * A newline has no encoding (matches neither RAW_CHAR branch).
+//   * A body ending in an odd run of backslashes has no encoding:
+//     the trailing `\` consumes the closing `'` as part of `\'`,
+//     leaving the literal unterminated.
+//
+// We refuse those inputs rather than silently emit a different
+// regex than the caller asked for. (Aside: CodeQL flags
+// `s.replace(/'/g, "\\'")` here under js/incomplete-sanitization
+// because it escapes one character without escaping the escape
+// character. That rule assumes a non-raw quoted-string context;
+// it doesn't fit r'...', where the right answer is "refuse what
+// can't be encoded," not "escape more.")
 function toMalloyRegex(s: string): string {
-  if (s.includes("'")) {
+  const trailingBackslashes = s.match(/\\*$/)![0].length;
+  if (s.includes("'") || s.includes('\n') || trailingBackslashes % 2 === 1) {
     throw new Error(
-      `toMalloyRegex cannot encode a regex containing a single quote: ${JSON.stringify(s)}`
+      `toMalloyRegex cannot encode this string as r'...': ${JSON.stringify(s)}`
     );
   }
   return "r'" + s + "'";

--- a/test/src/databases/all/escape.spec.ts
+++ b/test/src/databases/all/escape.spec.ts
@@ -1,0 +1,119 @@
+/*
+ * Copyright Contributors to the Malloy project
+ * SPDX-License-Identifier: MIT
+ */
+
+// End-to-end escape round-trip tests. Each dialect's escape functions
+// are unit-tested in packages/malloy/src/dialect/escape.spec.ts; this
+// file is the integration counterpart, which proves the output actually
+// parses against the real database. Without these, a unit-test parser
+// blind to a dialect-specific quirk could declare success while the
+// real database rejects or mis-interprets our SQL — the MySQL/Databricks
+// sqlLiteralRegexp bug (now fixed) is exactly that shape: a regex
+// pattern containing `\d` round-tripped through our parser, but the
+// real database dropped the backslash, and the regex never matched.
+
+import {RuntimeList, allDatabases} from '../../runtimes';
+import '@malloydata/malloy/test/matchers';
+import {wrapTestModel} from '@malloydata/malloy/test';
+import {databasesFromEnvironmentOr} from '../../util';
+
+const runtimes = new RuntimeList(databasesFromEnvironmentOr(allDatabases));
+
+afterAll(async () => {
+  await runtimes.closeAll();
+});
+
+// Adversarial bytes that have historically smuggled past dialect escape
+// functions. Kept small so a failure points clearly at the offending
+// input.
+const STRING_CORPUS: {name: string; value: string}[] = [
+  {name: 'simple', value: 'hello'},
+  {name: 'single_quote', value: "o'brien"},
+  {name: 'backslash', value: 'a\\b'},
+  {name: 'trailing_backslash', value: 'foo\\'},
+  {name: 'injection', value: "';DROP TABLE x;--"},
+];
+
+// Regex patterns that exercise backslash semantics in backslash-style
+// dialects. `\d` is the canonical case: in MySQL/Databricks/Snowflake/
+// BigQuery the SQL parser decodes `\X` sequences, so the regex engine
+// only sees `\d` if our regex literal output is `'\\d'`. A buggy
+// doubled-style escape (which produced just `'\d'` for those dialects)
+// would silently drop the backslash and never match a digit.
+const REGEX_CORPUS: {name: string; pattern: string; haystack: string}[] = [
+  {name: 'digit_class', pattern: 'a\\d', haystack: 'a5'},
+  {name: 'word_class', pattern: '\\w+', haystack: 'hello'},
+  {name: 'escaped_literal', pattern: 'a\\.b', haystack: 'a.b'},
+];
+
+// Identifiers that exercise sqlQuoteIdentifier and (via nest:) the
+// per-dialect rawName-in-fieldList code paths fixed in this PR.
+const IDENT_CORPUS: {name: string; value: string}[] = [
+  {name: 'space', value: 'has space'},
+  {name: 'single_quote', value: "o'brien"},
+  {name: 'reserved_word', value: 'select'},
+];
+
+function toMalloyString(s: string): string {
+  return "'" + s.replace(/\\/g, '\\\\').replace(/'/g, "\\'") + "'";
+}
+
+// Malloy r'...' is a raw string — backslash is literal, no escape
+// processing on the contents. The only character that needs handling
+// is a single quote (rendered as \' in the source so the lexer keeps
+// scanning to the actual closing quote).
+function toMalloyRegex(s: string): string {
+  return "r'" + s.replace(/'/g, "\\'") + "'";
+}
+
+function toMalloyIdent(s: string): string {
+  return '`' + s.replace(/\\/g, '\\\\').replace(/`/g, '\\`') + '`';
+}
+
+describe.each(runtimes.runtimeList)(
+  '%s escape round-trip',
+  (dbName, runtime) => {
+    const testModel = wrapTestModel(runtime, '');
+
+    describe('string literal', () => {
+      for (const {name, value} of STRING_CORPUS) {
+        test(name, async () => {
+          await expect(`
+            run: ${dbName}.sql("SELECT 1 as one") -> {
+              select: x is ${toMalloyString(value)}
+            }
+          `).toMatchResult(testModel, {x: value});
+        });
+      }
+    });
+
+    describe('regex literal', () => {
+      for (const {name, pattern, haystack} of REGEX_CORPUS) {
+        test(name, async () => {
+          await expect(`
+            run: ${dbName}.sql("SELECT 1 as one") -> {
+              select: m is ${toMalloyString(haystack)} ~ ${toMalloyRegex(pattern)}
+            }
+          `).toMatchResult(testModel, {m: true});
+        });
+      }
+    });
+
+    describe('adversarial column name', () => {
+      for (const {name, value} of IDENT_CORPUS) {
+        test(name, async () => {
+          // A Malloy backtick-quoted identifier with the adversarial
+          // value as the output column name. The dialect must quote
+          // this safely in the generated SQL, and the result row must
+          // be addressable by that exact column name.
+          await expect(`
+            run: ${dbName}.sql("SELECT 1 as one") -> {
+              select: ${toMalloyIdent(value)} is 42
+            }
+          `).toMatchResult(testModel, {[value]: 42});
+        });
+      }
+    });
+  }
+);

--- a/test/src/databases/all/escape.spec.ts
+++ b/test/src/databases/all/escape.spec.ts
@@ -59,12 +59,20 @@ function toMalloyString(s: string): string {
   return "'" + s.replace(/\\/g, '\\\\').replace(/'/g, "\\'") + "'";
 }
 
-// Malloy r'...' is a raw string — backslash is literal, no escape
-// processing on the contents. The only character that needs handling
-// is a single quote (rendered as \' in the source so the lexer keeps
-// scanning to the actual closing quote).
+// Malloy r'...' is a raw string: backslash is literal, no escape
+// processing inside the body. As a consequence the body cannot
+// contain a single quote — `\'` in r'...' is parsed as two raw chars
+// (backslash + quote), not as an escape that vanishes the quote, so
+// there is no syntax that produces a regex literal containing a `'`.
+// Assert the precondition rather than fake an escape that wouldn't
+// round-trip.
 function toMalloyRegex(s: string): string {
-  return "r'" + s.replace(/'/g, "\\'") + "'";
+  if (s.includes("'")) {
+    throw new Error(
+      `toMalloyRegex cannot encode a regex containing a single quote: ${JSON.stringify(s)}`
+    );
+  }
+  return "r'" + s + "'";
 }
 
 function toMalloyIdent(s: string): string {

--- a/test/src/databases/all/join.spec.ts
+++ b/test/src/databases/all/join.spec.ts
@@ -336,8 +336,8 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
 
       source: sql_mfrs is ${databaseName}.sql("""
         SELECT
-          ${runtime.dialect.sqlMaybeQuoteIdentifier('manufacturer')}
-          as ${runtime.dialect.sqlMaybeQuoteIdentifier('sql_mfr')}
+          ${runtime.dialect.sqlQuoteIdentifier('manufacturer')}
+          as ${runtime.dialect.sqlQuoteIdentifier('sql_mfr')}
           FROM %{ base_models -> mfr_list } as SpOrKlE
       """)
 

--- a/test/src/databases/all/problems.spec.ts
+++ b/test/src/databases/all/problems.spec.ts
@@ -43,7 +43,7 @@ async function getError<T>(fn: () => Promise<T>) {
 runtimes.runtimeMap.forEach((runtime, databaseName) => {
   const testModel = wrapTestModel(runtime, '');
   it(`properly quotes nested field names in ${databaseName}`, async () => {
-    const one = runtime.dialect.sqlMaybeQuoteIdentifier('one');
+    const one = runtime.dialect.sqlQuoteIdentifier('one');
     await expect(`
       run: ${databaseName}.sql(""" SELECT 1 as ${one} """) -> {
         nest: foo is {

--- a/test/src/test-select.ts
+++ b/test/src/test-select.ts
@@ -485,7 +485,7 @@ export class TestSelect {
 
         if (idx === 0) {
           // First row: include column aliases and explicit casts if needed
-          const quotedName = this.dialect.sqlMaybeQuoteIdentifier(colName);
+          const quotedName = this.dialect.sqlQuoteIdentifier(colName);
           if (typedValue.needsCast) {
             const sqlType = this.dialect.malloyTypeToSQLType(
               typedValue.malloyType
@@ -519,7 +519,7 @@ export class TestSelect {
 
     // Multiple rows: double wrap - inner for sorting, outer for column selection
     const quotedColumns = columnList
-      .map(col => this.dialect.sqlMaybeQuoteIdentifier(col))
+      .map(col => this.dialect.sqlQuoteIdentifier(col))
       .join(', ');
     const innerQuery = selects.join('\nUNION ALL ');
 


### PR DESCRIPTION
## Summary

- Audits and fixes a class of SQL-escape bugs across every dialect where user-controlled strings (record field names, table paths, regex/string literals) were rendered into SQL without proper escaping.
- Hoists the safe escape logic into the base `Dialect` class, driven by two fields per dialect (`stringLiteralStyle`, `identifierEscapeStyle`) that default to `EscapeStyle.Unset` — base methods throw with a clear named error if a dialect forgets to set them.
- Renames `sqlMaybeQuoteIdentifier` → `sqlQuoteIdentifier` (the "Maybe" was aspirational; we always quote) across all 152 callsites.

## Bugs fixed

- `quoteTablePath` leaked unescaped delimiters in every dialect.
- BigQuery `sqlQuoteIdentifier` never escaped backticks; BQ also uses string-literal-style escapes inside backticks (`\\` not `` `` ``), per the lexical reference.
- MySQL/Databricks `sqlLiteralRegexp` used a different escape style from `sqlLiteralString`, silently dropping backslashes from regex patterns containing `\d` etc.
- Postgres/MySQL `sqlFieldReference` interpolated `childName` raw into a single-quoted JSON path.
- Postgres/Snowflake `sqlLiteralRecord` interpolated `kName` raw into a single-quoted JSON/object key.
- Databricks/MySQL/Snowflake unnest helpers interpolated user-controlled `rawName` raw into JSON keys and JSONPath strings.
- `duckdb_common.fetchTableSchema` and `mysql_connection.fetchTableSchema` now route through `dialect.quoteTablePath` instead of open-coding their own quoting.

## Tests

- New `packages/malloy/src/dialect/escape.spec.ts`: 732 unit tests over every registered dialect via `getDialects()`. Iteration is automatic — a new dialect is held to the same contract the moment it's added to `dialect_map.ts`. Includes a meta-test that subclassing `Dialect` without setting the flags causes the base methods to throw with the dialect's name in the message.
- New `test/src/databases/all/escape.spec.ts`: integration round-trip tests covering string literals, regex literals (would have caught the MySQL/Databricks regex bug), and adversarial column names (exercises `rawName`-in-`fieldList` paths against the live DB).

## Docs

- `packages/malloy/src/dialect/CONTEXT.md`: documents the three-field escape contract and the `EscapeStyle` constants.
- `packages/malloy/src/lang/CONTEXT.md`: documents Malloy's string-literal forms (single, double, backtick, raw `s'...'`, regex `r'...'`, triple-quoted, embedded SQL block) after a raw-string confusion bit me while writing the integration tests.
- Top-level `CONTEXT.md`: hardens the copyright-header guidance against the "copy from a neighbor" pitfall.

## Open questions deferred

- Snowflake and Trino `quoteTablePath` still use `perPartMaybeQuoted`. Switching to always-quote would let users address reserved-word tables (e.g. `select`), but Snowflake folds bare identifiers to UPPERCASE and Trino to lowercase — switching could break every existing user whose tables are bare-named and addressed in mixed case. Both sites carry an `OPEN QUESTION` comment.
