### PR TITLE
Route-based annotation API; formalize prefix grammar

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -52,13 +52,14 @@ The Malloy language uses dotted path notation to access nested data. Nested data
 Objects in Malloy (sources, queries, joins, measures, dimensions, `group_by`, `aggregate`, etc.) can have metadata attached via **annotations**.
 
 **Annotation syntax:**
-- `#` marks the beginning of an annotation
-- An annotation continues to end-of-line
-- Annotations apply to objects declared below them
-- In block declarations, block-level annotations apply to all items, and each item can have its own
-- `##` marks **model-level annotations** that apply to the entire model
+- `#` (object) or `##` (model) marks the beginning of an annotation
+- Single-line annotations run to end-of-line: `# tag`, `## model_tag`
+- Block annotations span multiple lines between `#|`/`|#` (object) or `##|`/`|##` (model); the body is dedented to its common leading-whitespace prefix
+- Annotations apply to the construct declared below them; block-level annotations on a multi-item construct (e.g. `dimension: { ... }`) apply to every item
 
-**Annotations are just text** - the design intentionally leaves room for multiple DSLs. Each application extracts its annotations via pattern matching and defines its own syntax. For details on the Malloy Tag Language used for parsing annotations, see [packages/malloy-tag/CONTEXT.md](packages/malloy-tag/CONTEXT.md).
+**Prefix and route.** Everything from the marker (`#`/`##`/`#|`/`##|`) up to the first whitespace is the annotation's **prefix**; it resolves to a **route** — a namespace key like `''` (the renderer's default), `!` (compiler flags), `@` (persistence), `docs`, `myApp`. Routes claimed by an app (`#(myApp) ...`) are how applications stake a namespace and decline MOTLY in favor of their own payload language. The grammar is formalized in [packages/malloy/src/prefix.ts](packages/malloy/src/prefix.ts); MOTLY itself is in [packages/malloy-tag/CONTEXT.md](packages/malloy-tag/CONTEXT.md).
+
+Read annotations on any tagged entity through its `annotations` view (`entity.annotations.parseAsTag(route)` for MOTLY; `entity.annotations.forRoute(route)` for raw text + source offsets when bringing your own parser).
 
 ## Data Model and Type System
 

--- a/packages/malloy-render/.storybook/malloy-stories-indexer.ts
+++ b/packages/malloy-render/.storybook/malloy-stories-indexer.ts
@@ -6,9 +6,6 @@ import {DuckDBConnection} from '@malloydata/db-duckdb';
 import type {Model, URLReader} from '@malloydata/malloy';
 import {SingleConnectionRuntime} from '@malloydata/malloy';
 
