### PR TITLE
fix(snowflake): recover variant schema when a BLOCK sample draws no rows

### DIFF
--- a/packages/malloy-db-snowflake/src/snowflake_connection.ts
+++ b/packages/malloy-db-snowflake/src/snowflake_connection.ts
@@ -74,9 +74,11 @@ export interface TableSizeProbe {
  *
  *   tablesample-only: probe confirmed a base table above the small
  *     threshold. TABLESAMPLE BLOCK is safe (reads a few micro
- *     partitions). Plain LIMIT without a WHERE is unsafe on large
- *     partitioned tables, so we skip the LIMIT fallback — we'd rather
- *     degrade to variant than issue a runaway query.
+ *     partitions); plain LIMIT without a WHERE is unsafe on large
+ *     partitioned tables, so we skip the LIMIT fallback and instead
+ *     escalate the BLOCK percentage until a draw returns rows (see
+ *     sampleVariantBlocks). A column degrades to variant only on a
+ *     genuinely empty table or a hard failure, never an unlucky draw.
  *
  *   tablesample-then-limit: probe gave no size info (views, temp
  *     views, exotic names). We can't distinguish a small view from a
@@ -98,30 +100,30 @@ export function pickSampleStrategy(
 }
 
 /**
- * BLOCK sampling percentages tried, in order, when sampling a known-large
- * base table for VARIANT schema inference. See sampleVariantBlocks.
+ * `TABLESAMPLE BLOCK` percentages tried, in order, when sampling a known-large
+ * base table for VARIANT schema inference. Terminates at 100 so the only empty
+ * draw is a genuinely empty table. See sampleVariantBlocks.
  */
