### PR TITLE
Fix model loading failure when virtual sources are used with query sources

### DIFF
--- a/packages/malloy/src/lang/test/source.spec.ts
+++ b/packages/malloy/src/lang/test/source.spec.ts
@@ -31,7 +31,8 @@ import {
   getFieldDef,
 } from './test-translator';
 import './parse-expects';
-import {isSourceDef} from '../../model';
+import {isSourceDef, QueryModel} from '../../model';
+import type {VirtualMap} from '../../model';
 
 describe('source:', () => {
   test('table', () => {
@@ -1357,6 +1358,33 @@ describe('virtual sources', () => {
       errors: {connectionDialects: {a: 'a is not a connection'}},
     });
     expect(m).toLog(error('invalid-connection-for-table-source'));
+  });
+
+  test('query source referencing virtual source compiles with virtualMap', () => {
+    const m = vsModel(`
+      type: facts_fields is { category :: string, amount :: number }
+      source: facts_raw is _db_.virtual('facts_raw')::facts_fields
+
+      source: facts_agg is facts_raw -> {
+        group_by: category
+        aggregate: total is sum(amount)
+      } extend {
+        dimension: total_display is concat(category, ': ', total::string)
+      }
+
+      run: facts_raw -> { group_by: category; aggregate: total is sum(amount) }
+    `);
+    expect(m).toTranslate();
+
+    const modelDef = m.translate().modelDef!;
+    const virtualMap: VirtualMap = new Map([
+      ['_db_', new Map([['facts_raw', 'facts_table']])],
+    ]);
+    const queryModel = new QueryModel(modelDef);
+    const query = modelDef.queryList[0];
+    expect(() =>
+      queryModel.compileQuery(query, {virtualMap})
+    ).not.toThrow();
   });
 });
 

