### PR TITLE
Stop linting generated tokenizations/darkPlus.ts

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -14,6 +14,7 @@ module.exports = defineConfig([
       'packages/malloy-malloy-sql/src/grammar/**',
       'packages/malloy-tag/src/peggy/dist/**',
       'packages/malloy-syntax-highlight/**/*.monarch.ts',
+      'packages/malloy-syntax-highlight/**/tokenizations/*.ts',
       'packages/malloy-interfaces/docs/**',
       'packages/malloy-query-builder/docs/**',
       'packages/malloy-tag/src/lib/**',


### PR DESCRIPTION
`npm run lint-fix` rewrites the generated file `packages/malloy-syntax-highlight/grammars/malloy/tokenizations/darkPlus.ts` on every run, dirtying a generated artifact and producing spurious diffs that have to be reverted by hand.

The generator emits backtick template literals for the few lines whose content contains both `'` and `"`, which the inherited `quotes` rule flags as warnings. CI's `lint` exits 0 on warnings so the file merges as-is, but `lint-fix` auto-fixes them — that's the entire churn.

`darkPlus.ts` is the one generated artifact in this package still subject to lint; the sibling `*.monarch.ts` output is already ignored. This adds the generated tokenizations output to the same ignore list.

Fixes #2851