### PR TITLE
Publish via npm trusted publishing (OIDC) in release.yaml

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,6 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
     steps:
       - uses: actions/checkout@v5
         with:
@@ -42,6 +43,8 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: 20.x
+      - name: Upgrade npm for trusted publishing (OIDC)
+        run: npm install -g npm@latest
       - name: npm install, build, and publish
         run: |
           # Configure git user
@@ -82,6 +85,5 @@ jobs:
           git push origin $BRANCH_NAME
         env:
           CI: true
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           BRANCH_NAME: main
           GH_TOKEN: ${{ github.token }}

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-//registry.npmjs.org/:_authToken=${NPM_TOKEN}


### PR DESCRIPTION
Today is the long delayed day.

Switch the npmjs.com Release workflow from a static `NPM_TOKEN` to GitHub Actions **OIDC trusted publishing**.

## Changes
- `release.yaml`: add `id-token: write`, upgrade the runner npm to ≥11.5.1, remove `NPM_TOKEN` from the publish env.
- Delete `.npmrc` — its only purpose was injecting `${NPM_TOKEN}`.

## Why
The shared static publish token is no longer "the right way to do things"

All 22 `@malloydata` packages have been registered on npmjs.com with `malloydata/malloy` + `release.yaml` as their trusted publisher (the two repos for CLI and explorer are registered separately).

## Scope
Deliberately limited to `release.yaml`. `prerelease.yaml` is left untouched (already inert); consolidating release/prerelease and de-duplicating the CI test gates is a planned follow-up.