### PR TITLE
Fix syntax-highlight provenance + gate release on precheck

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,33 +4,7 @@ permissions: {}
 on: [workflow_dispatch]
 
 jobs:
-  db-bigquery:
-    uses: './.github/workflows/db-bigquery.yaml'
-    secrets:
-      BIGQUERY_KEY: ${{ secrets.BIGQUERY_KEY }}
-  db-duckdb:
-    uses: './.github/workflows/db-duckdb.yaml'
-  db-postgres:
-    uses: './.github/workflows/db-postgres.yaml'
-  db-snowflake:
-    uses: './.github/workflows/db-snowflake.yaml'
-    secrets:
-      SNOWFLAKE_CONNECTION: ${{ secrets.SNOWFLAKE_CONNECTION }}
-  db-publisher:
-    uses: './.github/workflows/db-publisher.yaml'
-  main:
-    uses: './.github/workflows/main.yaml'
-    secrets:
-      BIGQUERY_KEY: ${{ secrets.BIGQUERY_KEY }}
-
   npm-release:
-    needs:
-      - db-bigquery
-      - db-duckdb
-      - db-publisher
-      - db-postgres
-      - db-snowflake
-      - main
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -53,6 +27,8 @@ jobs:
           # Build
           npm --no-audit --no-fund ci --loglevel error
           npm run build
+          # Sanity-check before publishing: dialect-agnostic tests + duckdb
+          npm run precheck
           # Publish
           PACKAGES=$(jq -r '.workspaces.packages[]' ./package.json | xargs echo)
           echo Publishing $PACKAGES

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,7 +4,23 @@ permissions: {}
 on: [workflow_dispatch]
 
 jobs:
+  precheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Use Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 20.x
+      - name: Install and build
+        run: |
+          npm --no-audit --no-fund ci --loglevel error
+          npm run build
+      - name: Precheck (dialect-agnostic tests + duckdb)
+        run: npm run precheck
+
   npm-release:
+    needs: precheck
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -27,8 +43,6 @@ jobs:
           # Build
           npm --no-audit --no-fund ci --loglevel error
           npm run build
-          # Sanity-check before publishing: dialect-agnostic tests + duckdb
-          npm run precheck
           # Publish
           PACKAGES=$(jq -r '.workspaces.packages[]' ./package.json | xargs echo)
           echo Publishing $PACKAGES

--- a/packages/malloy-syntax-highlight/package.json
+++ b/packages/malloy-syntax-highlight/package.json
@@ -2,6 +2,10 @@
   "name": "@malloydata/syntax-highlight",
   "version": "0.0.396",
   "description": "A package to simplify the process of developing, testing, and syncnig Malloy syntax highlighting grammars",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/malloydata/malloy"
+  },
   "files": [
     "grammars/**/*.tmGrammar.json",
     "grammars/**/*-language.json",


### PR DESCRIPTION
Two related fixes to the OIDC release path (follows #2823).

## 1. Add `repository` field to `@malloydata/syntax-highlight`
OIDC trusted publishing auto-generates provenance, which requires each package.json to declare a `repository.url` matching the source repo. `syntax-highlight` had no `repository` field, so its publish failed provenance validation with a 422:

```
Error verifying sigstore provenance bundle: package.json: "repository.url" is "",
expected to match "https://github.com/malloydata/malloy" from provenance
```

This stopped the 0.0.396 release partway (17 of 20 published). Adding the field its siblings already carry lets it publish. Re-running the release at 0.0.396 will skip the already-published packages and publish the three remaining, then bump.

## 2. Gate release on `npm run precheck` instead of the cloud-db job subset
`npm-release` previously depended on a hand-picked set of reusable `db-*` jobs (bigquery, duckdb, postgres, snowflake, publisher, main) that had drifted from branch protection's required checks — it added `db-publisher` and omitted `db-mysql`, `db-duckdb-wasm`, `db-presto`, `db-trino`, and `malloy-tests`. Duplicated effort *and* incomplete coverage.

Replaced with a dedicated `precheck` job (dialect-agnostic tests + duckdb) that `npm-release` depends on, so the privileged publish job only starts once the gate is green. Dialect-specific suites remain required checks to merge to main, so release-time no longer re-verifies them but the bar for reaching main is unchanged.