### PR TITLE
Translator CONTEXT docs + TestTranslator options-bag refactor

### DIFF
--- a/packages/malloy/src/api/CONTEXT.md
+++ b/packages/malloy/src/api/CONTEXT.md
@@ -66,8 +66,9 @@ These are the actual compiler internals that do the work. Not a public API.
 
 ### MalloyTranslator (`src/lang/`)
 - Parses Malloy source text into IR types (`ModelDef`, `Query`, `SourceDef`, etc.)
-- Handles imports, schema fetching requests, iterative compilation
-- Returns `translator.translate()` results with either final `ModelDef` or `needs` for more info
+- Runs as a sequence of named steps (`ParseStep` → `ImportsAndTablesStep` → `ASTStep` → `TranslateStep`, plus IDE-facing steps); synchronous, so async fetches happen through a `translate()` ↔ `update(ParseUpdate)` pause-and-resume protocol
+- `translate()` returns either the final `ModelDef`, a `DataRequestResponse` listing `urls` / `tables` / `compileSQL` / `connectionDialects` it needs, or errors
+- See [`../lang/CONTEXT.md`](../lang/CONTEXT.md) for the step machinery, the needs protocol, and the AST integration entry points (`DocStatement.execute`, `ExpressionDef.getExpression`)
 
 ### QueryModel (`src/model/query_model_impl.ts`)
 - Takes a compiled `ModelDef` and compiles queries to SQL

--- a/packages/malloy/src/lang/CONTEXT.md
+++ b/packages/malloy/src/lang/CONTEXT.md
@@ -89,6 +89,13 @@ The AST is a tree of `MalloyElement` objects that represents the semantic struct
 - `visitX(pcx: XContext)` — visits a parse-tree node and returns the AST node for it (a `MalloyElement` subclass). Use this even if the method is only ever called from one parent visitor; the name signals "this is the parse-tree-to-AST mapping for rule `X`."
 - `getX(pcx: XContext)` — transforms a parse-tree fragment into something that is *not* an AST node (a typeDef, a primitive, a list of notes, etc.), or is a shared helper used from multiple callers. Distinct from `visitX` so a reader can tell at a glance whether the return is an AST node or a piece of supporting data.
 
+**AST integration entry points:**
+
+Two methods anchor how AST nodes plug into the translator's drivers. They're distinct from the `visitX`/`getX` parse-tree-builder conventions above and from the `structShapeFieldDef()`/`getX(parameterSpace)` IR-shaped accessor conventions.
+
+- **`DocStatement.execute(doc: Document): void`** — the interface declared at `malloy-element.ts:377`. `Document.compile()` (in the same file, ~`:588`) walks its `DocStatementList` via `executeList(doc)`, which iterates `this.elements` and for each non-list element calls `el.needs(doc)` first and `el.execute(doc)` only if `needs` returned undefined. Implementers: `ImportStatement`, `DefineSource`, `DefineGivens`, `ModelAnnotation`, `ExperimentalExperiment`, and others under `ast/statements/`.
+- **`ExpressionDef.getExpression(fs: FieldSpace): ExprValue`** — the abstract method at `expression-def.ts:82`. `ExpressionDef` is the base class for all expression-shaped AST nodes; operators recursively call `getExpression` on their operand `ExpressionDef`s to obtain the IR value + type for that subtree. Representative call sites: `expressions/case.ts`, `expressions/expr-cast.ts`, `expressions/pick-when.ts`, `expressions/apply.ts`. This is the integration point for expression evaluation, separate from the AST-element-wide naming conventions.
+
 ### 3. Translator (`parse-malloy.ts`)
 
 The translator defines the interface for transforming AST into IR.
@@ -97,11 +104,42 @@ The translator defines the interface for transforming AST into IR.
 - Used by translator to construct and comprehend `StructDef` objects
 - Manages namespace and field resolution during translation
 
