### PR TITLE
Annotations.forRoute(): restore no-arg form, lost in shuffle

### DIFF
--- a/packages/malloy/src/api/foundation/annotation.spec.ts
+++ b/packages/malloy/src/api/foundation/annotation.spec.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright Contributors to the Malloy project
+ * SPDX-License-Identifier: MIT
+ */
+
+import {Annotations} from './annotation';
+import type {Note} from '../../model';
+
+const at: Note['at'] = {
+  url: 'test://x',
+  range: {start: {line: 0, character: 0}, end: {line: 0, character: 0}},
+};
+const note = (text: string): Note => ({text, at});
+
+describe('Annotations API class', () => {
+  describe('forRoute', () => {
+    test('with a route filters to that route', () => {
+      const a = new Annotations({
+        notes: [note('# tag'), note('#(docs) one'), note('#(docs) two')],
+      });
+      expect(a.forRoute('docs').map(n => n.content)).toEqual(['one', 'two']);
+    });
+
+    test('no argument enumerates every annotation, each carrying its route', () => {
+      const a = new Annotations({
+        notes: [note('# tag'), note('#(docs) hello'), note('#! flag')],
+      });
+      const all = a.forRoute();
+      expect(all.map(n => n.route)).toEqual(['', 'docs', '!']);
+    });
+
+    test('no argument reaches malformed-prefix annotations that filtering excludes', () => {
+      const a = new Annotations({
+        notes: [note('#malformed'), note('#(docs) ok')],
+      });
+      expect(a.forRoute('docs').map(n => n.text)).toEqual(['#(docs) ok']);
+      expect(a.forRoute().map(n => n.text)).toContain('#malformed');
+    });
+
+    test('undefined annotations yields empty for both forms', () => {
+      const a = new Annotations(undefined);
+      expect(a.forRoute()).toEqual([]);
+      expect(a.forRoute('docs')).toEqual([]);
+    });
+  });
+
+  describe('texts', () => {
+    test('no argument returns every annotation text', () => {
+      const a = new Annotations({
+        notes: [note('# tag'), note('#(docs) hello')],
+      });
+      expect(a.texts()).toEqual(['# tag', '#(docs) hello']);
+    });
+
+    test('with a route filters to that route', () => {
+      const a = new Annotations({
+        notes: [note('# tag'), note('#(docs) hello')],
+      });
+      expect(a.texts('docs')).toEqual(['#(docs) hello']);
+    });
+  });
+
+  describe('parseAsTag', () => {
+    test('default route is the MOTLY tag route', () => {
+      const a = new Annotations({notes: [note('# size=large')]});
+      expect(a.parseAsTag().tag.text('size')).toBe('large');
+    });
+
+    test('an explicit route parses that route', () => {
+      const a = new Annotations({notes: [note('#(viz) chart=bar')]});
+      expect(a.parseAsTag('viz').tag.text('chart')).toBe('bar');
+    });
+  });
+});

--- a/packages/malloy/src/api/foundation/annotation.ts
+++ b/packages/malloy/src/api/foundation/annotation.ts
@@ -217,18 +217,12 @@ export class Annotations {
   }
 
   /**
-   * Your route's notes as {@link RoutedNote}s — for callers that parse the
-   * payload with their own parser (instead of MOTLY). Read `.content` to
-   * feed your parser, and `.at` + `.indentStripped` to map your parser's
-   * errors back to source.
-   *
-   * `malformed-route` annotations are excluded (no clean route to resolve
-   * to). `reserved-route` annotations are included — they parse to a real
-   * route and the user got a compile-time warning. Route filtering is
-   * level-blind (`#` and `##` both go to route `''`); the entity hands
-   * you the annotations that apply at its level.
+   * Notes as {@link RoutedNote}s — for callers that parse the payload with
+   * their own parser (instead of MOTLY). Pass a route to filter; omit it
+   * to enumerate every annotation (the only way to reach malformed-prefix
+   * ones). `malformed-route` annotations are excluded when filtering.
    */
-  forRoute(route: string): RoutedNote[] {
+  forRoute(route?: string): RoutedNote[] {
     return collectAnnotations(this.annote, route);
   }
 


### PR DESCRIPTION
`design.md` had `forRoute()` with no arg returning every annotation on the entity, each carrying its parsed route — the only way to reach annotations with malformed prefixes (where the filter form can't resolve them to a route). That capability got lost in the shuffle to the surface that shipped in #2838; only the route-filtered form survived.

The underlying `collectAnnotations(annote, route?)` already supports both modes — the public method signature just needed widening to `forRoute(route?: string)`.

Also: add the missing test file for the public `Annotations` class. It shipped with zero direct test coverage; behavior was indirectly tested via `collectAnnotations()`, which kept passing even as the wrapper-class surface narrowed. The absent class-level tests are what let the regression through.