### PR TITLE
Fix model load when a query source is built on a virtual source

### DIFF
--- a/packages/malloy/src/lang/test/source.spec.ts
+++ b/packages/malloy/src/lang/test/source.spec.ts
@@ -31,7 +31,8 @@ import {
   getFieldDef,
 } from './test-translator';
 import './parse-expects';
-import {isSourceDef} from '../../model';
+import {isSourceDef, QueryModel} from '../../model';
+import type {VirtualMap} from '../../model';
 
 describe('source:', () => {
   test('table', () => {
@@ -1357,6 +1358,58 @@ describe('virtual sources', () => {
       errors: {connectionDialects: {a: 'a is not a connection'}},
     });
     expect(m).toLog(error('invalid-connection-for-table-source'));
+  });
+
+  // Regression for #2845: a query source built on a virtual source used to
+  // fail model load, because loading eagerly generated SQL for the query
+  // source before a virtualMap was available.
+  test('query source built on a virtual source loads and compiles', () => {
+    const m = vsModel(`
+      type: ff is { category :: string, amount :: number }
+      source: facts_raw is _db_.virtual('facts_raw')::ff
+      source: facts_agg is facts_raw -> {
+        group_by: category
+        aggregate: total is sum(amount)
+      }
+      run: facts_agg -> { group_by: category }
+    `);
+    expect(m).toTranslate();
+    const modelDef = m.translate().modelDef!;
+    const virtualMap: VirtualMap = new Map([
+      ['_db_', new Map([['facts_raw', 'facts_table']])],
+    ]);
+    const queryModel = new QueryModel(modelDef);
+    const compiled = queryModel.compileQuery(modelDef.queryList[0], {
+      virtualMap,
+    });
+    expect(compiled.sql).toContain('facts_table');
+  });
+
+  // A query source on a virtual source, reached through a join, exercises the
+  // nested-query-source path that the old load-time field resolution walked.
+  test('joined query source on a virtual source compiles', () => {
+    const m = vsModel(`
+      type: ff is { id :: number, category :: string, amount :: number }
+      source: facts_raw is _db_.virtual('facts_raw')::ff
+      source: cat_totals is facts_raw -> {
+        group_by: category
+        aggregate: total is sum(amount)
+      }
+      source: enriched is facts_raw extend {
+        join_one: cat_totals on category = cat_totals.category
+      }
+      run: enriched -> { select: category, cat_totals.total }
+    `);
+    expect(m).toTranslate();
+    const modelDef = m.translate().modelDef!;
+    const virtualMap: VirtualMap = new Map([
+      ['_db_', new Map([['facts_raw', 'facts_table']])],
+    ]);
+    const queryModel = new QueryModel(modelDef);
+    const compiled = queryModel.compileQuery(modelDef.queryList[0], {
+      virtualMap,
+    });
+    expect(compiled.sql).toContain('facts_table');
   });
 });
 

--- a/packages/malloy/src/model/query_model_impl.ts
+++ b/packages/malloy/src/model/query_model_impl.ts
@@ -48,33 +48,21 @@ export class QueryModelImpl implements QueryModel, ModelRootInterface {
     }
   }
 