-**Translation process:**
-1. AST is traversed
-2. Semantic analysis is performed (type checking, name resolution)
-3. IR structures are built incrementally
-4. Final IR represents complete semantic model
+#### Steps
+
+A translation is a series of named **steps**. Each step implements `TranslationStep { step(that: MalloyTranslation): StepResponses }`. Steps declare dependencies via constructor arguments — a step holds references to the steps it depends on and asks them for their answers up-chain. A step's response is one of three things: errors (go no further), a `DataRequestResponse` saying it needs more data, or its successful result.
+
+The steps and their dependency wiring are constructed in `MalloyTranslation`'s constructor (the comment there calls it "the makefile for the translation"):
+
+| Step | Depends on | Purpose |
+|---|---|---|
+| `ParseStep` | — | Fetch the source URL (may emit a `urls` need), run the ANTLR parser, hold the parse tree |
+| `ImportsAndTablesStep` | `ParseStep` | Walk the parse tree for `import` / table references, request the URLs and schemas that downstream steps will need |
+| `ASTStep` | `ImportsAndTablesStep` | Build the `MalloyElement` AST from the parse tree |
+| `TranslateStep` | `ASTStep` | Drive `Document.compile()` to produce the final `ModelDef` |
+| `MetadataStep` | `ParseStep` | Symbols/metadata for IDE features |
+| `CompletionsStep` | `ParseStep` | Completion candidates at a position |
+| `HelpContextStep` | `ParseStep` | Help-context lookup at a position |
+| `ModelAnnotationStep` | `ParseStep` | Extract model-level annotations (`##!` etc.) without full translation |
+| `TablePathInfoStep` | `ParseStep` | Table references found in the source |
+
+`MalloyTranslator.translate()` is the entry point for full translation: it caches a `finalAnswer` and otherwise delegates to `translateStep.step(this, extendingModel)`. `metadata()`, `modelAnnotation()`, `tablePathInfo()`, `completions()`, `helpContext()` are the entry points for the IDE-facing steps.
+
+#### Needs/update protocol
+
+The translator is **synchronous**. Async work — fetching the text of an imported URL, getting a table schema from a connection, compiling SQL to discover its schema, looking up a connection's dialect — is surfaced through a pause-and-resume protocol:
+
+1. The caller calls `translate()` (or one of the IDE-facing step methods).
+2. If the step needs data, the response carries one or more of the fields in `DataRequestResponse` (`translate-response.ts`):
+   - `urls: string[]` — files the translator wants the contents of
+   - `tables: Record<string, {connectionName, tablePath}>` — table schemas it wants
+   - `compileSQL: SQLSourceRequest` — a SQL block whose output schema it wants (from a `db.sql("""...""")` or turducken)
+   - `connectionDialects: Record<string, {connectionName}>` — dialect lookups for named connections
+3. The caller fetches what was requested and calls `MalloyTranslator.update(dd: ParseUpdate)` to feed results into the translator's `Zone`s (`importZone`, `schemaZone`, `sqlQueryZone`, `connectionDialectZone`).
+4. The caller calls `translate()` again; steps see populated zones and continue.
+
+A response with `final: true` ends the loop. The header comment on `MalloyTranslator` describes the call pattern; `Core.statedCompileModel` / `Core.updateCompileModelState` in `api/core.ts` are the standard driver. The async API (`api/asynchronous.ts`) wraps the loop with auto-fetching; the stateless and sessioned APIs leave it to the caller.
+
+Per-statement `needs()` during `Document.compile()` is a narrower variant of the same protocol. `DocStatementList.executeList(doc)` (see "AST integration entry points" above) calls `el.needs(doc)` before `el.execute(doc)`; a non-undefined return value pauses the statement loop. The per-statement `ModelDataRequest` type is just `NeedCompileSQL | undefined` (a single SQL compile request) — URL fetches and table schemas have already been resolved by `ImportsAndTablesStep` before the AST is built, so statement-level pauses are only for SQL-source schema discovery encountered mid-compile.
 
 ## Intermediate Representation (IR)
 

