### PR TITLE
Consolidate aliased-name reads onto activeName()

### DIFF
--- a/packages/malloy/src/api/foundation/core.ts
+++ b/packages/malloy/src/api/foundation/core.ts
@@ -43,6 +43,7 @@ import type {
   PrepareResultOptions,
 } from '../../model';
 import {
+  activeName,
   fieldIsIntrinsic,
   QueryModel,
   expressionIsCalculation,
@@ -258,7 +259,7 @@ export class Explore extends Entity implements Taggable {
   private _allFieldsWithOrder: SortableField[] | undefined;
 
   constructor(structDef: StructDef, parentExplore?: Explore, source?: Explore) {
-    super(structDef.as || structDef.name, parentExplore, source);
+    super(activeName(structDef), parentExplore, source);
     this._structDef = structDef;
     this._parentExplore = parentExplore;
     this.sourceExplore = source;
@@ -305,7 +306,7 @@ export class Explore extends Entity implements Taggable {
    * @return The name of the entity.
    */
   public get name(): string {
-    return this.structDef.as || this.structDef.name;
+    return activeName(this.structDef);
   }
 
   public getQueryByName(name: string): PreparedQuery {
@@ -315,7 +316,7 @@ export class Explore extends Entity implements Taggable {
         `Cannot get query by name from a struct of type ${this.structDef.type}`
       );
     }
-    const view = structRef.fields.find(f => (f.as ?? f.name) === name);
+    const view = structRef.fields.find(f => activeName(f) === name);
     if (view === undefined) {
       throw new Error(`No such view named \`${name}\``);
     }
@@ -355,7 +356,7 @@ export class Explore extends Entity implements Taggable {
       const sourceFields = this.source?.fieldMap || new Map();
       this._fieldMap = new Map(
         this.structDef.fields.map(fieldDef => {
-          const name = fieldDef.as || fieldDef.name;
+          const name = activeName(fieldDef);
           const sourceField = sourceFields.get(fieldDef.name);
           if (isJoined(fieldDef)) {
             return [name, new ExploreField(fieldDef, this, sourceField)];
@@ -617,7 +618,7 @@ export class AtomicField extends Entity implements Taggable {
     parent: Explore,
     source?: AtomicField
   ) {
-    super(fieldTypeDef.as || fieldTypeDef.name, parent, source);
+    super(activeName(fieldTypeDef), parent, source);
     this.fieldTypeDef = fieldTypeDef;
     this.parent = parent;
   }
@@ -904,7 +905,7 @@ export class Query extends Entity implements Taggable {
   private sourceQuery?: Query;
 
   constructor(turtleDef: TurtleDef, parent?: Explore, source?: Query) {
-    super(turtleDef.as || turtleDef.name, parent, source);
+    super(activeName(turtleDef), parent, source);
     this.turtleDef = turtleDef;
   }
 

--- a/packages/malloy/src/api/foundation/result.ts
+++ b/packages/malloy/src/api/foundation/result.ts
@@ -15,7 +15,12 @@ import type {
   AtomicTypeDef,
   QueryValue,
 } from '../../model';
-import {isRepeatedRecord, isBasicArray, isCompoundArrayData} from '../../model';
+import {
+  activeName,
+  isRepeatedRecord,
+  isBasicArray,
+  isCompoundArrayData,
+} from '../../model';
 import {
   rowDataToNumber,
   rowDataToSerializedBigint,
@@ -639,7 +644,7 @@ function walkQueryRecord(
 ): QueryRecord {
   const result: QueryRecord = {};
   for (const fieldDef of structDef.fields) {
-    const fieldName = fieldDef.as ?? fieldDef.name;
+    const fieldName = activeName(fieldDef);
     const value = row[fieldName];
     result[fieldName] = walkValue(value, fieldDef, normalizers);
   }

--- a/packages/malloy/src/dialect/snowflake/snowflake.ts
+++ b/packages/malloy/src/dialect/snowflake/snowflake.ts
@@ -36,6 +36,7 @@ import type {
   RecordLiteralNode,
 } from '../../model/malloy_types';
 import {
+  activeName,
   isSamplingEnable,
   isSamplingPercent,
   isSamplingRows,
@@ -583,7 +584,7 @@ ${indent(sql)}
     } else if (malloyType.type === 'record' || isRepeatedRecord(malloyType)) {
       const sqlFields = malloyType.fields.reduce((ret, f) => {
         if (isAtomic(f)) {
-          const name = f.as ?? f.name;
+          const name = activeName(f);
           const oneSchema = `${this.sqlQuoteIdentifier(
             name
           )} ${this.malloyTypeToSQLType(f)}`;
@@ -652,7 +653,7 @@ ${indent(sql)}
   sqlLiteralRecord(lit: RecordLiteralNode): string {
     const rowVals: string[] = [];
     for (const f of lit.typeDef.fields) {
-      const name = f.as ?? f.name;
+      const name = activeName(f);
       const propVal =
         safeRecordGet(lit.kids, name)?.sql ?? 'internal-error-record-literal';
       rowVals.push(`${this.sqlLiteralString(name)},${propVal}`);

--- a/packages/malloy/src/dialect/trino/trino.ts
+++ b/packages/malloy/src/dialect/trino/trino.ts
@@ -35,6 +35,7 @@ import type {
   RecordLiteralNode,
 } from '../../model/malloy_types';
 import {
+  activeName,
   isSamplingEnable,
   isSamplingPercent,
   isSamplingRows,
@@ -746,7 +747,7 @@ ${indent(sql)}
     const rowTypes: string[] = [];
     for (const f of lit.typeDef.fields) {
       if (isAtomic(f)) {
-        const name = f.as ?? f.name;
+        const name = activeName(f);
         rowVals.push(
           safeRecordGet(lit.kids, name)?.sql ?? 'internal-error-record-literal'
         );

--- a/packages/malloy/src/lang/ast/expressions/expr-func.ts
+++ b/packages/malloy/src/lang/ast/expressions/expr-func.ts
@@ -45,6 +45,7 @@ import type {
   AggregateUngrouping,
 } from '../../../model/malloy_types';
 import {
+  activeName,
   expressionIsAggregate,
   expressionIsAnalytic,
   expressionIsScalar,
@@ -747,10 +748,10 @@ function isDataTypeMatch(
     const genericsSet: GenericAssignment[] = [];
     const paramFieldsByName = new Map<string, FunctionParameterFieldDef>();
     for (const field of paramT.fields) {
-      paramFieldsByName.set(field.as ?? field.name, field);
+      paramFieldsByName.set(activeName(field), field);
     }
     for (const field of arg.fields) {
-      const match = paramFieldsByName.get(field.as ?? field.name);
+      const match = paramFieldsByName.get(activeName(field));
       if (match === undefined) {
         return {dataTypeMatch: false, genericsSet: []};
       }

--- a/packages/malloy/src/lang/ast/field-space/dynamic-space.ts
+++ b/packages/malloy/src/lang/ast/field-space/dynamic-space.ts
@@ -152,7 +152,7 @@ export abstract class DynamicSpace
       // Add access modifiers at the end so views don't obey them
       for (const [name, access] of this.newAccessModifiers) {
         const index = this.sourceDef.fields.findIndex(
-          f => (f.as ?? f.name) === name
+          f => activeName(f) === name
         );
         if (index === -1) {
           throw new Error(`Can't find field '${name}' to set access modifier`);

--- a/packages/malloy/src/lang/ast/field-space/include-utils.ts
+++ b/packages/malloy/src/lang/ast/field-space/include-utils.ts
@@ -12,7 +12,7 @@ import type {
   FieldDef,
   SourceDef,
 } from '../../../model/malloy_types';
-import {isJoined} from '../../../model/malloy_types';
+import {activeName, isJoined} from '../../../model/malloy_types';
 import type {IncludeItem} from '../source-query-elements/include-item';
 import {
   IncludeAccessItem,
@@ -55,7 +55,7 @@ function getJoinFields(
 ): FieldDef[] {
   let fields = from.fields;
   for (const joinName of joinPath) {
-    const join = fields.find(f => (f.as ?? f.name) === joinName);
+    const join = fields.find(f => activeName(f) === joinName);
     if (join === undefined) {
       logTo.logError('field-not-found', `\`${joinName}\` not found`);
       return [];
@@ -100,14 +100,14 @@ function getOrCreateIncludeStateForJoin(
   if (joinState !== undefined) return joinState.state;
   else {
     const fromFields = getJoinFields(from, joinPath, logTo);
-    const allFields = new Set(fromFields.map(f => f.as ?? f.name));
+    const allFields = new Set(fromFields.map(f => activeName(f)));
     const joinNames = new Set(
-      fromFields.filter(f => isJoined(f)).map(f => f.as ?? f.name)
+      fromFields.filter(f => isJoined(f)).map(f => activeName(f))
     );
     const alreadyPrivateFields = new Set(
       fromFields
         .filter(f => f.accessModifier === 'private')
-        .map(f => f.as ?? f.name)
+        .map(f => activeName(f))
     );
     const joinState: JoinIncludeProcessingState = {
       star: undefined,

--- a/packages/malloy/src/lang/ast/field-space/query-spaces.ts
+++ b/packages/malloy/src/lang/ast/field-space/query-spaces.ts
@@ -286,7 +286,7 @@ export abstract class QuerySpace extends QueryOperationSpace {
         this.addValidatedCompositeFieldUserFromEntry(name, referenceField);
       } else {
         const entry = new RefineFromSpaceField(field);
-        const name = field.as ?? field.name;
+        const name = model.activeName(field);
         this.setEntry(name, entry);
         this.addValidatedCompositeFieldUserFromEntry(name, entry);
       }
@@ -323,7 +323,7 @@ export abstract class QuerySpace extends QueryOperationSpace {
       name = queryFieldDef.path[queryFieldDef.path.length - 1];
       location = queryFieldDef.at;
     } else {
-      name = queryFieldDef.as ?? queryFieldDef.name;
+      name = model.activeName(queryFieldDef);
       location = queryFieldDef.location;
     }
     let ret: model.FieldDef;
@@ -384,7 +384,7 @@ export abstract class QuerySpace extends QueryOperationSpace {
     if (primaryKeyField.type === 'fieldref') {
       return primaryKeyField.path[primaryKeyField.path.length - 1];
     } else {
-      return primaryKeyField.as ?? primaryKeyField.name;
+      return model.activeName(primaryKeyField);
     }
   }
 

--- a/packages/malloy/src/lang/ast/field-space/refined-space.ts
+++ b/packages/malloy/src/lang/ast/field-space/refined-space.ts
@@ -23,6 +23,7 @@
 
 import type {FieldDef, StructDef} from '../../../model/malloy_types';
 import {
+  activeName,
   isJoined,
   type AccessModifierLabel,
   type AnnotationsDef,
@@ -186,7 +187,7 @@ function editJoinsFromIncludeState(
   if (isJoin) {
     if (joinedState.fieldsToInclude) {
       fields = from.fields.filter(f =>
-        joinedState.fieldsToInclude?.has(f.as ?? f.name)
+        joinedState.fieldsToInclude?.has(activeName(f))
       );
     } else {
       fields = from.fields;
@@ -197,13 +198,13 @@ function editJoinsFromIncludeState(
   // const fields = from.fields;
   const updatedFields: FieldDef[] = [];
   for (const field of fields) {
-    const name = field.as ?? field.name;
+    const name = activeName(field);
     // TODO ensure you can't make it more permissive here...
     const accessModifier =
       joinedState.modifiers.get(name) ?? field.accessModifier;
     const notes = joinedState.notes.get(name);
     const rename = joinedState.renames.find(
-      r => r.name.nameString === (field.as ?? field.name)
+      r => r.name.nameString === activeName(field)
     );
     const editedField: FieldDef = isJoin
       ? {
@@ -224,7 +225,7 @@ function editJoinsFromIncludeState(
       updatedFields.push({
         ...editedField,
         fields: editJoinsFromIncludeState(
-          [...path, field.as ?? field.name],
+          [...path, activeName(field)],
           editedField,
           includeState
         ),

--- a/packages/malloy/src/lang/ast/field-space/rename-space-field.ts
+++ b/packages/malloy/src/lang/ast/field-space/rename-space-field.ts
@@ -26,7 +26,7 @@ import type {
   DocumentLocation,
   FieldDef,
 } from '../../../model/malloy_types';
-import {mapFieldUsage} from '../../../model/malloy_types';
+import {activeName, mapFieldUsage} from '../../../model/malloy_types';
 
 import {SpaceField} from '../types/space-field';
 
@@ -62,7 +62,7 @@ export class RenameSpaceField extends SpaceField {
       refSummary: mapFieldUsage(returnFieldDef.refSummary, u => ({
         ...u,
         path:
-          u.path[0] === (returnFieldDef.as ?? returnFieldDef.name)
+          u.path[0] === activeName(returnFieldDef)
             ? [this.newName, ...u.path.slice(1)]
             : u.path,
       })),

--- a/packages/malloy/src/lang/ast/field-space/static-space.ts
+++ b/packages/malloy/src/lang/ast/field-space/static-space.ts
@@ -31,6 +31,7 @@ import type {
   AccessModifierLabel,
 } from '../../../model/malloy_types';
 import {
+  activeName,
   isJoined,
   isTurtle,
   isSourceDef,
@@ -97,7 +98,7 @@ export class StaticSpace implements FieldSpace {
     if (this.memoMap === undefined) {
       this.memoMap = new Map<string, SpaceEntry>();
       for (const f of this.fromStruct.fields) {
-        const name = f.as || f.name;
+        const name = activeName(f);
         this.memoMap.set(name, this.defToSpaceField(f));
       }
       if (isSourceDef(this.fromStruct)) {

--- a/packages/malloy/src/lang/ast/field-space/struct-space-field-base.ts
+++ b/packages/malloy/src/lang/ast/field-space/struct-space-field-base.ts
@@ -22,7 +22,7 @@
  */
 
 import type {JoinFieldDef, TypeDesc} from '../../../model/malloy_types';
-import {isSourceDef} from '../../../model/malloy_types';
+import {activeName, isSourceDef} from '../../../model/malloy_types';
 import * as TDU from '../typedesc-utils';
 import type {FieldSpace} from '../types/field-space';
 import type {JoinPathElement} from '../types/lookup-result';
@@ -41,7 +41,7 @@ export abstract class StructSpaceFieldBase extends SpaceField {
 
   get joinPathElement(): JoinPathElement {
     return {
-      name: this.structDef.as || this.structDef.name,
+      name: activeName(this.structDef),
       joinType: this.structDef.join,
       joinElementType: this.structDef.type,
     };

--- a/packages/malloy/src/lang/ast/query-properties/drill.ts
+++ b/packages/malloy/src/lang/ast/query-properties/drill.ts
@@ -184,7 +184,7 @@ export class Drill extends Filter implements QueryPropertyInterface {
             return undefined;
           } else {
             if (isAtomic(f) && expressionIsScalar(f.expressionType))
-              return f.as ?? f.name;
+              return activeName(f);
           }
         })
         .filter(isNotUndefined);
@@ -465,7 +465,7 @@ export function attachDrillPaths(
           return updateNestedDrillPaths(f, nestName);
         }
         const fieldName =
-          f.type === 'fieldref' ? f.path[f.path.length - 1] : (f.as ?? f.name);
+          f.type === 'fieldref' ? f.path[f.path.length - 1] : activeName(f);
 
         return {
           ...f,

--- a/packages/malloy/src/lang/ast/source-elements/composite-source.ts
+++ b/packages/malloy/src/lang/ast/source-elements/composite-source.ts
@@ -14,7 +14,13 @@ import type {
   MatrixOperation,
   SourceDef,
 } from '../../../model/malloy_types';
-import {isAtomic, isJoined, isSourceDef, TD} from '../../../model/malloy_types';
+import {
+  activeName,
+  isAtomic,
+  isJoined,
+  isSourceDef,
+  TD,
+} from '../../../model/malloy_types';
 
 import type {HasParameter} from '../parameters/has-parameter';
 import {Source} from './source';
@@ -82,7 +88,7 @@ function composeSources(
       );
     }
     for (const field of sourceDef.fields) {
-      const fieldName = field.as ?? field.name;
+      const fieldName = activeName(field);
       if (field.accessModifier === 'private') {
         continue;
       }

--- a/packages/malloy/src/lang/ast/source-elements/sql-source.ts
+++ b/packages/malloy/src/lang/ast/source-elements/sql-source.ts
@@ -21,6 +21,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+import {activeName} from '../../../model/malloy_types';
 import type {
   InvokedStructRef,
   SourceDef,
@@ -165,7 +166,7 @@ export class SQLSource extends Source {
         fields: lookup.value.fields.map(f => ({
           ...f,
           location,
-          refSummary: {fieldUsage: [{path: [f.as ?? f.name], at: location}]},
+          refSummary: {fieldUsage: [{path: [activeName(f)], at: location}]},
         })),
         location: this.location,
       };

--- a/packages/malloy/src/lang/ast/source-elements/table-source.ts
+++ b/packages/malloy/src/lang/ast/source-elements/table-source.ts
@@ -21,6 +21,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+import {activeName} from '../../../model/malloy_types';
 import type {SourceDef} from '../../../model/malloy_types';
 import {constructTableKey} from '../../parse-tree-walkers/find-external-references';
 import {Source} from './source';
@@ -74,7 +75,7 @@ export abstract class TableSource extends Source {
             ...field,
             location: this.location,
             refSummary: {
-              fieldUsage: [{path: [field.as ?? field.name], at: this.location}],
+              fieldUsage: [{path: [activeName(field)], at: this.location}],
             },
           })),
           location: this.location,

--- a/packages/malloy/src/lang/ast/source-elements/typed-source.ts
+++ b/packages/malloy/src/lang/ast/source-elements/typed-source.ts
@@ -11,6 +11,7 @@ import type {
   SourceDef,
 } from '../../../model/malloy_types';
 import {
+  activeName,
   TD,
   fieldIsIntrinsic,
   isUserTypeDef,
@@ -75,9 +76,7 @@ export class TypedSource extends Source {
     }
 
     const isVirtual = sourceDef.type === 'virtual';
-    const sourceFields = new Map(
-      sourceDef.fields.map(f => [f.as ?? f.name, f])
-    );
+    const sourceFields = new Map(sourceDef.fields.map(f => [activeName(f), f]));
     const fieldsToAdd: FieldDef[] = [];
 
     // Validate/Enforce that this source matches the shape
@@ -107,7 +106,7 @@ export class TypedSource extends Source {
     // Intrinsic fields not in any shape: mark as hidden.
     // Matching fields inherit annotations from the shape.
     const resultFields = sourceDef.fields.map(f => {
-      const name = f.as ?? f.name;
+      const name = activeName(f);
       const shapeEntry = outputShape.get(name);
       if (!shapeEntry || !fieldIsIntrinsic(f)) {
         return fieldIsIntrinsic(f) && !shapeEntry

--- a/packages/malloy/src/lang/ast/source-properties/join.ts
+++ b/packages/malloy/src/lang/ast/source-properties/join.ts
@@ -29,7 +29,7 @@ import type {
   SourceDef,
   AccessModifierLabel,
 } from '../../../model/malloy_types';
-import {isSourceDef, isJoinable} from '../../../model/malloy_types';
+import {activeName, isSourceDef, isJoinable} from '../../../model/malloy_types';
 import type {DynamicSpace} from '../field-space/dynamic-space';
 import {JoinSpaceField} from '../field-space/join-space-field';
 import {DefinitionList} from '../types/definition-list';
@@ -125,7 +125,7 @@ export class KeyJoin extends Join {
     const exprX = this.keyExpr.getExpression(outer);
     if (isSourceDef(inStruct) && inStruct.primaryKey) {
       const pkey = inStruct.fields.find(
-        f => (f.as || f.name) === inStruct.primaryKey
+        f => activeName(f) === inStruct.primaryKey
       );
       if (pkey) {
         if (pkey.type === exprX.type) {

--- a/packages/malloy/src/lang/ast/source-query-elements/sq-reference.ts
+++ b/packages/malloy/src/lang/ast/source-query-elements/sq-reference.ts
@@ -29,7 +29,7 @@ import {QuerySource} from '../source-elements/query-source';
 import {NamedSource} from '../source-elements/named-source';
 import {QueryReference} from '../query-elements/query-reference';
 import type {Argument} from '../parameters/argument';
-import {isSourceDef} from '../../../model';
+import {activeName, isSourceDef} from '../../../model';
 
 /**
  * A reference to either a source or a query.
@@ -58,8 +58,7 @@ export class SQReference extends SourceQueryElement {
         this.has({query});
         return query;
       } else {
-        const label =
-          entry.type === 'given' ? entry.name : entry.as || entry.name;
+        const label = entry.type === 'given' ? entry.name : activeName(entry);
         this.sqLog(
           'cannot-use-as-query',
           `Illegal reference to '${label}', query expected`

--- a/packages/malloy/src/lang/ast/statements/define-source.ts
+++ b/packages/malloy/src/lang/ast/statements/define-source.ts
@@ -22,7 +22,7 @@
  */
 
 import type {AnnotationsDef, StructDef} from '../../../model/malloy_types';
-import {isPersistableSourceDef} from '../../../model/malloy_types';
+import {activeName, isPersistableSourceDef} from '../../../model/malloy_types';
 import {mkSourceID} from '../../../model/source_def_utils';
 import {checkPersistAnnotation} from '../../../model/persist_utils';
 import {ErrorFactory} from '../error-factory';
@@ -121,9 +121,7 @@ export class DefineSource
   ) {
     for (const parameter of parameters) {
       if (
-        structDef.fields.find(
-          field => (field.as ?? field.name) === parameter.name
-        )
+        structDef.fields.find(field => activeName(field) === parameter.name)
       ) {
         parameter.logError(
           'parameter-shadowing-field',

--- a/packages/malloy/src/lang/composite-source-utils.ts
+++ b/packages/malloy/src/lang/composite-source-utils.ts
@@ -37,6 +37,7 @@ import type {
   StructDef,
 } from '../model/malloy_types';
 import {
+  activeName,
   expressionIsScalar,
   fieldUsageFrom,
   givenUsageFrom,
@@ -134,7 +135,7 @@ function _resolveCompositeSources(
       const fieldNames = new Set<string>();
       for (const field of inputSource.fields) {
         if (field.accessModifier !== 'private') {
-          fieldNames.add(field.as ?? field.name);
+          fieldNames.add(activeName(field));
         }
       }
 
@@ -781,7 +782,7 @@ export function getPartitionCompositeDesc(
     partitions.push({id, fields});
   }
   for (const field of [partitionField, ...allFields]) {
-    const def = structDef.fields.find(f => (f.as ?? f.name) === field);
+    const def = structDef.fields.find(f => activeName(f) === field);
     if (def === undefined) {
       logTo.logError(
         'invalid-partition-composite',
@@ -789,7 +790,7 @@ export function getPartitionCompositeDesc(
       );
     }
   }
-  const compositeFields = structDef.fields.map(f => f.as ?? f.name);
+  const compositeFields = structDef.fields.map(f => activeName(f));
   return {partitionField, partitions, compositeFields};
 }
 
@@ -812,7 +813,7 @@ function mergeFields(...fields: FieldDef[][]): FieldDef[] {
   const fieldsByName: {[name: string]: FieldDef} = {};
   for (const list of fields) {
     for (const field of list) {
-      fieldsByName[field.as ?? field.name] = field;
+      fieldsByName[activeName(field)] = field;
     }
   }
   return Object.values(fieldsByName);
@@ -831,7 +832,7 @@ function genRootFields(
   const headJoinName = joinPath[0];
   const fieldsByName: {[name: string]: FieldDef} = {};
   for (const field of rootFields) {
-    fieldsByName[field.as ?? field.name] = field;
+    fieldsByName[activeName(field)] = field;
   }
   const join = fieldsByName[headJoinName];
   if (join === undefined) {
@@ -875,7 +876,7 @@ function processJoins(
   const fieldsByName: {[name: string]: FieldDef} = {};
   const errors: {error: CompositeError; firstUsage: FieldUsageEntry}[] = [];
   for (const field of base.fields) {
-    fieldsByName[field.as ?? field.name] = field;
+    fieldsByName[activeName(field)] = field;
   }
   for (const [joinName, joinedUsage] of Object.entries(
     categorizedFieldUsage.joinUsage
@@ -936,7 +937,7 @@ function processJoins(
     fieldsByName[joinName] = {
       ...resolved.success,
       join: join.join,
-      as: join.as ?? join.name,
+      as: activeName(join),
       onExpression: join.onExpression,
     };
     base.fields = Object.values(fieldsByName);
@@ -1677,7 +1678,7 @@ function buildNamespace(fields: FieldDef[]): Namespace {
   };
 
   for (const field of fields) {
-    const name = field.as ?? field.name;
+    const name = activeName(field);
     namespace.fields[name] = field;
 
     // If it's a join with nested fields, recursively build its hierarchy
@@ -1709,7 +1710,7 @@ function inNamespace(path: string[], space: Namespace): FieldDef | undefined {
 
 function lookup(field: string[], fields: FieldDef[]): FieldDef {
   const [head, ...rest] = field;
-  const def = fields.find(f => (f.as ?? f.name) === head);
+  const def = fields.find(f => activeName(f) === head);
   if (def === undefined) {
     throw new Error(
       `No definition for ${head} when resolving composite source`

--- a/packages/malloy/src/lang/field-utils.ts
+++ b/packages/malloy/src/lang/field-utils.ts
@@ -21,6 +21,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+import {activeName} from '../model/malloy_types';
 import type {FieldDef, QueryFieldDef} from '../model/malloy_types';
 
 type NamedFieldThing = FieldDef | QueryFieldDef;
@@ -29,7 +30,7 @@ export function nameFromDef(f1: NamedFieldThing): string {
   if (f1.type === 'fieldref') {
     return f1.path[f1.path.length - 1];
   }
-  return f1.as ?? f1.name;
+  return activeName(f1);
 }
 
 export function mergeFields<T extends NamedFieldThing>(

--- a/packages/malloy/src/lang/test/query.spec.ts
+++ b/packages/malloy/src/lang/test/query.spec.ts
@@ -33,6 +33,7 @@ import {
 import './parse-expects';
 import type {Query, QueryFieldDef, QuerySegment} from '../../model';
 import {
+  activeName,
   expressionIsCalculation,
   isJoined,
   isQuerySegment,
@@ -1184,7 +1185,7 @@ describe('query:', () => {
       const notb = model.getSourceDef('notb');
       expect(notb).toBeDefined();
       if (notb) {
-        const d = notb.fields.find(f => f.as || f.name === 'd');
+        const d = notb.fields.find(f => activeName(f) === 'd');
         expect(d).toBeDefined();
         expect(d?.type).toBe('number');
         if (d?.type === 'number') {

--- a/packages/malloy/src/lang/test/source.spec.ts
+++ b/packages/malloy/src/lang/test/source.spec.ts
@@ -31,7 +31,7 @@ import {
   getFieldDef,
 } from './test-translator';
 import './parse-expects';
-import {isSourceDef, QueryModel} from '../../model';
+import {activeName, isSourceDef, QueryModel} from '../../model';
 import type {VirtualMap} from '../../model';
 
 describe('source:', () => {
@@ -64,7 +64,7 @@ describe('source:', () => {
     expect(x).toTranslate();
     const a = x.getSourceDef('a');
     if (a) {
-      const aFields = a.fields.map(f => f.as || f.name);
+      const aFields = a.fields.map(f => activeName(f));
       expect(aFields).toContain('astr');
       expect(aFields).not.toContain('one');
     }
@@ -517,13 +517,13 @@ describe('source:', () => {
           const d = t.modelDef.contents['d'];
           expect(isSourceDef(d)).toBe(true);
           if (isSourceDef(d)) {
-            const dC = d.fields.find(f => (f.as ?? f.name) === 'c');
+            const dC = d.fields.find(f => activeName(f) === 'c');
             expect(dC).toBeDefined();
             if (dC === undefined) throw new Error('Expected dC to be defined');
             expect(isSourceDef(dC)).toBe(true);
             expect(isSourceDef(d)).toBe(true);
             if (isSourceDef(dC)) {
-              const dCAi = dC.fields.find(f => (f.as ?? f.name) === 'ai');
+              const dCAi = dC.fields.find(f => activeName(f) === 'ai');
               expect(dCAi?.annotations).toMatchObject({
                 notes: [{text: '# new_note\n'}],
               });

--- a/packages/malloy/src/model/field_instance.ts
+++ b/packages/malloy/src/model/field_instance.ts
@@ -14,6 +14,7 @@ import type {
 } from './malloy_types';
 import {MalloyCompileError} from './malloy_compile_error';
 import {
+  activeName,
   isIndexSegment,
   isRawSegment,
   isJoined,
@@ -128,7 +129,7 @@ export class FieldInstanceField implements FieldInstance {
   private generateDistinctKeyExpression(): string {
     if (this.f.parent.primaryKey()) {
       const pk = this.f.parent.getPrimaryKeyField(this.f.fieldDef);
-      const pkName = pk.fieldDef.as || pk.fieldDef.name;
+      const pkName = activeName(pk.fieldDef);
       const pkField = this.parent.getField(pkName);
       return pkField.generateExpression();
     } else if (this.f.parent.structDef.type === 'array') {

--- a/packages/malloy/src/model/malloy_types.ts
+++ b/packages/malloy/src/model/malloy_types.ts
@@ -2015,14 +2015,6 @@ export type TypedDef =
   | RefToField
   | StructDef;
 
-/** Get the output name for a NamedObject */
-export function getIdentifier(n: AliasedName): string {
-  if (n.as !== undefined) {
-    return n.as;
-  }
-  return n.name;
-}
-
 export interface UserTypeFieldDef extends HasAnnotations {
   name: string;
   typeDef: AtomicTypeDef;

--- a/packages/malloy/src/model/query_model_impl.ts
+++ b/packages/malloy/src/model/query_model_impl.ts
@@ -18,7 +18,7 @@ import type {
   TurtleDefPlusFilters,
   TurtleDef,
 } from './malloy_types';
-import {isSourceDef, getIdentifier, isAtomic} from './malloy_types';
+import {activeName, isSourceDef, isAtomic} from './malloy_types';
 import {StageWriter} from './stage_writer';
 import {StandardSQLDialect, type Dialect} from '../dialect';
 import type {Connection} from '../connection/types';
@@ -55,7 +55,7 @@ export class QueryModelImpl implements QueryModel, ModelRootInterface {
       // metadata, not queryable, and are skipped.
       if (isSourceDef(s)) {
         this.structs.set(
-          getIdentifier(s),
+          activeName(s),
           new QueryStruct(s, undefined, {model: this}, {})
         );
       } else if (
@@ -148,7 +148,7 @@ export class QueryModelImpl implements QueryModel, ModelRootInterface {
     if (emitFinalStage && q.parent.dialect.hasFinalStage) {
       // const fieldNames: string[] = [];
       // for (const f of ret.outputStruct.fields) {
-      //   fieldNames.push(getIdentifier(f));
+      //   fieldNames.push(activeName(f));
       // }
       const fieldNames: string[] = [];
       for (const f of ret.outputStruct.fields) {
@@ -218,9 +218,7 @@ export class QueryModelImpl implements QueryModel, ModelRootInterface {
     );
     const structRef = query.compositeResolvedSourceDef ?? query.structRef;
     const sourceExplore =
-      typeof structRef === 'string'
-        ? structRef
-        : structRef.as || structRef.name;
+      typeof structRef === 'string' ? structRef : activeName(structRef);
     const sourceArguments =
       query.sourceArguments ??
       (typeof structRef === 'string' ? undefined : structRef.arguments);

--- a/packages/malloy/src/model/query_node.ts
+++ b/packages/malloy/src/model/query_node.ts
@@ -30,8 +30,8 @@ import type {
 } from './malloy_types';
 import {MalloyCompileError} from './malloy_compile_error';
 import {
+  activeName,
   isSourceDef,
-  getIdentifier,
   isBaseTable,
   hasExpression,
   isAtomic,
@@ -69,7 +69,7 @@ export class QueryField extends QueryNode {
   }
 
   getIdentifier() {
-    return getIdentifier(this.fieldDef);
+    return activeName(this.fieldDef);
   }
 
   getJoinableParent(): QueryStruct {
@@ -410,7 +410,7 @@ export class QueryStruct {
 
   private addFieldsFromFieldList(fields: FieldDef[]) {
     for (const field of fields) {
-      const as = getIdentifier(field);
+      const as = activeName(field);
 
       if (field.type === 'turtle') {
         if (!QueryStruct.turtleFieldMaker) {
@@ -457,7 +457,7 @@ export class QueryStruct {
     // make a unique alias name
     if (ret === undefined) {
       const aliases = Array.from(this.pathAliasMap.values());
-      const base = identifierNormalize(getIdentifier(this.structDef));
+      const base = identifierNormalize(activeName(this.structDef));
       let name = `${base}_0`;
       let n = 1;
       while (aliases.includes(name) && n < 1000) {
@@ -483,7 +483,7 @@ export class QueryStruct {
       const x =
         this.parent.getSQLIdentifier() +
         '.' +
-        getIdentifier(this.structDef) +
+        activeName(this.structDef) +
         `[${this.getIdentifier()}.__row_id]`;
       return x;
     } else {
@@ -532,7 +532,7 @@ export class QueryStruct {
 
     // if this is an inline object, include the parents alias.
     if (this.structDef.type === 'record' && this.parent) {
-      return this.parent.sqlSimpleChildReference(getIdentifier(this.structDef));
+      return this.parent.sqlSimpleChildReference(activeName(this.structDef));
     }
     // we are somewhere in the join tree.  Make sure the alias is unique.
     return this.getAliasIdentifier();
@@ -541,9 +541,7 @@ export class QueryStruct {
   // return the name of the field in Malloy
   getFullOutputName(): string {
     if (this.parent) {
-      return (
-        this.parent.getFullOutputName() + getIdentifier(this.structDef) + '.'
-      );
+      return this.parent.getFullOutputName() + activeName(this.structDef) + '.';
     } else {
       return '';
     }
@@ -583,8 +581,8 @@ export class QueryStruct {
       return pk;
     } else {
       throw new MalloyCompileError(
-        `Source '${getIdentifier(this.structDef)}' has no primary key; ` +
-          `cannot compute a unique key for field '${getIdentifier(fieldDef)}'. ` +
+        `Source '${activeName(this.structDef)}' has no primary key; ` +
+          `cannot compute a unique key for field '${activeName(fieldDef)}'. ` +
           'Add `primary_key: <field>` to the source definition.',
         'compiler-missing-primary-key',
         fieldDef.location

--- a/packages/malloy/src/model/query_query.ts
+++ b/packages/malloy/src/model/query_query.ts
@@ -43,7 +43,7 @@ import {
   isAtomic,
   expressionIsCalculation,
   expressionIsScalar,
-  getIdentifier,
+  activeName,
   isJoinedSource,
   isBasicArray,
   isIndexSegment,
@@ -871,9 +871,7 @@ export class QueryQuery extends QueryField {
       }
       default:
         throw new Error(
-          `Cannot create SQL StageWriter from '${getIdentifier(
-            qs.structDef
-          )}' type '${qs.structDef.type}`
+          `Cannot create SQL StageWriter from '${activeName(qs.structDef)}' type '${qs.structDef.type}`
         );
     }
   }
@@ -959,7 +957,7 @@ export class QueryQuery extends QueryField {
     let s = '';
     const qs = ji.queryStruct;
     const qsDef = qs.structDef;
-    qs.eventStream?.emit('join-used', {name: getIdentifier(qsDef)});
+    qs.eventStream?.emit('join-used', {name: activeName(qsDef)});
     qs.maybeEmitParameterizedSourceUsage();
     if (isJoinedSource(qsDef)) {
       let structSQL = this.getStructSourceSQL(qs, stageWriter);

--- a/packages/malloy/src/model/utils.ts
+++ b/packages/malloy/src/model/utils.ts
@@ -38,7 +38,7 @@ import {
   exprHasE,
   exprHasKids,
   fieldIsIntrinsic,
-  getIdentifier,
+  activeName,
   mkSafeRecord,
 } from './malloy_types';
 import type {DialectFieldList} from '../dialect';
@@ -291,9 +291,9 @@ export function getDialectFieldList(structDef: StructDef): DialectFieldList {
   for (const f of structDef.fields.filter(fieldIsIntrinsic)) {
     dialectFieldList.push({
       typeDef: f,
-      sqlExpression: getIdentifier(f),
-      rawName: getIdentifier(f),
-      sqlOutputName: getIdentifier(f),
+      sqlExpression: activeName(f),
+      rawName: activeName(f),
+      sqlOutputName: activeName(f),
     });
   }
   return dialectFieldList;

--- a/packages/malloy/src/to_stable.ts
+++ b/packages/malloy/src/to_stable.ts
@@ -23,6 +23,7 @@ import type {
   TimestampUnit,
 } from './model';
 import {
+  activeName,
   expressionIsAggregate,
   expressionIsScalar,
   isAtomic,
@@ -63,7 +64,7 @@ export function sourceDefToSourceInfo(sourceDef: SourceDef): Malloy.SourceInfo {
       : undefined;
 
   const sourceInfo: Malloy.SourceInfo = {
-    name: sourceDef.as ?? sourceDef.name,
+    name: activeName(sourceDef),
     schema: {
       fields: convertFieldInfos(sourceDef, sourceDef.fields),
     },
@@ -204,7 +205,7 @@ export function convertFieldInfos(source: SourceDef, fields: FieldDef[]) {
       ];
       const fieldInfo: Malloy.FieldInfo = {
         kind: 'view',
-        name: field.as ?? field.name,
+        name: activeName(field),
         annotations: fieldAnnotations.length > 0 ? fieldAnnotations : undefined,
         schema: {fields: convertFieldInfos(outputStruct, outputStruct.fields)},
       };
@@ -233,7 +234,7 @@ export function convertFieldInfos(source: SourceDef, fields: FieldDef[]) {
       ];
       const fieldInfo: Malloy.FieldInfo = {
         kind: aggregate ? 'measure' : 'dimension',
-        name: field.as ?? field.name,
+        name: activeName(field),
         type: typeDefToType(field),
         annotations: fieldAnnotations.length > 0 ? fieldAnnotations : undefined,
       };
@@ -241,7 +242,7 @@ export function convertFieldInfos(source: SourceDef, fields: FieldDef[]) {
     } else if (isJoinedSource(field)) {
       const fieldInfo: Malloy.FieldInfo = {
         kind: 'join',
-        name: field.as ?? field.name,
+        name: activeName(field),
         annotations,
         schema: {
           fields: convertFieldInfos(field, field.fields),
@@ -383,8 +384,7 @@ export function getResultStructMetadataAnnotation(
       const orderBy = resultMetadata.orderBy[i];
       const orderByField =
         typeof orderBy.field === 'number'
-          ? (field.fields[orderBy.field - 1].as ??
-            field.fields[orderBy.field - 1].name)
+          ? activeName(field.fields[orderBy.field - 1])
           : orderBy.field;
       const direction = orderBy.dir ?? null;
       tag.set(['ordered_by', i, orderByField], direction);


### PR DESCRIPTION
Follow-up to #2856, which added `activeName(an) = an.as ?? an.name` and documented the `name`/`as` invariant. This routes the rest of the codebase through it.

`as ?? name` was hand-rolled in ~60 places, plus a body-identical second helper (`getIdentifier`), plus a handful of `x.as ?? x.name === y` precedence bugs hiding in the inline copies. One canonical reader removes all three problems.

- Deleted the free function `getIdentifier(n: AliasedName)` and routed its call sites through `activeName`. The unrelated `QueryNode.getIdentifier()` method — same name, different thing — is untouched.
- Replaced the inline `x.as ?? x.name` / `x.as || x.name` reads with `activeName(x)` across `model/`, `lang/`, `dialect/`, `api/foundation/`, and tests.
- Fixed one more precedence bug (`x.as || x.name === y` in a test), same class as the four in #2856.

The five `name || as` reads in the drill / `sourceClasses` paths are deliberately left as-is: they prefer the intrinsic name over the alias for drill metadata, the opposite of `activeName`.