### PR TITLE
Add CONTEXT.md for .github/workflows (CI + npm publishing guide)

### DIFF
--- a/.github/workflows/CONTEXT.md
+++ b/.github/workflows/CONTEXT.md
@@ -1,8 +1,37 @@
 # GitHub Actions Workflows — AI Guide
 
-This directory holds the CI and release workflows. Most of them (`run-tests.yaml`, the `db-*.yaml` reusable workflows) are ordinary test runners. This guide is about the part with no other documentation and a high obscure-knowledge tax: **how packages get published to npm.**
+This directory is the repo's CI and release machinery. The two things you most likely came here to understand: **what CI runs on a pull request**, and **how packages get published to npm**. Both have pieces that aren't visible from the YAML at a glance — including one security rule you must not break.
 
-## Publishing is OIDC trusted publishing, not a token
+## What CI runs
+
+`run-tests.yaml` ("Malloy Tests") is the entry point. It runs on every pull request and on push to `main`, and fans out to one job per database dialect plus a core job, then a rollup:
+
+- **`main.yaml` ("Core")** — the dialect-agnostic tests (`npm run ci-core`): everything that doesn't touch a database, plus tests that touch duckdb/bigquery/postgres but don't need to run once per dialect. Also runs `npm run lint` and the `scripts/ci-*-sanity-check.sh` guards.
+- **`db-<dialect>.yaml`** — one reusable workflow (`on: workflow_call`) per dialect: duckdb, duckdb-wasm, bigquery, postgres, mysql, snowflake, trino, presto, databricks, publisher. Each runs `npm run ci-<dialect>` — the **same script you run locally** (see "Mirroring CI locally" in the root CONTEXT.md). So `db-trino.yaml` ≈ `npm run ci-trino`.
+- **`malloy-tests`** — an aggregate job that `needs:` every dialect job and does nothing but `echo Success`. It's the single rollup meaning "all of CI passed"; the dialect jobs and this rollup are wired as required status checks on `main`.
+
+`db-motherduck.yaml` exists but is **commented out** of `run-tests.yaml` — motherduck is not currently run in CI. `db-databricks.yaml` is active.
+
+### The security rule — `pull_request_target` + `check-permission`
+
+This is the landmine. `run-tests.yaml` triggers on **`pull_request_target`**, not `pull_request`. That means CI runs in the context of the *base* repo and **has access to secrets even for pull requests from forks**. Unguarded, a fork PR could exfiltrate `BIGQUERY_KEY`, `SNOWFLAKE_CONNECTION`, the databricks tokens, etc.
+
+The guard is the **`check-permission`** job (`malloydata/check-ci-permissions`), which fails if the PR author lacks write access. **Any job that consumes a secret must declare `needs: check-permission`.** There is an explicit comment to this effect in `run-tests.yaml` — honor it. This is not optional; it's the thing standing between the repo and leaked credentials.
+
+### Conventions across the test workflows
+
+- Every workflow starts with `permissions: {}` — least privilege by default. Grant narrowly only where needed (e.g. `release.yaml` adds `contents: write` + `id-token: write`).
+- Each checks out `ref: ${{ github.event.pull_request.head.sha || github.sha }}` — the PR head, falling back to the pushed SHA.
+- Node is pinned to 20.x via `setup-node`. (Note: the runner's bundled npm is old; `release.yaml` upgrades it in-job — see below.)
+- Jobs using duckdb-backed test data run `npm run build-duckdb-db` first; postgres loads its fixture from `test/data/postgres/*.sql.gz`; trino/presto/mysql start and stop a docker service via `test/<db>/<db>_start.sh` / `_stop.sh`.
+
+### Adding a new dialect
+
+Copy an existing `db-<dialect>.yaml` (pick one whose service setup matches — plain, a postgres-style service container, or a docker start/stop script), point it at `npm run ci-<dialect>`, then wire it into `run-tests.yaml`: add the job, add it to the `malloy-tests` `needs:` list, and **add `needs: check-permission` if it uses any secret.**
+
+## How packages are published to npm
+
+### Publishing is OIDC trusted publishing, not a token
 
 Releases authenticate to npm with **GitHub Actions OIDC trusted publishing**, not a stored `NPM_TOKEN`. At publish time GitHub mints a short-lived OIDC token, npm verifies it against a per-package registration, and hands back a publish credential. There is no npm secret in this repo, and one should not be reintroduced — if you find yourself adding `NPM_TOKEN` back, something is wrong.
 
@@ -14,7 +43,7 @@ npm trust github @malloydata/<pkg> --file release.yaml --repo malloydata/malloy 
 
 This needs npm ≥ 11.10 locally (`npm trust` + bulk support) and a logged-in account that owns the package. The repo's pinned node (`.node-version`) ships an older npm; `npm install -g npm@latest` upgrades it for that node version only. CI does its own `npm install -g npm@latest` inside the job for the same reason.
 
-## Rules that bite (none of these are guessable)
+### Rules that bite (none of these are guessable)
 
 - **One trusted publisher per package.** You cannot trust both `release.yaml` and `prerelease.yaml` for the same package — a second registration is rejected with a 409. Pick one. We chose `release.yaml`.
 - **Matching is on the top-level caller workflow filename.** If a workflow uses a *reusable* workflow (`workflow_call`) to run `npm publish`, npm checks the **calling** workflow's filename, not the reusable one. Register the file that GitHub triggers.
@@ -24,23 +53,23 @@ This needs npm ≥ 11.10 locally (`npm trust` + bulk support) and a logged-in ac
   ```
   A package missing this fails publish with a `422 ... Error verifying sigstore provenance bundle`. This is the most likely failure when adding a new package, because the rest of the build won't warn you.
 
-## Adding a new published package — checklist
+### Adding a new published package — checklist
 
 1. Add the `repository` field above to its `package.json`.
 2. Register its trusted publisher: `npm trust github @malloydata/<pkg> --file release.yaml --repo malloydata/malloy --allow-publish --yes`.
 
 Miss step 1 and the release fails partway (provenance 422). Miss step 2 and it fails on auth.
 
-## The release workflow (`release.yaml`)
+### The release workflow (`release.yaml`)
 
 `workflow_dispatch` only. Two jobs:
 
 - **`precheck`** — runs `npm run precheck` (dialect-agnostic tests + duckdb). This is the gate; the publish job depends on it, so the privileged publish job only starts once tests are green.
 - **`npm-release`** — builds, publishes each workspace package via OIDC, creates the GitHub Release, then bumps the version (`lerna version patch`) and pushes the `Version x-dev` commit to `main`.
 
-The release gate is deliberately **not** the full dialect matrix. Dialect-specific suites (bigquery, snowflake, postgres, trino, mysql, …) are required checks to *merge to main*, so a regression can't reach main unnoticed; the release just doesn't re-verify them. (See the publish-workflow rework issue for the longer-term plan around this and a merge queue.)
+The release gate is deliberately **not** the full dialect matrix that gates a merge. Dialect-specific suites are required checks to *merge to main*, so a regression can't reach main unnoticed; the release just doesn't re-verify them. (See the publish-workflow rework issue for the longer-term plan around this and a merge queue.)
 
-## Recovering from a partial release
+### Recovering from a partial release
 
 The publish loop is idempotent by version: it runs `npm view "$PKG@$VERSION"` and **skips** anything already published. npm versions are immutable, so this is the recovery mechanism — **do not bump the version to recover**.
 
@@ -51,10 +80,10 @@ If a release dies mid-publish (e.g. one package's provenance fails):
 
 The version bump is the *last* step, so a failed release leaves the repo at the version it was publishing — which is exactly the precondition for finishing it. A repo stuck at a half-published version is normal and recoverable, not broken.
 
-## prerelease.yaml
+### prerelease.yaml
 
 Currently **inert** — `workflow_dispatch` only and not wired for OIDC (all packages' single trusted publisher points at `release.yaml`). At one point it published a prerelease on every merge to `main`. Restoring that collides with the one-publisher-per-package rule, so it's part of the planned publish-workflow rework, not a flip-the-trigger change.
 
-## Other repos
+### Other repos
 
 The CLI (`malloydata/malloy-cli`, `@malloydata/cli`) and explorer (`malloydata/malloy-explorer`, `@malloydata/malloy-explorer`) publish from their own repos and have their own trusted-publisher registrations against their own workflow files. They are not published from here.

--- a/.github/workflows/CONTEXT.md
+++ b/.github/workflows/CONTEXT.md
@@ -1,0 +1,60 @@
+# GitHub Actions Workflows — AI Guide
+
+This directory holds the CI and release workflows. Most of them (`run-tests.yaml`, the `db-*.yaml` reusable workflows) are ordinary test runners. This guide is about the part with no other documentation and a high obscure-knowledge tax: **how packages get published to npm.**
+
+## Publishing is OIDC trusted publishing, not a token
+
+Releases authenticate to npm with **GitHub Actions OIDC trusted publishing**, not a stored `NPM_TOKEN`. At publish time GitHub mints a short-lived OIDC token, npm verifies it against a per-package registration, and hands back a publish credential. There is no npm secret in this repo, and one should not be reintroduced — if you find yourself adding `NPM_TOKEN` back, something is wrong.
+
+Each published `@malloydata/*` package has a **trusted publisher** registered on npmjs.com, bound to repo `malloydata/malloy` + workflow `release.yaml`. Registration is done from a maintainer's machine, not from CI:
+
+```bash
+npm trust github @malloydata/<pkg> --file release.yaml --repo malloydata/malloy --allow-publish --yes
+```
+
+This needs npm ≥ 11.10 locally (`npm trust` + bulk support) and a logged-in account that owns the package. The repo's pinned node (`.node-version`) ships an older npm; `npm install -g npm@latest` upgrades it for that node version only. CI does its own `npm install -g npm@latest` inside the job for the same reason.
+
+## Rules that bite (none of these are guessable)
+
+- **One trusted publisher per package.** You cannot trust both `release.yaml` and `prerelease.yaml` for the same package — a second registration is rejected with a 409. Pick one. We chose `release.yaml`.
+- **Matching is on the top-level caller workflow filename.** If a workflow uses a *reusable* workflow (`workflow_call`) to run `npm publish`, npm checks the **calling** workflow's filename, not the reusable one. Register the file that GitHub triggers.
+- **OIDC silently turns on provenance, and provenance hard-requires `repository.url`.** Every published package.json must declare a `repository` field whose URL matches this repo:
+  ```json
+  "repository": { "type": "git", "url": "https://github.com/malloydata/malloy" }
+  ```
+  A package missing this fails publish with a `422 ... Error verifying sigstore provenance bundle`. This is the most likely failure when adding a new package, because the rest of the build won't warn you.
+
+## Adding a new published package — checklist
+
+1. Add the `repository` field above to its `package.json`.
+2. Register its trusted publisher: `npm trust github @malloydata/<pkg> --file release.yaml --repo malloydata/malloy --allow-publish --yes`.
+
+Miss step 1 and the release fails partway (provenance 422). Miss step 2 and it fails on auth.
+
+## The release workflow (`release.yaml`)
+
+`workflow_dispatch` only. Two jobs:
+
+- **`precheck`** — runs `npm run precheck` (dialect-agnostic tests + duckdb). This is the gate; the publish job depends on it, so the privileged publish job only starts once tests are green.
+- **`npm-release`** — builds, publishes each workspace package via OIDC, creates the GitHub Release, then bumps the version (`lerna version patch`) and pushes the `Version x-dev` commit to `main`.
+
+The release gate is deliberately **not** the full dialect matrix. Dialect-specific suites (bigquery, snowflake, postgres, trino, mysql, …) are required checks to *merge to main*, so a regression can't reach main unnoticed; the release just doesn't re-verify them. (See the publish-workflow rework issue for the longer-term plan around this and a merge queue.)
+
+## Recovering from a partial release
+
+The publish loop is idempotent by version: it runs `npm view "$PKG@$VERSION"` and **skips** anything already published. npm versions are immutable, so this is the recovery mechanism — **do not bump the version to recover**.
+
+If a release dies mid-publish (e.g. one package's provenance fails):
+
+1. Fix the cause (usually a missing `repository` field), merge it.
+2. Re-run `release.yaml` at the **same** version. Already-published packages are skipped; the missing ones publish; then the version bump runs.
+
+The version bump is the *last* step, so a failed release leaves the repo at the version it was publishing — which is exactly the precondition for finishing it. A repo stuck at a half-published version is normal and recoverable, not broken.
+
+## prerelease.yaml
+
+Currently **inert** — `workflow_dispatch` only and not wired for OIDC (all packages' single trusted publisher points at `release.yaml`). At one point it published a prerelease on every merge to `main`. Restoring that collides with the one-publisher-per-package rule, so it's part of the planned publish-workflow rework, not a flip-the-trigger change.
+
+## Other repos
+
+The CLI (`malloydata/malloy-cli`, `@malloydata/cli`) and explorer (`malloydata/malloy-explorer`, `@malloydata/malloy-explorer`) publish from their own repos and have their own trusted-publisher registrations against their own workflow files. They are not published from here.

--- a/.github/workflows/CONTEXT.md
+++ b/.github/workflows/CONTEXT.md
@@ -1,113 +1,38 @@
 # GitHub Actions Workflows — AI Guide
 
-This directory is the repo's CI and release machinery. The two things you most likely came here to understand: **what CI runs on a pull request**, and **how packages get published to npm**. Both have pieces that aren't visible from the YAML at a glance — including one security rule you must not break.
+CI and release machinery. Read the YAML for mechanics; this covers what's *not* visible there — the structure, the security model, and the publishing rules that bite.
 
-## What CI runs
+## CI
 
-`run-tests.yaml` ("Malloy Tests") is the entry point. It runs on every pull request and on push to `main`, and fans out to one job per database dialect plus a core job, then a rollup:
+`run-tests.yaml` is the entry point (runs on PRs and pushes to `main`). It fans out to reusable workflows — `main.yaml` (dialect-agnostic `ci-core`, plus `lint` and the `scripts/ci-*-sanity-check.sh` guards) and one `db-<dialect>.yaml` per dialect — then a `malloy-tests` rollup job that `needs:` them all. Each `db-<dialect>.yaml` runs `npm run ci-<dialect>`, the same script you run locally. `db-motherduck.yaml` is commented out of CI.
 
-- **`main.yaml` ("Core")** — the dialect-agnostic tests (`npm run ci-core`): everything that doesn't touch a database, plus tests that touch duckdb/bigquery/postgres but don't need to run once per dialect. Also runs `npm run lint` and the `scripts/ci-*-sanity-check.sh` guards.
-- **`db-<dialect>.yaml`** — one reusable workflow (`on: workflow_call`) per dialect: duckdb, duckdb-wasm, bigquery, postgres, mysql, snowflake, trino, presto, databricks, publisher. Each runs `npm run ci-<dialect>` — the **same script you run locally** (see "Mirroring CI locally" in the root CONTEXT.md). So `db-trino.yaml` ≈ `npm run ci-trino`.
-- **`malloy-tests`** — an aggregate job that `needs:` every dialect job and does nothing but `echo Success`. It's the single rollup meaning "all of CI passed"; the dialect jobs and this rollup are wired as required status checks on `main`.
+`scripts/ci-test-sanity-check.sh` (run by `main.yaml`) fails if any `*.spec.ts(x)` isn't wired into a `jest.config.ts` project — so no test can be silently absent from CI.
 
-`db-motherduck.yaml` exists but is **commented out** of `run-tests.yaml` — motherduck is not currently run in CI. `db-databricks.yaml` is active.
+### Safely accepting external PRs — do not break this
 
-### Safely accepting external PRs (the scary part)
+`run-tests.yaml` triggers on **`pull_request_target`**, so it runs with the repo's secrets *and* checks out the PR's head code — arbitrary code from any author running on a runner that holds production credentials. This is a known privilege-escalation footgun; the **`check-permission`** job (`malloydata/check-ci-permissions`) contains it, failing the run unless **`github.triggering_actor`** has write access (design: PR #2087).
 
-Read this before touching `run-tests.yaml`. How this repo runs CI on outside contributions is a deliberate design (PR #2087, Jan 2025) that does, on purpose, the exact combination GitHub documents as a privilege-escalation vulnerability. A single job is what keeps it safe, and the safety depends on a human step that's easy to perform carelessly.
+- **Every secret-bearing job MUST `needs: check-permission`** (today: `main`, `db-trino`, `db-presto`, `db-bigquery`, `db-snowflake`, `db-databricks`). Secret-free jobs deliberately don't. Adding a secret to an ungated job leaks it to external-PR code.
+- The gate trusts the *triggering actor*, not the PR author — so **re-running a fork PR's CI authorizes its code to run with full secrets.** Review the diff (especially workflow/build-script changes) before re-running.
 
-**Why it's built this way.** Database tests need real credentials (BigQuery, Snowflake, Databricks, …). A normal `pull_request` workflow from a fork gets **no** secrets, so DB tests could never run on external contributions. To allow them, #2087 switched to **`pull_request_target`**, which runs in the *base* repo's context and therefore *has* the secrets — even for fork PRs, with no automatic "approve to run" prompt.
+Contributor-facing side (DCO sign-off, licensing, review) is in [CONTRIBUTING.md](../../CONTRIBUTING.md). Adding a dialect: [adding-a-new-database.md](../../packages/malloy/src/doc/adding-a-new-database.md).
 
-**Why that's dangerous.** The workflow also checks out the PR's head code (`ref: ${{ github.event.pull_request.head.sha || github.sha }}`) and runs `npm ci` + build + test on it. That is **arbitrary code from the PR author executing on a runner that holds production credentials.** `pull_request_target` + checkout-the-PR-head + secrets is *the* canonical Actions footgun: unguarded, a stranger's PR could print or exfiltrate every secret.
+## Publishing (`release.yaml`)
 
-**What makes it safe — and the flow.** The **`check-permission`** job (`malloydata/check-ci-permissions`) fails the run unless **`github.triggering_actor`** has write access. It checks the *triggering actor*, **not** the PR author. So:
+Publishing uses **GitHub Actions OIDC trusted publishing**, not a stored `NPM_TOKEN` — there is no npm secret in this repo and one should not be added back. Each `@malloydata/*` package has a trusted publisher registered on npmjs.com bound to `malloydata/malloy` + `release.yaml`, set from a maintainer's machine (`npm trust github <pkg> --file release.yaml --repo malloydata/malloy --allow-publish --yes`, needs npm ≥ 11.10).
 
-- A stranger opens a PR → they are the triggering actor → `check-permission` fails → no credentialed job runs.
-- A **maintainer reviews the diff and re-runs CI** → the maintainer becomes the triggering actor → the gate passes → DB tests run with secrets.
+`release.yaml` is `workflow_dispatch`-only: a `precheck` job (`npm run precheck`) gates the `npm-release` job, which publishes every workspace package, cuts the GitHub Release, then bumps the version. The gate is intentionally just precheck, not the full dialect matrix — those are required checks to *merge*, so they aren't re-verified at release.
 
-A write-access person vouching for the code is the thing that unlocks secret access. That's the intended human-in-the-loop.
+**Rules that bite (not guessable):**
 
-**Pitfalls:**
+- **One trusted publisher per package** — can't trust both `release.yaml` and `prerelease.yaml`; a second registration 409s.
+- **Matching is on the top-level caller workflow filename**, not a reusable workflow it calls.
+- **OIDC auto-enables provenance, which requires `repository.url`** in each published package.json (`{ "type": "git", "url": "https://github.com/malloydata/malloy" }`). Missing it → publish fails with a `422 ... provenance` error. This is the likely failure when adding a new package.
 
-- **Adding a secret to a job without `needs: check-permission`** exposes that secret to arbitrary external-PR code. The secret-bearing jobs that MUST gate today: `main`, `db-trino`, `db-presto`, `db-bigquery`, `db-snowflake`, `db-databricks`. Secret-free jobs (`db-duckdb`, `db-postgres`, `db-mysql`, `db-publisher`, `db-duckdb-wasm`) deliberately don't gate — they run untrusted code but hold no credentials, so the blast radius is just ephemeral compute. There's a comment to this effect in `run-tests.yaml`; honor it.
-- **Re-running an external PR's CI is an authorization act.** Because the gate trusts the triggering actor, clicking "re-run" on a fork PR makes *you* the authorizer and runs that PR's code with full secrets. Review the diff — especially any change to a workflow or a build script — before you re-run. Never re-run a PR you haven't read.
-- **Don't "simplify" the trigger back to `pull_request`.** That silently strips secret access, and DB tests stop exercising anything real on external PRs.
+**Adding a published package:** add the `repository` field, then register the trusted publisher (the two failure modes above).
 
-The contributor-facing half — DCO sign-off, licensing, the committers list, the review requirement — lives in [CONTRIBUTING.md](../../CONTRIBUTING.md). DCO is enforced as a required status check, which is why bot/release commits use `git commit -s`.
+**Recovering a partial release:** the publish loop skips already-published versions (npm versions are immutable), so fix the cause, merge, and **re-run at the same version** — don't bump. The version bump is the last step, so a failed release correctly leaves the repo at the version it was finishing.
 
-### CI integrity guards
+`prerelease.yaml` is currently inert (not OIDC-wired; the single trusted publisher points at `release.yaml`). Restoring prerelease-on-merge collides with the one-publisher rule — part of the planned publish rework.
 
-`main.yaml` runs two guard scripts before the core tests:
-
-- **`scripts/ci-test-sanity-check.sh`** — diffs every `*.spec.ts(x)` in the tree against `npx jest --listTests`. If you add a test file but don't wire it into a `jest.config.ts` project, CI fails here. The point is that **no test can be silently absent from CI.**
-- **`scripts/ci-env-sanity-check.sh`** — fails if `.node-version` is missing or empty.
-
-### Conventions across the test workflows
-
-- Every workflow starts with `permissions: {}` — least privilege by default. Grant narrowly only where needed (e.g. `release.yaml` adds `contents: write` + `id-token: write`).
-- Each checks out `ref: ${{ github.event.pull_request.head.sha || github.sha }}` — the PR head, falling back to the pushed SHA.
-- Node is pinned to 20.x via `setup-node`. (Note: the runner's bundled npm is old; `release.yaml` upgrades it in-job — see below.)
-- Jobs using duckdb-backed test data run `npm run build-duckdb-db` first; postgres loads its fixture from `test/data/postgres/*.sql.gz`; trino/presto/mysql start and stop a docker service via `test/<db>/<db>_start.sh` / `_stop.sh`.
-
-### Adding a new dialect
-
-Copy an existing `db-<dialect>.yaml` (pick one whose service setup matches — plain, a postgres-style service container, or a docker start/stop script), point it at `npm run ci-<dialect>`, then wire it into `run-tests.yaml`: add the job, add it to the `malloy-tests` `needs:` list, and **add `needs: check-permission` if it uses any secret.**
-
-## How packages are published to npm
-
-### Publishing is OIDC trusted publishing, not a token
-
-Releases authenticate to npm with **GitHub Actions OIDC trusted publishing**, not a stored `NPM_TOKEN`. At publish time GitHub mints a short-lived OIDC token, npm verifies it against a per-package registration, and hands back a publish credential. There is no npm secret in this repo, and one should not be reintroduced — if you find yourself adding `NPM_TOKEN` back, something is wrong.
-
-Each published `@malloydata/*` package has a **trusted publisher** registered on npmjs.com, bound to repo `malloydata/malloy` + workflow `release.yaml`. Registration is done from a maintainer's machine, not from CI:
-
-```bash
-npm trust github @malloydata/<pkg> --file release.yaml --repo malloydata/malloy --allow-publish --yes
-```
-
-This needs npm ≥ 11.10 locally (`npm trust` + bulk support) and a logged-in account that owns the package. The repo's pinned node (`.node-version`) ships an older npm; `npm install -g npm@latest` upgrades it for that node version only. CI does its own `npm install -g npm@latest` inside the job for the same reason.
-
-### Rules that bite (none of these are guessable)
-
-- **One trusted publisher per package.** You cannot trust both `release.yaml` and `prerelease.yaml` for the same package — a second registration is rejected with a 409. Pick one. We chose `release.yaml`.
-- **Matching is on the top-level caller workflow filename.** If a workflow uses a *reusable* workflow (`workflow_call`) to run `npm publish`, npm checks the **calling** workflow's filename, not the reusable one. Register the file that GitHub triggers.
-- **OIDC silently turns on provenance, and provenance hard-requires `repository.url`.** Every published package.json must declare a `repository` field whose URL matches this repo:
-  ```json
-  "repository": { "type": "git", "url": "https://github.com/malloydata/malloy" }
-  ```
-  A package missing this fails publish with a `422 ... Error verifying sigstore provenance bundle`. This is the most likely failure when adding a new package, because the rest of the build won't warn you.
-
-### Adding a new published package — checklist
-
-1. Add the `repository` field above to its `package.json`.
-2. Register its trusted publisher: `npm trust github @malloydata/<pkg> --file release.yaml --repo malloydata/malloy --allow-publish --yes`.
-
-Miss step 1 and the release fails partway (provenance 422). Miss step 2 and it fails on auth.
-
-### The release workflow (`release.yaml`)
-
-`workflow_dispatch` only. Two jobs:
-
-- **`precheck`** — runs `npm run precheck` (dialect-agnostic tests + duckdb). This is the gate; the publish job depends on it, so the privileged publish job only starts once tests are green.
-- **`npm-release`** — builds, publishes each workspace package via OIDC, creates the GitHub Release, then bumps the version (`lerna version patch`) and pushes the `Version x-dev` commit to `main`.
-
-The release gate is deliberately **not** the full dialect matrix that gates a merge. Dialect-specific suites are required checks to *merge to main*, so a regression can't reach main unnoticed; the release just doesn't re-verify them. (See the publish-workflow rework issue for the longer-term plan around this and a merge queue.)
-
-### Recovering from a partial release
-
-The publish loop is idempotent by version: it runs `npm view "$PKG@$VERSION"` and **skips** anything already published. npm versions are immutable, so this is the recovery mechanism — **do not bump the version to recover**.
-
-If a release dies mid-publish (e.g. one package's provenance fails):
-
-1. Fix the cause (usually a missing `repository` field), merge it.
-2. Re-run `release.yaml` at the **same** version. Already-published packages are skipped; the missing ones publish; then the version bump runs.
-
-The version bump is the *last* step, so a failed release leaves the repo at the version it was publishing — which is exactly the precondition for finishing it. A repo stuck at a half-published version is normal and recoverable, not broken.
-
-### prerelease.yaml
-
-Currently **inert** — `workflow_dispatch` only and not wired for OIDC (all packages' single trusted publisher points at `release.yaml`). At one point it published a prerelease on every merge to `main`. Restoring that collides with the one-publisher-per-package rule, so it's part of the planned publish-workflow rework, not a flip-the-trigger change.
-
-### Other repos
-
-The CLI (`malloydata/malloy-cli`, `@malloydata/cli`) and explorer (`malloydata/malloy-explorer`, `@malloydata/malloy-explorer`) publish from their own repos and have their own trusted-publisher registrations against their own workflow files. They are not published from here.
+The CLI (`malloydata/malloy-cli`) and explorer (`malloydata/malloy-explorer`) publish from their own repos with their own registrations.

--- a/.github/workflows/CONTEXT.md
+++ b/.github/workflows/CONTEXT.md
@@ -12,11 +12,35 @@ This directory is the repo's CI and release machinery. The two things you most l
 
 `db-motherduck.yaml` exists but is **commented out** of `run-tests.yaml` — motherduck is not currently run in CI. `db-databricks.yaml` is active.
 
-### The security rule — `pull_request_target` + `check-permission`
+### Safely accepting external PRs (the scary part)
 
-This is the landmine. `run-tests.yaml` triggers on **`pull_request_target`**, not `pull_request`. That means CI runs in the context of the *base* repo and **has access to secrets even for pull requests from forks**. Unguarded, a fork PR could exfiltrate `BIGQUERY_KEY`, `SNOWFLAKE_CONNECTION`, the databricks tokens, etc.
+Read this before touching `run-tests.yaml`. How this repo runs CI on outside contributions is a deliberate design (PR #2087, Jan 2025) that does, on purpose, the exact combination GitHub documents as a privilege-escalation vulnerability. A single job is what keeps it safe, and the safety depends on a human step that's easy to perform carelessly.
 
-The guard is the **`check-permission`** job (`malloydata/check-ci-permissions`), which fails if the PR author lacks write access. **Any job that consumes a secret must declare `needs: check-permission`.** There is an explicit comment to this effect in `run-tests.yaml` — honor it. This is not optional; it's the thing standing between the repo and leaked credentials.
+**Why it's built this way.** Database tests need real credentials (BigQuery, Snowflake, Databricks, …). A normal `pull_request` workflow from a fork gets **no** secrets, so DB tests could never run on external contributions. To allow them, #2087 switched to **`pull_request_target`**, which runs in the *base* repo's context and therefore *has* the secrets — even for fork PRs, with no automatic "approve to run" prompt.
+
+**Why that's dangerous.** The workflow also checks out the PR's head code (`ref: ${{ github.event.pull_request.head.sha || github.sha }}`) and runs `npm ci` + build + test on it. That is **arbitrary code from the PR author executing on a runner that holds production credentials.** `pull_request_target` + checkout-the-PR-head + secrets is *the* canonical Actions footgun: unguarded, a stranger's PR could print or exfiltrate every secret.
+
+**What makes it safe — and the flow.** The **`check-permission`** job (`malloydata/check-ci-permissions`) fails the run unless **`github.triggering_actor`** has write access. It checks the *triggering actor*, **not** the PR author. So:
+
+- A stranger opens a PR → they are the triggering actor → `check-permission` fails → no credentialed job runs.
+- A **maintainer reviews the diff and re-runs CI** → the maintainer becomes the triggering actor → the gate passes → DB tests run with secrets.
+
+A write-access person vouching for the code is the thing that unlocks secret access. That's the intended human-in-the-loop.
+
+**Pitfalls:**
+
+- **Adding a secret to a job without `needs: check-permission`** exposes that secret to arbitrary external-PR code. The secret-bearing jobs that MUST gate today: `main`, `db-trino`, `db-presto`, `db-bigquery`, `db-snowflake`, `db-databricks`. Secret-free jobs (`db-duckdb`, `db-postgres`, `db-mysql`, `db-publisher`, `db-duckdb-wasm`) deliberately don't gate — they run untrusted code but hold no credentials, so the blast radius is just ephemeral compute. There's a comment to this effect in `run-tests.yaml`; honor it.
+- **Re-running an external PR's CI is an authorization act.** Because the gate trusts the triggering actor, clicking "re-run" on a fork PR makes *you* the authorizer and runs that PR's code with full secrets. Review the diff — especially any change to a workflow or a build script — before you re-run. Never re-run a PR you haven't read.
+- **Don't "simplify" the trigger back to `pull_request`.** That silently strips secret access, and DB tests stop exercising anything real on external PRs.
+
+The contributor-facing half — DCO sign-off, licensing, the committers list, the review requirement — lives in [CONTRIBUTING.md](../../CONTRIBUTING.md). DCO is enforced as a required status check, which is why bot/release commits use `git commit -s`.
+
+### CI integrity guards
+
+`main.yaml` runs two guard scripts before the core tests:
+
+- **`scripts/ci-test-sanity-check.sh`** — diffs every `*.spec.ts(x)` in the tree against `npx jest --listTests`. If you add a test file but don't wire it into a `jest.config.ts` project, CI fails here. The point is that **no test can be silently absent from CI.**
+- **`scripts/ci-env-sanity-check.sh`** — fails if `.node-version` is missing or empty.
 
 ### Conventions across the test workflows
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -326,7 +326,7 @@ For deeper context on specific subsystems, see:
 - [packages/malloy-tag/CONTEXT.md](packages/malloy-tag/CONTEXT.md) - Tag language for annotation parsing
 - [packages/malloy-render/CONTEXT.md](packages/malloy-render/CONTEXT.md) - Data visualization and rendering
 - [test/CONTEXT.md](test/CONTEXT.md) - Test organization and infrastructure
-- [.github/workflows/CONTEXT.md](.github/workflows/CONTEXT.md) - CI and release: what CI runs on a PR, the `pull_request_target`/`check-permission` security rule, and how packages are published to npm (OIDC trusted publishing, release gate, recovery)
+- [.github/workflows/CONTEXT.md](.github/workflows/CONTEXT.md) - CI and release: what CI runs, the external-PR security model, and npm publishing (OIDC trusted publishing)
 
 ## Maintaining the CONTEXT Tree
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -326,6 +326,7 @@ For deeper context on specific subsystems, see:
 - [packages/malloy-tag/CONTEXT.md](packages/malloy-tag/CONTEXT.md) - Tag language for annotation parsing
 - [packages/malloy-render/CONTEXT.md](packages/malloy-render/CONTEXT.md) - Data visualization and rendering
 - [test/CONTEXT.md](test/CONTEXT.md) - Test organization and infrastructure
+- [.github/workflows/CONTEXT.md](.github/workflows/CONTEXT.md) - How packages are published to npm (OIDC trusted publishing, release gate, recovery)
 
 ## Maintaining the CONTEXT Tree
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -326,7 +326,7 @@ For deeper context on specific subsystems, see:
 - [packages/malloy-tag/CONTEXT.md](packages/malloy-tag/CONTEXT.md) - Tag language for annotation parsing
 - [packages/malloy-render/CONTEXT.md](packages/malloy-render/CONTEXT.md) - Data visualization and rendering
 - [test/CONTEXT.md](test/CONTEXT.md) - Test organization and infrastructure
-- [.github/workflows/CONTEXT.md](.github/workflows/CONTEXT.md) - How packages are published to npm (OIDC trusted publishing, release gate, recovery)
+- [.github/workflows/CONTEXT.md](.github/workflows/CONTEXT.md) - CI and release: what CI runs on a PR, the `pull_request_target`/`check-permission` security rule, and how packages are published to npm (OIDC trusted publishing, release gate, recovery)
 
 ## Maintaining the CONTEXT Tree
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,14 +50,10 @@ use GitHub pull requests for this purpose. Consult
 [GitHub Help](https://help.github.com/articles/about-pull-requests/) for more
 information on using pull requests.
 
-All pull requests must pass tests. Some of those tests run against real
-databases using credentials that only the Malloy team's CI holds, so **CI does
-not run automatically on pull requests from forks.** A Malloy team member with
-write access reviews the change and triggers the test run; until they do, the
-checks on your PR will stay pending or fail at the permission gate. This is
-expected — it's how we let external contributions run the full database test
-suite without exposing those credentials. If your PR is ready and CI hasn't
-been triggered, reach out via the `#developing` channel on the
+All pull requests must pass tests. Because some tests use database credentials
+that only the Malloy team's CI holds, **CI doesn't run automatically on fork
+PRs** — a Malloy team member reviews and triggers it. If your PR is ready and CI
+hasn't run, reach out via the `#developing` channel on the
 [Malloy Slack](https://malloydata.github.io/slack).
 
 ## Code of Conduct

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,8 +50,15 @@ use GitHub pull requests for this purpose. Consult
 [GitHub Help](https://help.github.com/articles/about-pull-requests/) for more
 information on using pull requests.
 
-All pull requests must pass tests. Outside contributors should contact the Malloy
-team via the`#developing` channel on the [Malloy Slack](https://malloydata.github.io/slack).
+All pull requests must pass tests. Some of those tests run against real
+databases using credentials that only the Malloy team's CI holds, so **CI does
+not run automatically on pull requests from forks.** A Malloy team member with
+write access reviews the change and triggers the test run; until they do, the
+checks on your PR will stay pending or fail at the permission gate. This is
+expected — it's how we let external contributions run the full database test
+suite without exposing those credentials. If your PR is ready and CI hasn't
+been triggered, reach out via the `#developing` channel on the
+[Malloy Slack](https://malloydata.github.io/slack).
 
 ## Code of Conduct
 


### PR DESCRIPTION
Adds an AI guide for `.github/workflows/` — the one part of the lifecycle with no existing CONTEXT.md — plus the contributor-facing half in CONTRIBUTING.md. Covers what CI runs, how external PRs are safely accepted, and how packages are published.

## What CI runs
- `run-tests.yaml` entry point; per-dialect reusable-workflow fan-out (`main.yaml` core + `db-<dialect>.yaml`) and the `malloy-tests` rollup.
- `db-<dialect>.yaml` runs `npm run ci-<dialect>` — the same script you run locally.
- CI integrity guards (`ci-test-sanity-check.sh`, `ci-env-sanity-check.sh`).

## Safely accepting external PRs (the deliberate design from #2087)
- `pull_request_target` grants fork PRs the secrets DB tests need; `check-permission` (keyed on `github.triggering_actor`) is the load-bearing gate.
- The intended flow: a maintainer reviews the diff and re-runs CI, becoming the triggering actor.
- Pitfalls: adding a secret job without the gate; re-running an unreviewed fork PR (which authorizes its code to run with full secrets); "simplifying" back to `pull_request`.
- CONTRIBUTING.md now explains the contributor-facing side (why fork-PR CI doesn't run automatically).

## How publishing works
Captures the knowledge that was non-discoverable during the OIDC migration (#2823) and the partial 0.0.396 release: OIDC trusted publishing (no `NPM_TOKEN`); one trusted publisher per package; matching on the top-level caller workflow filename; provenance requiring `repository.url`; the `precheck` release gate; how to recover from a partial release; `prerelease.yaml` is inert; CLI/explorer publish from their own repos.

Linked from the root `CONTEXT.md` subsystem list.