--- a/packages/malloy/src/lang/test/givens.spec.ts
+++ b/packages/malloy/src/lang/test/givens.spec.ts
@@ -1281,10 +1281,7 @@ describe('given: query satisfiability check', () => {
         ##! experimental.givens
         run: childSrc -> { select: * }
       `,
-        null,
-        null,
-        'malloyDocument',
-        cell1Model
+        {internalModel: cell1Model}
       );
       cell2.translate();
       expect(cell2).toLog(

--- a/packages/malloy/src/lang/test/imports.spec.ts
+++ b/packages/malloy/src/lang/test/imports.spec.ts
@@ -42,10 +42,9 @@ describe('import:', () => {
     });
   });
   test('simple source with importBaseURL', () => {
-    const docParse = new TestTranslator(
-      'import "child"',
-      'http://example.com/'
-    );
+    const docParse = new TestTranslator('import "child"', {
+      importBaseURL: 'http://example.com/',
+    });
     const xr = docParse.unresolved();
     expect(docParse).toParse();
     expect(xr).toMatchObject({urls: ['http://example.com/child']});

--- a/packages/malloy/src/lang/test/test-translator.ts
+++ b/packages/malloy/src/lang/test/test-translator.ts
@@ -365,6 +365,14 @@ export class TestChildTranslator extends MalloyChildTranslator {
 }
 
 const testURI = 'internal://test/langtests/root.malloy';
+
+export interface TestTranslatorOptions {
+  rootRule?: string;
+  importBaseURL?: string | null;
+  eventStream?: EventStream | null;
+  internalModel?: ModelDef;
+}
+
 export class TestTranslator extends MalloyTranslator {
   allDialectsEnabled = true;
   testRoot?: TestRoot;
@@ -453,16 +461,18 @@ export class TestTranslator extends MalloyTranslator {
 
   constructor(
     readonly testSrc: string,
-    importBaseURL: string | null = null,
-    eventStream: EventStream | null = null,
-    rootRule = 'malloyDocument',
-    internalModel?: ModelDef
+    options: TestTranslatorOptions = {}
   ) {
-    super(testURI, importBaseURL, null, eventStream);
-    this.grammarRule = rootRule;
+    super(
+      testURI,
+      options.importBaseURL ?? null,
+      null,
+      options.eventStream ?? null
+    );
+    this.grammarRule = options.rootRule ?? 'malloyDocument';
     this.importZone.define(testURI, testSrc);
-    if (internalModel !== undefined) {
-      this.internalModel = internalModel;
+    if (options.internalModel !== undefined) {
+      this.internalModel = options.internalModel;
     }
     for (const actualSchema of mockSchema) {
       this.schemaZone.define(
@@ -596,7 +606,7 @@ export class BetaExpression extends TestTranslator {
     model?: ModelDef,
     readonly sourceName: string = 'ab'
   ) {
-    super(src, null, null, 'debugExpr', model);
+    super(src, {rootRule: 'debugExpr', internalModel: model});
   }
 
   private testFS() {
@@ -726,10 +736,7 @@ export function makeModelFunc(options: {
       translator: new TestTranslator(
         (options.prefix ?? '') +
           (options.wrap ? options.wrap(ms.code) : ms.code),
-        null,
-        null,
-        undefined,
-        options?.model
+        {internalModel: options?.model}
       ),
     };
   };


### PR DESCRIPTION
## Summary

Two small, related changes bundled into one PR.

**1. Expand the translator CONTEXT.md** to document things the existing prose paraphrased without naming:
- The named-step pipeline (`ParseStep` → `ImportsAndTablesStep` → `ASTStep` → `TranslateStep`, plus IDE-facing steps) and the per-step dependency wiring.
- The synchronous `translate()` ↔ `update(ParseUpdate)` "needs" protocol, with the four zones (`importZone`, `schemaZone`, `sqlQueryZone`, `connectionDialectZone`) and the four `DataRequestResponse` slots they feed (`urls` / `tables` / `compileSQL` / `connectionDialects`).
- The two AST integration entry points: `DocStatement.execute(doc)` for statement-shaped nodes (driven by `DocStatementList.executeList`, which checks `needs(doc)` before `execute`), and `ExpressionDef.getExpression(fs)` for expression-shaped nodes.
- A small companion edit in `api/CONTEXT.md` to cross-link instead of paraphrasing.

**2. Refactor `TestTranslator` / `BetaExpression` to use an options bag.**

The constructor had grown to five positional slots:
```ts
constructor(testSrc, importBaseURL = null, eventStream = null, rootRule = 'malloyDocument', internalModel?)
```

Of ~280 callsites in the repo, only two passed anything past `testSrc` explicitly: `imports.spec.ts` testing `importBaseURL`, and one `givens.spec.ts` cell-translator setup. `BetaExpression` and the `makeModelFunc` factory used the long form internally.

Collapsed to:
```ts
interface TestTranslatorOptions {
  rootRule?: string;          // defaults to 'malloyDocument'
  importBaseURL?: string | null;
  eventStream?: EventStream | null;
  internalModel?: ModelDef;
}

constructor(testSrc: string, options: TestTranslatorOptions = {})
```

`BetaExpression`'s own public constructor signature is unchanged — only its internal `super(...)` call adapts.

This is preparing for an upcoming PR that will add `restrictedMode` as a new `TestTranslator` option without growing the positional list further.
