### PR TITLE
Fix super-linear needs() on deep expression trees

### DIFF
--- a/packages/malloy/src/lang/ast/types/malloy-element.ts
+++ b/packages/malloy/src/lang/ast/types/malloy-element.ts
@@ -294,18 +294,21 @@ export abstract class MalloyElement {
     return asString;
   }
 
-  *walk(): Generator<MalloyElement> {
+  *allChildren(): Generator<MalloyElement> {
     for (const kidLabel of Object.keys(this.children)) {
       const kiddle = this.children[kidLabel];
       if (kiddle instanceof MalloyElement) {
         yield kiddle;
-        yield* kiddle.walk();
       } else {
-        for (const k of kiddle) {
-          yield k;
-          yield* k.walk();
-        }
+        yield* kiddle;
       }
+    }
+  }
+
+  *walk(): Generator<MalloyElement> {
+    for (const child of this.allChildren()) {
+      yield child;
+      yield* child.walk();
     }
   }
 
@@ -328,7 +331,7 @@ export abstract class MalloyElement {
   }
 
   needs(doc: Document): ModelDataRequest | undefined {
-    for (const child of this.walk()) {
+    for (const child of this.allChildren()) {
       const childNeeds = child.needs(doc);
       if (childNeeds) return childNeeds;
     }

--- a/packages/malloy/src/lang/test/expressions.spec.ts
+++ b/packages/malloy/src/lang/test/expressions.spec.ts
@@ -1842,4 +1842,13 @@ describe('number subtype propagation', () => {
       expect(getNumberType(result)).toBeUndefined();
     });
   });
+
+  // Guards against MalloyElement.needs() re-walking the whole subtree per node,
+  // which made a long binary `or` chain blow up super-linearly and hang.
+  test('long or-chain compiles in reasonable time', () => {
+    const where = Array.from({length: 100}, (_, i) => `astr = 't${i}'`).join(
+      ' or '
+    );
+    expect(model`run: a -> { where: ${where}; group_by: astr }`).toTranslate();
+  });
 });


### PR DESCRIPTION
A query with a long chain of ORed predicates (`title = 'a' or title = 'b' or ...`, ~30 of them) hung the compiler. Each `or` nests one binary node, and `MalloyElement.needs()` walked the entire transitive subtree via `this.walk()` and *then* recursed through `child.needs()` — which walks each subtree again. That's 2^n work, so it fell off a cliff somewhere around 30 terms.

`needs()` now iterates direct children only and lets the recursion do the descending, so every node is visited once. The element-or-array child unwrap that `walk()` and `needs()` both wanted is factored out into `allChildren()`.

The new test compiles a 100-term `or` chain; before this it would not have finished.