### PR TITLE
Joins rebind via `as`, not by overwriting `name`

### DIFF
--- a/packages/malloy/src/lang/ast/field-space/dynamic-space.ts
+++ b/packages/malloy/src/lang/ast/field-space/dynamic-space.ts
@@ -22,7 +22,7 @@
  */
 
 import * as model from '../../../model/malloy_types';
-import {mkSafeRecord} from '../../../model/malloy_types';
+import {activeName, mkSafeRecord} from '../../../model/malloy_types';
 import {nameFromDef} from '../../field-utils';
 import type {SpaceEntry} from '../types/space-entry';
 import {ErrorFactory} from '../error-factory';
@@ -170,7 +170,7 @@ export abstract class DynamicSpace
       // e.g. if a field had a compiler flag on it...
       for (const [name, note] of this.newNotes) {
         const index = this.sourceDef.fields.findIndex(
-          f => f.as ?? f.name === name
+          f => activeName(f) === name
         );
         if (index === -1) {
           throw new Error(`Can't find field '${name}' to set access modifier`);

--- a/packages/malloy/src/lang/ast/query-properties/drill.ts
+++ b/packages/malloy/src/lang/ast/query-properties/drill.ts
@@ -22,6 +22,7 @@ import type {
   TypeDesc,
 } from '../../../model/malloy_types';
 import {
+  activeName,
   expressionIsAggregate,
   expressionIsAnalytic,
   expressionIsScalar,
@@ -215,7 +216,7 @@ export class Drill extends Filter implements QueryPropertyInterface {
         if (f.type === 'fieldref') {
           return f.path[f.path.length - 1] === name.refString;
         } else {
-          return f.as ?? f.name === name.refString;
+          return activeName(f) === name.refString;
         }
       });
       if (field === undefined) {

--- a/packages/malloy/src/lang/ast/source-properties/join.ts
+++ b/packages/malloy/src/lang/ast/source-properties/join.ts
@@ -107,13 +107,12 @@ export class KeyJoin extends Join {
     }
     const joinStruct: JoinFieldDef = {
       ...sourceDef,
-      name: this.name.refString,
+      as: this.name.refString,
       join: 'one',
       matrixOperation: 'left',
       onExpression: {node: 'error', message: "('join fixup'='not done yet')"},
       location: this.location,
     };
-    delete joinStruct.as;
 
     if (this.note) {
       joinStruct.annotations = this.note;
@@ -225,12 +224,11 @@ export class ExpressionJoin extends Join {
     }
     const joinStruct: JoinFieldDef = {
       ...sourceDef,
-      name: this.name.refString,
+      as: this.name.refString,
       join: this.joinType,
       matrixOperation,
       location: this.location,
     };
-    delete joinStruct.as;
     if (this.note) {
       joinStruct.annotations = this.note;
     }

--- a/packages/malloy/src/lang/test/imports.spec.ts
+++ b/packages/malloy/src/lang/test/imports.spec.ts
@@ -20,7 +20,7 @@
  * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-import {isJoined} from '../../model';
+import {activeName, isJoined} from '../../model';
 import './parse-expects';
 import {TestTranslator, errorMessage, model} from './test-translator';
 import escapeRegEx from 'lodash/escapeRegExp';
@@ -96,7 +96,7 @@ source: botProjQSrc is botProjQ
     });
     expect(docParse).toTranslate();
     const newSrc = docParse.getSourceDef('newSrc');
-    const maybeField = newSrc?.fields.find(f => (f.as ?? f.name) === 'b');
+    const maybeField = newSrc?.fields.find(f => activeName(f) === 'b');
     expect(maybeField).toBeDefined();
     if (maybeField && isJoined(maybeField)) {
       expect(maybeField.type).toBe('query_source');

--- a/packages/malloy/src/lang/test/imports.spec.ts
+++ b/packages/malloy/src/lang/test/imports.spec.ts
@@ -96,7 +96,7 @@ source: botProjQSrc is botProjQ
     });
     expect(docParse).toTranslate();
     const newSrc = docParse.getSourceDef('newSrc');
-    const maybeField = newSrc?.fields.find(f => f.name === 'b');
+    const maybeField = newSrc?.fields.find(f => (f.as ?? f.name) === 'b');
     expect(maybeField).toBeDefined();
     if (maybeField && isJoined(maybeField)) {
       expect(maybeField.type).toBe('query_source');

--- a/packages/malloy/src/lang/test/test-translator.ts
+++ b/packages/malloy/src/lang/test/test-translator.ts
@@ -41,6 +41,7 @@ import type {
   UserTypeDef,
 } from '../../model/malloy_types';
 import {
+  activeName,
   isQuerySegment,
   isSourceDef,
   isUserTypeDef,
@@ -668,7 +669,7 @@ export function getModelQuery(modelDef: ModelDef, name: string): Query {
 
 export function getFieldDef(source: StructDef, name: string): FieldDef {
   for (const f of source.fields) {
-    if (f.as ?? f.name === name) {
+    if (activeName(f) === name) {
       return f;
     }
   }
@@ -685,7 +686,7 @@ export function getQueryFieldDef(
         if (name === f.path[f.path.length - 1]) {
           return f;
         }
-      } else if (f.as ?? f.name === name) {
+      } else if (activeName(f) === name) {
         return f;
       }
     }

--- a/packages/malloy/src/model/CONTEXT.md
+++ b/packages/malloy/src/model/CONTEXT.md
@@ -22,6 +22,17 @@ The compiler consumes **Intermediate Representation (IR)** produced by the trans
 - **`SourceDef`** - A data source (table or derived table) with its schema and extended fields
 - **`StructDef`** - Schema definition for any structured data (records, arrays, tables, query results)
 
+**The `name` / `as` invariant (`AliasedName`):**
+
+Every `StructDef`, `SourceDef`, and `FieldDef` is an `AliasedName` with two name slots:
+
+- **`name`** — the intrinsic name, fixed when the def is created. It is **write-once**: nothing rebinds a def by reassigning `name`. For some def kinds `name` carries identity that must survive every rebinding — e.g. `VirtualSourceDef.name` *is* the `virtual('…')` argument, the key into the `virtualMap`.
+- **`as`** — the local binding name. Every rename, `X is …`, join, or `rename:` sets `as`, never `name`.
+
+The name a thing goes by in a given context is therefore **`getIdentifier(x)` = `x.as ?? x.name`**, and the `as ?? name` idiom is mandatory at every use site — you cannot tell from the use site whether this particular def is one whose `name` is load-bearing identity, so you always preserve `name` and always read through `as`.
+
+**Corollary for writers:** to rebind a def, set `as`. Never assign `name` and never `delete x.as` to "reset" a name — doing so destroys any identity payload `name` carried. (This was the cause of the joined-virtual-source bug: the join wrote the join name into `name` and deleted `as`, erasing the `virtualMap` key.)
+
 **Type Definitions:**
 - **`BasicAtomicType`** - String union of simple type names (`string | number | boolean | date | timestamp | timestamptz | json | sql native | error`). Guard: `isBasicAtomicType()`.
 - **`BasicAtomicTypeDef`** - TypeDef union for basic types (each variant may carry metadata, e.g. `NumberTypeDef` has optional `numberType`)

--- a/packages/malloy/src/model/CONTEXT.md
+++ b/packages/malloy/src/model/CONTEXT.md
@@ -29,7 +29,7 @@ Every `StructDef`, `SourceDef`, and `FieldDef` is an `AliasedName` with two name
 - **`name`** — the intrinsic name, fixed when the def is created. It is **write-once**: nothing rebinds a def by reassigning `name`. For some def kinds `name` carries identity that must survive every rebinding — e.g. `VirtualSourceDef.name` *is* the `virtual('…')` argument, the key into the `virtualMap`.
 - **`as`** — the local binding name. Every rename, `X is …`, join, or `rename:` sets `as`, never `name`.
 
-The name a thing goes by in a given context is therefore **`getIdentifier(x)` = `x.as ?? x.name`**, and the `as ?? name` idiom is mandatory at every use site — you cannot tell from the use site whether this particular def is one whose `name` is load-bearing identity, so you always preserve `name` and always read through `as`.
+The name a thing goes by in a given context is therefore **`activeName(x)` = `x.as ?? x.name`** (the one helper for this, defined next to the `AliasedName` interface in `malloy_types.ts`). Always call `activeName` at use sites — never hand-roll `x.as ?? x.name`, which is easy to get wrong (`x.as ?? x.name === n` parses as `x.as ?? (x.name === n)`). You cannot tell from a use site whether this particular def is one whose `name` is load-bearing identity, so you always preserve `name` and always read through `activeName`.
 
 **Corollary for writers:** to rebind a def, set `as`. Never assign `name` and never `delete x.as` to "reset" a name — doing so destroys any identity payload `name` carried. (This was the cause of the joined-virtual-source bug: the join wrote the join name into `name` and deleted `as`, erasing the `virtualMap` key.)
 

--- a/packages/malloy/src/model/malloy_types.ts
+++ b/packages/malloy/src/model/malloy_types.ts
@@ -708,6 +708,16 @@ export interface AliasedName {
   as?: string;
 }
 
+/**
+ * The name an `AliasedName` goes by in its current context: its `as` binding
+ * if it has one, otherwise its intrinsic `name`. This is the only correct way
+ * to ask "what is this called here" — see the `name`/`as` invariant in
+ * model/CONTEXT.md.
+ */
+export function activeName(an: AliasedName): string {
+  return an.as ?? an.name;
+}
+
 /** all named objects have a type an a name (optionally aliased) */
 export interface NamedObject extends AliasedName, HasLocation {
   type: string;

--- a/test/src/core/virtual.spec.ts
+++ b/test/src/core/virtual.spec.ts
@@ -152,6 +152,43 @@ describe('virtual source resolution', () => {
     expect(row['model_count']).toBeDefined();
   });
 
+  it('join to derived virtual source (extend)', async () => {
+    // A virtual source carries its `virtualMap` key in `name`. Joining a
+    // source rebinds it to the join name; that rebinding must go through `as`
+    // and leave `name` intact, otherwise the key ("vcarriers") is replaced by
+    // the join name ("carriers") and resolution fails with
+    // "No virtual-map entry for 'carriers'".
+    const code = `${VIRTUAL_ANNOTATION}
+      type: flight_fields is { carrier :: string }
+      type: carrier_fields is { code :: string, nickname :: string }
+
+      source: flights_raw is ${tstDB}.virtual('vflights')::flight_fields
+      source: carriers_raw is ${tstDB}.virtual('vcarriers')::carrier_fields
+
+      source: carriers is carriers_raw extend {
+        primary_key: code
+      }
+      source: flights is flights_raw extend {
+        join_one: carriers with carrier
+      }
+
+      run: flights -> {
+        group_by: carriers.nickname
+        aggregate: flight_count is count()
+      }
+    `;
+
+    const virtualMap = mkVirtualMap({
+      [tstDB]: {
+        vflights: 'malloytest.flights',
+        vcarriers: 'malloytest.carriers',
+      },
+    });
+
+    const result = await tstRuntime.loadQuery(code).run({virtualMap});
+    expect(result.data.value.length).toBeGreaterThan(0);
+  });
+
   it('virtualMap from MalloyConfig is available', () => {
     const configJSON = JSON.stringify({
       connections: {


### PR DESCRIPTION
Reported in #2855: extend a virtual source, join it, and resolution dies with `No virtual-map entry for 'carriers'` — the join name, not the `virtual('vcarriers')` key the map is actually keyed on.

Found a few places, including this one, where the `AliasedName` interface was not being used properly. Added a helper for that, fixed the broken places.

Closes #2855. Test is @jgogstad's from that PR.