-export const VARIANT_SAMPLE_BLOCK_PERCENTS = [1, 10, 50] as const;
+export const VARIANT_SAMPLE_BLOCK_PERCENTS = [1, 10, 100] as const;
 
 /**
  * Draw a VARIANT schema sample from a known-large base table, escalating the
  * `TABLESAMPLE BLOCK` percentage until a draw returns rows.
  *
- * BLOCK sampling decides independently *per micro-partition* at p%, so a small
- * p on a table with relatively few partitions can select ZERO partitions and
- * return no rows. An empty draw is indistinguishable downstream from "this
- * column is genuinely an opaque variant", so a single unlucky `BLOCK (1)` draw
- * would silently degrade every VARIANT/ARRAY/OBJECT column to `sql native` —
- * and non-deterministically, since BLOCK is unseeded, so the same table can
- * resolve differently on consecutive schema fetches. Escalating p recovers
- * evidence: each draw is still bounded by the caller's `LIMIT`, and because a
- * single selected partition already over-fills that limit, the extra
- * percentages cost at most about one partition's worth of scanning.
+ * BLOCK decides independently per micro-partition, so a low percentage on a
+ * table with few partitions can draw zero rows. An empty draw is
+ * indistinguishable downstream from a genuinely-opaque variant — and, since
+ * BLOCK is unseeded, non-deterministic — so accepting it would silently degrade
+ * every variant column to `sql native`. Escalate instead: an empty draw is
+ * itself evidence the table is small enough to sample harder. (Probabilities
+ * and sizing are in the PR description.)
  *
- * `runSample(blockPercent)` runs the sample at the given percentage and
- * resolves to the rows (or `undefined`/`[]` on error or empty draw). Returns
- * the first non-empty result, or `undefined` if every percentage came back
- * empty.
+ * Contract: a column degrades to variant only from a genuinely empty table
+ * (empty even at `BLOCK (100)`) or a hard failure — never an unlucky draw.
+ *
+ * `runSample` resolves to the rows, to `[]` on an empty draw (escalate), or to
+ * `undefined` on error/timeout (stop — no "table is small" evidence). Returns
+ * the first non-empty draw, else `undefined`.
  */
 export async function sampleVariantBlocks(
   runSample: (blockPercent: number) => Promise<QueryRecord[] | undefined>,
@@ -129,9 +131,11 @@ export async function sampleVariantBlocks(
 ): Promise<QueryRecord[] | undefined> {
   for (const blockPercent of blockPercents) {
     const rows = await runSample(blockPercent);
-    if (rows !== undefined && rows.length > 0) {
-      return rows;
-    }
+    // Error/timeout carries no "table is small" evidence, and a higher
+    // percentage only scans more — stop rather than escalate into more timeouts.
+    if (rows === undefined) return undefined;
+    if (rows.length > 0) return rows;
+    // Empty draw: proven small enough to sample harder — escalate.
   }
   return undefined;
 }
@@ -407,14 +411,11 @@ export class SnowflakeConnection
             `${projectVariants} from ${tablePath} TABLESAMPLE BLOCK (${blockPercent}) limit ${n}`
           );
         if (strategy === 'tablesample-only') {
-          // Known-large base table: TABLESAMPLE is safe (reads a few
-          // micro-partitions), plain LIMIT without a WHERE can be
-          // catastrophic on large partitioned tables. BLOCK decides
-          // per-partition, so a low percentage can return zero rows on a
-          // table with relatively few partitions; escalate the percentage
-          // until a draw yields evidence rather than silently degrading
-          // every variant column to sql native. Each draw is still bounded
-          // by `limit n`, so this never risks an unbounded scan.
+          // Known-large base table: BLOCK decides per-partition, so a low
+          // percentage can draw zero rows; escalate until one returns rows
+          // rather than degrade the column to sql native (see
+          // sampleVariantBlocks). Plain LIMIT without a WHERE is unsafe here,
+          // so there is no LIMIT fallback.
           fieldPathRows = await sampleVariantBlocks(blockPercent =>
             this.executor.tryBatch(
               blockSampleQuery(blockPercent),

--- a/packages/malloy-db-snowflake/src/snowflake_connection.ts
+++ b/packages/malloy-db-snowflake/src/snowflake_connection.ts
@@ -97,6 +97,45 @@ export function pickSampleStrategy(
   return 'tablesample-only';
 }
 
+/**
+ * BLOCK sampling percentages tried, in order, when sampling a known-large
+ * base table for VARIANT schema inference. See sampleVariantBlocks.
+ */
+export const VARIANT_SAMPLE_BLOCK_PERCENTS = [1, 10, 50] as const;
+
+/**
+ * Draw a VARIANT schema sample from a known-large base table, escalating the
+ * `TABLESAMPLE BLOCK` percentage until a draw returns rows.
+ *
+ * BLOCK sampling decides independently *per micro-partition* at p%, so a small
+ * p on a table with relatively few partitions can select ZERO partitions and
+ * return no rows. An empty draw is indistinguishable downstream from "this
+ * column is genuinely an opaque variant", so a single unlucky `BLOCK (1)` draw
+ * would silently degrade every VARIANT/ARRAY/OBJECT column to `sql native` —
+ * and non-deterministically, since BLOCK is unseeded, so the same table can
+ * resolve differently on consecutive schema fetches. Escalating p recovers
+ * evidence: each draw is still bounded by the caller's `LIMIT`, and because a
+ * single selected partition already over-fills that limit, the extra
+ * percentages cost at most about one partition's worth of scanning.
+ *
+ * `runSample(blockPercent)` runs the sample at the given percentage and
+ * resolves to the rows (or `undefined`/`[]` on error or empty draw). Returns
+ * the first non-empty result, or `undefined` if every percentage came back
+ * empty.
+ */
+export async function sampleVariantBlocks(
+  runSample: (blockPercent: number) => Promise<QueryRecord[] | undefined>,
+  blockPercents: readonly number[] = VARIANT_SAMPLE_BLOCK_PERCENTS
+): Promise<QueryRecord[] | undefined> {
+  for (const blockPercent of blockPercents) {
+    const rows = await runSample(blockPercent);
+    if (rows !== undefined && rows.length > 0) {
+      return rows;
+    }
+  }
+  return undefined;
+}
+
 export interface SnowflakeConnectionOptions {
   // snowflake sdk connection options
   connOptions?: ConnectionOptions;
@@ -363,28 +402,33 @@ export class SnowflakeConnection
       }
 
       if (fieldPathRows === undefined) {
-        const tablesampleQuery = makeSampleQuery(
-          `${projectVariants} from ${tablePath} TABLESAMPLE BLOCK (1) limit ${n}`
-        );
+        const blockSampleQuery = (blockPercent: number) =>
+          makeSampleQuery(
+            `${projectVariants} from ${tablePath} TABLESAMPLE BLOCK (${blockPercent}) limit ${n}`
+          );
         if (strategy === 'tablesample-only') {
           // Known-large base table: TABLESAMPLE is safe (reads a few
           // micro-partitions), plain LIMIT without a WHERE can be
-          // catastrophic on large partitioned tables. If TABLESAMPLE
-          // fails here we accept variant rather than risk an unbounded
-          // scan.
-          fieldPathRows =
-            (await this.executor.tryBatch(
-              tablesampleQuery,
+          // catastrophic on large partitioned tables. BLOCK decides
+          // per-partition, so a low percentage can return zero rows on a
+          // table with relatively few partitions; escalate the percentage
+          // until a draw yields evidence rather than silently degrading
+          // every variant column to sql native. Each draw is still bounded
+          // by `limit n`, so this never risks an unbounded scan.
+          fieldPathRows = await sampleVariantBlocks(blockPercent =>
+            this.executor.tryBatch(
+              blockSampleQuery(blockPercent),
               {},
               this.schemaSampleTimeoutMs
-            )) ?? undefined;
+            )
+          );
         } else {
           // Unknown size (view, temp view, non-parseable name) or
           // full-scan fallback: best-effort TABLESAMPLE→LIMIT chain.
           // The LIMIT fallback is the acknowledged "can't help" case
           // for views over large partitioned tables.
           fieldPathRows = await this.runSchemaSample(
-            tablesampleQuery,
+            blockSampleQuery(1),
             makeSampleQuery(`${projectVariants} from ${tablePath} limit ${n}`)
           );
         }

--- a/packages/malloy-db-snowflake/src/snowflake_sample_strategy.spec.ts
+++ b/packages/malloy-db-snowflake/src/snowflake_sample_strategy.spec.ts
@@ -72,14 +72,26 @@ describe('sampleVariantBlocks', () => {
     expect(tried).toEqual([1, 10]);
   });
 
-  test('treats an errored (undefined) draw like empty and continues', async () => {
+  test('stops on an errored (undefined) draw without escalating', async () => {
+    // A timeout/error carries no "table is small" evidence, and higher
+    // percentages only scan more — so we must not escalate into more timeouts.
     const tried: number[] = [];
     const result = await sampleVariantBlocks(blockPercent => {
       tried.push(blockPercent);
-      return Promise.resolve(blockPercent >= 50 ? rows(1) : undefined);
+      return Promise.resolve(undefined);
     });
-    expect(result).toHaveLength(1);
-    expect(tried).toEqual([...VARIANT_SAMPLE_BLOCK_PERCENTS]);
+    expect(result).toBeUndefined();
+    expect(tried).toEqual([1]);
+  });
+
+  test('escalates past an empty draw but stops at a later error', async () => {
+    const tried: number[] = [];
+    const result = await sampleVariantBlocks(blockPercent => {
+      tried.push(blockPercent);
+      return Promise.resolve(blockPercent === 1 ? [] : undefined);
+    });
+    expect(result).toBeUndefined();
+    expect(tried).toEqual([1, 10]);
   });
 
   test('returns undefined when every percentage comes back empty', async () => {

--- a/packages/malloy-db-snowflake/src/snowflake_sample_strategy.spec.ts
+++ b/packages/malloy-db-snowflake/src/snowflake_sample_strategy.spec.ts
@@ -3,7 +3,12 @@
  * SPDX-License-Identifier: MIT
  */
 
-import {pickSampleStrategy} from './snowflake_connection';
+import type {QueryRecord} from '@malloydata/malloy';
+import {
+  pickSampleStrategy,
+  sampleVariantBlocks,
+  VARIANT_SAMPLE_BLOCK_PERCENTS,
+} from './snowflake_connection';
 import {parseSnowflakeTableName} from './snowflake_table_name';
 
 describe('pickSampleStrategy', () => {
@@ -40,6 +45,63 @@ describe('pickSampleStrategy', () => {
     expect(pickSampleStrategy({bytes: 1, rowCount: 1}, 0)).toBe(
       'tablesample-only'
     );
+  });
+});
+
+describe('sampleVariantBlocks', () => {
+  const rows = (n: number): QueryRecord[] =>
+    Array.from({length: n}, (_, i) => ({N: i}));
+
+  test('returns the first non-empty draw and does not escalate', async () => {
+    const tried: number[] = [];
+    const result = await sampleVariantBlocks(blockPercent => {
+      tried.push(blockPercent);
+      return Promise.resolve(rows(3));
+    });
+    expect(result).toHaveLength(3);
+    expect(tried).toEqual([1]);
+  });
+
+  test('escalates past an empty draw until one returns rows', async () => {
+    const tried: number[] = [];
+    const result = await sampleVariantBlocks(blockPercent => {
+      tried.push(blockPercent);
+      return Promise.resolve(blockPercent >= 10 ? rows(2) : []);
+    });
+    expect(result).toHaveLength(2);
+    expect(tried).toEqual([1, 10]);
+  });
+
+  test('treats an errored (undefined) draw like empty and continues', async () => {
+    const tried: number[] = [];
+    const result = await sampleVariantBlocks(blockPercent => {
+      tried.push(blockPercent);
+      return Promise.resolve(blockPercent >= 50 ? rows(1) : undefined);
+    });
+    expect(result).toHaveLength(1);
+    expect(tried).toEqual([...VARIANT_SAMPLE_BLOCK_PERCENTS]);
+  });
+
+  test('returns undefined when every percentage comes back empty', async () => {
+    const tried: number[] = [];
+    const result = await sampleVariantBlocks(blockPercent => {
+      tried.push(blockPercent);
+      return Promise.resolve([]);
+    });
+    expect(result).toBeUndefined();
+    expect(tried).toEqual([...VARIANT_SAMPLE_BLOCK_PERCENTS]);
+  });
+
+  test('honors a custom percentage ladder, in order', async () => {
+    const tried: number[] = [];
+    await sampleVariantBlocks(
+      blockPercent => {
+        tried.push(blockPercent);
+        return Promise.resolve([]);
+      },
+      [5, 25]
+    );
+    expect(tried).toEqual([5, 25]);
   });
 });
 


### PR DESCRIPTION
## Problem

Snowflake `VARIANT`/`ARRAY`/`OBJECT` columns have no scalar type in metadata, so the connection samples data to infer one. For a base table above the full-scan byte threshold, the `tablesample-only` path samples with:

```sql
... FROM <table> TABLESAMPLE BLOCK (1) LIMIT <n>
```

`TABLESAMPLE BLOCK (p)` is **block (micro-partition) sampling**: each micro-partition is included independently with probability `p%`. On a table with relatively few micro-partitions, `BLOCK (1)` frequently selects **zero** partitions and returns **no rows**. The code treated that empty draw as final and fell through to `opaqueVariantType()`, typing the whole column as `sql native` variant. Because `BLOCK` is **unseeded**, this is **non-deterministic** — the same table resolves to a concrete type on one schema fetch and to `variant` on the next.

Downstream, any `count(col)`, join `on col = ...`, etc. then fails to compile:

```
Unsupported SQL native type 'variant' not allowed in expression
```

…so a model compiles and runs fine in one environment and fails to compile in another (e.g. on publish) with no change to the model.

### Measured on a real table (9.77M rows, uniformly INTEGER `VARIANT` id column)

- `SYSTEM$CLUSTERING_INFORMATION` → **152 micro-partitions** (~65,536 rows each — Snowflake's per-partition cap).
- `TABLESAMPLE BLOCK (1)` returns **either 0 rows or whole partitions** (65,536, 131,072, …) — never a small non-zero count, so `LIMIT 1000` is irrelevant to the failure.
- Empty draws observed in **10 / 60 trials (~17%)**, matching the theoretical `0.99^152 ≈ 22%`.
- A plain read yields clean `(col, INTEGER)` evidence → would infer `number`. The column is perfectly typeable; only the sampling miss degrades it.

It's feast-or-famine: any non-empty draw already over-delivers evidence; the **only** failure mode is the empty draw.

## Fix

Escalate the `BLOCK` percentage (`1 → 10 → 100`) until a draw returns rows, instead of accepting the first empty result. The logic is extracted into a pure, unit-tested `sampleVariantBlocks` helper, mirroring the existing `pickSampleStrategy`.

Two properties make this safe and correct.

**1. The escalation structurally can't run away — an empty draw is a *measurement*, not just a miss.** With `M` micro-partitions, `P(empty) = (1 − p/100)^M`, so each empty draw bounds the table:

| an empty draw at | proves the table is no bigger than |
|---|---|
| `BLOCK(1)`   | ~460 partitions (~7 GB) |
| `BLOCK(10)`  | ~45 partitions (~0.7 GB) |
| `BLOCK(100)` | 0 rows — it's genuinely empty |

So you only escalate on a table a prior failure has already proven is small: by the time `BLOCK(100)` could run, an empty `BLOCK(10)` has bounded the table to a few tens of partitions. A petabyte table (millions of partitions) can't produce the empty `BLOCK(1)` that starts the chain. Each rung is still bounded by the existing `LIMIT`, and because one selected partition already over-fills that limit, the extra rungs cost at most ~one partition's worth of scan. The safety has to come from here, not from `LIMIT` — `LIMIT` doesn't bound the scan on a large partitioned table, which is the whole premise of this path.

**Terminating at 100 (not 50) matters.** This path runs on tables just over the byte threshold, often a handful of partitions, where `BLOCK(50)` still draws empty an appreciable fraction of the time (`0.5^M` — e.g. ~12% at 3 partitions). Stopping at 50 only makes the bug rarer; at 100 the only empty draw is a genuinely empty table.

**2. An empty draw and an error/timeout are different signals.** `tryBatch` returns `[]` on a genuinely empty draw and `undefined` on any exception (including a 15s timeout). Only `[]` escalates; `undefined` stops. A timeout carries none of the "table is small" evidence, and higher rungs scan *more* — so escalating after a timeout would just buy more timeouts before the same `variant`.

**Contract:** a column degrades to `variant` only from a genuinely empty table (empty at `BLOCK(100)`) or a hard failure — never from an unlucky draw.

## Testing

New unit tests in `snowflake_sample_strategy.spec.ts` (no DB):

- first non-empty draw stops early (no escalation);
- escalates past an empty draw until one returns rows;
- **stops on an errored (`undefined`) draw without escalating;**
- **escalates past an empty draw but stops at a later error;**
- returns `undefined` only when every percentage comes back empty;
- honors a custom percentage ladder, in order.

`npx jest packages/malloy-db-snowflake/src/snowflake_sample_strategy.spec.ts` → 25 passed.

## Why escalation, rather than `SAMPLE ROW` / `SEED`

- **`SAMPLE ROW (p)`** is per-row Bernoulli sampling — it never draws empty at meaningful sizes, but it rolls the dice per row, which forces a **full-table scan**. `tablesample-only` exists precisely to avoid that scan on a large table; switching to ROW sampling here would reintroduce the exact cost this path was built to dodge. BLOCK reads only the selected micro-partitions, and escalation preserves that cheap-I/O property for the common case.
- **`SEED (n)`** makes BLOCK deterministic but adds no evidence — a seeded empty draw is still empty, so the column would still degrade to `variant`, just stably. Determinism without escalation only makes the wrong answer reproducible.

A deeper improvement would distinguish "sampled, saw nothing" from "sampled, saw conflicting types" in the inference layer so a miss never silently becomes `variant`; this PR fixes the empty-draw cause without changing that contract.