-const STORY_MODEL_PREFIX = /##\(story\)\s/;
-const STORY_PREFIX = /#\(story\)\s/;
-
 async function createConnection() {
   // TODO: figure out how to get duckdb.table to load based on taht path, rather than from workingDirectory. so that malloy story files can be anywhere
   const workingDirectory = path.join(__dirname, '../src/stories');
@@ -57,22 +54,23 @@ function getModelStories(materializedModel: Model, fileName: string) {
   const models = materializedModel.explores;
   const modelStories: ModelIndexInput[] = [];
 
-  const isLegacy = materializedModel.tagParse().tag.has('renderer_legacy');
+  const isLegacy = materializedModel.annotations
+    .parseAsTag()
+    .tag.has('renderer_legacy');
   const componentName =
-    materializedModel
-      .tagParse({prefix: STORY_MODEL_PREFIX})
-      .tag.text('component') ?? fileNameToComponentName(fileName);
+    materializedModel.annotations.parseAsTag('story').tag.text('component') ??
+    fileNameToComponentName(fileName);
 
   models.forEach(model => {
     model.allFields
-      .filter(f => f.isQueryField() && f.getTaglines(STORY_PREFIX).length > 0)
+      .filter(f => f.isQueryField() && f.annotations.texts('story').length > 0)
       .forEach(query => {
         modelStories.push({
           type: 'story',
           importPath: fileName,
           title: `Malloy ${isLegacy ? 'Legacy' : 'Next'}/${componentName}`,
           exportName: query.name,
-          name: query.tagParse({prefix: STORY_PREFIX}).tag.text('story'),
+          name: query.annotations.parseAsTag('story').tag.text('story'),
           sourceName: model.name,
           queryName: query.name,
         });

--- a/packages/malloy-render/src/data_tree/fields/base.ts
+++ b/packages/malloy-render/src/data_tree/fields/base.ts
@@ -6,7 +6,7 @@ import {
 } from '../utils';
 import * as Malloy from '@malloydata/malloy-interfaces';
 import type {Tag} from '@malloydata/malloy-tag';
-import {renderTagFromAnnotations, NULL_SYMBOL, notUndefined} from '../../util';
+import {tagFromAnnotations, NULL_SYMBOL, notUndefined} from '../../util';
 import type {
   Field,
   NestField,
@@ -107,7 +107,7 @@ export abstract class FieldBase {
      */
     skipTagParsing = false
   ) {
-    this.tag = renderTagFromAnnotations(this.field.annotations);
+    this.tag = tagFromAnnotations(this.field.annotations);
     this.metadataTag = skipTagParsing
       ? this.tag
       : tagFor(this.field, '#(malloy) ');

--- a/packages/malloy-render/src/util.spec.ts
+++ b/packages/malloy-render/src/util.spec.ts
@@ -8,99 +8,12 @@
 import type * as Malloy from '@malloydata/malloy-interfaces';
 import {
   tagFromAnnotations,
-  renderTagFromAnnotations,
   formatBigNumber,
   formatScaledNumber,
   parseNumberShorthand,
   parseCurrencyShorthand,
   normalizeScale,
 } from './util';
-
-describe('renderTagFromAnnotations namespace support', () => {
-  test('should parse default namespace only', () => {
-    const annotations: Malloy.Annotation[] = [
-      {value: '# bar_chart'},
-      {value: '# size=lg'},
-    ];
-
-    const tag = renderTagFromAnnotations(annotations);
-    expect(tag.has('bar_chart')).toBe(true);
-    expect(tag.text('size')).toBe('lg');
-  });
-
-  test('should parse render namespace only', () => {
-    const annotations: Malloy.Annotation[] = [
-      {value: '#r bar_chart'},
-      {value: '#r size=md'},
-      {value: '#foo baz=42'},
-    ];
-
-    const tag = renderTagFromAnnotations(annotations);
-    expect(tag.has('bar_chart')).toBe(true);
-    expect(tag.text('size')).toBe('md');
-    expect(tag.text('baz')).toBeUndefined();
-  });
-
-  test('should prefer render namespace over default when both exist', () => {
-    const annotations: Malloy.Annotation[] = [
-      {value: '# bar_chart'},
-      {value: '# size=lg'},
-      {value: '#r size=sm'},
-      {value: '#r color=blue'},
-    ];
-
-    const tag = renderTagFromAnnotations(annotations);
-    expect(tag.has('bar_chart')).toBe(true);
-    expect(tag.text('size')).toBe('sm'); // render namespace wins
-    expect(tag.text('color')).toBe('blue'); // only in render namespace
-  });
-
-  test('should merge properties from both namespaces with render taking precedence', () => {
-    const annotations: Malloy.Annotation[] = [
-      {value: '# bar_chart'},
-      {value: '# title="Default Title"'},
-      {value: '# height=100'},
-      {value: '#r title="Render Title"'},
-      {value: '#r width=200'},
-    ];
-
-    const tag = renderTagFromAnnotations(annotations);
-    expect(tag.has('bar_chart')).toBe(true);
-    expect(tag.text('title')).toBe('Render Title'); // render wins
-    expect(tag.text('height')).toBe('100'); // from default namespace
-    expect(tag.text('width')).toBe('200'); // from render namespace
-  });
-
-  test('should handle empty annotations', () => {
-    const tag = renderTagFromAnnotations(undefined);
-    expect(tag).toBeDefined();
-    expect(Object.keys(tag.dict)).toHaveLength(0);
-  });
-
-  test('should handle annotations without matching prefixes', () => {
-    const annotations: Malloy.Annotation[] = [
-      {value: 'no prefix'},
-      {value: '#x wrong prefix'},
-    ];
-
-    const tag = renderTagFromAnnotations(annotations);
-    expect(Object.keys(tag.dict)).toHaveLength(0);
-  });
-
-  test('should handle complex tag structures in both namespaces', () => {
-    const annotations: Malloy.Annotation[] = [
-      {value: '# chart { type=bar x=sales }'},
-      {value: '#r chart { type=line color=red }'},
-    ];
-
-    const tag = renderTagFromAnnotations(annotations);
-    const chartTag = tag.tag('chart');
-    expect(chartTag).toBeDefined();
-    expect(chartTag?.text('type')).toBe('line'); // render wins
-    expect(chartTag?.text('x')).toBe('sales'); // from default
-    expect(chartTag?.text('color')).toBe('red'); // from render
-  });
-});
 
 describe('tagFromAnnotations original behavior', () => {
   test('should preserve original behavior for non-default prefixes', () => {

--- a/packages/malloy-render/src/util.ts
+++ b/packages/malloy-render/src/util.ts
@@ -67,24 +67,6 @@ export function tagFromAnnotations(
   return session.finish();
 }
 
-export function renderTagFromAnnotations(
-  annotations: Malloy.Annotation[] | undefined
-) {
-  // Support both '# ' and '#r ' namespaces for render tags
-  const defaultTagLines =
-    annotations?.map(a => a.value)?.filter(l => l.startsWith('# ')) ?? [];
-  const renderTagLines =
-    annotations?.map(a => a.value)?.filter(l => l.startsWith('#r ')) ?? [];
-
-  // Merge both namespaces with #r taking precedence (later in array)
-  const allLines = [...defaultTagLines, ...renderTagLines];
-  const session = new TagParser();
-  for (const line of allLines) {
-    session.parseAnnotation(line);
-  }
-  return session.finish();
-}
-
 export function getTextWidthCanvas(
   text: string,
   font: string,

--- a/packages/malloy-tag/CONTEXT.md
+++ b/packages/malloy-tag/CONTEXT.md
@@ -1,16 +1,14 @@
 # Malloy Tag Language (MOTLY)
 
-Malloy annotations use a configuration language called MOTLY. The MOTLY language specification and parser live in a separate repository (TODO: add link to MOTLY git repository when available).
+MOTLY is the payload language for Malloy annotations whose route is MOTLY-shaped
+(the empty route `# tag`, the compiler-flag route `##! flag`, etc.). The
+language spec and parser live at
+[github.com/malloydata/motly](https://github.com/malloydata/motly). This
+package wraps the parser with type-safe accessors via a `Tag` class.
 
-MOTLY is a concise, readable syntax for adding structured metadata to Malloy objects through annotations. It's designed to work seamlessly with Malloy's annotation system and can also be used as a standalone configuration language.
-
-## Purpose
-
-While Malloy annotations can contain arbitrary text, the Tag Language provides a standardized way to express structured metadata that is:
-- Human-readable and writable
-- Easy to parse programmatically
-- Flexible enough for various use cases
-- Concise and unobtrusive in code
+Malloy annotations are *just text* — MOTLY is one possible payload format, used
+where it's claimed. Routes that aren't MOTLY-shaped (e.g. `#" markdown`) pass
+their payload through some other parser.
 
 ## Syntax Overview
 
@@ -98,54 +96,46 @@ Two ways to add properties to objects with different semantics:
 
 ## Annotation Prefixes
 
-Different prefixes are used to avoid collision between different uses of annotations:
+Annotations have a **prefix** (everything from `#`/`##` up to the first
+whitespace) that resolves to a **route** — a namespace key. The prefix grammar
+(forms, bracket pairs, malformation warnings) is defined in `packages/malloy`
+(`src/prefix.ts`); this package just parses MOTLY content once a consumer has
+split the prefix off.
 
-- **`# `** (hash-space) - Reserved for Malloy renderer
-- **`#!`** - Compiler directives
-- **`#(docs)`** - Malloy documentation
-- **`#(appName) `** - Encouraged pattern for application-specific tags
+Claimed routes:
 
-Example with application prefix:
-```malloy
-#(myApp) visible theme=dark priority=high
+- **`# tag`** — empty route. Reserved for the Malloy renderer; if you write
+  to it, you are talking to the renderer. Other apps should claim their own
+  route.
+- **`##! flag`** — model-level compiler flag (route `!`, internal sigil).
+- **`#@ persist`** — persistence directive (route `@`, internal sigil).
+- **`#" markdown`** — doc string (route `"`, payload is markdown, not MOTLY).
+- **`#(appName) ...`** — app route. Bracket forms `() <> [] {}` are
+  equivalent (`#(docs)` ≡ `#<docs>`). This is how a new app stakes a
+  namespace.
+
+## Reading tags from a compiled model
+
+Tag reading lives in `packages/malloy`. From a `Taggable` core entity, use
+the `annotations` view to filter by route and parse as MOTLY:
+
+```typescript
+field.annotations.parseAsTag()        // empty route (renderer tags)
+field.annotations.parseAsTag('docs')  // route `docs`
+field.annotations.forRoute('vite')    // raw text + offsets, BYO parser
 ```
 
-## Multi-line Annotations
+The old `tagParse({prefix: /^#@ /})` / `getTaglines(/.../)` RegExp surface is
+deprecated — it can't see block annotations and has no content offsets.
 
-The tag language works with single-line annotations. For multi-line text that is NOT in the tag language:
-
-```malloy
-#" This is a multi-line string annotation
-#" which is NOT in the tag language
-#" but could be displayed as help text
-source: name is VALUE
-```
-
-## Usage Pattern
-
-The expected workflow for using tag annotations:
-
-1. **Write annotations** in Malloy code using tag syntax
-2. **Query annotations** from compiled model using pattern matching (filter by prefix)
-3. **Parse tags** using the malloy-tag package
-4. **Extract values** and use in your application
-
-## Implementation
-
-The `malloy-tag` package provides:
-- **MOTLY parser** via the `motly-ts` package
-- **Tag class** with methods for type-safe value access
-- **Type definitions** for parsed tag structures
-
-### Key API Methods
+## Tag API
 
 ```typescript
 import {Tag} from '@malloydata/malloy-tag';
 
 const {tag, log} = Tag.parse('enabled=@true port=8080 name="My App"');
 
-// Convert to plain JavaScript object
-const obj = tag.toObject();  // { enabled: true, port: 8080, name: "My App" }
+tag.toObject();             // { enabled: true, port: 8080, name: "My App" }
 
 // Type-safe accessors
 tag.text('name');           // "My App"
@@ -158,16 +148,5 @@ tag.has('name');            // true
 
 // Nested access
 tag.text('server', 'host');
-tag.tag('server');          // Get nested Tag object
+tag.tag('server');          // returns a nested Tag
 ```
-
-## Documentation
-
-For complete MOTLY language syntax and examples, see the MOTLY repository (TODO: add link).
-
-## Important Notes
-
-- Not all annotations use the tag language - raw text is also valid
-- The tag language is optional - annotations can be simple strings
-- Each application defines its own conventions for tag usage
-- Tags are metadata only - they don't affect query execution

--- a/packages/malloy-tag/src/parser.ts
+++ b/packages/malloy-tag/src/parser.ts
@@ -25,11 +25,13 @@ export interface SourceOrigin {
 /**
  * Strip the Malloy annotation prefix (e.g., "# " or "#(docs) ") from source.
  * Annotation text starts with # followed by routing characters and a
- * space or newline delimiter. Everything up to and including that delimiter
- * is stripped, leaving just the MOTLY content.
+ * whitespace delimiter (space, tab, CR, or LF — the same separator class
+ * `parsePrefix` uses in core). Everything up to (but not including) the
+ * delimiter is stripped; the delimiter itself is part of the returned
+ * MOTLY content (MOTLY skips leading whitespace).
  */
 function stripPrefix(source: string): string {
-  const skipTo = source.search(/[ \n]/);
+  const skipTo = source.search(/[ \t\r\n]/);
   if (skipTo > 0) {
     return source.slice(skipTo);
   }

--- a/packages/malloy/src/annotation.ts
+++ b/packages/malloy/src/annotation.ts
@@ -1,32 +1,83 @@
 import type {Tag, TagError, SourceOrigin} from '@malloydata/malloy-tag';
 import {TagParser} from '@malloydata/malloy-tag';
-import type {Annotation, Note} from './model';
+import type {Annotation, Note, DocumentLocation} from './model';
 import type {LogMessage} from './lang';
+import {parsePrefix} from './prefix';
 
 export interface TagParseSpec {
   prefix?: RegExp;
 }
 
+/** One annotation addressed to a requested route, in inheritance order. */
+export interface AnnotationText {
+  /** The annotation exactly as written — prefix + content. */
+  rawText: string;
+  /** Offset where the content begins; `rawText.slice(contentIndex)` is the content. */
+  contentIndex: number;
+  /** Where `rawText` begins in the source document. */
+  at: DocumentLocation;
+}
+
+/** An {@link AnnotationText} that also carries its own route (`''` is MOTLY). */
+export interface RoutedAnnotation extends AnnotationText {
+  route: string;
+}
+
+/** Every Note of an annotation, inherited first, in document order. */
+function* notesInOrder(annote: Annotation): Generator<Note> {
+  if (annote.inherits) yield* notesInOrder(annote.inherits);
+  if (annote.blockNotes) yield* annote.blockNotes;
+  if (annote.notes) yield* annote.notes;
+}
+
+/**
+ * Collect annotations by route, using the shared prefix parser.
+ * - no route: every annotation, each carrying its own `route` — the only way to
+ *   reach an annotation whose prefix is malformed.
+ * - a route: only annotations on that route, `route` omitted from each result
+ *   (the caller passed it). Malformed-prefix annotations are never returned here.
+ */
+export function collectAnnotations(
+  annote: Annotation | undefined
+): RoutedAnnotation[];
+export function collectAnnotations(
+  annote: Annotation | undefined,
+  route: string
+): AnnotationText[];
+export function collectAnnotations(
+  annote: Annotation | undefined,
+  route?: string
+): RoutedAnnotation[] | AnnotationText[] {
+  const notes = notesInOrder(annote ?? {});
+  if (route === undefined) {
+    return Array.from(notes, note => {
+      const {route: noteRoute, contentIndex} = parsePrefix(note.text);
+      return {rawText: note.text, contentIndex, at: note.at, route: noteRoute};
+    });
+  }
+  const matching: AnnotationText[] = [];
+  for (const note of notes) {
+    const parsed = parsePrefix(note.text);
+    if (parsed.route === route && parsed.malformation !== 'malformed-route') {
+      matching.push({
+        rawText: note.text,
+        contentIndex: parsed.contentIndex,
+        at: note.at,
+      });
+    }
+  }
+  return matching;
+}
+
 /**
  * Collect all matching Notes from an Annotation, walking the inherits
  * chain. Returns notes in inheritance order (inherited first).
+ *
+ * @deprecated RegExp prefix matching; use {@link collectAnnotations} with a route.
  */
 function collectNotes(annote: Annotation, prefix?: RegExp): Note[] {
-  const inherited = annote.inherits
-    ? collectNotes(annote.inherits, prefix)
-    : [];
-  const allNotes: Note[] = [];
-  if (annote.blockNotes) {
-    allNotes.push(...annote.blockNotes);
-  }
-  if (annote.notes) {
-    allNotes.push(...annote.notes);
-  }
-  if (prefix) {
-    const matching = allNotes.filter(note => note.text.match(prefix));
-    return inherited.concat(matching);
-  }
-  return inherited.concat(allNotes);
+  const notes = [...notesInOrder(annote)];
+  return prefix ? notes.filter(note => note.text.match(prefix)) : notes;
 }
 
 export function annotationToTaglines(

--- a/packages/malloy/src/annotation.ts
+++ b/packages/malloy/src/annotation.ts
@@ -8,18 +8,15 @@ export interface TagParseSpec {
   prefix?: RegExp;
 }
 
-/** One annotation addressed to a requested route, in inheritance order. */
-export interface AnnotationText {
+/** One annotation and the route its prefix resolves to (`''` is MOTLY). */
+export interface RoutedAnnotation {
   /** The annotation exactly as written — prefix + content. */
   rawText: string;
   /** Offset where the content begins; `rawText.slice(contentIndex)` is the content. */
   contentIndex: number;
   /** Where `rawText` begins in the source document. */
   at: DocumentLocation;
-}
-
-/** An {@link AnnotationText} that also carries its own route (`''` is MOTLY). */
-export interface RoutedAnnotation extends AnnotationText {
+  /** The route this annotation's prefix resolves to. */
   route: string;
 }
 
@@ -31,42 +28,31 @@ function* notesInOrder(annote: Annotation): Generator<Note> {
 }
 
 /**
- * Collect annotations by route, using the shared prefix parser.
- * - no route: every annotation, each carrying its own `route` — the only way to
- *   reach an annotation whose prefix is malformed.
- * - a route: only annotations on that route, `route` omitted from each result
- *   (the caller passed it). Malformed-prefix annotations are never returned here.
+ * Collect annotations, using the shared prefix parser. With no `route`, returns
+ * every annotation (the only way to reach one whose prefix is malformed). With a
+ * `route`, returns only annotations on that route, excluding malformed prefixes.
+ * Each result carries its own `route` either way.
  */
-export function collectAnnotations(
-  annote: Annotation | undefined
-): RoutedAnnotation[];
-export function collectAnnotations(
-  annote: Annotation | undefined,
-  route: string
-): AnnotationText[];
 export function collectAnnotations(
   annote: Annotation | undefined,
   route?: string
-): RoutedAnnotation[] | AnnotationText[] {
-  const notes = notesInOrder(annote ?? {});
-  if (route === undefined) {
-    return Array.from(notes, note => {
-      const {route: noteRoute, contentIndex} = parsePrefix(note.text);
-      return {rawText: note.text, contentIndex, at: note.at, route: noteRoute};
-    });
-  }
-  const matching: AnnotationText[] = [];
-  for (const note of notes) {
+): RoutedAnnotation[] {
+  const result: RoutedAnnotation[] = [];
+  for (const note of notesInOrder(annote ?? {})) {
     const parsed = parsePrefix(note.text);
-    if (parsed.route === route && parsed.malformation !== 'malformed-route') {
-      matching.push({
+    const matches =
+      route === undefined ||
+      (parsed.route === route && parsed.malformation !== 'malformed-route');
+    if (matches) {
+      result.push({
         rawText: note.text,
         contentIndex: parsed.contentIndex,
         at: note.at,
+        route: parsed.route,
       });
     }
   }
-  return matching;
+  return result;
 }
 
 /**
@@ -92,29 +78,25 @@ export interface MalloyTagParse {
   log: LogMessage[];
 }
 
-export function annotationToTag(
-  annote: Annotation | undefined,
-  spec: TagParseSpec = {}
+/** Parse a run of annotation lines as MOTLY into one Tag, collecting errors. */
+function parseTaglines(
+  lines: ReadonlyArray<{text: string; at: DocumentLocation}>
 ): MalloyTagParse {
-  const prefix = spec.prefix || /^##? /;
-  annote ||= {};
-  const notes = collectNotes(annote, prefix);
   const allErrs: LogMessage[] = [];
   const session = new TagParser();
-  for (const note of notes) {
+  for (const line of lines) {
     const origin: SourceOrigin = {
-      url: note.at.url,
-      startLine: note.at.range.start.line,
-      startColumn: note.at.range.start.character,
+      url: line.at.url,
+      startLine: line.at.range.start.line,
+      startColumn: line.at.range.start.character,
     };
-    const noteParse = session.parseAnnotation(note.text, origin);
+    const noteParse = session.parseAnnotation(line.text, origin);
     allErrs.push(
-      ...noteParse.log.map((e: TagError) => mapMalloyError(e, note))
+      ...noteParse.log.map((e: TagError) => mapMalloyError(e, line))
     );
   }
   const tag = session.finish();
-  const refErrors = tag.validateReferences();
-  for (const refError of refErrors) {
+  for (const refError of tag.validateReferences()) {
     allErrs.push({
       code: 'tag-reference-error',
       severity: 'warn',
@@ -122,6 +104,31 @@ export function annotationToTag(
     });
   }
   return {tag, log: allErrs};
+}
+
+/** Parse the annotations on `route` (default `''`, the MOTLY tag route) as MOTLY. */
+export function annotationToTag(
+  annote: Annotation | undefined,
+  route?: string
+): MalloyTagParse;
+/**
+ * @deprecated Pass a route string. The RegExp `prefix` form cannot report
+ * content offsets and matches against the whole annotation text.
+ */
+export function annotationToTag(
+  annote: Annotation | undefined,
+  spec: TagParseSpec
+): MalloyTagParse;
+export function annotationToTag(
+  annote: Annotation | undefined,
+  arg?: string | TagParseSpec
+): MalloyTagParse {
+  if (typeof arg === 'object') {
+    const prefix = arg.prefix || /^##? /;
+    return parseTaglines(collectNotes(annote ?? {}, prefix));
+  }
+  const matched = collectAnnotations(annote, arg ?? '');
+  return parseTaglines(matched.map(a => ({text: a.rawText, at: a.at})));
 }
 
 function mapMalloyError(e: TagError, note: Note): LogMessage {

--- a/packages/malloy/src/annotation.ts
+++ b/packages/malloy/src/annotation.ts
@@ -158,10 +158,19 @@ export function annotationToTag(
 }
 
 /**
- * The route-aware annotation API for a tagged entity. All annotation reading
- * lives here, written once; each tagged class only has to say *where* its
- * annotation is (by handing it to the constructor). Unlike the deprecated
- * RegExp readers (`tagParse`/`getTaglines`), this sees block annotations.
+ * The route-aware annotation API for a tagged entity.
+ *
+ * An annotation has a *prefix* (everything from `#`/`##` up to the first
+ * whitespace) that resolves to a *route* — a namespace key. Built-in routes:
+ * `''` (MOTLY tags, the human default), `!` (compiler flags), `@` (persistence
+ * directives), `"` (doc-string markdown). Apps stake their own routes with
+ * brackets: `#(myApp) ...` is route `myApp`. The grammar (forms, bracket
+ * pairs, malformation warnings) lives in `./prefix.ts`.
+ *
+ * All annotation reading lives here, written once; each tagged class only has
+ * to say *where* its annotation is (by handing it to the constructor). Unlike
+ * the deprecated RegExp readers (`tagParse`/`getTaglines`), this sees block
+ * annotations.
  */
 export class Annotations {
   constructor(private readonly annote: Annotation | undefined) {}

--- a/packages/malloy/src/annotation.ts
+++ b/packages/malloy/src/annotation.ts
@@ -22,6 +22,13 @@ export interface AnnotationText {
   contentIndex: number;
   /** Where `rawText` begins in the source document. */
   at: DocumentLocation;
+  /**
+   * For block annotations: characters of leading whitespace removed from
+   * each body line by the translator's dedent pass. A BYO parser that wants
+   * source-mapped error columns adds this to the parser's reported column for
+   * body lines (`source_col = indentStripped + parser_col`).
+   */
+  indentStripped?: number;
 }
 
 /** An {@link AnnotationText} that also carries its route (`''` is MOTLY). */
@@ -57,7 +64,13 @@ export function collectAnnotations(
   if (route === undefined) {
     return Array.from(notesInOrder(annote ?? {}), note => {
       const {route: noteRoute, contentIndex} = parsePrefix(note.text);
-      return {rawText: note.text, contentIndex, at: note.at, route: noteRoute};
+      return {
+        rawText: note.text,
+        contentIndex,
+        at: note.at,
+        route: noteRoute,
+        indentStripped: note.indentStripped,
+      };
     });
   }
   const matching: AnnotationText[] = [];
@@ -68,6 +81,7 @@ export function collectAnnotations(
         rawText: note.text,
         contentIndex: parsed.contentIndex,
         at: note.at,
+        indentStripped: note.indentStripped,
       });
     }
   }
@@ -102,10 +116,8 @@ export interface MalloyTagParse {
   log: LogMessage[];
 }
 
-/** Parse a run of annotation lines as MOTLY into one Tag, collecting errors. */
-function parseTaglines(
-  lines: ReadonlyArray<{text: string; at: DocumentLocation}>
-): MalloyTagParse {
+/** Parse a run of Notes as MOTLY into one Tag, collecting errors. */
+function parseTaglines(lines: ReadonlyArray<Note>): MalloyTagParse {
   const allErrs: LogMessage[] = [];
   const session = new TagParser();
   for (const line of lines) {
@@ -154,7 +166,13 @@ export function annotationToTag(
     return parseTaglines(collectNotes(annote ?? {}, prefix));
   }
   const matched = collectAnnotations(annote, arg ?? '');
-  return parseTaglines(matched.map(a => ({text: a.rawText, at: a.at})));
+  return parseTaglines(
+    matched.map(a => ({
+      text: a.rawText,
+      at: a.at,
+      indentStripped: a.indentStripped,
+    }))
+  );
 }
 
 /**
@@ -207,26 +225,18 @@ export class Annotations {
 }
 
 function mapMalloyError(e: TagError, note: Note): LogMessage {
-  // Calculate prefix length (same logic as stripPrefix in malloy-tag)
-  let prefixLen = 0;
-  if (note.text[0] === '#') {
-    const skipTo = note.text.search(/[ \n]/);
-    if (skipTo > 0) {
-      prefixLen = skipTo;
-    }
-  }
-
-  // Map error position to source location
-  // e.line is 0-based line within the (stripped) input
-  // e.offset is 0-based column within that line
-  // TODO: For block annotations, lines > 0 have indentation stripped by
-  // stripBlockIndent, so e.offset doesn't account for the removed columns.
-  // This makes error squigglies misaligned on block annotation body lines.
+  // MOTLY reports `e.line` / `e.offset` into the *stripped* note text it
+  // parsed. To map back to source:
+  //   line 0 (opener line):    col = opener_col + prefix_len + e.offset
+  //   line N>0 (body lines):   col = indentStripped + e.offset
+  // `indentStripped` is the per-line dedent recorded on the Note by the
+  // translator (uniform per block, so the same formula serves every body
+  // line). Prefix length is everything before the separator, via parsePrefix.
   const line = note.at.range.start.line + e.line;
   const character =
     e.line === 0
-      ? note.at.range.start.character + prefixLen + e.offset
-      : e.offset;
+      ? note.at.range.start.character + prefixLength(note.text) + e.offset
+      : (note.indentStripped ?? 0) + e.offset;
 
   const loc = {line, character};
   return {
@@ -235,10 +245,14 @@ function mapMalloyError(e: TagError, note: Note): LogMessage {
     message: e.message,
     at: {
       url: note.at.url,
-      range: {
-        start: loc,
-        end: loc,
-      },
+      range: {start: loc, end: loc},
     },
   };
+}
+
+/** Length of the annotation prefix per malloy-tag's `stripPrefix`: index of
+ *  the first whitespace, or 0 if none. */
+function prefixLength(text: string): number {
+  const {contentIndex} = parsePrefix(text);
+  return contentIndex === text.length ? 0 : contentIndex - 1;
 }

--- a/packages/malloy/src/annotation.ts
+++ b/packages/malloy/src/annotation.ts
@@ -8,15 +8,18 @@ export interface TagParseSpec {
   prefix?: RegExp;
 }
 
-/** One annotation and the route its prefix resolves to (`''` is MOTLY). */
-export interface RoutedAnnotation {
+/** One annotation, unparsed — its raw text and where its content begins. */
+export interface AnnotationText {
   /** The annotation exactly as written — prefix + content. */
   rawText: string;
   /** Offset where the content begins; `rawText.slice(contentIndex)` is the content. */
   contentIndex: number;
   /** Where `rawText` begins in the source document. */
   at: DocumentLocation;
-  /** The route this annotation's prefix resolves to. */
+}
+
+/** An {@link AnnotationText} that also carries its route (`''` is MOTLY). */
+export interface RoutedAnnotation extends AnnotationText {
   route: string;
 }
 
@@ -28,31 +31,41 @@ function* notesInOrder(annote: Annotation): Generator<Note> {
 }
 
 /**
- * Collect annotations, using the shared prefix parser. With no `route`, returns
- * every annotation (the only way to reach one whose prefix is malformed). With a
- * `route`, returns only annotations on that route, excluding malformed prefixes.
- * Each result carries its own `route` either way.
+ * Collect annotations, using the shared prefix parser.
+ * - no `route`: every annotation, each carrying its own `route` (the only way
+ *   to reach one whose prefix is malformed).
+ * - a `route`: only annotations on that route, `route` omitted from each result
+ *   (you passed it); malformed prefixes excluded.
  */
+export function collectAnnotations(
+  annote: Annotation | undefined
+): RoutedAnnotation[];
+export function collectAnnotations(
+  annote: Annotation | undefined,
+  route: string
+): AnnotationText[];
 export function collectAnnotations(
   annote: Annotation | undefined,
   route?: string
-): RoutedAnnotation[] {
-  const result: RoutedAnnotation[] = [];
+): RoutedAnnotation[] | AnnotationText[] {
+  if (route === undefined) {
+    return Array.from(notesInOrder(annote ?? {}), note => {
+      const {route: noteRoute, contentIndex} = parsePrefix(note.text);
+      return {rawText: note.text, contentIndex, at: note.at, route: noteRoute};
+    });
+  }
+  const matching: AnnotationText[] = [];
   for (const note of notesInOrder(annote ?? {})) {
     const parsed = parsePrefix(note.text);
-    const matches =
-      route === undefined ||
-      (parsed.route === route && parsed.malformation !== 'malformed-route');
-    if (matches) {
-      result.push({
+    if (parsed.route === route && parsed.malformation !== 'malformed-route') {
+      matching.push({
         rawText: note.text,
         contentIndex: parsed.contentIndex,
         at: note.at,
-        route: parsed.route,
       });
     }
   }
-  return result;
+  return matching;
 }
 
 /**
@@ -117,7 +130,7 @@ export function annotationToTag(
  */
 export function annotationToTag(
   annote: Annotation | undefined,
-  spec: TagParseSpec
+  spec?: TagParseSpec
 ): MalloyTagParse;
 export function annotationToTag(
   annote: Annotation | undefined,
@@ -129,6 +142,41 @@ export function annotationToTag(
   }
   const matched = collectAnnotations(annote, arg ?? '');
   return parseTaglines(matched.map(a => ({text: a.rawText, at: a.at})));
+}
+
+/**
+ * The route-aware annotation API for a tagged entity. All annotation reading
+ * lives here, written once; each tagged class only has to say *where* its
+ * annotation is (by handing it to the constructor). Unlike the deprecated
+ * RegExp readers (`tagParse`/`getTaglines`), this sees block annotations.
+ */
+export class Annotations {
+  constructor(private readonly annote: Annotation | undefined) {}
+
+  /**
+   * Every annotation, **unparsed** — each carries its `route` (`''` is the MOTLY
+   * tag route), its `rawText`, and `contentIndex` (where the content begins).
+   * The content itself is not interpreted; parse it yourself, or use
+   * {@link parseAsTag} for the built-in MOTLY reading.
+   */
+  all(): RoutedAnnotation[] {
+    return collectAnnotations(this.annote);
+  }
+
+  /**
+   * Your route's annotations, **unparsed** — the bring-your-own-parser door.
+   * A non-MOTLY app (e.g. JSON on its own route) reads these and parses the
+   * content (`rawText.slice(contentIndex)`) itself. `''` is the MOTLY route;
+   * malformed-prefix annotations are excluded.
+   */
+  forRoute(route: string): AnnotationText[] {
+    return collectAnnotations(this.annote, route);
+  }
+
+  /** Parse a route's annotations as a MOTLY tag. Default `''` is the tag route. */
+  parseAsTag(route = ''): MalloyTagParse {
+    return annotationToTag(this.annote, route);
+  }
 }
 
 function mapMalloyError(e: TagError, note: Note): LogMessage {

--- a/packages/malloy/src/annotation.ts
+++ b/packages/malloy/src/annotation.ts
@@ -154,20 +154,25 @@ export class Annotations {
   constructor(private readonly annote: Annotation | undefined) {}
 
   /**
-   * Every annotation, **unparsed** — each carries its `route` (`''` is the MOTLY
-   * tag route), its `rawText`, and `contentIndex` (where the content begins).
-   * The content itself is not interpreted; parse it yourself, or use
-   * {@link parseAsTag} for the built-in MOTLY reading.
+   * Raw annotation text strings (prefix + content) — all routes if `route` is
+   * omitted, just that route's otherwise. The route-based successor to the
+   * deprecated `getTaglines`. For source-mapped offsets (bring-your-own
+   * parsers), see {@link forRoute}.
    */
-  all(): RoutedAnnotation[] {
-    return collectAnnotations(this.annote);
+  texts(route?: string): string[] {
+    const items =
+      route === undefined
+        ? collectAnnotations(this.annote)
+        : collectAnnotations(this.annote, route);
+    return items.map(a => a.rawText);
   }
 
   /**
-   * Your route's annotations, **unparsed** — the bring-your-own-parser door.
-   * A non-MOTLY app (e.g. JSON on its own route) reads these and parses the
-   * content (`rawText.slice(contentIndex)`) itself. `''` is the MOTLY route;
-   * malformed-prefix annotations are excluded.
+   * Your route's annotations as objects (`rawText` + `contentIndex` + `at`) —
+   * the bring-your-own-parser door. A non-MOTLY app (e.g. JSON on its own
+   * route) reads these to slice the content (`rawText.slice(contentIndex)`)
+   * itself and map its parser's errors back to source via `at`. Malformed-prefix
+   * annotations are excluded.
    */
   forRoute(route: string): AnnotationText[] {
     return collectAnnotations(this.annote, route);

--- a/packages/malloy/src/annotation.ts
+++ b/packages/malloy/src/annotation.ts
@@ -4,6 +4,12 @@ import type {Annotation, Note, DocumentLocation} from './model';
 import type {LogMessage} from './lang';
 import {parsePrefix} from './prefix';
 
+/**
+ * @deprecated Argument shape for the deprecated RegExp form of
+ * {@link annotationToTag}. The RegExp form cannot see block annotations
+ * (`#|`…`|#`). Pass a route string to `annotationToTag` instead, or use the
+ * {@link Annotations} view on a tagged entity.
+ */
 export interface TagParseSpec {
   prefix?: RegExp;
 }
@@ -79,6 +85,11 @@ function collectNotes(annote: Annotation, prefix?: RegExp): Note[] {
   return prefix ? notes.filter(note => note.text.match(prefix)) : notes;
 }
 
+/**
+ * @deprecated The RegExp form cannot see block annotations (`#|`…`|#`). Use
+ * `new Annotations(annote).texts(route)` instead, or the {@link Annotations}
+ * view on a tagged entity (`entity.annotations.texts(route)`).
+ */
 export function annotationToTaglines(
   annote: Annotation | undefined,
   prefix?: RegExp
@@ -125,8 +136,10 @@ export function annotationToTag(
   route?: string
 ): MalloyTagParse;
 /**
- * @deprecated Pass a route string. The RegExp `prefix` form cannot report
- * content offsets and matches against the whole annotation text.
+ * @deprecated The RegExp `prefix` form cannot see block annotations
+ * (`#|`…`|#`) and cannot report content offsets for error mapping. Pass a route
+ * string (the other overload), or use {@link Annotations.parseAsTag} on a
+ * tagged entity.
  */
 export function annotationToTag(
   annote: Annotation | undefined,

--- a/packages/malloy/src/api/CONTEXT.md
+++ b/packages/malloy/src/api/CONTEXT.md
@@ -129,6 +129,23 @@ For the configuration pipeline internals (three states, section compilers, overl
 | `PersistSource` | Wraps a persistable source definition. Provides SQL compilation for persistent sources. |
 | `Result` | Query result with data + schema + metadata. |
 
+### Reading annotations
+
+Every class above implements `Taggable` and exposes annotations through an
+`annotations` view (`packages/malloy/src/annotation.ts`):
+
+```ts
+model.annotations.parseAsTag()           // empty route — renderer tags
+field.annotations.parseAsTag('docs')     // route `docs`, parsed as MOTLY
+field.annotations.texts('!')             // raw strings on the `!` route
+field.annotations.forRoute('vite')       // text + source offsets, BYO parser
+```
+
+`.annotations` sees both single-line and block annotations and routes by
+the prefix grammar in [`src/prefix.ts`](../prefix.ts). The legacy
+`tagParse({prefix: RegExp})` and `getTaglines(RegExp)` methods are
+`@deprecated` and cannot see block annotations — migrate to the view.
+
 ### Flow: Load Model → Get SQL for Named Query
 
 ```

--- a/packages/malloy/src/api/core.ts
+++ b/packages/malloy/src/api/core.ts
@@ -25,10 +25,13 @@ import {
   refIsStructDef,
   safeRecordGet,
 } from '../model';
-import {modelDefToModelInfo, writeLiteralToTag} from '../to_stable';
+import {
+  modelDefToModelInfo,
+  toStableAnnotations,
+  writeLiteralToTag,
+} from '../to_stable';
 import {sqlKey} from '../model/sql_block';
 import type {SQLSourceRequest} from '../lang/translate-response';
-import {Annotations} from '../annotation';
 import {Tag} from '@malloydata/malloy-tag';
 import {DEFAULT_LOG_RANGE, mapLogs, nodeToLiteralValue} from './util';
 import {Timer} from '../timing';
@@ -640,9 +643,7 @@ export function statedCompileQuery(
         defaultRowLimit: state.defaultRowLimit,
       });
       timer.contribute([sqlTimer.stop()]);
-      const modelAnnotations = new Annotations(result.modelDef.annotation)
-        .texts()
-        .map(t => ({value: t}));
+      const modelAnnotations = toStableAnnotations(result.modelDef.annotation);
       let source: StructDef;
       if (query.compositeResolvedSourceDef) {
         source = query.compositeResolvedSourceDef;
@@ -658,9 +659,7 @@ export function statedCompileQuery(
         }
       }
 
-      const sourceAnnotations = new Annotations(source.annotation)
-        .texts()
-        .map(t => ({value: t}));
+      const sourceAnnotations = toStableAnnotations(source.annotation);
       const sourceMetadataTag = Tag.withPrefix('#(malloy) ');
       sourceMetadataTag.set(['source', 'name'], translatedQuery.sourceExplore);
       const sourceArguments =

--- a/packages/malloy/src/api/core.ts
+++ b/packages/malloy/src/api/core.ts
@@ -641,8 +641,8 @@ export function statedCompileQuery(
       });
       timer.contribute([sqlTimer.stop()]);
       const modelAnnotations = new Annotations(result.modelDef.annotation)
-        .all()
-        .map(l => ({value: l.rawText}));
+        .texts()
+        .map(t => ({value: t}));
       let source: StructDef;
       if (query.compositeResolvedSourceDef) {
         source = query.compositeResolvedSourceDef;
@@ -659,8 +659,8 @@ export function statedCompileQuery(
       }
 
       const sourceAnnotations = new Annotations(source.annotation)
-        .all()
-        .map(l => ({value: l.rawText}));
+        .texts()
+        .map(t => ({value: t}));
       const sourceMetadataTag = Tag.withPrefix('#(malloy) ');
       sourceMetadataTag.set(['source', 'name'], translatedQuery.sourceExplore);
       const sourceArguments =

--- a/packages/malloy/src/api/core.ts
+++ b/packages/malloy/src/api/core.ts
@@ -28,7 +28,7 @@ import {
 import {modelDefToModelInfo, writeLiteralToTag} from '../to_stable';
 import {sqlKey} from '../model/sql_block';
 import type {SQLSourceRequest} from '../lang/translate-response';
-import {annotationToTaglines} from '../annotation';
+import {Annotations} from '../annotation';
 import {Tag} from '@malloydata/malloy-tag';
 import {DEFAULT_LOG_RANGE, mapLogs, nodeToLiteralValue} from './util';
 import {Timer} from '../timing';
@@ -640,11 +640,9 @@ export function statedCompileQuery(
         defaultRowLimit: state.defaultRowLimit,
       });
       timer.contribute([sqlTimer.stop()]);
-      const modelAnnotations = annotationToTaglines(
-        result.modelDef.annotation
-      ).map(l => ({
-        value: l,
-      }));
+      const modelAnnotations = new Annotations(result.modelDef.annotation)
+        .all()
+        .map(l => ({value: l.rawText}));
       let source: StructDef;
       if (query.compositeResolvedSourceDef) {
         source = query.compositeResolvedSourceDef;
@@ -660,11 +658,9 @@ export function statedCompileQuery(
         }
       }
 
-      const sourceAnnotations = annotationToTaglines(source.annotation).map(
-        l => ({
-          value: l,
-        })
-      );
+      const sourceAnnotations = new Annotations(source.annotation)
+        .all()
+        .map(l => ({value: l.rawText}));
       const sourceMetadataTag = Tag.withPrefix('#(malloy) ');
       sourceMetadataTag.set(['source', 'name'], translatedQuery.sourceExplore);
       const sourceArguments =

--- a/packages/malloy/src/api/foundation/core.ts
+++ b/packages/malloy/src/api/foundation/core.ts
@@ -1838,8 +1838,8 @@ export class PreparedResult implements Taggable {
     const struct = structs[structs.length - 1];
     const schema = {fields: convertFieldInfos(struct, struct.fields)};
     const annotations = new Annotations(this.inner.annotation)
-      .all()
-      .map(l => ({value: l.rawText}));
+      .texts()
+      .map(t => ({value: t}));
     const metadataAnnot = struct.resultMetadata
       ? getResultStructMetadataAnnotation(struct, struct.resultMetadata)
       : undefined;
@@ -1878,8 +1878,8 @@ export class PreparedResult implements Taggable {
     });
 
     const modelAnnotations = new Annotations(this.modelDef.annotation)
-      .all()
-      .map(l => ({value: l.rawText}));
+      .texts()
+      .map(t => ({value: t}));
 
     return {
       schema,

--- a/packages/malloy/src/api/foundation/core.ts
+++ b/packages/malloy/src/api/foundation/core.ts
@@ -1280,7 +1280,7 @@ export class Model implements Taggable {
    */
   public getBuildPlan(): BuildPlan {
     // Require experimental.persistence compiler flag
-    const modelTag = this.tagParse({prefix: /^##! /}).tag;
+    const modelTag = this.annotations.parseAsTag('!').tag;
     if (!modelTag.has('experimental', 'persistence')) {
       throw new Error(
         'Model must have ##! experimental.persistence to use getBuildPlan()'

--- a/packages/malloy/src/api/foundation/core.ts
+++ b/packages/malloy/src/api/foundation/core.ts
@@ -68,7 +68,11 @@ import {
 } from '../../model/given_binding';
 import {Tag} from '@malloydata/malloy-tag';
 import type {MalloyTagParse, TagParseSpec} from '../../annotation';
-import {annotationToTag, annotationToTaglines} from '../../annotation';
+import {
+  annotationToTag,
+  annotationToTaglines,
+  Annotations,
+} from '../../annotation';
 import type * as Malloy from '@malloydata/malloy-interfaces';
 import {
   convertFieldInfos,
@@ -272,6 +276,10 @@ export class Explore extends Entity implements Taggable {
 
   getTaglines(prefix?: RegExp): string[] {
     return annotationToTaglines(this._structDef.annotation, prefix);
+  }
+
+  get annotations(): Annotations {
+    return new Annotations(this._structDef.annotation);
   }
 
   private parsedModelTag?: Tag;
@@ -641,6 +649,10 @@ export class AtomicField extends Entity implements Taggable {
     return annotationToTaglines(this.fieldTypeDef.annotation, prefix);
   }
 
+  get annotations(): Annotations {
+    return new Annotations(this.fieldTypeDef.annotation);
+  }
+
   public isIntrinsic(): boolean {
     return fieldIsIntrinsic(this.fieldTypeDef);
   }
@@ -912,6 +924,10 @@ export class QueryField extends Query implements Taggable {
     return annotationToTaglines(this.turtleDef.annotation, prefix);
   }
 
+  get annotations(): Annotations {
+    return new Annotations(this.turtleDef.annotation);
+  }
+
   public isQueryField(): this is QueryField {
     return true;
   }
@@ -977,6 +993,10 @@ export class ExploreField extends Explore {
 
   override tagParse(spec?: TagParseSpec) {
     return annotationToTag(this._structDef.annotation, spec);
+  }
+
+  override get annotations(): Annotations {
+    return new Annotations(this._structDef.annotation);
   }
 
   public isQueryField(): this is QueryField {
@@ -1100,6 +1120,10 @@ export class Model implements Taggable {
 
   getTaglines(prefix?: RegExp) {
     return annotationToTaglines(this.modelDef.annotation, prefix);
+  }
+
+  get annotations(): Annotations {
+    return new Annotations(this.modelDef.annotation);
   }
 
   /**
@@ -1434,6 +1458,10 @@ export class PersistSource implements Taggable {
     return this.explore.getTaglines(prefix);
   }
 
+  get annotations(): Annotations {
+    return this.explore.annotations;
+  }
+
   /**
    * The connection name for this source.
    */
@@ -1552,6 +1580,10 @@ export class Given implements Taggable {
   getTaglines(prefix?: RegExp): string[] {
     return annotationToTaglines(this._internal.annotation, prefix);
   }
+
+  get annotations(): Annotations {
+    return new Annotations(this._internal.annotation);
+  }
 }
 
 export class PreparedQuery implements Taggable {
@@ -1576,6 +1608,10 @@ export class PreparedQuery implements Taggable {
 
   getTaglines(prefix?: RegExp) {
     return annotationToTaglines(this._query.annotation, prefix);
+  }
+
+  get annotations(): Annotations {
+    return new Annotations(this._query.annotation);
   }
 
   /**
@@ -1703,6 +1739,10 @@ export class PreparedResult implements Taggable {
 
   getTaglines(prefix?: RegExp) {
     return annotationToTaglines(this.inner.annotation, prefix);
+  }
+
+  get annotations(): Annotations {
+    return new Annotations(this.inner.annotation);
   }
 
   get annotation(): Annotation | undefined {

--- a/packages/malloy/src/api/foundation/core.ts
+++ b/packages/malloy/src/api/foundation/core.ts
@@ -77,6 +77,7 @@ import type * as Malloy from '@malloydata/malloy-interfaces';
 import {
   convertFieldInfos,
   getResultStructMetadataAnnotation,
+  toStableAnnotations,
   writeLiteralToTag,
 } from '../../to_stable';
 import {nodeToLiteralValue} from '../util';
@@ -1837,9 +1838,7 @@ export class PreparedResult implements Taggable {
     const structs = this.inner.structs;
     const struct = structs[structs.length - 1];
     const schema = {fields: convertFieldInfos(struct, struct.fields)};
-    const annotations = new Annotations(this.inner.annotation)
-      .texts()
-      .map(t => ({value: t}));
+    const annotations = toStableAnnotations(this.inner.annotation);
     const metadataAnnot = struct.resultMetadata
       ? getResultStructMetadataAnnotation(struct, struct.resultMetadata)
       : undefined;
@@ -1877,9 +1876,7 @@ export class PreparedResult implements Taggable {
         .toString(),
     });
 
-    const modelAnnotations = new Annotations(this.modelDef.annotation)
-      .texts()
-      .map(t => ({value: t}));
+    const modelAnnotations = toStableAnnotations(this.modelDef.annotation);
 
     return {
       schema,

--- a/packages/malloy/src/api/foundation/core.ts
+++ b/packages/malloy/src/api/foundation/core.ts
@@ -284,9 +284,9 @@ export class Explore extends Entity implements Taggable {
 
   private parsedModelTag?: Tag;
   public get modelTag(): Tag {
-    this.parsedModelTag ||= annotationToTag(
+    this.parsedModelTag ||= new Annotations(
       this._structDef.modelAnnotation
-    ).tag;
+    ).parseAsTag().tag;
     return this.parsedModelTag;
   }
 
@@ -1754,7 +1754,7 @@ export class PreparedResult implements Taggable {
   }
 
   get modelTag(): Tag {
-    return annotationToTag(this.modelDef.annotation).tag;
+    return new Annotations(this.modelDef.annotation).parseAsTag().tag;
   }
 
   /**
@@ -1837,9 +1837,9 @@ export class PreparedResult implements Taggable {
     const structs = this.inner.structs;
     const struct = structs[structs.length - 1];
     const schema = {fields: convertFieldInfos(struct, struct.fields)};
-    const annotations = annotationToTaglines(this.inner.annotation).map(l => ({
-      value: l,
-    }));
+    const annotations = new Annotations(this.inner.annotation)
+      .all()
+      .map(l => ({value: l.rawText}));
     const metadataAnnot = struct.resultMetadata
       ? getResultStructMetadataAnnotation(struct, struct.resultMetadata)
       : undefined;
@@ -1877,11 +1877,9 @@ export class PreparedResult implements Taggable {
         .toString(),
     });
 
-    const modelAnnotations = annotationToTaglines(this.modelDef.annotation).map(
-      l => ({
-        value: l,
-      })
-    );
+    const modelAnnotations = new Annotations(this.modelDef.annotation)
+      .all()
+      .map(l => ({value: l.rawText}));
 
     return {
       schema,

--- a/packages/malloy/src/api/foundation/runtime.ts
+++ b/packages/malloy/src/api/foundation/runtime.ts
@@ -1343,7 +1343,7 @@ export class QueryMaterializer extends FluentState<PreparedQuery> {
         buildManifest = undefined;
       }
       if (buildManifest) {
-        const modelTag = preparedQuery.model.tagParse({prefix: /^##! /}).tag;
+        const modelTag = preparedQuery.model.annotations.parseAsTag('!').tag;
         if (!modelTag.has('experimental', 'persistence')) {
           if (explicitManifest) {
             // Explicitly passed non-empty manifest requires persistence support

--- a/packages/malloy/src/lang/composite-source-utils.ts
+++ b/packages/malloy/src/lang/composite-source-utils.ts
@@ -54,7 +54,7 @@ import {
 } from '../model/malloy_types';
 import {isNotUndefined} from './utils';
 import {pathToKey} from '../model/utils';
-import {annotationToTag} from '../annotation';
+import {Annotations} from '../annotation';
 
 type CompositeCouldNotFindFieldError = {
   code: 'could_not_find_field';
@@ -735,7 +735,7 @@ export function getPartitionCompositeDesc(
   logTo: MalloyElement
 ): PartitionCompositeDesc | undefined {
   if (annotation === undefined) return undefined;
-  const compilerFlags = annotationToTag(annotation, {prefix: /^#!\s*/}).tag;
+  const compilerFlags = new Annotations(annotation).parseAsTag('!').tag;
   const partitionCompositeTag = compilerFlags.tag(
     'experimental',
     'partition_composite'

--- a/packages/malloy/src/lang/malloy-to-ast.ts
+++ b/packages/malloy/src/lang/malloy-to-ast.ts
@@ -37,6 +37,7 @@ import type {
 import {makeLogMessage} from './parse-log';
 import type {MalloyParseInfo} from './malloy-parse-info';
 import {Interval as StreamInterval} from 'antlr4ts/misc/Interval';
+import {parsePrefix} from '../prefix';
 import type {FieldDeclarationConstructor} from './ast';
 import {TableSource} from './ast';
 import type {HasString, HasID} from './parse-utils';
@@ -387,7 +388,25 @@ export class MalloyToAST
         severity: 'warn',
       });
     });
+    this.warnIfMalformedPrefix(text, cx);
     return {text: text, at: this.getLocation(cx)};
+  }
+
+  /**
+   * Warn if the annotation prefix is not a well-formed route. The note is still
+   * stored either way — the malformation only drives the diagnostic, never the
+   * IR. Warnings fire at note construction; inherited annotations carry no
+   * malformation marker through the IR and are not re-warned by importers.
+   */
+  private warnIfMalformedPrefix(text: string, cx: ParserRuleContext): void {
+    const parsed = parsePrefix(text);
+    if (parsed.malformation === undefined) return;
+    // The slice up to contentIndex is "prefix + separator"; trim trailing
+    // whitespace to land on the prefix the user wrote. (A no-content single-
+    // line note like `#malformed\n` exposes this: contentIndex === text.length
+    // but the slice still ends at the `\n`.)
+    const prefix = text.slice(0, parsed.contentIndex).replace(/\s+$/, '');
+    this.contextError(cx, parsed.malformation, {prefix});
   }
 
   protected getNotes(cx: HasAnnotations): Note[] {
@@ -2169,10 +2188,11 @@ export class MalloyToAST
         );
       }
     }
-    const allNotes = pcx.docAnnotation().map(a => ({
-      text: getAnnotationText(a),
-      at: this.getLocation(pcx),
-    }));
+    const allNotes = pcx.docAnnotation().map(a => {
+      const text = getAnnotationText(a);
+      this.warnIfMalformedPrefix(text, a);
+      return {text, at: this.getLocation(pcx)};
+    });
     const tags = new ast.ModelAnnotation(allNotes);
     this.updateCompilerFlags(tags);
     return tags;

--- a/packages/malloy/src/lang/malloy-to-ast.ts
+++ b/packages/malloy/src/lang/malloy-to-ast.ts
@@ -48,7 +48,7 @@ import {
   getShortString,
   idToStr,
   getPlainString,
-  getAnnotationText,
+  noteFromAnnotation,
 } from './parse-utils';
 import type {
   AccessModifierLabel,
@@ -383,13 +383,9 @@ export class MalloyToAST
   }
 
   protected getAnnotation(cx: parse.AnnotationContext): Note {
-    const text = getAnnotationText(cx, (wcx, msg) => {
-      this.contextError(wcx, 'block-annotation-warning', msg, {
-        severity: 'warn',
-      });
-    });
-    this.warnIfMalformedPrefix(text, cx);
-    return {text: text, at: this.getLocation(cx)};
+    const note = noteFromAnnotation(cx, this.parseInfo);
+    this.warnIfMalformedPrefix(note.text, cx);
+    return note;
   }
 
   /**
@@ -2188,10 +2184,10 @@ export class MalloyToAST
         );
       }
     }
-    const allNotes = pcx.docAnnotation().map(a => {
-      const text = getAnnotationText(a);
-      this.warnIfMalformedPrefix(text, a);
-      return {text, at: this.getLocation(pcx)};
+    const allNotes: Note[] = pcx.docAnnotation().map(a => {
+      const note = noteFromAnnotation(a, this.parseInfo);
+      this.warnIfMalformedPrefix(note.text, a);
+      return note;
     });
     const tags = new ast.ModelAnnotation(allNotes);
     this.updateCompilerFlags(tags);

--- a/packages/malloy/src/lang/malloy-to-stable-query.ts
+++ b/packages/malloy/src/lang/malloy-to-stable-query.ts
@@ -117,9 +117,9 @@ export class MalloyToQuery
   protected getAnnotations(
     cx: HasAnnotations
   ): Malloy.Annotation[] | undefined {
-    const annotations = cx.annotation().map(a => {
-      return {value: getAnnotationText(a)};
-    });
+    const annotations = cx.annotation().map(a => ({
+      value: getAnnotationText(a),
+    }));
     return annotations.length > 0 ? annotations : undefined;
   }
 

--- a/packages/malloy/src/lang/parse-log.ts
+++ b/packages/malloy/src/lang/parse-log.ts
@@ -380,7 +380,6 @@ type MessageParameterTypes = {
   'failed-to-parse-function-name': string;
   'orphaned-object-annotation': string;
   'unclosed-block-annotation': string;
-  'block-annotation-warning': string;
   'malformed-route': {prefix: string};
   'reserved-route': {prefix: string};
   'misplaced-model-annotation': string;

--- a/packages/malloy/src/lang/parse-log.ts
+++ b/packages/malloy/src/lang/parse-log.ts
@@ -381,6 +381,8 @@ type MessageParameterTypes = {
   'orphaned-object-annotation': string;
   'unclosed-block-annotation': string;
   'block-annotation-warning': string;
+  'malformed-route': {prefix: string};
+  'reserved-route': {prefix: string};
   'misplaced-model-annotation': string;
   'unexpected-non-source-query-expression-node': string;
   'sql-not-like': string;
@@ -514,6 +516,14 @@ export const MESSAGE_FORMATTERS: PartialErrorCodeMessageMap = {
   'restricted-construct-forbidden': e => ({
     message: e,
     tag: 'restricted-mode',
+  }),
+  'malformed-route': e => ({
+    message: `Annotation prefix \`${e.prefix}\` is not a well-formed route — write \`# ...\` for a tag (note the space) or \`#(name)\` for an app route`,
+    severity: 'warn',
+  }),
+  'reserved-route': e => ({
+    message: `Annotation prefix \`${e.prefix}\` uses an unclaimed sigil; punct-only prefixes are reserved for Malloy's own use`,
+    severity: 'warn',
   }),
 };
 

--- a/packages/malloy/src/lang/parse-malloy.ts
+++ b/packages/malloy/src/lang/parse-malloy.ts
@@ -633,9 +633,7 @@ class TranslateStep implements TranslationStep {
     if (extendingModel && !this.importedAnnotations) {
       const parseCompilerFlagsTimer = new Timer('parse_compiler_flags');
       that.compilerFlagSrc.push(
-        ...new Annotations(extendingModel.annotation)
-          .forRoute('!')
-          .map(a => a.rawText)
+        ...new Annotations(extendingModel.annotation).texts('!')
       );
 
       stepTimer.contribute([parseCompilerFlagsTimer.stop()]);

--- a/packages/malloy/src/lang/parse-malloy.ts
+++ b/packages/malloy/src/lang/parse-malloy.ts
@@ -81,7 +81,7 @@ import type {MalloyParseInfo} from './malloy-parse-info';
 import {walkForModelAnnotation} from './parse-tree-walkers/model-annotation-walker';
 import {walkForTablePath} from './parse-tree-walkers/find-table-path-walker';
 import type {EventStream} from '../runtime_types';
-import {annotationToTaglines} from '../annotation';
+import {Annotations} from '../annotation';
 import {runMalloyParser} from './run-malloy-parser';
 import type {ParserRuleContext} from 'antlr4ts';
 import {Timer} from '../timing';
@@ -633,7 +633,9 @@ class TranslateStep implements TranslationStep {
     if (extendingModel && !this.importedAnnotations) {
       const parseCompilerFlagsTimer = new Timer('parse_compiler_flags');
       that.compilerFlagSrc.push(
-        ...annotationToTaglines(extendingModel.annotation, /^##! /)
+        ...new Annotations(extendingModel.annotation)
+          .forRoute('!')
+          .map(a => a.rawText)
       );
 
       stepTimer.contribute([parseCompilerFlagsTimer.stop()]);

--- a/packages/malloy/src/lang/parse-tree-walkers/model-annotation-walker.ts
+++ b/packages/malloy/src/lang/parse-tree-walkers/model-annotation-walker.ts
@@ -21,18 +21,14 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import type {CommonTokenStream, ParserRuleContext} from 'antlr4ts';
+import type {CommonTokenStream} from 'antlr4ts';
 import {ParseTreeWalker} from 'antlr4ts/tree/ParseTreeWalker';
 import type {MalloyParserListener} from '../lib/Malloy/MalloyParserListener';
 import type * as parser from '../lib/Malloy/MalloyParser';
 import type {MalloyTranslation} from '../parse-malloy';
-import type {
-  Annotation,
-  DocumentLocation,
-  Note,
-} from '../../model/malloy_types';
+import type {Annotation, Note} from '../../model/malloy_types';
 import type {MalloyParseInfo} from '../malloy-parse-info';
-import {getAnnotationText} from '../parse-utils';
+import {noteFromAnnotation} from '../parse-utils';
 
 class ModelAnnotationWalker implements MalloyParserListener {
   private readonly notes: Note[] = [];
@@ -42,19 +38,10 @@ class ModelAnnotationWalker implements MalloyParserListener {
     private readonly parseInfo: MalloyParseInfo
   ) {}
 
-  protected getLocation(cx: ParserRuleContext): DocumentLocation {
-    return {
-      url: this.parseInfo.sourceURL,
-      range: this.translator.rangeFromContext(cx),
-    };
-  }
-
   enterDocAnnotations(pcx: parser.DocAnnotationsContext): void {
-    const allNotes: Note[] = pcx.docAnnotation().map(a => ({
-      text: getAnnotationText(a),
-      at: this.getLocation(pcx),
-    }));
-    this.notes.push(...allNotes);
+    for (const a of pcx.docAnnotation()) {
+      this.notes.push(noteFromAnnotation(a, this.parseInfo));
+    }
   }
 
   get annotation(): Annotation {

--- a/packages/malloy/src/lang/parse-utils.ts
+++ b/packages/malloy/src/lang/parse-utils.ts
@@ -232,7 +232,20 @@ function stripBlockIndent(
 }
 
 function stripTrailingNewline(s: string): string {
-  return s.endsWith('\n') ? s.slice(0, -1) : s;
+  // A trailing line ending may be CRLF or LF — strip either.
+  return s.replace(/\r?\n$/, '');
+}
+
+/**
+ * Annotation note text is normalized to LF line endings, so a block's stored
+ * text and content are identical regardless of the source's CRLF/LF style.
+ * The lexer keeps the source `\r` in token text (it sits at line ends, after a
+ * line's content); this is where it is dropped. Offsets are unaffected for the
+ * opener line, and block body-line column mapping is already approximate (see
+ * the TODO in annotation.ts mapMalloyError).
+ */
+function normalizeEol(s: string): string {
+  return s.replace(/\r\n/g, '\n');
 }
 
 export function getAnnotationText(
@@ -241,11 +254,29 @@ export function getAnnotationText(
 ): string {
   if (cx instanceof AnnotationContext) {
     const annot = cx.ANNOTATION();
-    if (annot) return annot.text;
+    if (annot) return normalizeEol(annot.text);
     const block = cx.blockAnnotation()!;
     const beginToken = block.BLOCK_ANNOTATION_BEGIN();
     const textLines = block.BLOCK_ANNOTATION_TEXT().map(t => t.text);
-    return stripTrailingNewline(
+    return normalizeEol(
+      stripTrailingNewline(
+        beginToken.text +
+          stripBlockIndent(
+            textLines,
+            beginToken.symbol.charPositionInLine,
+            cx,
+            warn
+          )
+      )
+    );
+  }
+  const doc = cx.DOC_ANNOTATION();
+  if (doc) return normalizeEol(doc.text);
+  const block = cx.docBlockAnnotation()!;
+  const beginToken = block.DOC_BLOCK_ANNOTATION_BEGIN();
+  const textLines = block.BLOCK_ANNOTATION_TEXT().map(t => t.text);
+  return normalizeEol(
+    stripTrailingNewline(
       beginToken.text +
         stripBlockIndent(
           textLines,
@@ -253,20 +284,6 @@ export function getAnnotationText(
           cx,
           warn
         )
-    );
-  }
-  const doc = cx.DOC_ANNOTATION();
-  if (doc) return doc.text;
-  const block = cx.docBlockAnnotation()!;
-  const beginToken = block.DOC_BLOCK_ANNOTATION_BEGIN();
-  const textLines = block.BLOCK_ANNOTATION_TEXT().map(t => t.text);
-  return stripTrailingNewline(
-    beginToken.text +
-      stripBlockIndent(
-        textLines,
-        beginToken.symbol.charPositionInLine,
-        cx,
-        warn
-      )
+    )
   );
 }

--- a/packages/malloy/src/lang/parse-utils.ts
+++ b/packages/malloy/src/lang/parse-utils.ts
@@ -31,6 +31,9 @@ import {
   AnnotationContext,
 } from './lib/Malloy/MalloyParser';
 import {ParseUtil} from '@malloydata/malloy-tag';
+import type {DocumentLocation, Note} from '../model/malloy_types';
+import type {MalloyParseInfo} from './malloy-parse-info';
+import {rangeFromContext} from './utils';
 
 /**
  * Take the text of a matched string, including the matching quote
@@ -199,36 +202,47 @@ export function getPlainString(
   return ['', errorList];
 }
 
-type AnnotationWarn = (cx: ParserRuleContext, msg: string) => void;
-
-function stripBlockIndent(
-  lines: string[],
-  column: number,
-  cx: ParserRuleContext,
-  warn?: AnnotationWarn
-): string {
-  if (column === 0) {
-    return lines.join('');
+/**
+ * Python `textwrap.dedent`-style: find the longest leading-whitespace prefix
+ * common to every non-blank body line and strip it from each line that starts
+ * with it. Blank (whitespace-only) lines don't constrain the prefix. Returns
+ * the stripped text and the number of characters removed per line — the
+ * latter is stored on the `Note` so payload-parser error columns can be
+ * mapped back to source (`source_col = indentStripped + parser_col`).
+ *
+ * Replaces an older "strip exactly opener_column spaces" rule that fired
+ * warnings for less-indented lines and had no clean column mapping when
+ * stripping was inconsistent. Common prefix is uniform per block, so column
+ * mapping is one number per block.
+ */
+function dedentBlockLines(lines: string[]): {
+  text: string;
+  indentStripped: number;
+} {
+  let common: string | undefined;
+  for (const line of lines) {
+    const content = line.replace(/\r?\n$/, '');
+    if (!/\S/.test(content)) continue;
+    const indent = content.match(/^[ \t]*/)![0];
+    if (common === undefined) {
+      common = indent;
+      continue;
+    }
+    let n = 0;
+    while (n < common.length && n < indent.length && common[n] === indent[n]) {
+      n++;
+    }
+    common = common.slice(0, n);
+    if (common === '') break;
   }
-  const prefix = ' '.repeat(column);
-  let warnedLeft = false;
-  let warnedTab = false;
-  return lines
-    .map(line => {
-      if (warn && !warnedTab && line.slice(0, column).includes('\t')) {
-        warn(cx, 'Block annotation indentation contains tabs, use spaces');
-        warnedTab = true;
-      }
-      if (line.startsWith(prefix)) {
-        return line.slice(column);
-      }
-      if (warn && !warnedLeft && !warnedTab && line.match(/\S/)) {
-        warn(cx, 'Block annotation content is left of the opening #|');
-        warnedLeft = true;
-      }
-      return line;
-    })
-    .join('');
+  const prefix = common ?? '';
+  if (prefix === '') return {text: lines.join(''), indentStripped: 0};
+  return {
+    text: lines
+      .map(line => (line.startsWith(prefix) ? line.slice(prefix.length) : line))
+      .join(''),
+    indentStripped: prefix.length,
+  };
 }
 
 function stripTrailingNewline(s: string): string {
@@ -240,50 +254,66 @@ function stripTrailingNewline(s: string): string {
  * Annotation note text is normalized to LF line endings, so a block's stored
  * text and content are identical regardless of the source's CRLF/LF style.
  * The lexer keeps the source `\r` in token text (it sits at line ends, after a
- * line's content); this is where it is dropped. Offsets are unaffected for the
- * opener line, and block body-line column mapping is already approximate (see
- * the TODO in annotation.ts mapMalloyError).
+ * line's content); this is where it is dropped.
  */
 function normalizeEol(s: string): string {
   return s.replace(/\r\n/g, '\n');
 }
 
-export function getAnnotationText(
-  cx: AnnotationContext | DocAnnotationContext,
-  warn?: AnnotationWarn
-): string {
+/**
+ * Read the text and dedent amount of an annotation from its parse tree.
+ * Internal — public callers want `noteFromAnnotation` or `getAnnotationText`.
+ */
+function readAnnotation(cx: AnnotationContext | DocAnnotationContext): {
+  text: string;
+  indentStripped: number;
+} {
   if (cx instanceof AnnotationContext) {
     const annot = cx.ANNOTATION();
-    if (annot) return normalizeEol(annot.text);
+    if (annot) return {text: normalizeEol(annot.text), indentStripped: 0};
     const block = cx.blockAnnotation()!;
     const beginToken = block.BLOCK_ANNOTATION_BEGIN();
     const textLines = block.BLOCK_ANNOTATION_TEXT().map(t => t.text);
-    return normalizeEol(
-      stripTrailingNewline(
-        beginToken.text +
-          stripBlockIndent(
-            textLines,
-            beginToken.symbol.charPositionInLine,
-            cx,
-            warn
-          )
-      )
-    );
+    const dedented = dedentBlockLines(textLines);
+    return {
+      text: normalizeEol(stripTrailingNewline(beginToken.text + dedented.text)),
+      indentStripped: dedented.indentStripped,
+    };
   }
   const doc = cx.DOC_ANNOTATION();
-  if (doc) return normalizeEol(doc.text);
+  if (doc) return {text: normalizeEol(doc.text), indentStripped: 0};
   const block = cx.docBlockAnnotation()!;
   const beginToken = block.DOC_BLOCK_ANNOTATION_BEGIN();
   const textLines = block.BLOCK_ANNOTATION_TEXT().map(t => t.text);
-  return normalizeEol(
-    stripTrailingNewline(
-      beginToken.text +
-        stripBlockIndent(
-          textLines,
-          beginToken.symbol.charPositionInLine,
-          cx,
-          warn
-        )
-    )
-  );
+  const dedented = dedentBlockLines(textLines);
+  return {
+    text: normalizeEol(stripTrailingNewline(beginToken.text + dedented.text)),
+    indentStripped: dedented.indentStripped,
+  };
+}
+
+/**
+ * Build the IR `Note` for an annotation: reads the text, dedents the body if
+ * it's a block, and computes the source `at` from the parse context. The
+ * single entry point for going from a parse-tree annotation to an IR note.
+ */
+export function noteFromAnnotation(
+  cx: AnnotationContext | DocAnnotationContext,
+  parseInfo: MalloyParseInfo
+): Note {
+  const {text, indentStripped} = readAnnotation(cx);
+  const at: DocumentLocation = {
+    url: parseInfo.sourceURL,
+    range: rangeFromContext(parseInfo.sourceInfo, cx),
+  };
+  const note: Note = {text, at};
+  if (indentStripped > 0) note.indentStripped = indentStripped;
+  return note;
+}
+
+/** Text-only reader, for callers that don't need an IR `Note`. */
+export function getAnnotationText(
+  cx: AnnotationContext | DocAnnotationContext
+): string {
+  return readAnnotation(cx).text;
 }

--- a/packages/malloy/src/lang/test/annotation.spec.ts
+++ b/packages/malloy/src/lang/test/annotation.spec.ts
@@ -901,7 +901,7 @@ describe('block annotations', () => {
     const na = m.getSourceDef('na');
     expect(na).toBeDefined();
     expect(na!.annotation).matchesAnnotation({
-      blockNotes: ['#|\n  content line'],
+      blockNotes: ['#|\ncontent line'],
     });
   });
   test('simple model block annotation', () => {
@@ -914,7 +914,7 @@ describe('block annotations', () => {
     const md = m.translate()?.modelDef;
     expect(md).toBeDefined();
     expect(md!.annotation).matchesAnnotation({
-      notes: ['##|\n  model content'],
+      notes: ['##|\nmodel content'],
     });
   });
   test('empty block annotation', () => {
@@ -941,7 +941,7 @@ describe('block annotations', () => {
     const na = m.getSourceDef('na');
     expect(na).toBeDefined();
     expect(na!.annotation).matchesAnnotation({
-      blockNotes: ['#|(markdown)\n  content'],
+      blockNotes: ['#|(markdown)\ncontent'],
     });
   });
   test('block annotation at column 0', () => {
@@ -990,8 +990,10 @@ describe('block annotations', () => {
     expect(m).toTranslate();
     const na = m.getSourceDef('na');
     expect(na).toBeDefined();
+    // Body lines share 8 leading spaces; the deeper `|#` line keeps its
+    // extra 2 spaces of relative indent.
     expect(na!.annotation).matchesAnnotation({
-      blockNotes: ['#|\n  content\n    |# not a closer\n  more content'],
+      blockNotes: ['#|\ncontent\n  |# not a closer\nmore content'],
     });
   });
   test('|# in middle of line is not a closer', () => {
@@ -1005,7 +1007,7 @@ describe('block annotations', () => {
     const na = m.getSourceDef('na');
     expect(na).toBeDefined();
     expect(na!.annotation).matchesAnnotation({
-      blockNotes: ['#|\n  some |# text'],
+      blockNotes: ['#|\nsome |# text'],
     });
   });
   test('mixed single-line and block annotations', () => {
@@ -1020,7 +1022,7 @@ describe('block annotations', () => {
     const na = m.getSourceDef('na');
     expect(na).toBeDefined();
     expect(na!.annotation).matchesAnnotation({
-      blockNotes: ['# single\n', '#|\n  block content'],
+      blockNotes: ['# single\n', '#|\nblock content'],
     });
   });
   test('unclosed block annotation', () => {
@@ -1062,7 +1064,10 @@ describe('block annotations', () => {
       blockNotes: ['#|\nnoted'],
     });
   });
-  test('indentation stripping based on opener column', () => {
+  // The body lines share 12 leading spaces; all 12 are stripped — including
+  // any "extra" indent beyond the opener. The dedent rule cares about what
+  // body lines share, not the opener's column.
+  test('dedent strips the common leading prefix of body lines', () => {
     const m = new TestTranslator(`
       source: na is a extend {
         #|
@@ -1077,10 +1082,10 @@ describe('block annotations', () => {
     expect(na).toBeDefined();
     const x = getFieldDef(na!, 'x');
     expect(x.annotation).matchesAnnotation({
-      blockNotes: ['#|\n    line one\n    line two'],
+      blockNotes: ['#|\nline one\nline two'],
     });
   });
-  test('indentation stripping preserves relative indent', () => {
+  test('dedent preserves relative indent past the common prefix', () => {
     const m = new TestTranslator(`
       source: na is a extend {
         #|
@@ -1096,10 +1101,10 @@ describe('block annotations', () => {
     expect(na).toBeDefined();
     const x = getFieldDef(na!, 'x');
     expect(x.annotation).matchesAnnotation({
-      blockNotes: ['#|\n  outer\n    inner\n  outer'],
+      blockNotes: ['#|\nouter\n  inner\nouter'],
     });
   });
-  test('indentation stripping ignores blank lines', () => {
+  test('blank lines do not constrain the common prefix', () => {
     const m = new TestTranslator(`
       source: na is a extend {
         #|
@@ -1115,34 +1120,53 @@ describe('block annotations', () => {
     expect(na).toBeDefined();
     const x = getFieldDef(na!, 'x');
     expect(x.annotation).matchesAnnotation({
-      blockNotes: ['#|\n  line one\n\n  line two'],
+      blockNotes: ['#|\nline one\n\nline two'],
     });
   });
-  test('warns when content is left of opener', () => {
-    expect(`
+  // The point of switching to Python-style dedent: pasting flush-left code
+  // inside a block annotation no longer warns and no longer mangles the body.
+  // The shortest non-blank line wins the common prefix (here, 0).
+  test('flush-left content among indented body produces zero strip', () => {
+    const m = new TestTranslator(`
       source: na is a extend {
         #|
-    TOO FAR LEFT
+          line one
+flush left line
+          line three
         |#
         dimension: x is 1
       }
-    `).toLog(
-      warningMessage('Block annotation content is left of the opening #|')
-    );
+    `);
+    expect(m).toTranslate();
+    const na = m.getSourceDef('na');
+    expect(na).toBeDefined();
+    const x = getFieldDef(na!, 'x');
+    expect(x.annotation).matchesAnnotation({
+      blockNotes: [
+        '#|\n          line one\nflush left line\n          line three',
+      ],
+    });
   });
-  test('warns when indentation contains tabs', () => {
-    expect(`
+  test('tabs and spaces mix limits the common prefix', () => {
+    const m = new TestTranslator(`
       source: na is a extend {
         #|
-\t\tcontent
+\tcontent
+        more content
         |#
         dimension: x is 1
       }
-    `).toLog(
-      warningMessage('Block annotation indentation contains tabs, use spaces')
-    );
+    `);
+    expect(m).toTranslate();
+    const na = m.getSourceDef('na');
+    expect(na).toBeDefined();
+    const x = getFieldDef(na!, 'x');
+    // Tab vs spaces share no leading-WS prefix → no stripping, no warning.
+    expect(x.annotation).matchesAnnotation({
+      blockNotes: ['#|\n\tcontent\n        more content'],
+    });
   });
-  test('no stripping when opener at column 0', () => {
+  test('opener at column 0 still dedents body by common prefix', () => {
     const m = new TestTranslator(
       '#|\n    indented content\n|#\nsource: na is a\n'
     );
@@ -1150,7 +1174,7 @@ describe('block annotations', () => {
     const na = m.getSourceDef('na');
     expect(na).toBeDefined();
     expect(na!.annotation).matchesAnnotation({
-      blockNotes: ['#|\n    indented content'],
+      blockNotes: ['#|\nindented content'],
     });
   });
 });
@@ -1459,5 +1483,34 @@ describe('route warnings', () => {
       blockNotes: ['# good_child\n'],
       inherits: {blockNotes: ['#malformed_parent\n']},
     });
+  });
+});
+
+describe('mapMalloyError body-line column', () => {
+  // Construct a block annotation by hand and assert tag-parse error columns
+  // map back to source correctly. The opener is at line 5 column 4; the body
+  // line was at column 10 in source; dedent stripped 6 chars. So any
+  // body-line error must land at column 6 + parser_offset.
+  test('body-line errors land at indentStripped + parser_offset', () => {
+    const note: Note = {
+      text: '#|\n=oops',
+      at: {
+        url: 'test://x',
+        range: {
+          start: {line: 5, character: 4},
+          end: {line: 5, character: 6},
+        },
+      },
+      indentStripped: 6,
+    };
+    const annote: Annotation = {notes: [note]};
+    const errs = annotationToTag(annote).log.filter(
+      l => l.code === 'tag-parse-error'
+    );
+    expect(errs.length).toBeGreaterThan(0);
+    const e = errs[0];
+    expect(e.at?.range.start.line).toBe(6);
+    // `=` is at IR-line offset 0; source col = indentStripped (6) + 0.
+    expect(e.at?.range.start.character).toBe(6);
   });
 });

--- a/packages/malloy/src/lang/test/annotation.spec.ts
+++ b/packages/malloy/src/lang/test/annotation.spec.ts
@@ -32,7 +32,7 @@ import {
 import './parse-expects';
 import {diff} from 'jest-diff';
 import type {Annotation, Note} from '../../model/malloy_types';
-import {collectAnnotations} from '../../annotation';
+import {collectAnnotations, annotationToTag} from '../../annotation';
 
 interface TstAnnotation {
   inherits?: TstAnnotation;
@@ -1295,7 +1295,7 @@ describe('collectAnnotations (route-based)', () => {
     ]);
   });
 
-  test('a route filters to that route and omits route from the results', () => {
+  test('a route filters to that route; each result carries that route', () => {
     const annote: Annotation = {
       notes: [note('#(docs) one'), note('# tag'), note('#(docs) two')],
     };
@@ -1304,8 +1304,7 @@ describe('collectAnnotations (route-based)', () => {
       'one',
       'two',
     ]);
-    // The AnnotationText overload has no `route` field.
-    expect(docs.every(a => !('route' in a))).toBe(true);
+    expect(docs.every(a => a.route === 'docs')).toBe(true);
   });
 
   test('a malformed prefix is excluded from its route query, present in all', () => {
@@ -1332,5 +1331,17 @@ describe('collectAnnotations (route-based)', () => {
   test('undefined annotation yields nothing', () => {
     expect(collectAnnotations(undefined)).toEqual([]);
     expect(collectAnnotations(undefined, 'docs')).toEqual([]);
+  });
+
+  test('annotationToTag parses the requested route as MOTLY', () => {
+    const annote: Annotation = {
+      notes: [note('# size=large'), note('#(viz) chart=bar')],
+    };
+    // default route '' is the MOTLY tag namespace
+    expect(annotationToTag(annote).tag.text('size')).toBe('large');
+    expect(annotationToTag(annote).tag.text('chart')).toBeUndefined();
+    // a named route parses only that route's content
+    expect(annotationToTag(annote, 'viz').tag.text('chart')).toBe('bar');
+    expect(annotationToTag(annote, 'viz').tag.text('size')).toBeUndefined();
   });
 });

--- a/packages/malloy/src/lang/test/annotation.spec.ts
+++ b/packages/malloy/src/lang/test/annotation.spec.ts
@@ -1486,6 +1486,25 @@ describe('route warnings', () => {
   });
 });
 
+describe('tab-separated annotations round-trip to MOTLY', () => {
+  // parsePrefix accepts space, tab, CR, and LF as the prefix/content boundary;
+  // malloy-tag's stripPrefix must agree, or a tab-separated annotation gets
+  // selected for a route but its payload is silently dropped before MOTLY
+  // sees it.
+  const at: Note['at'] = {
+    url: 'test://x',
+    range: {start: {line: 0, character: 0}, end: {line: 0, character: 0}},
+  };
+  test('tab after marker — empty route, MOTLY parses payload', () => {
+    const annote: Annotation = {notes: [{text: '#\tfoo=true\n', at}]};
+    expect(annotationToTag(annote).tag.has('foo')).toBe(true);
+  });
+  test('tab after sigil route — `!` route, MOTLY parses payload', () => {
+    const annote: Annotation = {notes: [{text: '##!\tflag=on\n', at}]};
+    expect(annotationToTag(annote, '!').tag.text('flag')).toBe('on');
+  });
+});
+
 describe('mapMalloyError body-line column', () => {
   // Construct a block annotation by hand and assert tag-parse error columns
   // map back to source correctly. The opener is at line 5 column 4; the body

--- a/packages/malloy/src/lang/test/annotation.spec.ts
+++ b/packages/malloy/src/lang/test/annotation.spec.ts
@@ -31,7 +31,8 @@ import {
 } from './test-translator';
 import './parse-expects';
 import {diff} from 'jest-diff';
-import type {Annotation} from '../../model/malloy_types';
+import type {Annotation, Note} from '../../model/malloy_types';
+import {collectAnnotations} from '../../annotation';
 
 interface TstAnnotation {
   inherits?: TstAnnotation;
@@ -1273,5 +1274,63 @@ describe('user type annotation', () => {
         notes: ['# from s2\n'],
       },
     });
+  });
+});
+
+describe('collectAnnotations (route-based)', () => {
+  const at: Note['at'] = {
+    url: 'test://x',
+    range: {start: {line: 0, character: 0}, end: {line: 0, character: 0}},
+  };
+  const note = (text: string): Note => ({text, at});
+
+  test('no route returns every annotation, each carrying its route', () => {
+    const annote: Annotation = {
+      notes: [note('# tag1'), note('#(docs) hello'), note('#! flag')],
+    };
+    expect(collectAnnotations(annote).map(a => a.route)).toEqual([
+      '',
+      'docs',
+      '!',
+    ]);
+  });
+
+  test('a route filters to that route and omits route from the results', () => {
+    const annote: Annotation = {
+      notes: [note('#(docs) one'), note('# tag'), note('#(docs) two')],
+    };
+    const docs = collectAnnotations(annote, 'docs');
+    expect(docs.map(a => a.rawText.slice(a.contentIndex))).toEqual([
+      'one',
+      'two',
+    ]);
+    // The AnnotationText overload has no `route` field.
+    expect(docs.every(a => !('route' in a))).toBe(true);
+  });
+
+  test('a malformed prefix is excluded from its route query, present in all', () => {
+    // `#docs` (no brackets) is malformed; its best-effort route is still 'docs'.
+    const annote: Annotation = {notes: [note('#docs'), note('#(docs) ok')]};
+    const docs = collectAnnotations(annote, 'docs');
+    expect(docs.map(a => a.rawText)).toEqual(['#(docs) ok']);
+    expect(collectAnnotations(annote).map(a => a.rawText)).toContain('#docs');
+  });
+
+  test('inherited annotations come first', () => {
+    const parent: Annotation = {notes: [note('#(docs) parent')]};
+    const child: Annotation = {
+      inherits: parent,
+      notes: [note('#(docs) child')],
+    };
+    expect(
+      collectAnnotations(child, 'docs').map(a =>
+        a.rawText.slice(a.contentIndex)
+      )
+    ).toEqual(['parent', 'child']);
+  });
+
+  test('undefined annotation yields nothing', () => {
+    expect(collectAnnotations(undefined)).toEqual([]);
+    expect(collectAnnotations(undefined, 'docs')).toEqual([]);
   });
 });

--- a/packages/malloy/src/lang/test/annotation.spec.ts
+++ b/packages/malloy/src/lang/test/annotation.spec.ts
@@ -1339,10 +1339,8 @@ describe('collectAnnotations (route-based)', () => {
     const annote: Annotation = {
       notes: [note('# size=large'), note('#(viz) chart=bar')],
     };
-    // default route '' is the MOTLY tag namespace
     expect(annotationToTag(annote).tag.text('size')).toBe('large');
     expect(annotationToTag(annote).tag.text('chart')).toBeUndefined();
-    // a named route parses only that route's content
     expect(annotationToTag(annote, 'viz').tag.text('chart')).toBe('bar');
     expect(annotationToTag(annote, 'viz').tag.text('size')).toBeUndefined();
   });

--- a/packages/malloy/src/lang/test/annotation.spec.ts
+++ b/packages/malloy/src/lang/test/annotation.spec.ts
@@ -953,6 +953,29 @@ describe('block annotations', () => {
       blockNotes: ['#|\nline one\nline two'],
     });
   });
+  test('CRLF block annotation normalizes to LF note text', () => {
+    // Windows line endings: the lexer keeps the \r in token text; the note
+    // must come out byte-identical to the LF version above (internal \r and the
+    // trailing \r\n both gone), so an annotation does not depend on EOL style.
+    const m = new TestTranslator(
+      '#|\r\nline one\r\nline two\r\n|#\r\nsource: na is a\r\n'
+    );
+    expect(m).toTranslate();
+    const na = m.getSourceDef('na');
+    expect(na).toBeDefined();
+    expect(na!.annotation).matchesAnnotation({
+      blockNotes: ['#|\nline one\nline two'],
+    });
+  });
+  test('CRLF single-line annotation normalizes to LF (trailing newline kept)', () => {
+    const m = new TestTranslator('## modelNote\r\nsource: na is a\r\n');
+    expect(m).toTranslate();
+    const md = m.translate()?.modelDef;
+    expect(md).toBeDefined();
+    expect(md!.annotation).matchesAnnotation({
+      notes: ['## modelNote\n'],
+    });
+  });
   test('indented closer must match opener column', () => {
     const m = new TestTranslator(`
       #|

--- a/packages/malloy/src/lang/test/annotation.spec.ts
+++ b/packages/malloy/src/lang/test/annotation.spec.ts
@@ -1295,7 +1295,7 @@ describe('collectAnnotations (route-based)', () => {
     ]);
   });
 
-  test('a route filters to that route; each result carries that route', () => {
+  test('a route filters to that route and omits route from results', () => {
     const annote: Annotation = {
       notes: [note('#(docs) one'), note('# tag'), note('#(docs) two')],
     };
@@ -1304,7 +1304,8 @@ describe('collectAnnotations (route-based)', () => {
       'one',
       'two',
     ]);
-    expect(docs.every(a => a.route === 'docs')).toBe(true);
+    // The route-filtered form returns AnnotationText — no `route` field.
+    expect(docs.every(a => !('route' in a))).toBe(true);
   });
 
   test('a malformed prefix is excluded from its route query, present in all', () => {

--- a/packages/malloy/src/lang/test/annotation.spec.ts
+++ b/packages/malloy/src/lang/test/annotation.spec.ts
@@ -27,6 +27,7 @@ import {
   getFieldDef,
   getQueryFieldDef,
   model,
+  warning,
   warningMessage,
 } from './test-translator';
 import './parse-expects';
@@ -1344,5 +1345,121 @@ describe('collectAnnotations (route-based)', () => {
     // a named route parses only that route's content
     expect(annotationToTag(annote, 'viz').tag.text('chart')).toBe('bar');
     expect(annotationToTag(annote, 'viz').tag.text('size')).toBeUndefined();
+  });
+});
+
+describe('route warnings', () => {
+  test('bare-word object prefix warns malformed-route once', () => {
+    expect(`
+      source: na is a extend {
+        #malformed
+        dimension: x is 1
+      }
+    `).toLog(warning('malformed-route', {prefix: '#malformed'}));
+  });
+
+  test('bare-word model prefix warns malformed-route', () => {
+    expect('##malformed\nsource: na is a\n').toLog(
+      warning('malformed-route', {prefix: '##malformed'})
+    );
+  });
+
+  test('unclosed bracket warns malformed-route', () => {
+    expect(`
+      source: na is a extend {
+        #(docs
+        dimension: x is 1
+      }
+    `).toLog(warning('malformed-route', {prefix: '#(docs'}));
+  });
+
+  test('unclaimed sigil warns reserved-route', () => {
+    expect(`
+      source: na is a extend {
+        #% nope
+        dimension: x is 1
+      }
+    `).toLog(warning('reserved-route', {prefix: '#%'}));
+  });
+
+  test('well-formed prefixes do not warn', () => {
+    expect(`
+      ##! flag
+      source: na is a extend {
+        # tag
+        #(docs) hello
+        #! flag2
+        #@ persist
+        #" desc
+        dimension: x is 1
+      }
+    `).toTranslate();
+  });
+
+  // The dedup case: a block-level note attaches to every item inside the
+  // block, but is constructed once at the parse site — so we must warn once,
+  // not N times. Three malformed prefixes in source → exactly three warnings.
+  test('block-level note dedups to one warning per source annotation', () => {
+    expect(`
+      source: na is a extend {
+        #malformed
+        dimension:
+          #mf2
+          x is 1
+          #mf3
+          y is 2
+      }
+    `).toLog(
+      // The block-level note (`#malformed`) is emitted after the inner items
+      // because the AST builder visits inner item annotations first, then
+      // assembles the block-level annotation list.
+      warning('malformed-route', {prefix: '#mf2'}),
+      warning('malformed-route', {prefix: '#mf3'}),
+      warning('malformed-route', {prefix: '#malformed'})
+    );
+  });
+
+  test('block annotation with malformed route warns once', () => {
+    expect(`
+      source: na is a extend {
+        #|malformed
+        body
+        |#
+        dimension: x is 1
+      }
+    `).toLog(warning('malformed-route', {prefix: '#|malformed'}));
+  });
+
+  // `inherits` is populated when a child source has its own notes AND extends
+  // a parent source: `define-source.ts` does
+  // `entry.annotation = {...this.note, inherits: structDef.annotation}`.
+  // The inherited Notes never re-flow through getAnnotation, so the warning
+  // fires only at the parse site even though the malformed Note ends up
+  // reachable from child.annotation.inherits.
+  test('extend populates `inherits`; malformed parent note warns once', () => {
+    const m = new TestTranslator(`
+      #malformed_parent
+      source: parent is a extend { dimension: x is 1 }
+
+      # good_child
+      source: child is parent extend { dimension: y is 2 }
+    `);
+    m.translate();
+    // Exactly one problem total — the parent-site warning — even though the
+    // malformed Note is also reachable through child.annotation.inherits.
+    expect(m.problemResponse().problems).toEqual([
+      expect.objectContaining({
+        code: 'malformed-route',
+        severity: 'warn',
+        data: {prefix: '#malformed_parent'},
+      }),
+    ]);
+    // And inherits is in fact populated — the malformed note is reachable
+    // through child.annotation.inherits, proving the chain is live.
+    const child = m.getSourceDef('child');
+    expect(child!.annotation).matchesAnnotation({
+      blockNotes: ['# good_child\n'],
+      inherits: {blockNotes: ['#malformed_parent\n']},
+    });
   });
 });

--- a/packages/malloy/src/model/CONTEXT.md
+++ b/packages/malloy/src/model/CONTEXT.md
@@ -53,6 +53,38 @@ The compiler consumes **Intermediate Representation (IR)** produced by the trans
   - Field references and path expressions
 - Forms a complete expression tree that can be compiled to SQL
 
+### Annotations in the IR
+
+Annotations attach to any IR entity with an `annotation?: Annotation` field:
+
+```ts
+interface Annotation {
+  inherits?: Annotation;     // parent's annotation when this entity is derived
+  blockNotes?: Note[];       // block-level notes shared across items in a block
+  notes?: Note[];            // notes attached directly to this entity
+}
+interface Note { text: string; at: DocumentLocation; }
+```
+
+`text` is the raw source, marker and prefix included. Routes are derived at
+retrieval by `parsePrefix` (`../prefix.ts`); the Note stores no route. **Read
+through the `Annotations` view (`../annotation.ts`)** — it flattens
+`inherits` and filters by route. Walking the three buckets yourself is a
+smell.
+
+`inherits` is populated when an entity *derives* from another (most
+prominently `source: child is parent extend { ... }` in
+`lang/ast/statements/define-source.ts`, but also model-extends-model in
+`malloy-element.ts:initModelDef`, queries in `define-query.ts`, and several
+field-space sites). Grep for `inherits:` in `lang/ast/` for the full list.
+
+**One Note, many paths.** `MalloyToAST.getAnnotation` builds each source-level
+annotation exactly once; the same `Note` object then appears on every entity
+that earns it — directly via `notes`/`blockNotes`, transitively via
+`inherits`. Construction-time diagnostics (e.g. the prefix `malformed-route`
+/ `reserved-route` warnings) fire once per source annotation, not once per
+reachable copy.
+
 ## Compilation Pipeline
 
 ```

--- a/packages/malloy/src/model/CONTEXT.md
+++ b/packages/malloy/src/model/CONTEXT.md
@@ -63,14 +63,26 @@ interface Annotation {
   blockNotes?: Note[];       // block-level notes shared across items in a block
   notes?: Note[];            // notes attached directly to this entity
 }
-interface Note { text: string; at: DocumentLocation; }
+interface Note {
+  text: string;
+  at: DocumentLocation;
+  indentStripped?: number;   // characters dedented per body line (block notes)
+}
 ```
 
-`text` is the raw source, marker and prefix included. Routes are derived at
-retrieval by `parsePrefix` (`../prefix.ts`); the Note stores no route. **Read
-through the `Annotations` view (`../annotation.ts`)** — it flattens
-`inherits` and filters by route. Walking the three buckets yourself is a
-smell.
+`text` is the annotation **as stored**: the marker and prefix are kept
+verbatim, line endings are LF-normalized, and for block annotations the body
+is dedented (`indentStripped` records how many leading characters were
+removed per non-blank body line). Routes are derived at retrieval by
+`parsePrefix` (`../prefix.ts`); the Note stores no route. **Read through the
+`Annotations` view (`../annotation.ts`)** — it flattens `inherits` and
+filters by route. Walking the three buckets yourself is a smell.
+
+`indentStripped` is what lets payload-parser error columns map back to
+source: for a body line, `source_col = indentStripped + parser_col`. The
+`Annotations` view's `mapMalloyError` and the BYO-door `forRoute(route)`
+both surface this — consumers parsing non-MOTLY content can compute their
+own source columns the same way.
 
 `inherits` is populated when an entity *derives* from another (most
 prominently `source: child is parent extend { ... }` in

--- a/packages/malloy/src/model/malloy_types.ts
+++ b/packages/malloy/src/model/malloy_types.ts
@@ -2072,6 +2072,13 @@ export interface Annotation {
 export interface Note {
   text: string;
   at: DocumentLocation;
+  /**
+   * For block annotations: characters of leading whitespace removed from each
+   * body line by the dedent pass. Used to map payload-parser error columns
+   * back to source (`source_col = indentStripped + parser_col` for body lines).
+   * Omitted for single-line notes and blocks with no common indent.
+   */
+  indentStripped?: number;
 }
 /** Annotations with a uuid to make it easier to stream */
 export interface ModelAnnotation extends Annotation {

--- a/packages/malloy/src/model/persist_utils.ts
+++ b/packages/malloy/src/model/persist_utils.ts
@@ -20,7 +20,7 @@ import {
   safeRecordGet,
 } from './malloy_types';
 import {resolveSourceID} from './source_def_utils';
-import {annotationToTag} from '../annotation';
+import {Annotations} from '../annotation';
 import type {LogMessage} from '../lang';
 import type {BuildNode} from '../api/foundation/types';
 
@@ -44,7 +44,7 @@ export function checkPersistAnnotation(source: SourceDef): {
   log: LogMessage[];
 } {
   if (!source.annotation) return {persist: false, log: []};
-  const {tag, log} = annotationToTag(source.annotation, {prefix: /^#@ /});
+  const {tag, log} = new Annotations(source.annotation).parseAsTag('@');
   return {persist: tag.has('persist'), log};
 }
 

--- a/packages/malloy/src/model/query_node.ts
+++ b/packages/malloy/src/model/query_node.ts
@@ -42,7 +42,7 @@ import {
   expressionIsCalculation,
 } from './malloy_types';
 import type {EventStream} from '../runtime_types';
-import {annotationToTag} from '../annotation';
+import {Annotations} from '../annotation';
 import type {Tag} from '@malloydata/malloy-tag';
 import type {Dialect, FieldReferenceType} from '../dialect';
 import {getDialect} from '../dialect';
@@ -328,7 +328,7 @@ export class QueryStruct {
   modelCompilerFlags(): Tag {
     if (this._modelTag === undefined) {
       const annotation = this.structDef.modelAnnotation;
-      const {tag} = annotationToTag(annotation, {prefix: /^##!\s*/});
+      const {tag} = new Annotations(annotation).parseAsTag('!');
       this._modelTag = tag;
     }
     return this._modelTag;

--- a/packages/malloy/src/prefix.spec.ts
+++ b/packages/malloy/src/prefix.spec.ts
@@ -1,0 +1,129 @@
+/*
+ * Copyright Contributors to the Malloy project
+ * SPDX-License-Identifier: MIT
+ */
+
+import {parsePrefix} from './prefix';
+
+describe('parsePrefix', () => {
+  describe('Form 1: empty routing -> MOTLY', () => {
+    test.each(['# foo=1', '#\tfoo', '## foo=1', '##\tfoo'])(
+      '%j -> route ""',
+      text => {
+        const p = parsePrefix(text);
+        expect(p.route).toBe('');
+        expect(p.malformation).toBeUndefined();
+      }
+    );
+
+    test('a bare-pipe block is the empty route, not route "|"', () => {
+      // The lexer keeps the opener and de-indents the body: '#|\n  x' -> '#|\nx'
+      const p = parsePrefix('#|\nx');
+      expect(p.route).toBe('');
+      expect(p.malformation).toBeUndefined();
+    });
+  });
+
+  describe('Form 2: sigil routes (reserved, closed set)', () => {
+    test.each([
+      ['#!', '!'],
+      ['#@', '@'],
+      ['#"', '"'],
+      ['#:', ':'],
+      ['##!', '!'],
+    ])('%j -> claimed sigil route %j', (text, route) => {
+      const p = parsePrefix(text);
+      expect(p.route).toBe(route);
+      expect(p.malformation).toBeUndefined();
+    });
+
+    test.each(['#%', '#$', '#~'])(
+      '%j -> route present but reserved-route warning',
+      text => {
+        const p = parsePrefix(text);
+        expect(p.malformation).toBe('reserved-route');
+      }
+    );
+  });
+
+  describe('Form 3: opaque bracketed app routes', () => {
+    test.each([
+      ['#(docs)', 'docs'],
+      ['#<docs>', 'docs'],
+      ['#[docs]', 'docs'],
+      ['#{docs}', 'docs'],
+      ['#(bar-chart)', 'bar-chart'],
+      ['#(https://foo/bar)', 'https://foo/bar'],
+      ['#(my.app)', 'my.app'],
+      ['#(v1.2.3)', 'v1.2.3'],
+      ['#<has(parens)>', 'has(parens)'],
+      ['#(══SECURITY══)', '══SECURITY══'],
+      ['#|(ABC)', 'ABC'],
+    ])('%j -> route %j (opaque)', (text, route) => {
+      const p = parsePrefix(text);
+      expect(p.route).toBe(route);
+      expect(p.malformation).toBeUndefined();
+    });
+
+    test('different bracket pairs resolve to the same route', () => {
+      const route = parsePrefix('#(docs)').route;
+      for (const text of ['#<docs>', '#[docs]', '#{docs}']) {
+        expect(parsePrefix(text).route).toBe(route);
+      }
+    });
+
+    test('decoration is significant — banner does not collapse to a clean route', () => {
+      expect(parsePrefix('#(══X══)').route).toBe('══X══');
+      expect(parsePrefix('#(══X══)').route).not.toBe('X');
+    });
+  });
+
+  describe('malformed routes', () => {
+    test.each([
+      '#foo', // bare word, no brackets
+      '#a.b', // word chars, no brackets
+      '#(docs', // unclosed
+      '#((((SPECIAL))))', // trailing junk after first close
+      '#word)', // lone close, no open
+      '#)', // lone close bracket
+      '#()', // empty bracketed name
+    ])('%j -> malformed-route', text => {
+      expect(parsePrefix(text).malformation).toBe('malformed-route');
+    });
+  });
+
+  describe('Windows (CRLF) line endings — \\r must not pollute the route', () => {
+    test.each([
+      ['#(docs)\r\n', 'docs'], // content-less bracketed: \r had been pulled into routing
+      ['#(docs) hi\r\n', 'docs'], // space boundary already precedes the \r
+      ['#!\r\n', '!'], // sigil
+      ['#|\r\nA\r', ''], // empty-route block (CRLF), trailing \r left by stripTrailingNewline
+    ])('%j -> route %j, not malformed/reserved', (text, route) => {
+      const p = parsePrefix(text);
+      expect(p.route).toBe(route);
+      expect(p.malformation).toBeUndefined();
+    });
+  });
+
+  describe('contentIndex (single separator excluded)', () => {
+    test('single space, the content is everything after it', () => {
+      const text = '#(docs) hello world';
+      const p = parsePrefix(text);
+      expect(text.slice(p.contentIndex)).toBe('hello world');
+    });
+
+    test('no whitespace -> empty content at end of text', () => {
+      const text = '#(docs)';
+      const p = parsePrefix(text);
+      expect(p.contentIndex).toBe(text.length);
+      expect(text.slice(p.contentIndex)).toBe('');
+    });
+
+    test('block: the newline is the separator', () => {
+      const text = '#|(ABC)\n123';
+      const p = parsePrefix(text);
+      expect(p.route).toBe('ABC');
+      expect(text.slice(p.contentIndex)).toBe('123');
+    });
+  });
+});

--- a/packages/malloy/src/prefix.ts
+++ b/packages/malloy/src/prefix.ts
@@ -1,0 +1,137 @@
+/*
+ * Copyright Contributors to the Malloy project
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+ * The result of parsing an annotation's leading prefix.
+ *
+ * An annotation is `prefix sep content`. `parsePrefix` splits the captured
+ * annotation text at the first whitespace, strips the sigil (`#`/`##` plus an
+ * optional block `|`), and classifies the routing into one of three forms.
+ * `route` is one field; `contentIndex` and `malformation` are equally why this
+ * routine exists.
+ */
+export interface ParsedPrefix {
+  /** The route the prefix resolves to. `''` is the MOTLY (empty) route. */
+  route: string;
+  /**
+   * Offset into the annotation text where the content begins;
+   * `text.slice(contentIndex)` is the content, with the single separator
+   * character excluded.
+   */
+  contentIndex: number;
+  /**
+   * Set iff the prefix is not a well-formed route. The annotation is still
+   * stored and reachable via the all-routes API; this only drives a warning.
+   * - `malformed-route`: not one of the three forms — a bare word, an unclosed
+   *   or mismatched bracket, an empty bracketed name, or trailing junk.
+   * - `reserved-route`: a punct-only (sigil) routing that Malloy has not
+   *   claimed; the punct-only namespace is reserved for Malloy's own use.
+   */
+  malformation?: 'malformed-route' | 'reserved-route';
+}
+
+/**
+ * Punct-only (sigil) routes are reserved for Malloy's own use. This is the
+ * closed, enumerated set the compiler claims; any other punct-only routing
+ * warns `reserved-route`. The set being closed is what makes the warning
+ * possible — the compiler knows its own complete sigil vocabulary.
+ */
+const CLAIMED_SIGILS = new Set(['!', '@', '"', ':']);
+
+/** Bracket pairs an app route may use, as [open, close] — the single source. */
+const BRACKET_PAIRS: [string, string][] = [
+  ['(', ')'],
+  ['<', '>'],
+  ['[', ']'],
+  ['{', '}'],
+];
+
+/** Two views of BRACKET_PAIRS: open->close for lookup, all halves for membership. */
+const OPEN_TO_CLOSE = new Map(BRACKET_PAIRS);
+const BRACKETS = new Set(BRACKET_PAIRS.flat());
+
+/** Letter, number, or underscore — the "word" characters. */
+const WORDISH = /[\p{L}\p{N}_]/u;
+
+/**
+ * Parse the leading prefix of a captured annotation.
+ *
+ * `text` is the entire annotation as the lexer captured it, marker included: a
+ * single line `#... content`, or a block `#|...\n<body>` whose body the lexer
+ * has already de-indented and whose closer it has removed. This routine never
+ * parses the content — it returns where the content begins.
+ *
+ * The prefix runs from the marker to the **first whitespace**; that boundary
+ * never moves (no bracket or quote changes it, so a route can never contain
+ * whitespace). After stripping the sigil (`^##?\|?`), the routing matches one
+ * of three forms:
+ *
+ *   1. empty                 -> route `''`        (MOTLY, the human default)
+ *   2. PUNCT+ (no bracket)   -> sigil route       (reserved; unclaimed warns)
+ *   3. OPEN ... CLOSE        -> route = bracketed text (opaque app route)
+ *
+ * Anything else is `malformed-route`. Bracket pairs are `()`, `<>`, `[]`, `{}`;
+ * the route is everything up to the matching close (first close wins, no
+ * nesting), taken literally — no character classification, so `#(bar-chart)`,
+ * `#(https://x/y)`, and `#(v1.2.3)` are all just their bracketed text.
+ */
+export function parsePrefix(text: string): ParsedPrefix {
+  // 1. Split prefix from content at the first whitespace. The single separator
+  //    character is excluded from the content.
+  //    `\r` is in the class because Windows line endings put a `\r` right before
+  //    the `\n` at every line end (the lexer keeps `\r` out of line *content*),
+  //    so on a content-less prefix like `#(docs)\r\n` the `\r` must not be pulled
+  //    into the routing. We split on it rather than mutating the text, so source
+  //    offsets stay intact for error mapping; any line-ending bytes remain in the
+  //    content, which is faithful to source and harmless to payload parsers.
+  const boundary = text.search(/[ \t\r\n]/);
+  const prefix = boundary === -1 ? text : text.slice(0, boundary);
+  const contentIndex = boundary === -1 ? text.length : boundary + 1;
+
+  // 2. Strip the sigil: one or two '#', then an optional block '|'.
+  const sigil = /^(#{1,2})(\|?)/.exec(prefix);
+  if (!sigil) {
+    // A captured annotation always starts with '#'; if it somehow does not,
+    // there is no route to speak of — likely a compiler bug upstream.
+    return {route: prefix, contentIndex, malformation: 'malformed-route'};
+  }
+  const routing = prefix.slice(sigil[0].length);
+
+  // Form 1: empty routing -> the MOTLY namespace.
+  if (routing === '') {
+    return {route: '', contentIndex};
+  }
+
+  // Form 3: opens with a bracket -> route is the text up to the matching close.
+  // A non-undefined close both proves routing[0] is an open bracket and gives
+  // us its partner in one lookup.
+  const close = OPEN_TO_CLOSE.get(routing[0]);
+  if (close !== undefined) {
+    const closeIdx = routing.indexOf(close, 1);
+    const malformed =
+      closeIdx === -1 || // unclosed
+      closeIdx !== routing.length - 1 || // trailing junk after the close
+      closeIdx === 1; // empty bracketed text: `#()`
+    if (malformed) {
+      return {route: routing, contentIndex, malformation: 'malformed-route'};
+    }
+    return {route: routing.slice(1, closeIdx), contentIndex};
+  }
+
+  // Form 2: pure punctuation (no word chars, no brackets) -> sigil route.
+  const isPurePunct = [...routing].every(
+    c => !WORDISH.test(c) && !BRACKETS.has(c)
+  );
+  if (isPurePunct) {
+    return {
+      route: routing,
+      contentIndex,
+      malformation: CLAIMED_SIGILS.has(routing) ? undefined : 'reserved-route',
+    };
+  }
+
+  // Otherwise: a bare word, or mixed text with no brackets.
+  return {route: routing, contentIndex, malformation: 'malformed-route'};
+}

--- a/packages/malloy/src/taggable.ts
+++ b/packages/malloy/src/taggable.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-import type {TagParseSpec, MalloyTagParse} from './annotation';
+import type {TagParseSpec, MalloyTagParse, Annotations} from './annotation';
 
 /**
  * Interface for objects that have Malloy tag annotations.
@@ -11,6 +11,11 @@ import type {TagParseSpec, MalloyTagParse} from './annotation';
  * runtime implement this interface to expose their tag metadata.
  */
 export interface Taggable {
+  /**
+   * Route-aware annotation access. Unlike `tagParse`/`getTaglines`, this sees
+   * block annotations (`#|`…`|#`).
+   */
+  readonly annotations: Annotations;
   tagParse: (spec?: TagParseSpec) => MalloyTagParse;
   getTaglines: (prefix?: RegExp) => string[];
 }

--- a/packages/malloy/src/taggable.ts
+++ b/packages/malloy/src/taggable.ts
@@ -16,6 +16,16 @@ export interface Taggable {
    * block annotations (`#|`…`|#`).
    */
   readonly annotations: Annotations;
+  /**
+   * @deprecated The RegExp form cannot see block annotations (`#|`…`|#`) and
+   * cannot report content offsets for error mapping. Use
+   * `annotations.parseAsTag(route)` instead.
+   */
   tagParse: (spec?: TagParseSpec) => MalloyTagParse;
+  /**
+   * @deprecated The RegExp form cannot see block annotations. Use
+   * `annotations.texts(route)` (raw strings) or `annotations.forRoute(route)`
+   * (objects with offsets) instead.
+   */
   getTaglines: (prefix?: RegExp) => string[];
 }

--- a/packages/malloy/src/taggable.ts
+++ b/packages/malloy/src/taggable.ts
@@ -12,8 +12,9 @@ import type {TagParseSpec, MalloyTagParse, Annotations} from './annotation';
  */
 export interface Taggable {
   /**
-   * Route-aware annotation access. Unlike `tagParse`/`getTaglines`, this sees
-   * block annotations (`#|`…`|#`).
+   * Route-aware annotation access — read annotations by *route*. See
+   * `Annotations` for what a route is and which ones are claimed. Unlike
+   * `tagParse`/`getTaglines`, this sees block annotations (`#|`…`|#`).
    */
   readonly annotations: Annotations;
   /**

--- a/packages/malloy/src/test/resultMatchers.ts
+++ b/packages/malloy/src/test/resultMatchers.ts
@@ -155,7 +155,8 @@ async function runQueryInternal(
   let queryTestTag: Tag | undefined = undefined;
   try {
     query = tm.model.loadQuery(src);
-    const queryTags = (await query.getPreparedQuery()).tagParse().tag;
+    const queryTags = (await query.getPreparedQuery()).annotations.parseAsTag()
+      .tag;
     queryTestTag = queryTags.tag('test');
   } catch (e) {
     // Add line numbers, helpful if failure is a compiler error

--- a/packages/malloy/src/to_stable.ts
+++ b/packages/malloy/src/to_stable.ts
@@ -175,7 +175,7 @@ function convertParameterDefaultValue(
 function getAnnotationsFromField(
   field: FieldDef | Query | SourceDef
 ): Malloy.Annotation[] {
-  const taglines = new Annotations(field.annotation).all().map(a => a.rawText);
+  const taglines = new Annotations(field.annotation).texts();
   return taglines.map(tagline => ({
     value: tagline,
   }));
@@ -186,9 +186,7 @@ export function convertFieldInfos(source: SourceDef, fields: FieldDef[]) {
   for (const field of fields) {
     const isPublic = field.accessModifier === undefined;
     if (!isPublic) continue;
-    const taglines = new Annotations(field.annotation)
-      .all()
-      .map(a => a.rawText);
+    const taglines = new Annotations(field.annotation).texts();
     const rawAnnotations: Malloy.Annotation[] = taglines.map(tagline => ({
       value: tagline,
     }));
@@ -492,9 +490,7 @@ function convertRecordType(
         }
       }
       if (f.annotation) {
-        const taglines = new Annotations(f.annotation)
-          .all()
-          .map(a => a.rawText);
+        const taglines = new Annotations(f.annotation).texts();
         annotations.push(
           ...taglines.map(tagline => ({
             value: tagline,

--- a/packages/malloy/src/to_stable.ts
+++ b/packages/malloy/src/to_stable.ts
@@ -35,7 +35,7 @@ import {
   getResultStructDefForQuery,
   getResultStructDefForView,
 } from './model';
-import {annotationToTaglines} from './annotation';
+import {Annotations} from './annotation';
 import {Tag} from '@malloydata/malloy-tag';
 
 export function sourceDefToSourceInfo(sourceDef: SourceDef): Malloy.SourceInfo {
@@ -175,7 +175,7 @@ function convertParameterDefaultValue(
 function getAnnotationsFromField(
   field: FieldDef | Query | SourceDef
 ): Malloy.Annotation[] {
-  const taglines = annotationToTaglines(field.annotation);
+  const taglines = new Annotations(field.annotation).all().map(a => a.rawText);
   return taglines.map(tagline => ({
     value: tagline,
   }));
@@ -186,7 +186,9 @@ export function convertFieldInfos(source: SourceDef, fields: FieldDef[]) {
   for (const field of fields) {
     const isPublic = field.accessModifier === undefined;
     if (!isPublic) continue;
-    const taglines = annotationToTaglines(field.annotation);
+    const taglines = new Annotations(field.annotation)
+      .all()
+      .map(a => a.rawText);
     const rawAnnotations: Malloy.Annotation[] = taglines.map(tagline => ({
       value: tagline,
     }));
@@ -490,7 +492,9 @@ function convertRecordType(
         }
       }
       if (f.annotation) {
-        const taglines = annotationToTaglines(f.annotation);
+        const taglines = new Annotations(f.annotation)
+          .all()
+          .map(a => a.rawText);
         annotations.push(
           ...taglines.map(tagline => ({
             value: tagline,

--- a/packages/malloy/src/to_stable.ts
+++ b/packages/malloy/src/to_stable.ts
@@ -7,6 +7,7 @@
 
 import * as Malloy from '@malloydata/malloy-interfaces';
 import type {
+  Annotation,
   AtomicTypeDef,
   DateUnit,
   Expr,
@@ -14,7 +15,6 @@ import type {
   FilterCondition,
   JoinType,
   ModelDef,
-  Query,
   RecordTypeDef,
   RepeatedRecordTypeDef,
   ResultMetadataDef,
@@ -68,7 +68,7 @@ export function sourceDefToSourceInfo(sourceDef: SourceDef): Malloy.SourceInfo {
       fields: convertFieldInfos(sourceDef, sourceDef.fields),
     },
     parameters,
-    annotations: getAnnotationsFromField(sourceDef),
+    annotations: toStableAnnotations(sourceDef.annotation),
   };
   return sourceInfo;
 }
@@ -88,7 +88,7 @@ export function modelDefToModelInfo(modelDef: ModelDef): Malloy.ModelInfo {
       });
     } else if (entry.type === 'query') {
       const outputStruct = getResultStructDefForQuery(modelDef, entry);
-      const annotations = getAnnotationsFromField(entry);
+      const annotations = toStableAnnotations(entry.annotation);
       const resultMetadataAnnotation = outputStruct.resultMetadata
         ? getResultStructMetadataAnnotation(
             outputStruct,
@@ -112,7 +112,7 @@ export function modelDefToModelInfo(modelDef: ModelDef): Malloy.ModelInfo {
   }
   for (const query of modelDef.queryList) {
     const outputStruct = getResultStructDefForQuery(modelDef, query);
-    const annotations = getAnnotationsFromField(query);
+    const annotations = toStableAnnotations(query.annotation);
     const resultMetadataAnnotation = outputStruct.resultMetadata
       ? getResultStructMetadataAnnotation(
           outputStruct,
@@ -172,13 +172,15 @@ function convertParameterDefaultValue(
   }
 }
 
-function getAnnotationsFromField(
-  field: FieldDef | Query | SourceDef
+/**
+ * IR annotation → stable `Malloy.Annotation[]` shape used across `to_stable`
+ * and the api surfaces. The stable shape carries the raw annotation strings;
+ * routes are derivable at the consumer via `parsePrefix` (`./prefix.ts`).
+ */
+export function toStableAnnotations(
+  annot: Annotation | undefined
 ): Malloy.Annotation[] {
-  const taglines = new Annotations(field.annotation).texts();
-  return taglines.map(tagline => ({
-    value: tagline,
-  }));
+  return new Annotations(annot).texts().map(value => ({value}));
 }
 
 export function convertFieldInfos(source: SourceDef, fields: FieldDef[]) {
@@ -186,10 +188,7 @@ export function convertFieldInfos(source: SourceDef, fields: FieldDef[]) {
   for (const field of fields) {
     const isPublic = field.accessModifier === undefined;
     if (!isPublic) continue;
-    const taglines = new Annotations(field.annotation).texts();
-    const rawAnnotations: Malloy.Annotation[] = taglines.map(tagline => ({
-      value: tagline,
-    }));
+    const rawAnnotations = toStableAnnotations(field.annotation);
     const annotations = rawAnnotations.length > 0 ? rawAnnotations : undefined;
     if (isTurtle(field)) {
       const outputStruct = getResultStructDefForView(source, field);
@@ -490,12 +489,7 @@ function convertRecordType(
         }
       }
       if (f.annotation) {
-        const taglines = new Annotations(f.annotation).texts();
-        annotations.push(
-          ...taglines.map(tagline => ({
-            value: tagline,
-          }))
-        );
+        annotations.push(...toStableAnnotations(f.annotation));
       }
       if (isAtomic(f)) {
         return {


### PR DESCRIPTION
# Overview

It turns out that multi-line (`#|`...`|#`) annotations have been mostly broken. The API for "find the subset of annotations this feature or application cares about" was a RegExp matched against the annotation text, and that RegExp can't see block annotations and can't report content offsets back to source — so any consumer that wanted source-mapped errors couldn't have them.

This PR deprecates the imprecise and unfixable RegExp-prefix APIs in favor of a route-based read API that handles single-line and block annotations uniformly.

At the same time, since annotations have been around for a while, we are formalizing a small amount of structure on the annotation prefix — what was previously a convention now has actual rules the compiler checks.

## Annotation structure

It has always been true, and continues to be true, that everything from the annotation marker (`#` or `##`) to the first space or newline is a special part of the annotation called the **prefix**. The actual content of the annotation starts after the prefix. So `#(docs) Info` is an annotation with a prefix of `#(docs)` and content `Info`.

What's new: the prefix is now parsed at compile time, and a non-empty prefix must match one of two forms:

- `#` followed by punctuation characters — for example `#!`, `#@`. These are reserved for Malloy's internal use. An unrecognized punctuation prefix (`#%`, `#~`) emits a `reserved-route` warning.
- `#` followed by a bracket pair — `(`, `<`, `[`, or `{` — with any non-matching-close characters inside, then the close. For example `#(docs)`, `#[bar-chart]`, `#<https://x/y>`. The content inside the brackets is opaque — no nesting, no character classification.

Anything else gets a `malformed-route` warning. This will cause `#bar_chart` to warn as the syntax error it always was. Both warnings are non-fatal; the annotation is still stored.

## API changes

Annotations are now selected by **route** — the punctuation string for internal prefixes (`!`, `@`), the bracketed text for app prefixes (`docs`, `bar-chart`), or the empty string for the bare `# tag` form. Bracket choice doesn't matter: route `docs` picks up `#(docs)`, `#[docs]`, `#<docs>`, `#{docs}`.

```ts
// Before — RegExp prefix
field.tagParse({prefix: /#\(docs\)\s/}).tag.text('section')
field.getTaglines(/^##! /)

// After — route
field.annotations.parseAsTag('docs').tag.text('section')
field.annotations.texts('!')
```

The new `.annotations` view sits on every tagged entity (sources, fields, queries, the model). It sees block annotations, reports source offsets, and is the only way to read annotations whose prefix uses the new bracket forms.

## Impact

This PR is the in-repo half. Downstream apps (explorer, publisher, vscode, docs, docs-site) keep working on the deprecated RegExp API and migrate on their own schedule once this publishes. In a month or two we will delete the prefix-based APIs. Note that apps which do not migrate are very likely broken with multi line annotations until they move to the new api.
