### PR TITLE
Add validate() on QueryMaterializer and ModelMaterializer

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -154,7 +154,7 @@ npm run watch                  # Watch for TypeScript changes across the repo
 
 Builds, tests, and lints in this repo are slow. The wrong instinct is to re-run a command with different flags or verbosity to dig into a failure. The right instinct is to **capture the full output once and grep the saved log**.
 
-Pattern for any long-running command (build, dev, jest, lint, ci-*, test-duckdb) — plain redirection, no `&&` / `||` / `;` chaining:
+Pattern for any long-running command (build, dev, jest, lint, ci-*, precheck) — plain redirection, no `&&` / `||` / `;` chaining:
 
 ```
 CMD > /tmp/CMD.log 2>&1
@@ -273,12 +273,16 @@ npm run ci-postgres     # PostgreSQL
 
 Use these when you want a local pass that matches what CI will do.
 
-#### Comprehensive local sanity check
+#### `npm run precheck` — "did I break anything?"
 
 ```
-npm run test-duckdb     # all tests, duckdb dialect only — broadest dev-machine option
-npm run test-publisher  # all tests, publisher dialect only
+npm run precheck        # the broad regression check (alias for test-duckdb)
+npm run test-publisher  # same shape, publisher as the dialect
 ```
+
+The broadest check a dev machine can run before declaring a change done. `precheck` runs every test in every package, choosing duckdb wherever a dialect must be picked. If `precheck` passes, anything still failing in CI is dialect-specific.
+
+Different shape from `ci-<dialect>` above: `ci-duckdb` runs the duckdb CI job's specific selection; `precheck` runs **everything**. They're not interchangeable.
 
 Slow. Wrap in the capture-output pattern.
 

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "test": "echo 'npm run test' not supported, see test/README.md for details ; exit 1",
     "test-publisher": "MALLOY_DATABASE=publisher jest",
     "test-duckdb": "MALLOY_DATABASE=duckdb JEST_SILENT_REPORTER_SHOW_PATHS=true jest --selectProjects malloy-core malloy-render db-all db-duckdb db-duckdb-core --reporters jest-silent-reporter summary",
+    "precheck": "npm run test-duckdb",
     "test-mssql-via-duckdb": "MALLOY_DATABASE=mssql_via_duckdb JEST_SILENT_REPORTER_SHOW_PATHS=true jest --selectProjects db-all --reporters jest-silent-reporter summary",
     "ci-core": "JEST_SILENT_REPORTER_SHOW_PATHS=true jest --reporters --selectProjects malloy-core malloy-render --reporters jest-silent-reporter summary --runInBand",
     "ci-bigquery": "MALLOY_DATABASE=bigquery JEST_SILENT_REPORTER_SHOW_PATHS=true jest --selectProjects db-all db-bigquery --reporters jest-silent-reporter summary",

--- a/packages/malloy/src/api/CONTEXT.md
+++ b/packages/malloy/src/api/CONTEXT.md
@@ -229,6 +229,16 @@ Two-layer enforcement, both in `packages/malloy/src/lang/`:
 
 API-level documentation lives in the JSDoc on `ModelMaterializer.loadRestrictedQuery`.
 
+### Non-throwing validation
+
+`QueryMaterializer.validate(options?)` and `ModelMaterializer.validate()` return `Promise<LogMessage[]>` — empty array means clean compile, otherwise the array carries structured problems (`code`, `severity`, optional `at: DocumentLocation`). The query-level method surfaces both translator-time errors (possibly several) and SQL-compile errors (at most one — the compiler is fail-fast). The model-level method surfaces only translator-time errors; SQL-compile is per-query.
+
+`getPreparedResult()` / `getSQL()` / `run()` still throw `MalloyError` on failure; the thrown `.problems` is the same array. A `validate()` followed by a no-options consumer reuses one cached compile via `QueryMaterializer._compileAttempt`.
+
+SQL-compile errors that are user-actionable throw `MalloyCompileError` (`packages/malloy/src/model/malloy_compile_error.ts`) at the throw site, carrying `{message, code, at?}`. The materializer's `_compileAndCollect` helper translates it to a `LogMessage`. Invariant violations stay as bare `Error` and surface with `code: 'compiler-bug'`.
+
+API-level documentation lives in the JSDoc on the two `validate` methods.
+
 ---
 
 ## Layer 3: Core API

--- a/packages/malloy/src/api/foundation/runtime.ts
+++ b/packages/malloy/src/api/foundation/runtime.ts
@@ -16,7 +16,8 @@ import type {
   GivenValue,
   VirtualMap,
 } from '../../model';
-import {isSourceDef, mkSafeRecord} from '../../model';
+import {isSourceDef, mkSafeRecord, MalloyCompileError} from '../../model';
+import type {LogMessage} from '../../lang';
 import {getDialect} from '../../dialect';
 import {requireCanonicalTablePathAnyDialect} from '../../connection/validate_table_path';
 import {isBuildManifestEntry} from './config';
@@ -30,7 +31,7 @@ import type {ParseOptions, CompileOptions, CompileQueryOptions} from './types';
 import type {PreparedResult, Explore} from './core';
 import {Model, PreparedQuery} from './core';
 import type {DataRecord, Result} from './result';
-import {Malloy} from './compile';
+import {Malloy, MalloyError} from './compile';
 
 // =============================================================================
 // Type Aliases
@@ -866,11 +867,16 @@ export class ModelMaterializer extends FluentState<Model> {
    * fully available regardless of whether the model's own definitions
    * use any of the forbidden constructs.
    *
-   * Each rejection surfaces as a problem on the thrown `MalloyError`
-   * with `code: 'restricted-construct-forbidden'` and
-   * `errorTag: 'restricted-mode'`. The message quotes the offending
-   * source text and states the rule. Multiple violations are reported
-   * in one compile — the translation does not stop at the first.
+   * Errors reach the caller in the same way as any other Malloy
+   * compile: `.validate()` returns a `LogMessage[]`, and `.run()` /
+   * `.getPreparedResult()` / `.getSQL()` throw `MalloyError` whose
+   * `.problems` is the same array. The list holds every compile
+   * problem — ordinary translator and SQL-compile errors as well as
+   * restricted-mode rejections. The restricted-mode subset is
+   * identifiable by `code: 'restricted-construct-forbidden'` and
+   * `errorTag: 'restricted-mode'`; restricted-mode rejection messages
+   * quote the offending source text and state the rule. Multiple
+   * violations are reported in one compile.
    *
    * The input is required to be a string. Restricted text arrives from
    * an untrusted caller as bytes the host already has in hand; there
@@ -878,10 +884,7 @@ export class ModelMaterializer extends FluentState<Model> {
    *
    * @param text The Malloy text to compile as a restricted query.
    * @return A `QueryMaterializer` capable of materializing or running
-   *   the query. Calling `.run()`, `.getSQL()`, `.getPreparedResult()`,
-   *   etc. throws `MalloyError` if the restricted compile produced any
-   *   problems; the `.problems` array on the error carries the
-   *   structured rejection list.
+   *   the query.
    */
   public loadRestrictedQuery(text: string): QueryMaterializer {
     return this.makeQueryMaterializer(async () => {
@@ -1116,6 +1119,36 @@ export class ModelMaterializer extends FluentState<Model> {
   public getModel(): Promise<Model> {
     return this.materialize();
   }
+
+  /**
+   * Compile this model and return any problems as structured
+   * `LogMessage`s; empty array means clean. Non-throwing.
+   *
+   * Only translator-time problems surface here; SQL-compile problems
+   * are per-query and live on `QueryMaterializer.validate()`.
+   *
+   * A subsequent `getModel()` reuses the cached materialize.
+   */
+  public async validate(): Promise<LogMessage[]> {
+    try {
+      await this.materialize();
+      return [];
+    } catch (e) {
+      if (e instanceof MalloyError) return e.problems;
+      if (e instanceof Error) {
+        return [
+          {
+            message:
+              'Internal compiler error (likely a Malloy bug — please file ' +
+              `an issue): ${e.message}`,
+            severity: 'error',
+            code: 'compiler-bug',
+          },
+        ];
+      }
+      throw e;
+    }
+  }
 }
 
 // =============================================================================
@@ -1138,8 +1171,20 @@ function runSQLOptionsWithAnnotations(
  * materializing the query (via `getPreparedQuery()`) or extending the task to load
  * prepared results or run the query (via e.g. `loadPreparedResult()` or `run()`).
  */
+type CompileAttempt = {
+  preparedResult?: PreparedResult;
+  problems: LogMessage[];
+};
+
 export class QueryMaterializer extends FluentState<PreparedQuery> {
   private readonly compileQueryOptions: CompileQueryOptions | undefined;
+  /**
+   * Memoizes the no-options compile so `validate()` + a follow-up
+   * `getPreparedResult()` / `run()` shares one compilation. Calls with
+   * explicit options bypass — options aren't hashed.
+   */
+  private _compileAttempt: Promise<CompileAttempt> | undefined;
+
   constructor(
     protected runtime: Runtime,
     materialize: () => Promise<PreparedQuery>,
@@ -1147,6 +1192,80 @@ export class QueryMaterializer extends FluentState<PreparedQuery> {
   ) {
     super(runtime, materialize);
     this.compileQueryOptions = options;
+  }
+
+  /**
+   * `MalloyError` (translator) is unwrapped into its `problems` array.
+   * `MalloyCompileError` (SQL compiler) becomes one structured problem.
+   * Any other `Error` is treated as an invariant violation and surfaces
+   * as one `code: 'compiler-bug'` problem.
+   */
+  private async _compileAndCollect(
+    options?: CompileQueryOptions
+  ): Promise<CompileAttempt> {
+    try {
+      const preparedResult =
+        await this.loadPreparedResult(options).getPreparedResult();
+      return {preparedResult, problems: []};
+    } catch (e) {
+      if (e instanceof MalloyError) {
+        return {problems: e.problems};
+      }
+      if (e instanceof MalloyCompileError) {
+        return {
+          problems: [
+            {
+              message: e.message,
+              severity: 'error',
+              code: e.code,
+              at: e.at,
+            },
+          ],
+        };
+      }
+      if (e instanceof Error) {
+        return {
+          problems: [
+            {
+              message:
+                'Internal compiler error (likely a Malloy bug — please file ' +
+                `an issue): ${e.message}`,
+              severity: 'error',
+              code: 'compiler-bug',
+            },
+          ],
+        };
+      }
+      throw e;
+    }
+  }
+
+  private compileAttempt(
+    options?: CompileQueryOptions
+  ): Promise<CompileAttempt> {
+    if (options === undefined && this._compileAttempt) {
+      return this._compileAttempt;
+    }
+    const p = this._compileAndCollect(options);
+    if (options === undefined) {
+      this._compileAttempt = p;
+    }
+    return p;
+  }
+
+  /**
+   * Compile this query and return any problems as structured
+   * `LogMessage`s; empty array means clean. Non-throwing.
+   *
+   * Surfaces translator-time errors (may be several) and compile-time
+   * errors (at most one — the compiler is fail-fast). LogMessages carry
+   * `code` and, where the IR has it, `at: DocumentLocation`.
+   *
+   * A subsequent no-options `getPreparedResult()` / `getSQL()` / `run()`
+   * reuses the cached compile.
+   */
+  public async validate(options?: CompileQueryOptions): Promise<LogMessage[]> {
+    return (await this.compileAttempt(options)).problems;
   }
 
   /**
@@ -1228,8 +1347,12 @@ export class QueryMaterializer extends FluentState<PreparedQuery> {
         if (!modelTag.has('experimental', 'persistence')) {
           if (explicitManifest) {
             // Explicitly passed non-empty manifest requires persistence support
-            throw new Error(
-              'Model must have ##! experimental.persistence to use buildManifest'
+            throw new MalloyCompileError(
+              'A non-empty `buildManifest` was supplied, but the model is ' +
+                'missing `##! experimental.persistence`. Add the flag to the ' +
+                'model or pass `EMPTY_BUILD_MANIFEST` to suppress substitution.',
+              'runtime-manifest-needs-persistence-flag',
+              undefined
             );
           }
           // Runtime-level manifest (e.g. from config): silently ignore