--- a/packages/malloy/src/model/query_model_impl.ts
+++ b/packages/malloy/src/model/query_model_impl.ts
@@ -37,6 +37,8 @@ export class QueryModelImpl implements QueryModel, ModelRootInterface {
   // dialect: Dialect = new PostgresDialect();
   modelDef: ModelDef | undefined = undefined;
   structs = new Map<string, QueryStruct>();
+  private _modelLoaded = false;
+  private _pendingModelDef: ModelDef | undefined = undefined;
 
   get givens(): Record<string, Given> {
     return this.modelDef?.givens ?? {};
@@ -44,8 +46,18 @@ export class QueryModelImpl implements QueryModel, ModelRootInterface {
 
   constructor(modelDef: ModelDef | undefined) {
     if (modelDef) {
-      this.loadModelFromDef(modelDef);
+      this._pendingModelDef = modelDef;
+      this.modelDef = modelDef;
     }
+  }
+
+  private ensureModelLoaded(
+    prepareResultOptions: PrepareResultOptions | undefined
+  ): void {
+    if (this._modelLoaded || !this._pendingModelDef) return;
+    this._modelLoaded = true;
+    this._loadModelFromDef(this._pendingModelDef, prepareResultOptions ?? {});
+    this._pendingModelDef = undefined;
   }
 
   // Another circularity breaking method ... call into QueryQuery
@@ -54,16 +66,31 @@ export class QueryModelImpl implements QueryModel, ModelRootInterface {
     query: Query,
     options: PrepareResultOptions | undefined
   ): SourceDef | undefined {
+    this.ensureModelLoaded(options);
     const result = this.loadQuery(query, undefined, options, false, false);
     return result.structs.pop();
   }
 
   loadModelFromDef(modelDef: ModelDef): void {
+    this._pendingModelDef = modelDef;
     this.modelDef = modelDef;
-    for (const s of Object.values(this.modelDef.contents)) {
+    this._modelLoaded = false;
+    this.structs.clear();
+  }
+
+  private _loadModelFromDef(
+    modelDef: ModelDef,
+    prepareResultOptions: PrepareResultOptions
+  ): void {
+    for (const s of Object.values(modelDef.contents)) {
       let qs;
       if (isSourceDef(s)) {
-        qs = new QueryStruct(s, undefined, {model: this}, {});
+        qs = new QueryStruct(
+          s,
+          undefined,
+          {model: this},
+          prepareResultOptions
+        );
         this.structs.set(getIdentifier(s), qs);
         qs.resolveQueryFields((query, options) =>
           this.getFinalOutputStruct(query, options)
@@ -80,7 +107,11 @@ export class QueryModelImpl implements QueryModel, ModelRootInterface {
     }
   }
 
-  getStructByName(name: string): QueryStruct {
+  getStructByName(
+    name: string,
+    prepareResultOptions?: PrepareResultOptions
+  ): QueryStruct {
+    this.ensureModelLoaded(prepareResultOptions);
     const s = this.structs.get(name);
     if (s) {
       return s;
@@ -98,17 +129,15 @@ export class QueryModelImpl implements QueryModel, ModelRootInterface {
     prepareResultOptions?: PrepareResultOptions
   ): QueryStruct {
     prepareResultOptions ??= {};
+    this.ensureModelLoaded(prepareResultOptions);
     if (typeof structRef === 'string') {
-      const ret = this.getStructByName(structRef);
-      if (sourceArguments !== undefined) {
-        return new QueryStruct(
-          ret.structDef,
-          sourceArguments,
-          ret.parent ? {struct: ret.parent} : {model: this},
-          prepareResultOptions
-        );
-      }
-      return ret;
+      const ret = this.getStructByName(structRef, prepareResultOptions);
+      return new QueryStruct(
+        ret.structDef,
+        sourceArguments ?? ret.sourceArguments,
+        ret.parent ? {struct: ret.parent} : {model: this},
+        prepareResultOptions
+      );
     }
     return new QueryStruct(
       structRef,
@@ -218,6 +247,7 @@ export class QueryModelImpl implements QueryModel, ModelRootInterface {
     prepareResultOptions?: PrepareResultOptions,
     finalize = true
   ): CompiledQuery {
+    this.ensureModelLoaded(prepareResultOptions);
     const addDefaultRowLimit = this.addDefaultRowLimit(
       query,
       prepareResultOptions?.defaultRowLimit

--- a/test/src/core/virtual.spec.ts
+++ b/test/src/core/virtual.spec.ts
@@ -239,6 +239,33 @@ describe('virtual source resolution', () => {
     const result = await runtime.loadQuery(code).run();
     expect(result.data.value.length).toBe(5);
   });
+
+  it('query source from virtual source with extend compiles', async () => {
+    const code = `${VIRTUAL_ANNOTATION}
+      type: flight_fields is {
+        carrier :: string,
+        dep_delay :: number,
+        distance :: number
+      }
+      source: flights is ${tstDB}.virtual('vflights')::flight_fields
+
+      source: flights_agg is flights -> {
+        group_by: carrier
+        aggregate: total_distance is sum(distance)
+      } extend {
+        dimension: carrier_display is concat(carrier, ' airlines')
+      }
+
+      run: flights -> { group_by: carrier; aggregate: cnt is count(); limit: 5 }
+    `;
+
+    const virtualMap = mkVirtualMap({
+      [tstDB]: {vflights: 'malloytest.flights'},
+    });
+
+    const result = await tstRuntime.loadQuery(code).run({virtualMap});
+    expect(result.data.value.length).toBe(5);
+  });
 });
 
 describe('ManagedConnectionLookup', () => {


### PR DESCRIPTION
Fixes #2845

This PR is 100% AI, you can likely reproduce exactly the same solution or better by running your own model on the issue above. Definitely close at will!

## Summary

- Defer `QueryModelImpl.loadModelFromDef` to the first `compileQuery` call so that `prepareResultOptions` (including `virtualMap`) is available when `resolveQueryFields` triggers SQL generation for `query_source` definitions
- Fix `getStructFromRef` to always propagate the caller's `prepareResultOptions` to returned structs instead of returning pre-loaded structs with empty options