### PR TITLE
Build the duckdb test database in the release precheck job

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,6 +16,7 @@ jobs:
         run: |
           npm --no-audit --no-fund ci --loglevel error
           npm run build
+          npm run build-duckdb-db
       - name: Precheck (dialect-agnostic tests + duckdb)
         run: npm run precheck
 


### PR DESCRIPTION
The `precheck` gate added in #2825 runs the duckdb jest projects, which open `test/data/duckdb/duckdb_test.db`. The job built the code but not that database, so the release re-run failed:

```
Cannot open database ".../test/data/duckdb/duckdb_test.db" in read-only mode: database does not exist
```

The `db-duckdb` CI job runs `npm run build-duckdb-db` before its tests for exactly this reason. Add the same step to the release `precheck` job.

(The gate worked: `npm-release` was skipped, so nothing half-published. This unblocks finishing the 0.0.396 release.)