@@ -1270,8 +1393,11 @@ export class QueryMaterializer extends FluentState<PreparedQuery> {
       if (finalizedSet.size > 0 && mergedOptions.givens) {
         for (const name of Object.keys(mergedOptions.givens)) {
           if (finalizedSet.has(name)) {
-            throw new Error(
-              `Cannot supply '${name}' per-query: it is finalized at the runtime layer (config.finalizeGivens).`
+            throw new MalloyCompileError(
+              `Cannot supply given '${name}' per-query: it is finalized at ` +
+                'the runtime layer via `config.finalizeGivens`.',
+              'runtime-given-finalized',
+              undefined
             );
           }
         }
@@ -1301,7 +1427,7 @@ export class QueryMaterializer extends FluentState<PreparedQuery> {
       const queryGivenUsage = preparedQuery._query.givenUsage ?? [];
       if (finalizedSet.size > 0 && queryGivenUsage.length > 0) {
         const referencedIds = new Set(queryGivenUsage.map(g => g.id));
-        const missing: string[] = [];
+        const missingProblems: LogMessage[] = [];
         for (const [surfaceName, entry] of Object.entries(
           preparedQuery._modelDef.contents
         )) {
@@ -1309,11 +1435,21 @@ export class QueryMaterializer extends FluentState<PreparedQuery> {
           if (!referencedIds.has(entry.id)) continue;
           if (!finalizedSet.has(surfaceName)) continue;
           if (mergedGivens && surfaceName in mergedGivens) continue;
-          missing.push(surfaceName);
+          const firstUse = queryGivenUsage.find(u => u.id === entry.id);
+          missingProblems.push({
+            message:
+              `Finalized given '${surfaceName}' has no resolved value. ` +
+              'It must be supplied in `givensPath` or in the Runtime ' +
+              "constructor's `givens`.",
+            severity: 'error',
+            code: 'runtime-given-finalized-missing',
+            at: firstUse?.at,
+          });
         }
-        if (missing.length > 0) {
-          throw new Error(
-            `Query references finalized given(s) with no resolved value: ${missing.join(', ')}. Each finalized given the query needs must have a value in givensPath or in the Runtime constructor's \`givens\`.`
+        if (missingProblems.length > 0) {
+          throw new MalloyError(
+            missingProblems.map(p => p.message).join('\n'),
+            missingProblems
           );
         }
       }
@@ -1337,12 +1473,21 @@ export class QueryMaterializer extends FluentState<PreparedQuery> {
   /**
    * Materialize the prepared result of this loaded query.
    *
+   * Throws `MalloyError` on failure, with `.problems` populated for both
+   * translator and compiler errors. For non-throwing access to the same
+   * problem list, use `validate()`.
+   *
    * @return A promise of the prepared result of this loaded query.
    */
-  public getPreparedResult(
+  public async getPreparedResult(
     options?: CompileQueryOptions
   ): Promise<PreparedResult> {
-    return this.loadPreparedResult(options).getPreparedResult();
+    const attempt = await this.compileAttempt(options);
+    if (attempt.preparedResult) return attempt.preparedResult;
+    throw new MalloyError(
+      attempt.problems.map(p => p.message).join('\n') || 'Compilation failed.',
+      attempt.problems
+    );
   }
 
   /**

--- a/packages/malloy/src/lang/ast/expressions/expr-func.ts
+++ b/packages/malloy/src/lang/ast/expressions/expr-func.ts
@@ -448,7 +448,11 @@ export class ExprFunc extends ExpressionDef {
               );
             }
             if (result.found.refType === 'parameter') {
-              expr.push({node: 'parameter', path: part.path});
+              expr.push({
+                node: 'parameter',
+                path: part.path,
+                at: this.args[0].location,
+              });
             } else {
               sqlFunctionFieldUsage.push({
                 path: part.path,

--- a/packages/malloy/src/lang/ast/expressions/expr-given.ts
+++ b/packages/malloy/src/lang/ast/expressions/expr-given.ts
@@ -65,6 +65,7 @@ export class GivenReference extends ExpressionDef {
       node: 'given',
       id: entry.id,
       refName: this.name,
+      at: this.location,
     };
     return {
       ...literalExprValue({value: refNode, dataType: given.type}),

--- a/packages/malloy/src/lang/ast/field-space/reference-field.ts
+++ b/packages/malloy/src/lang/ast/field-space/reference-field.ts
@@ -70,7 +70,7 @@ export class ReferenceField extends SpaceField {
         if (TD.isAtomic(foundType)) {
           this.queryFieldDef = {
             ...mkFieldDef(TDU.atomicDef(foundType), path[0]),
-            e: {node: 'parameter', path},
+            e: {node: 'parameter', path, at: this.fieldRef.location},
           };
         } else {
           // not sure what to do here, if we get here

--- a/packages/malloy/src/model/constant_expression_compiler.ts
+++ b/packages/malloy/src/model/constant_expression_compiler.ts
@@ -4,6 +4,7 @@
  */
 
 import type {
+  DocumentLocation,
   Expr,
   Parameter,
   TurtleDef,
@@ -24,10 +25,21 @@ import type {JoinInstance} from './join_instance';
  * Used to distinguish expected errors from unexpected ones.
  */
 class ConstantExpressionError extends Error {
-  constructor(message: string) {
+  constructor(
+    message: string,
+    readonly at?: DocumentLocation
+  ) {
     super(message);
     this.name = 'ConstantExpressionError';
   }
+}
+
+function locSuffix(at: DocumentLocation | undefined): string {
+  if (!at) return '';
+  // Display 1-based line/column; range positions are 0-based.
+  const line = at.range.start.line + 1;
+  const col = at.range.start.character + 1;
+  return ` at ${at.url}:${line}:${col}`;
 }
 
 /**
@@ -141,15 +153,17 @@ class ConstantQueryStruct extends QueryStruct {
   /**
    * These methods should not be called for constant expressions
    */
-  override getFieldByName(path: string[]): never {
+  override getFieldByName(path: string[], at?: DocumentLocation): never {
     throw new ConstantExpressionError(
-      `Illegal reference to '${path.join('.')}' in constant expressions`
+      `Illegal reference to '${path.join('.')}' in constant expressions${locSuffix(at)}`,
+      at
     );
   }
 
-  override getStructByName(path: string[]): never {
+  override getStructByName(path: string[], at?: DocumentLocation): never {
     throw new ConstantExpressionError(
-      `Illegal reference to '${path.join('.')}' in constant expressions`
+      `Illegal reference to '${path.join('.')}' in constant expressions${locSuffix(at)}`,
+      at
     );
   }
 

--- a/packages/malloy/src/model/expression_compiler.ts
+++ b/packages/malloy/src/model/expression_compiler.ts
@@ -61,6 +61,7 @@ import {
 import {isBasicScalar} from './query_node';
 import type {QueryStruct, QueryField} from './query_node';
 import type {Dialect, QueryInfo} from '../dialect';
+import {MalloyCompileError} from './malloy_compile_error';
 
 const NUMERIC_DECIMAL_PRECISION = 9;
 
@@ -236,11 +237,7 @@ function compileExpr<T extends Expr>(
         return `${expr.kids.e.sql} ${expr.not ? 'NOT IN' : 'IN'} (${oneOf})`;
       }
       case 'inGiven': {
-        const bound = resolveGivenBoundExpr(
-          context,
-          expr.givenRef.id,
-          expr.givenRef.refName
-        );
+        const bound = resolveGivenBoundExpr(context, expr.givenRef);
         // null binding collapses to empty-set semantics — not the SQL
         // `IN (NULL)` shape, which has confusing NULL-membership rules.
         if (bound.node === 'null') {
@@ -359,28 +356,38 @@ function generateAppliedFilter(
     if (argument?.value) {
       filterExpr = argument.value;
     } else {
-      throw new Error(
-        `Parameter ${name} was expected to be a filter expression`
+      throw new MalloyCompileError(
+        `Parameter '${name}' has no value, but a filter expression is required here.`,
+        'compiler-filter-parameter-no-value',
+        filterExpr.at
       );
     }
   }
   if (filterExpr.node === 'given') {
-    const id = filterExpr.id;
-    const supplied = context.prepareResultOptions?.resolvedGivens?.get(id);
+    const supplied = context.prepareResultOptions?.resolvedGivens?.get(
+      filterExpr.id
+    );
     if (supplied !== undefined) {
       filterExpr = supplied;
     } else {
-      const decl = context.getModel().givens[id];
+      const decl = context.getModel().givens[filterExpr.id];
       if (decl?.default !== undefined) {
         filterExpr = decl.default;
       } else {
-        throw new Error(unsatisfiedGivenMessage(filterExpr.refName));
+        throw new MalloyCompileError(
+          unsatisfiedGivenMessage(filterExpr.refName),
+          'compiler-given-no-value',
+          filterExpr.at
+        );
       }
     }
   }
   if (filterExpr.node !== 'filterLiteral') {
-    throw new Error(
-      'Can only use filter expression literals or parameters as filter expressions'
+    throw new MalloyCompileError(
+      "Filter context requires a filter-expression literal (e.g., `f'...'`) " +
+        `or a parameter that resolves to one; got node '${filterExpr.node}'.`,
+      'compiler-filter-not-literal',
+      undefined
     );
   }
   const filterSrc = filterExpr.filterSrc;
@@ -401,10 +408,19 @@ function generateAppliedFilter(
       fParse = TemporalFilterExpression.parse(filterSrc);
       break;
     default:
-      throw new Error(`unsupported filter type ${filterMatchExpr.dataType}`);
+      throw new MalloyCompileError(
+        `Filter type '${filterMatchExpr.dataType}' is not supported. ` +
+          'Supported filter types: string, number, boolean, date, timestamp, timestamptz.',
+        'compiler-filter-type-unsupported',
+        undefined
+      );
   }
   if (fParse.log.length > 0) {
-    throw new Error(`Filter expression parse error: ${fParse.log[0]}`);
+    throw new MalloyCompileError(
+      `Filter expression parse error: ${fParse.log[0]}.`,
+      'compiler-filter-parse-error',
+      undefined
+    );
   }
 
   return FilterCompilers.compile(
@@ -783,7 +799,7 @@ export function generateFieldFragment(
   state: GenerateState
 ): string {
   // find the structDef and return the path to the field...
-  const fieldRef = context.getFieldByName(expr.path);
+  const fieldRef = context.getFieldByName(expr.path, expr.at);
   if (hasExpression(fieldRef.fieldDef)) {
     const ret = exprToSQL(
       resultSet,
@@ -839,7 +855,11 @@ export function generateParameterFragment(
   if (argument?.value) {
     return exprToSQL(resultSet, context, argument.value, state);
   }
-  throw new Error(`Can't generate SQL, no value for ${expr.path}`);
+  throw new MalloyCompileError(
+    `Parameter '${expr.path.join('.')}' has no value supplied.`,
+    'compiler-parameter-no-value',
+    expr.at
+  );
 }
 
 /**
@@ -851,16 +871,16 @@ export function generateParameterFragment(
  * Shared by `generateGivenFragment` ($NAME directly in an expression)
  * and the `'inGiven'` SQL-emit case ($ARR in `expr in $ARR`).
  */
-function resolveGivenBoundExpr(
-  context: QueryStruct,
-  id: string,
-  refName: string
-): Expr {
-  const supplied = context.prepareResultOptions?.resolvedGivens?.get(id);
+function resolveGivenBoundExpr(context: QueryStruct, ref: GivenRefNode): Expr {
+  const supplied = context.prepareResultOptions?.resolvedGivens?.get(ref.id);
   if (supplied !== undefined) return supplied;
-  const decl = context.getModel().givens[id];
+  const decl = context.getModel().givens[ref.id];
   if (decl?.default !== undefined) return decl.default;
-  throw new Error(unsatisfiedGivenMessage(refName));
+  throw new MalloyCompileError(
+    unsatisfiedGivenMessage(ref.refName),
+    'compiler-given-no-value',
+    ref.at
+  );
 }
 
 export function generateGivenFragment(
@@ -871,7 +891,7 @@ export function generateGivenFragment(
 ): string {
   // The bound expr may itself be a `$OTHER`-bearing expression; recursive
   // compile handles default chains.
-  const bound = resolveGivenBoundExpr(context, expr.id, expr.refName);
+  const bound = resolveGivenBoundExpr(context, expr);
   return exprToSQL(resultSet, context, bound, state);
 }
 
@@ -922,7 +942,11 @@ export function generateUngroupedFragment(
   state: GenerateState
 ): string {
   if (state.totalGroupSet !== -1) {
-    throw new Error('Already in ALL.  Cannot nest within an all calcuation.');
+    throw new MalloyCompileError(
+      "Cannot nest 'all()' or 'exclude()' inside another 'all()' calculation.",
+      'compiler-nested-ungroup',
+      undefined
+    );
   }
 
   let totalGroupSet;

--- a/packages/malloy/src/model/field_instance.ts
+++ b/packages/malloy/src/model/field_instance.ts
@@ -12,6 +12,7 @@ import type {
   TurtleDef,
   UniqueKeyRequirement,
 } from './malloy_types';
+import {MalloyCompileError} from './malloy_compile_error';
 import {
   isIndexSegment,
   isRawSegment,
@@ -251,8 +252,11 @@ export class FieldInstanceResult implements FieldInstance {
     const fi = this.allFields.get(as);
     if (fi) {
       if (fi.type === 'query') {
-        throw new Error(
-          `Redefinition of field ${field.fieldDef.name} as struct`
+        throw new MalloyCompileError(
+          `Field '${field.fieldDef.name}' is already defined as a nested view; ` +
+            'cannot also use it as a scalar field in this output.',
+          'compiler-field-redefined-as-struct',
+          field.fieldDef.location
         );
       }
       const fif = fi as FieldInstanceField;
@@ -261,8 +265,11 @@ export class FieldInstanceResult implements FieldInstance {
           // its already in the result, we can just ignore it.
           return;
         } else {
-          throw new Error(
-            `Ambiguous output field name '${field.fieldDef.name}'.`
+          throw new MalloyCompileError(
+            `Output field name '${field.fieldDef.name}' is ambiguous — ` +
+              'defined more than once at the query output level.',
+            'compiler-ambiguous-output-name',
+            field.fieldDef.location
           );
         }
       }
@@ -546,8 +553,11 @@ export class FieldInstanceResult implements FieldInstance {
     // verify that all names specified are available in the current scope.
     for (const fieldName of ungroupSet?.fields || []) {
       if (inScopeFieldNames.indexOf(fieldName) === -1) {
-        throw new Error(
-          `${ungroupSet?.type}(): unknown field name "${fieldName}" or name not in scope.`
+        throw new MalloyCompileError(
+          `'${ungroupSet?.type}()' references field '${fieldName}', ` +
+            'which is not defined or not in scope at this nesting level.',
+          'compiler-ungroup-field-unknown',
+          undefined
         );
       }
     }

--- a/packages/malloy/src/model/given_binding.ts
+++ b/packages/malloy/src/model/given_binding.ts
@@ -16,6 +16,7 @@ import type {
   ModelDef,
   SafeRecord,
 } from './malloy_types';
+import {MalloyCompileError} from './malloy_compile_error';
 
 export function resolveSuppliedGivens(
   supplied: Record<string, GivenValue> | undefined,
@@ -28,10 +29,12 @@ export function resolveSuppliedGivens(
   // prototype pollution from e.g. an Object.create(...)-derived input.
   for (const [name, value] of Object.entries(supplied)) {
     if (value === undefined) {
-      throw new Error(
+      throw new MalloyCompileError(
         `givens.${name}: explicit undefined is not a valid value. ` +
           'Omit the key to defer to declaration default or a lower supply ' +
-          'layer; use null for an explicit null value.'
+          'layer; use null for an explicit null value.',
+        'runtime-given-undefined',
+        undefined
       );
     }
     const entry = modelDef.contents[name];
@@ -42,8 +45,11 @@ export function resolveSuppliedGivens(
       }
       const suggestion = closestMatch(name, surfaceNames);
       const hint = suggestion ? ` (did you mean '${suggestion}'?)` : '';
-      throw new Error(
-        `givens: unknown given '${name}'${hint}. Model surfaces [${surfaceNames.join(', ')}]`
+      throw new MalloyCompileError(
+        `givens: unknown given '${name}'${hint}. ` +
+          `Model surfaces [${surfaceNames.join(', ')}]`,
+        'runtime-given-unknown',
+        undefined
       );
     }
     const decl = givens[entry.id];
@@ -98,12 +104,13 @@ function valueToExpr(
   if (value === null) {
     return {node: 'null'};
   }
+  function bad(msg: string, code = 'runtime-given-bad-value'): never {
+    throw new MalloyCompileError(`givens.${path}: ${msg}`, code, undefined);
+  }
   switch (type.type) {
     case 'string': {
       if (typeof value !== 'string') {
-        throw new TypeError(
-          `givens.${path}: expected string, got ${describeJs(value)}`
-        );
+        bad(`expected string, got ${describeJs(value)}`);
       }
       return {node: 'stringLiteral', literal: value};
     }
@@ -111,45 +118,33 @@ function valueToExpr(
       let lit: string;
       if (typeof value === 'number') {
         if (!Number.isFinite(value)) {
-          throw new TypeError(
-            `givens.${path}: number must be finite, got ${value}`
-          );
+          bad(`number must be finite, got ${value}`);
         }
         lit = String(value);
       } else if (typeof value === 'bigint') {
         lit = value.toString();
       } else if (typeof value === 'string') {
         if (!/^-?(\d+(\.\d+)?|\.\d+)([eE][+-]?\d+)?$/.test(value)) {
-          throw new TypeError(
-            `givens.${path}: number-as-string must be numeric, got '${value}'`
-          );
+          bad(`number-as-string must be numeric, got '${value}'`);
         }
         lit = value;
       } else {
-        throw new TypeError(
-          `givens.${path}: expected number | bigint | string, got ${describeJs(value)}`
-        );
+        bad(`expected number | bigint | string, got ${describeJs(value)}`);
       }
       return {node: 'numberLiteral', literal: lit};
     }
     case 'boolean': {
       if (typeof value !== 'boolean') {
-        throw new TypeError(
-          `givens.${path}: expected boolean, got ${describeJs(value)}`
-        );
+        bad(`expected boolean, got ${describeJs(value)}`);
       }
       return {node: value ? 'true' : 'false'};
     }
     case 'date': {
       if (typeof value !== 'string') {
-        throw new TypeError(
-          `givens.${path}: expected ISO date string 'YYYY-MM-DD', got ${describeJs(value)}`
-        );
+        bad(`expected ISO date string 'YYYY-MM-DD', got ${describeJs(value)}`);
       }
       if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
-        throw new TypeError(
-          `givens.${path}: date must match 'YYYY-MM-DD', got '${value}'`
-        );
+        bad(`date must match 'YYYY-MM-DD', got '${value}'`);
       }
       return {node: 'dateLiteral', literal: value, typeDef: {type: 'date'}};
     }
@@ -159,21 +154,21 @@ function valueToExpr(
       // strings (those want 'timestamptz'). Parse the rest with Luxon and
       // emit canonical "YYYY-MM-DD HH:MM:SS.sss" for the dialect.
       if (typeof value !== 'string') {
-        throw new TypeError(
-          `givens.${path}: expected ISO timestamp string (no offset), got ${describeJs(value)}`
+        bad(
+          `expected ISO timestamp string (no offset), got ${describeJs(value)}`
         );
       }
       if (/Z$|[+-]\d{2}:?\d{2}$/.test(value)) {
-        throw new TypeError(
-          `givens.${path}: 'timestamp' is naive — use 'timestamptz' for offset/zoned values, got '${value}'`
+        bad(
+          `'timestamp' is naive — use 'timestamptz' for offset/zoned values, got '${value}'`
         );
       }
       // ISO uses T-separator; SQL form uses space. Accept both.
       let dt = DateTime.fromISO(value, {zone: 'utc'});
       if (!dt.isValid) dt = DateTime.fromSQL(value, {zone: 'utc'});
       if (!dt.isValid) {
-        throw new TypeError(
-          `givens.${path}: invalid timestamp value '${value}': ${dt.invalidReason ?? 'unknown'}`
+        bad(
+          `invalid timestamp value '${value}': ${dt.invalidReason ?? 'unknown'}`
         );
       }
       return {
@@ -190,13 +185,13 @@ function valueToExpr(
         dt = DateTime.fromISO(value, {setZone: true});
         if (dt.isValid) dt = dt.toUTC();
       } else {
-        throw new TypeError(
-          `givens.${path}: expected JS Date or ISO timestamptz string, got ${describeJs(value)}`
+        bad(
+          `expected JS Date or ISO timestamptz string, got ${describeJs(value)}`
         );
       }
       if (!dt.isValid) {
-        throw new TypeError(
-          `givens.${path}: invalid timestamptz value '${value}': ${dt.invalidReason ?? 'unknown'}`
+        bad(
+          `invalid timestamptz value '${value}': ${dt.invalidReason ?? 'unknown'}`
         );
       }
       return {
@@ -208,17 +203,15 @@ function valueToExpr(
     }
     case 'filter expression': {
       if (typeof value !== 'string') {
-        throw new TypeError(
-          `givens.${path}: filter<T> givens require a JS string of Malloy filter source, got ${describeJs(value)}`
+        bad(
+          `filter<T> givens require a JS string of Malloy filter source, got ${describeJs(value)}`
         );
       }
       return {node: 'filterLiteral', filterSrc: value};
     }
     case 'array': {
       if (!Array.isArray(value)) {
-        throw new TypeError(
-          `givens.${path}: expected array, got ${describeJs(value)}`
-        );
+        bad(`expected array, got ${describeJs(value)}`);
       }
       // RepeatedRecord (array of records) carries `record_element` as its
       // element type and the record's schema in `fields`. Each element is
@@ -238,24 +231,26 @@ function valueToExpr(
         Array.isArray(value) ||
         value instanceof Date
       ) {
-        throw new TypeError(
-          `givens.${path}: expected object, got ${describeJs(value)}`
-        );
+        bad(`expected object, got ${describeJs(value)}`);
       }
       const obj = value;
       const declared = new Set(type.fields.map(f => f.name));
       for (const k of Object.keys(obj)) {
         if (!declared.has(k)) {
-          throw new TypeError(
-            `givens.${path}.${k}: unexpected key (not in record type [${[...declared].join(', ')}])`
+          throw new MalloyCompileError(
+            `givens.${path}.${k}: unexpected key (not in record type [${[...declared].join(', ')}])`,
+            'runtime-given-record-extra-key',
+            undefined
           );
         }
       }
       const kids: SafeRecord<Expr> = mkSafeRecord();
       for (const field of type.fields) {
         if (!(field.name in obj)) {
-          throw new TypeError(
-            `givens.${path}.${field.name}: missing required key`
+          throw new MalloyCompileError(
+            `givens.${path}.${field.name}: missing required key`,
+            'runtime-given-record-missing-key',
+            undefined
           );
         }
         kids[field.name] = valueToExpr(
@@ -269,7 +264,11 @@ function valueToExpr(
     case 'json':
     case 'sql native':
     case 'error':
-      throw new Error(`givens.${path}: type '${type.type}' is not bindable`);
+      throw new MalloyCompileError(
+        `givens.${path}: type '${type.type}' is not bindable as a given value.`,
+        'runtime-given-type-not-bindable',
+        undefined
+      );
     default: {
       // Exhaustiveness: future GivenTypeDef additions will trip this.
       const _x: never = type;

--- a/packages/malloy/src/model/index.ts
+++ b/packages/malloy/src/model/index.ts
@@ -65,6 +65,7 @@ export {
 } from './utils';
 export {constantExprToSQL} from './constant_expression_compiler';
 export {getCompiledSQL} from './sql_compiled';
+export {MalloyCompileError} from './malloy_compile_error';
 export {
   mkSourceID,
   mkBuildID,

--- a/packages/malloy/src/model/malloy_compile_error.ts
+++ b/packages/malloy/src/model/malloy_compile_error.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Contributors to the Malloy project
+ * SPDX-License-Identifier: MIT
+ */
+
+import type {DocumentLocation} from './malloy_types';
+
+/**
+ * Thrown by the SQL compiler (`src/model/`) for user-actionable errors the
+ * translator didn't catch. Caught at the materializer boundary and turned
+ * into a `LogMessage`. Singular `at` reflects the fail-fast contract — the
+ * first such error stops compilation. Invariant violations stay as bare
+ * `Error` and surface as `code: 'compiler-bug'` instead.
+ */
+export class MalloyCompileError extends Error {
+  constructor(
+    message: string,
+    readonly code: string,
+    readonly at: DocumentLocation | undefined
+  ) {
+    super(message);
+  }
+}

--- a/packages/malloy/src/model/malloy_types.ts
+++ b/packages/malloy/src/model/malloy_types.ts
@@ -256,12 +256,14 @@ export interface SourceReferenceNode extends ExprLeaf {
 export interface ParameterNode extends ExprLeaf {
   node: 'parameter';
   path: string[];
+  at?: DocumentLocation;
 }
 
 export interface GivenRefNode extends ExprLeaf {
   node: 'given';
   id: GivenID;
   refName: string;
+  at?: DocumentLocation;
 }
 
 export interface NowNode extends ExprLeaf {

--- a/packages/malloy/src/model/query_model_impl.ts
+++ b/packages/malloy/src/model/query_model_impl.ts
@@ -26,6 +26,7 @@ import type {ModelRootInterface} from './query_node';
 import {QueryStruct, isScalarField} from './query_node';
 import type {QueryModel, QueryResults} from './query_model_contract';
 import {rowDataToNumber} from '../api/row_data_utils';
+import {MalloyCompileError} from './malloy_compile_error';
 
 export function makeQueryModel(modelDef: ModelDef | undefined): QueryModel {
   return new QueryModelImpl(modelDef);
@@ -84,7 +85,11 @@ export class QueryModelImpl implements QueryModel, ModelRootInterface {
     if (s) {
       return s;
     }
-    throw new Error(`Struct ${name} not found in model.`);
+    throw new MalloyCompileError(
+      `Source '${name}' is not defined in this model.`,
+      'compiler-undefined-source',
+      undefined
+    );
   }
 
   getStructFromRef(

--- a/packages/malloy/src/model/query_node.ts
+++ b/packages/malloy/src/model/query_node.ts
@@ -8,6 +8,7 @@ import type {
   FieldDef,
   BooleanFieldDef,
   DateFieldDef,
+  DocumentLocation,
   StringFieldDef,
   JSONFieldDef,
   NumberFieldDef,
@@ -29,6 +30,7 @@ import type {
   SourceDef,
   Query,
 } from './malloy_types';
+import {MalloyCompileError} from './malloy_compile_error';
 import {
   isSourceDef,
   getIdentifier,
@@ -370,7 +372,12 @@ export class QueryStruct {
                   ? this.parent.resolveParentParameterReferences(resolved1)
                   : resolved1;
                 if (resolved2.value === null) {
-                  throw new Error('Invalid parameter value');
+                  throw new MalloyCompileError(
+                    `Parameter '${frag.path[0]}' resolves to a null value chain; ` +
+                      'this parameter was not supplied.',
+                    'compiler-parameter-no-value',
+                    undefined
+                  );
                 } else {
                   return resolved2.value;
                 }
@@ -413,9 +420,13 @@ export class QueryStruct {
             'INTERNAL ERROR: QueryQuery must initialize QueryStruct nested factory method'
           );
         }
-        this.addFieldToNameMap(as, QueryStruct.turtleFieldMaker(field, this));
+        this.addFieldToNameMap(
+          as,
+          QueryStruct.turtleFieldMaker(field, this),
+          field.location
+        );
       } else if (isAtomic(field) || isJoinedSource(field)) {
-        this.addFieldToNameMap(as, this.makeQueryField(field));
+        this.addFieldToNameMap(as, this.makeQueryField(field), field.location);
       } else {
         // According to the type system this should be impossible, but we have seen this happen
         // in the wild, so we are leaving error handling here to help debug if it happens again.
@@ -556,9 +567,13 @@ export class QueryStruct {
     return this;
   }
 
-  addFieldToNameMap(as: string, n: QueryField) {
+  addFieldToNameMap(as: string, n: QueryField, at?: DocumentLocation) {
     if (this.nameMap.has(as)) {
-      throw new Error(`Redefinition of ${as}`);
+      throw new MalloyCompileError(
+        `Field name '${as}' is defined more than once in this scope.`,
+        'compiler-name-redefined',
+        at
+      );
     }
     this.nameMap.set(as, n);
   }
@@ -569,7 +584,13 @@ export class QueryStruct {
     if ((pk = this.primaryKey())) {
       return pk;
     } else {
-      throw new Error(`Missing primary key for ${fieldDef}`);
+      throw new MalloyCompileError(
+        `Source '${getIdentifier(this.structDef)}' has no primary key; ` +
+          `cannot compute a unique key for field '${getIdentifier(fieldDef)}'. ` +
+          'Add `primary_key: <field>` to the source definition.',
+        'compiler-missing-primary-key',
+        fieldDef.location
+      );
     }
   }
 
@@ -697,7 +718,7 @@ export class QueryStruct {
   }
 
   /** convert a path into a field reference */
-  getFieldByName(path: string[]): QueryField {
+  getFieldByName(path: string[], at?: DocumentLocation): QueryField {
     let found: QueryField | undefined = undefined;
     let lookIn = this as QueryStruct | undefined;
     let notFound = path[0];
@@ -711,24 +732,33 @@ export class QueryStruct {
         found instanceof QueryFieldStruct ? found.queryStruct : undefined;
     }
     if (found === undefined) {
-      const pathErr = path.length > 1 ? ` in ${path.join('.')}` : '';
-      throw new Error(`${notFound} not found${pathErr}`);
+      const pathErr = path.length > 1 ? ` in path '${path.join('.')}'` : '';
+      throw new MalloyCompileError(
+        `Field '${notFound}' not found${pathErr}.`,
+        'compiler-field-not-found',
+        at
+      );
     }
     return found;
   }
 
   // structs referenced in queries are converted to fields.
-  getQueryFieldByName(name: string[]): QueryField {
-    const field = this.getFieldByName(name);
+  getQueryFieldByName(name: string[], at?: DocumentLocation): QueryField {
+    const field = this.getFieldByName(name, at);
     if (field instanceof QueryFieldStruct) {
-      throw new Error(`Cannot reference ${name.join('.')} as a scalar'`);
+      throw new MalloyCompileError(
+        `'${name.join('.')}' refers to a source or join, not a scalar field. ` +
+          'Use `source.field` to reference fields inside it.',
+        'compiler-cannot-reference-as-scalar',
+        at
+      );
     }
     return field;
   }
 
   getQueryFieldReference(f: RefToField): QueryField {
     const {path, annotation, drillExpression} = f;
-    const field = this.getFieldByName(path);
+    const field = this.getFieldByName(path, f.at);
     if (annotation || drillExpression) {
       if (field.parent === undefined) {
         throw new Error(
@@ -773,15 +803,19 @@ export class QueryStruct {
   }
 
   /** returns a query object for the given name */
-  getStructByName(name: string[]): QueryStruct {
+  getStructByName(name: string[], at?: DocumentLocation): QueryStruct {
     if (name.length === 0) {
       return this;
     }
-    const struct = this.getFieldByName(name);
+    const struct = this.getFieldByName(name, at);
     if (struct instanceof QueryFieldStruct) {
       return struct.queryStruct;
     }
-    throw new Error(`Error: Path to structure not found '${name.join('.')}'`);
+    throw new MalloyCompileError(
+      `'${name.join('.')}' is not a source or join.`,
+      'compiler-struct-not-found',
+      at
+    );
   }
 
   getDistinctKey(): QueryBasicField {

--- a/packages/malloy/src/model/query_query.ts
+++ b/packages/malloy/src/model/query_query.ts
@@ -82,6 +82,7 @@ import {
 import type * as Malloy from '@malloydata/malloy-interfaces';
 import {getCompiledSQL} from './sql_compiled';
 import {mkBuildID} from './source_def_utils';
+import {MalloyCompileError} from './malloy_compile_error';
 
 function pathToCol(path: string[]): string {
   return path.map(el => encodeURIComponent(el)).join('/');
@@ -317,10 +318,11 @@ export class QueryQuery extends QueryField {
       for (const pathSegment of ungrouping.path) {
         const nextStruct = destResult.allFields.get(pathSegment);
         if (!(nextStruct instanceof FieldInstanceResult)) {
-          throw new Error(
-            `Ungroup path ${ungrouping.path.join(
-              '.'
-            )} segment '${pathSegment}' is not a nested query`
+          throw new MalloyCompileError(
+            `Ungrouping path '${ungrouping.path.join('.')}' references ` +
+              `'${pathSegment}', which is not a nested view at this level.`,
+            'compiler-ungrouped-invalid-path',
+            this.fieldDef.location
           );
         }
         destResult = nextStruct;
@@ -378,8 +380,12 @@ export class QueryQuery extends QueryField {
 
       if (field instanceof QueryQuery) {
         if (this.firstSegment.type === 'project') {
-          throw new Error(
-            `Nested views cannot be used in select - '${field.fieldDef.name}'`
+          throw new MalloyCompileError(
+            `Cannot include nested view '${field.fieldDef.name}' in a ` +
+              "'select:' stage. Nested views require `group_by:` or " +
+              '`aggregate:` to be included in output.',
+            'compiler-nested-view-in-select',
+            field.fieldDef.location
           );
         }
         const fir = new FieldInstanceResult(
@@ -411,8 +417,11 @@ export class QueryQuery extends QueryField {
 
         if (isBasicAggregate(field)) {
           if (this.firstSegment.type === 'project') {
-            throw new Error(
-              `Aggregate Fields cannot be used in select - '${field.fieldDef.name}'`
+            throw new MalloyCompileError(
+              `Cannot include aggregate field '${field.fieldDef.name}' in ` +
+                "a 'select:' stage. Use `aggregate:` instead to compute aggregates.",
+              'compiler-aggregate-in-select',
+              field.fieldDef.location
             );
           }
         }
@@ -773,8 +782,12 @@ export class QueryQuery extends QueryField {
           ?.get(qs.structDef.connection)
           ?.get(qs.structDef.name);
         if (!tablePath) {
-          throw new Error(
-            `No virtual map entry for '${qs.structDef.name}' on connection '${qs.structDef.connection}'`
+          throw new MalloyCompileError(
+            `No virtual-map entry for virtual source '${qs.structDef.name}' ` +
+              `on connection '${qs.structDef.connection}'. ` +
+              'Add a virtual-map entry via the `virtualMap` runtime option.',
+            'runtime-virtual-map-missing',
+            qs.structDef.location
           );
         }
         // virtualMap entries are application-supplied — assumed already
@@ -832,11 +845,16 @@ export class QueryQuery extends QueryField {
             }
 
             if (buildManifest.strict) {
-              const base = `Persist source '${qs.structDef.sourceID}' not found in manifest (buildId: ${buildId})`;
-              throw new Error(
+              const base =
+                `Persist source '${qs.structDef.sourceID}' not found ` +
+                `in manifest (buildId: ${buildId}); strict manifest mode ` +
+                'forbids fallback to live compilation.';
+              throw new MalloyCompileError(
                 buildManifest.loadError
                   ? `${base}\n  ${buildManifest.loadError}`
-                  : base
+                  : base,
+                'runtime-manifest-strict-miss',
+                qs.structDef.location
               );
             }
           }
@@ -890,8 +908,11 @@ export class QueryQuery extends QueryField {
     if (typeof structRef === 'string') {
       const struct = this.structRefToQueryStruct(structRef);
       if (!struct) {
-        throw new Error(
-          `Unexpected reference to an undefined source '${structRef}'`
+        throw new MalloyCompileError(
+          `Query references source '${structRef}', ` +
+            'which is not defined in this model.',
+          'compiler-undefined-source',
+          undefined
         );
       }
       sourceStruct = struct;
@@ -1226,7 +1247,11 @@ export class QueryQuery extends QueryField {
             o.push(`${fieldExpr} ${f.dir || 'ASC'}`);
           }
         } else {
-          throw new Error(`Unknown field in ORDER BY ${f.field}`);
+          throw new MalloyCompileError(
+            `ORDER BY references unknown field '${f.field}'.`,
+            'compiler-orderby-field-not-found',
+            queryDef.referencedAt
+          );
         }
       } else {
         if (this.parent.dialect.orderByClause === 'ordinal') {
@@ -1686,7 +1711,13 @@ export class QueryQuery extends QueryField {
       this.firstSegment.type === 'project' &&
       !this.parent.modelCompilerFlags().has('unsafe_complex_select_query')
     ) {
-      throw new Error('PROJECT cannot be used on queries with turtles');
+      throw new MalloyCompileError(
+        "Cannot use 'select:' in a stage that contains nested views. " +
+          'Use `group_by:` or restructure the pipeline. ' +
+          'Set `##! unsafe_complex_select_query` to bypass at your own risk.',
+        'compiler-project-with-turtles',
+        this.fieldDef.location
+      );
     }
 
     const groupBy = 'GROUP BY ' + f.dimensionIndexes.join(',') + '\n';
@@ -2268,7 +2299,7 @@ class QueryQueryIndexStage extends QueryQuery {
 
   expandField(f: IndexFieldDef) {
     const as = f.path.join('.');
-    const field = this.parent.getQueryFieldByName(f.path);
+    const field = this.parent.getQueryFieldByName(f.path, f.at);
     return {as, field};
   }
 

--- a/packages/malloy/src/model/sql_compiled.ts
+++ b/packages/malloy/src/model/sql_compiled.ts
@@ -12,6 +12,7 @@ import type {
 } from './malloy_types';
 import {isSegmentSQL, isSegmentSource, safeRecordGet} from './malloy_types';
 import {mkBuildID} from './source_def_utils';
+import {MalloyCompileError} from './malloy_compile_error';
 
 /**
  * Callback type for compiling a Query to SQL.
@@ -101,11 +102,16 @@ function expandPersistableSource(
 
       // Not in manifest
       if (buildManifest.strict) {
-        const base = `Persist source '${source.sourceID}' not found in manifest (buildId: ${buildId})`;
-        throw new Error(
+        const base =
+          `Persist source '${source.sourceID}' not found in manifest ` +
+          `(buildId: ${buildId}); strict manifest mode forbids fallback ` +
+          'to live compilation.';
+        throw new MalloyCompileError(
           buildManifest.loadError
             ? `${base}\n  ${buildManifest.loadError}`
-            : base
+            : base,
+          'runtime-manifest-strict-miss',
+          source.location
         );
       }
     }

--- a/packages/malloy/src/model/test/constant_expression.spec.ts
+++ b/packages/malloy/src/model/test/constant_expression.spec.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright Contributors to the Malloy project
+ * SPDX-License-Identifier: MIT
+ */
+
 import {DuckDBDialect} from '../../dialect';
 import {constantExprToSQL} from '../constant_expression_compiler';
 import type {Expr, Parameter} from '../malloy_types';
@@ -136,7 +141,7 @@ describe('Constant Expression Compiler', () => {
 
       // Parameter errors from the original expression compiler are thrown, not returned
       expect(() => constantExprToSQL(expr, dialect, parameters)).toThrow(
-        'no value for missing'
+        /Parameter 'missing' has no value supplied/
       );
     });
 

--- a/test/src/core/givens.spec.ts
+++ b/test/src/core/givens.spec.ts
@@ -761,7 +761,7 @@ describe('givens — finalizeGivens (Stage 4e)', () => {
         )
         .loadQueryByName('q')
         .run()
-    ).rejects.toThrow(/finalized given.*no resolved value.*STATE/);
+    ).rejects.toThrow(/finalized given 'STATE' has no resolved value/i);
   });
 
   test('unsatisfied finalize entry does NOT block a query that does not reference it', async () => {

--- a/test/src/core/validate.spec.ts
+++ b/test/src/core/validate.spec.ts
@@ -1,0 +1,173 @@
+/*
+ * Copyright Contributors to the Malloy project
+ * SPDX-License-Identifier: MIT
+ */
+
+import {runtimeFor} from '../runtimes';
+import {MalloyError} from '@malloydata/malloy';
+
+const runtime = runtimeFor('duckdb');
+
+const envDatabases = (
+  process.env['MALLOY_DATABASES'] ||
+  process.env['MALLOY_DATABASE'] ||
+  'duckdb'
+).split(',');
+
+let describe = globalThis.describe;
+if (!envDatabases.includes('duckdb')) {
+  describe = describe.skip;
+  describe.skip = describe;
+}
+
+afterAll(async () => {
+  await runtime.connection.close();
+});
+
+describe('ModelMaterializer.validate()', () => {
+  test('clean model returns empty array', async () => {
+    const model = runtime.loadModel(`
+      source: states is duckdb.table('malloytest.state_facts')
+    `);
+    const problems = await model.validate();
+    expect(problems).toEqual([]);
+  });
+
+  test('translator errors surface as structured LogMessages', async () => {
+    const model = runtime.loadModel(`
+      source: states is duckdb.table('malloytest.state_facts') extend {
+        dimension: bad is no_such_thing
+      }
+    `);
+    const problems = await model.validate();
+    expect(problems.length).toBeGreaterThan(0);
+    expect(problems.every(p => p.severity === 'error')).toBe(true);
+    expect(problems.every(p => typeof p.code === 'string')).toBe(true);
+  });
+
+  test('validate() is non-throwing even on hard translator failures', async () => {
+    const model = runtime.loadModel('this is not malloy syntax at all');
+    await expect(model.validate()).resolves.toEqual(expect.any(Array));
+    const problems = await model.validate();
+    expect(problems.length).toBeGreaterThan(0);
+  });
+
+  test('cached: validate() then getModel() does not re-translate', async () => {
+    const model = runtime.loadModel(`
+      source: states is duckdb.table('malloytest.state_facts')
+    `);
+    const problems = await model.validate();
+    expect(problems).toEqual([]);
+    const m = await model.getModel();
+    expect(m).toBeDefined();
+  });
+});
+
+describe('QueryMaterializer.validate()', () => {
+  test('clean query returns empty array', async () => {
+    const model = runtime.loadModel(`
+      source: states is duckdb.table('malloytest.state_facts')
+    `);
+    const problems = await model
+      .loadQuery('run: states -> { aggregate: ct is count() }')
+      .validate();
+    expect(problems).toEqual([]);
+  });
+
+  test('translator error in query surfaces structured problems', async () => {
+    const model = runtime.loadModel(`
+      source: states is duckdb.table('malloytest.state_facts')
+    `);
+    const problems = await model
+      .loadQuery('run: states -> { aggregate: x is no_such_field }')
+      .validate();
+    expect(problems.length).toBeGreaterThan(0);
+    expect(problems[0].severity).toBe('error');
+  });
+
+  test('an invalid query surfaces problems with codes', async () => {
+    const model = runtime.loadModel(`
+      source: states is duckdb.table('malloytest.state_facts')
+    `);
+    const problems = await model
+      .loadQuery(
+        `run: states -> {
+          select: state
+          nest: by_year is { aggregate: ct is count() }
+        }`
+      )
+      .validate();
+    expect(problems.length).toBeGreaterThan(0);
+    expect(problems[0].severity).toBe('error');
+    expect(typeof problems[0].code).toBe('string');
+  });
+
+  test('validate() then run() shares cache — single compile', async () => {
+    const model = runtime.loadModel(`
+      source: states is duckdb.table('malloytest.state_facts')
+    `);
+    const q = model.loadQuery('run: states -> { aggregate: ct is count() }');
+    expect(await q.validate()).toEqual([]);
+    const result = await q.run();
+    expect(result.data.path(0, 'ct').value).toBeGreaterThan(0);
+  });
+
+  test('validate() then getPreparedResult() does not re-compile', async () => {
+    const model = runtime.loadModel(`
+      source: states is duckdb.table('malloytest.state_facts')
+    `);
+    const q = model.loadQuery('run: states -> { aggregate: ct is count() }');
+    expect(await q.validate()).toEqual([]);
+    const pr = await q.getPreparedResult();
+    expect(pr.sql.toUpperCase()).toContain('COUNT');
+  });
+
+  test('getPreparedResult on a failed compile throws MalloyError with problems', async () => {
+    const model = runtime.loadModel(`
+      source: states is duckdb.table('malloytest.state_facts')
+    `);
+    const q = model.loadQuery(
+      `run: states -> {
+        select: state
+        nest: by_year is { aggregate: ct is count() }
+      }`
+    );
+    await expect(q.getPreparedResult()).rejects.toBeInstanceOf(MalloyError);
+    let err: MalloyError | undefined;
+    try {
+      await q.getPreparedResult();
+    } catch (e) {
+      if (e instanceof MalloyError) err = e;
+    }
+    expect(err!.problems.length).toBeGreaterThan(0);
+    expect(typeof err!.problems[0].code).toBe('string');
+  });
+
+  test('SQL-compile error surfaces with its specific code via validate()', async () => {
+    // Unresolved virtual sources reach SQL compile (the translator can't
+    // know what virtualMap the runtime will supply), so this exercises
+    // the MalloyCompileError → LogMessage path end-to-end.
+    const model = runtime.loadModel(`
+      ##! experimental.virtual_source
+      type: s is { x :: string }
+      source: v is duckdb.virtual('no_such_table')::s
+    `);
+    const problems = await model
+      .loadQuery('run: v -> { select: x; limit: 1 }')
+      .validate();
+    expect(problems.length).toBe(1);
+    expect(problems[0].code).toBe('runtime-virtual-map-missing');
+    expect(problems[0].severity).toBe('error');
+  });
+
+  test('restricted-mode rejections show up in validate()', async () => {
+    const model = runtime.loadModel(`
+      source: states is duckdb.table('malloytest.state_facts')
+    `);
+    const problems = await model
+      .loadRestrictedQuery('import "other"')
+      .validate();
+    expect(problems.length).toBeGreaterThan(0);
+    expect(problems.some(p => p.errorTag === 'restricted-mode')).toBe(true);
+  });
+});

--- a/test/src/core/virtual.spec.ts
+++ b/test/src/core/virtual.spec.ts
@@ -83,7 +83,7 @@ describe('virtual source resolution', () => {
     `;
 
     await expect(tstRuntime.loadQuery(code).run()).rejects.toThrow(
-      "No virtual map entry for 'no_such_table'"
+      /No virtual-map entry for virtual source 'no_such_table'/
     );
   });
 


### PR DESCRIPTION
## API

```ts
// QueryMaterializer
async validate(options?: CompileQueryOptions): Promise<LogMessage[]>

// ModelMaterializer
async validate(): Promise<LogMessage[]>
```

Non-throwing: empty array means the model/query compiles. Otherwise the array carries structured `LogMessage`s with `code`, `severity`, and (where the IR has it) `at: DocumentLocation`.

Covers both translator-time errors (possibly several) and SQL-compile errors (at most one — the compiler is fail-fast).

`getPreparedResult()` / `getSQL()` / `run()` still throw `MalloyError` on failure; the thrown `.problems` is now populated for compile-time errors too. A `validate()` followed by a no-options `getPreparedResult()` reuses the cached compile.

## Also

`npm run precheck` — alias for `test-duckdb`, the broad local "did I break anything?" check.