-  // Another circularity breaking method ... call into QueryQuery
-  // to find the output shape of a query
-  getFinalOutputStruct(
-    query: Query,
-    options: PrepareResultOptions | undefined
-  ): SourceDef | undefined {
-    const result = this.loadQuery(query, undefined, options, false, false);
-    return result.structs.pop();
-  }
-
   loadModelFromDef(modelDef: ModelDef): void {
     this.modelDef = modelDef;
     for (const s of Object.values(this.modelDef.contents)) {
-      let qs;
+      // Only sources become QueryStructs. query/userType/given are namespace
+      // metadata, not queryable, and are skipped.
       if (isSourceDef(s)) {
-        qs = new QueryStruct(s, undefined, {model: this}, {});
-        this.structs.set(getIdentifier(s), qs);
-        qs.resolveQueryFields((query, options) =>
-          this.getFinalOutputStruct(query, options)
+        this.structs.set(
+          getIdentifier(s),
+          new QueryStruct(s, undefined, {model: this}, {})
         );
-      } else if (s.type === 'query') {
-        /* TODO */
-      } else if (s.type === 'userType') {
-        // User type definitions are metadata only, not queryable
-      } else if (s.type === 'given') {
-        // Givens are metadata in the namespace, not queryable structures.
-      } else {
+      } else if (
+        s.type !== 'query' &&
+        s.type !== 'userType' &&
+        s.type !== 'given'
+      ) {
         throw new Error('Internal Error: Unknown structure type');
       }
     }
@@ -100,15 +88,12 @@ export class QueryModelImpl implements QueryModel, ModelRootInterface {
     prepareResultOptions ??= {};
     if (typeof structRef === 'string') {
       const ret = this.getStructByName(structRef);
-      if (sourceArguments !== undefined) {
-        return new QueryStruct(
-          ret.structDef,
-          sourceArguments,
-          ret.parent ? {struct: ret.parent} : {model: this},
-          prepareResultOptions
-        );
-      }
-      return ret;
+      return new QueryStruct(
+        ret.structDef,
+        sourceArguments ?? ret.sourceArguments,
+        ret.parent ? {struct: ret.parent} : {model: this},
+        prepareResultOptions
+      );
     }
     return new QueryStruct(
       structRef,

--- a/packages/malloy/src/model/query_node.ts
+++ b/packages/malloy/src/model/query_node.ts
@@ -27,8 +27,6 @@ import type {
   StructDef,
   TurtleDef,
   TurtleDefPlusFilters,
-  SourceDef,
-  Query,
 } from './malloy_types';
 import {MalloyCompileError} from './malloy_compile_error';
 import {
@@ -591,51 +589,6 @@ export class QueryStruct {
         'compiler-missing-primary-key',
         fieldDef.location
       );
-    }
-  }
-
-  /**
-   * called after all structure has been loaded.  Examine this structure to see
-   * if if it is based on a query and if it is, add the output fields (unless
-   * they exist) to the structure.
-   *
-   * finalOutputStruct exists so that query_node doesn't need to
-   * to import query_query
-   */
-  resolveQueryFields(
-    finalOutputStruct: (
-      query: Query,
-      options: PrepareResultOptions | undefined
-    ) => SourceDef | undefined
-  ) {
-    if (this.structDef.type === 'query_source' && finalOutputStruct) {
-      const resultStruct = finalOutputStruct(
-        this.structDef.query,
-        this.prepareResultOptions
-      );
-
-      // should never happen.
-      if (!resultStruct) {
-        throw new Error("Internal Error, query didn't produce a struct");
-      }
-
-      const structDef = {...this.structDef};
-      for (const f of resultStruct.fields) {
-        const as = getIdentifier(f);
-        if (!this.nameMap.has(as)) {
-          structDef.fields.push(f);
-          this.nameMap.set(as, this.makeQueryField(f));
-        }
-      }
-      this.structDef = structDef;
-      if (!this.structDef.primaryKey && resultStruct.primaryKey) {
-        this.structDef.primaryKey = resultStruct.primaryKey;
-      }
-    }
-    for (const [, v] of this.nameMap) {
-      if (v instanceof QueryFieldStruct) {
-        v.queryStruct.resolveQueryFields(finalOutputStruct);
-      }
     }
   }
 


### PR DESCRIPTION
Reported and diagnosed by @jgogstad in #2847, which this supersedes with a smaller, deletion-based fix.

Reviewing the PR was an interesting experience because I pulled on one tiny annoyance, which was that the AI had essentially turned a binary "loaded / not loaded" intro a tri-state "not loaded / loading / not loaded" but hidden that behind a comment to explain when it was trying to detect "detect loading but not loaded"

Pulling on that thread revealed that actually we don't need that third state because there was a computation be re-run at compile time which long ago moved up the the translation step, and it was this computation which trigged the "loaded but not loaded" problem.

Anyway, we stopped trying to recompute something which was already known and things cleaned up nicely.

Many thanks to @jgogstad 


Fixes #2845
