### PR TITLE
model.queries() enumerator (deprecates namedQueries); PipelineBase; widen Pipeline IR

### DIFF
--- a/packages/malloy-render/README.md
+++ b/packages/malloy-render/README.md
@@ -1,6 +1,6 @@
 # Malloy Renderer
 
-The Malloy Renderer is a web component for rendering Malloy query results. It is included by default in the Malloy VSCode extension, but can also be embedded by developers into their own applications that use Malloy query results. To learn more about how to use the renderer in a Malloy model, see [the Renderer docs](https://docs.malloydata.dev/documentation/visualizations/overview).
+The Malloy Renderer is a web component for rendering Malloy query results. It is included by default in the Malloy VSCode extension, but can also be embedded by developers into their own applications. To learn more about how to use the renderer in a Malloy model, see [the Renderer docs](https://docs.malloydata.dev/documentation/visualizations/overview).
 
 ## Using the Renderer in Web Apps
 
@@ -25,7 +25,7 @@ malloyRenderElement.result = myMalloyResult;
 
 /*
 Alternatively, you can pass Malloy QueryResult and ModelDef objects to the renderer,
-which will then construct the Result object. This is useful when you are receiving serialiazed Malloy results via an API.
+which will then construct the Result object. This is useful when you are receiving serialized Malloy results via an API.
 */
 malloyRenderElement.queryResult = myQueryResult;
 malloyRenderElement.modelDef = myModelDef;

--- a/packages/malloy/src/api/foundation/core.ts
+++ b/packages/malloy/src/api/foundation/core.ts
@@ -19,6 +19,7 @@ import type {
   GivenID,
   GivenTypeDef,
   Query as InternalQuery,
+  Pipeline,
   ModelDef,
   DocumentPosition as ModelDocumentPosition,
   NamedQueryDef,
@@ -233,6 +234,17 @@ export type PreparedResultJSON = {
   query: CompiledQuery;
   modelDef: ModelDef;
 };
+
+/**
+ * Identifier-only enumeration of a model's top-level queries.
+ * Internal: returned by `Model.queries()`, not exported. Callers pair
+ * the names with `getPreparedQueryByName` and the indices `0..unnamed-1`
+ * with `getPreparedQueryByIndex` to load any one of them.
+ */
+interface ModelQueries {
+  named: string[];
+  unnamed: number;
+}
 
 // =============================================================================
 // Explore
@@ -887,7 +899,7 @@ export class StringField extends AtomicField {
 // Query and QueryField
 // =============================================================================
 
-export class Query extends Entity {
+export class Query extends Entity implements Taggable {
   protected turtleDef: TurtleDef;
   private sourceQuery?: Query;
 
@@ -907,15 +919,6 @@ export class Query extends Entity {
   public get location(): DocumentLocation | undefined {
     return this.turtleDef.location;
   }
-}
-
-export class QueryField extends Query implements Taggable {
-  protected parent: Explore;
-
-  constructor(turtleDef: TurtleDef, parent: Explore, source?: Query) {
-    super(turtleDef, parent, source);
-    this.parent = parent;
-  }
 
   /** @deprecated Use `.annotations.parseAsTag(route)`. */
   tagParse(spec?: TagParseSpec) {
@@ -929,6 +932,15 @@ export class QueryField extends Query implements Taggable {
 
   get annotations(): Annotations {
     return new Annotations(this.turtleDef.annotations);
+  }
+}
+
+export class QueryField extends Query {
+  protected parent: Explore;
+
+  constructor(turtleDef: TurtleDef, parent: Explore, source?: Query) {
+    super(turtleDef, parent, source);
+    this.parent = parent;
   }
 
   public isQueryField(): this is QueryField {
@@ -1331,9 +1343,27 @@ export class Model implements Taggable {
   }
 
   /**
-   * Get an array of `NamedQueryDef`s contained in the model.
+   * Enumerate the model's top-level queries by identifier.
    *
-   * @return An array of `NamedQueryDef`s contained in the model.
+   * Returns the names of named queries (`query: foo is ...`) and the count
+   * of unnamed `run:` statements. Pair with {@link getPreparedQueryByName}
+   * and {@link getPreparedQueryByIndex} to load any of them — those are the
+   * only path to the query itself; this getter exposes only identifiers,
+   * not IR.
+   */
+  public queries(): ModelQueries {
+    const named: string[] = [];
+    for (const object of Object.values(this.modelDef.contents)) {
+      if (object.type === 'query') {
+        named.push(object.name);
+      }
+    }
+    return {named, unnamed: this.modelDef.queryList.length};
+  }
+
+  /**
+   * @deprecated Leaks IR. Use {@link queries} for enumeration and
+   *   {@link getPreparedQueryByName} to load a named query.
    */
   public get namedQueries(): NamedQueryDef[] {
     const isNamedQueryDef = (
@@ -1678,34 +1708,50 @@ export class Given implements Taggable {
   }
 }
 
-export class PreparedQuery implements Taggable {
-  public _query: InternalQuery | NamedQueryDef;
+/**
+ * Internal abstract base for Foundation wrappers around an IR `Pipeline`
+ * (an IR object that has a pipeline, annotations, and a source location).
+ * Owns the four `Taggable` accessors and a `location` getter, all reading
+ * from the wrapped IR. Not exported.
+ */
+abstract class PipelineBase implements Taggable {
+  constructor(protected pipelineDef: Pipeline) {}
 
+  get annotations(): Annotations {
+    return new Annotations(this.pipelineDef.annotations);
+  }
+
+  get location(): DocumentLocation | undefined {
+    return this.pipelineDef.location;
+  }
+
+  /** @deprecated Use `.annotations.parseAsTag(route)`. */
+  tagParse(spec?: TagParseSpec): MalloyTagParse {
+    return annotationToTag(this.pipelineDef.annotations, spec);
+  }
+
+  /** @deprecated Use `.annotations.texts(route)`. */
+  getTaglines(prefix?: RegExp): string[] {
+    return annotationToTaglines(this.pipelineDef.annotations, prefix);
+  }
+}
+
+export class PreparedQuery extends PipelineBase {
   constructor(
     query: InternalQuery,
     private _model: Model,
     public problems: LogMessage[],
     public name?: string
   ) {
-    this._query = query;
+    super(query);
+  }
+
+  public get _query(): InternalQuery | NamedQueryDef {
+    return this.pipelineDef as InternalQuery | NamedQueryDef;
   }
 
   public get _modelDef(): ModelDef {
     return this._model._modelDef;
-  }
-
-  /** @deprecated Use `.annotations.parseAsTag(route)`. */
-  tagParse(spec?: TagParseSpec) {
-    return annotationToTag(this._query.annotations, spec);
-  }
-
-  /** @deprecated Use `.annotations.texts(route)`. */
-  getTaglines(prefix?: RegExp) {
-    return annotationToTaglines(this._query.annotations, prefix);
-  }
-
-  get annotations(): Annotations {
-    return new Annotations(this._query.annotations);
   }
 
   /**

--- a/packages/malloy/src/model/malloy_types.ts
+++ b/packages/malloy/src/model/malloy_types.ts
@@ -1245,10 +1245,10 @@ export interface Filtered {
 export interface TurtleSegment extends Filtered {
   name: string;
 }
-export interface Pipeline {
+export interface Pipeline extends HasAnnotations, HasLocation {
   pipeline: PipeSegment[];
 }
-export interface Query extends Pipeline, Filtered, HasLocation, HasAnnotations {
+export interface Query extends Pipeline, Filtered {
   type?: 'query';
   name?: string;
   structRef: StructRef;
@@ -1517,7 +1517,7 @@ export interface QuerySegment extends Filtered, Ordered, SegmentUsageSummary {
 export type NonDefaultAccessModifierLabel = 'private' | 'internal';
 export type AccessModifierLabel = NonDefaultAccessModifierLabel | 'public';
 
-export interface TurtleDef extends NamedObject, Pipeline, HasAnnotations {
+export interface TurtleDef extends NamedObject, Pipeline {
   type: 'turtle';
   accessModifier?: NonDefaultAccessModifierLabel | undefined;
   refSummary?: RefSummary;


### PR DESCRIPTION
malloy-cli's `compile.ts` has been rummaging through `model.namedQueries` (which leaks `NamedQueryDef[]` IR) and `_modelDef.queryList` (back door) because Foundation gave no other way to enumerate top-level queries.

Add `model.queries(): {named: string[]; unnamed: number}` as the identifier-only enumerator; callers pair the results with the existing `getPreparedQueryByName` / `getPreparedQueryByIndex` loaders. `namedQueries` marked `@deprecated`. No IR leak.
