### PR TITLE
release.yaml: build once, fan out via workspace artifact

### DIFF
--- a/.github/workflows/CONTEXT.md
+++ b/.github/workflows/CONTEXT.md
@@ -21,7 +21,9 @@ Contributor-facing side (DCO sign-off, licensing, review) is in [CONTRIBUTING.md
 
 Publishing uses **GitHub Actions OIDC trusted publishing**, not a stored `NPM_TOKEN` — there is no npm secret in this repo and one should not be added back. Each `@malloydata/*` package has a trusted publisher registered on npmjs.com bound to `malloydata/malloy` + `release.yaml`, set from a maintainer's machine (`npm trust github <pkg> --file release.yaml --repo malloydata/malloy --allow-publish --yes`, needs npm ≥ 11.10).
 
-`release.yaml` is `workflow_dispatch`-only: a `precheck` job (`npm run precheck`) gates the `npm-release` job, which publishes every workspace package, cuts the GitHub Release, then bumps the version. The gate is intentionally just precheck, not the full dialect matrix — those are required checks to *merge*, so they aren't re-verified at release.
+`release.yaml` is `workflow_dispatch`-only and runs three sequential jobs: `pull_and_build` checks out the repo, runs `npm ci` + `npm run build` + `npm run build-duckdb-db`, then uploads the entire built workspace (excluding `.git`) as a zstd-compressed tar artifact. `precheck` and `npm-release` both download that artifact instead of rebuilding — `precheck` runs `npm run precheck`, then `npm-release` publishes every workspace package, cuts the GitHub Release, and bumps the version. The gate is intentionally just precheck, not the full dialect matrix — those are required checks to *merge*, so they aren't re-verified at release.
+
+The artifact pattern (build once, fan out) lives entirely inside `release.yaml` rather than a separate top-level workflow because OIDC trusted publishing binds to the top-level caller filename — moving build to a different workflow file would break npm publish.
 
 **Rules that bite (not guessable):**
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,7 +4,7 @@ permissions: {}
 on: [workflow_dispatch]
 
 jobs:
-  precheck:
+  pull_and_build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -17,6 +17,28 @@ jobs:
           npm --no-audit --no-fund ci --loglevel error
           npm run build
           npm run build-duckdb-db
+      - name: Tar workspace
+        run: tar --exclude='./.git' --use-compress-program='zstd -3 -T0' -cf /tmp/workspace.tzst .
+      - uses: actions/upload-artifact@v4
+        with:
+          name: workspace
+          path: /tmp/workspace.tzst
+          retention-days: 1
+          compression-level: 0
+
+  precheck:
+    needs: pull_and_build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: workspace
+      - name: Extract workspace
+        run: tar --use-compress-program='zstd -d -T0' -xf workspace.tzst && rm workspace.tzst
+      - name: Use Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 20.x
       - name: Precheck (dialect-agnostic tests + duckdb)
         run: npm run precheck
 
@@ -30,20 +52,22 @@ jobs:
       - uses: actions/checkout@v5
         with:
           ssh-key: ${{ secrets.MALLOY_GHAPI }}
+      - uses: actions/download-artifact@v4
+        with:
+          name: workspace
+      - name: Extract workspace
+        run: tar --use-compress-program='zstd -d -T0' -xf workspace.tzst && rm workspace.tzst
       - name: Use Node.js
         uses: actions/setup-node@v5
         with:
           node-version: 20.x
       - name: Upgrade npm for trusted publishing (OIDC)
         run: npm install -g npm@latest
-      - name: npm install, build, and publish
+      - name: Publish and bump version
         run: |
           # Configure git user
           git config --global user.email "malloy-ci-bot@malloydata.org"
           git config --global user.name "Malloy CI Bot"
-          # Build
-          npm --no-audit --no-fund ci --loglevel error
-          npm run build
           # Publish
           PACKAGES=$(jq -r '.workspaces.packages[]' ./package.json | xargs echo)
           echo Publishing $PACKAGES


### PR DESCRIPTION
Splits `release.yaml` into three sequential jobs:

1. **`pull_and_build`** — checkout, `npm ci`, `npm run build`, `npm run build-duckdb-db`, then tars the built workspace (excluding `.git`) with zstd and uploads it as an artifact.
2. **`precheck`** — downloads the artifact, extracts, runs `npm run precheck`.
3. **`npm-release`** — checkout (still needed for `.git` + the SSH key for the push), downloads the artifact on top, publishes, bumps the version, pushes.

The artifact is ~370 MB compressed (1.4 GB raw), transfers in seconds, and removes the duplicated `npm ci` + `npm run build` from `precheck` and `npm-release` — net savings ~4-5 min of wall time per release run.

The post-publish `npm install` in `npm-release` still runs because it has to operate on the `lerna version patch`-modified `package.json` files; that part hasn't changed.

The build job stays inside `release.yaml` rather than being lifted into a separate top-level workflow because OIDC trusted publishing binds to the top-level caller filename — moving it would break npm publish. Updated `CONTEXT.md` to call this out.

If this proves out, the same pattern will apply to `run-tests.yaml` next, where the savings are much larger (10+ dialect jobs all redoing the same prelude).