### PR TITLE
Fix temporal filter on timestamptz column (#2834)

### DIFF
--- a/packages/malloy/src/model/filter_compilers.ts
+++ b/packages/malloy/src/model/filter_compilers.ts
@@ -394,7 +394,7 @@ export class TemporalFilterCompiler {
   }
 
   time(timeSQL: string): string {
-    if (this.timetype === 'timestamp') {
+    if (this.timetype !== 'date') {
       return timeSQL;
     }
     return this.d.sqlCast(

--- a/test/src/databases/all/db_filter_expressions.spec.ts
+++ b/test/src/databases/all/db_filter_expressions.spec.ts
@@ -1116,6 +1116,39 @@ describe.each(runtimes.runtimeList)('filter expressions %s', (dbName, db) => {
           }
         `).toMatchResult(exactTimeModel, {n: 'exact'});
       });
+      test.when(tzTesting && db.dialect.hasTimestamptz)(
+        'date filter on timestamptz column respects query time zone',
+        async () => {
+          // Tokyo May 23 = 2026-05-22 15:00 UTC to 2026-05-23 15:00 UTC.
+          // Build a source whose `t` column is timestamptz, and confirm the
+          // f`2026-05-23` filter (in Tokyo) picks the right rows.
+          const tstzLit = (s: string): string => {
+            const node = Dialect.makeTimeLiteralNode(
+              db.dialect,
+              s,
+              'UTC',
+              undefined,
+              'timestamp'
+            );
+            return db.dialect.exprToSQL({}, node) || '';
+          };
+          const events = wrapTestModel(
+            db,
+            `query: events is ${dbName}.sql("""
+              SELECT ${tstzLit('2026-05-22 14:00:00')} AS ${q`t`}, 'before' AS ${q`n`}
+              UNION ALL SELECT ${tstzLit('2026-05-22 16:00:00')}, 'first'
+              UNION ALL SELECT ${tstzLit('2026-05-23 14:59:59')}, 'last'
+              UNION ALL SELECT ${tstzLit('2026-05-23 15:00:00')}, 'post-range'
+            """) -> {
+              timezone: 'Asia/Tokyo'
+              where: t ~ f'2026-05-23'
+              select: t, n
+              order_by: n
+            }`
+          );
+          await expect('run: events').toMatchRows(events, inRange);
+        }
+      );
       test.when(tzTesting)(
         'month offsets cross DST boundary in query time zone',
         async () => {


### PR DESCRIPTION
Fixes #2834.

User noticed that we can't compare a date-shaped literal to a
timestamptz value. Simple bug in the filter expression compiler.