### PR TITLE
fix(dialect): escape control chars in backslash-style literals and identifiers

### DIFF
--- a/packages/malloy/src/dialect/CONTEXT.md
+++ b/packages/malloy/src/dialect/CONTEXT.md
@@ -262,7 +262,9 @@ Every dialect must declare three fields that drive identifier and string-literal
 
 The base class provides safe implementations of `sqlQuoteIdentifier`, `sqlLiteralString`, and `sqlLiteralRegexp` driven by these flags. Dialects normally do not override them. If a subclass forgets to set a flag, the base method throws at first use with a message naming the dialect and the missing flag — `escape.spec.ts` exercises this fail-fast path on every registered dialect, so a forgotten flag fails CI rather than producing wrong SQL silently.
 
-The contract is verified by `packages/malloy/src/dialect/escape.spec.ts`, which iterates `getDialects()` and asserts that an adversarial input corpus round-trips through each escape function. A new dialect is covered automatically the moment it is registered in `dialect_map.ts`; you do not need to edit the spec file.
+For `EscapeStyle.Backslash`, both the literal and identifier paths share `escapeBackslashStyle`, which escapes the backslash, the closing delimiter, and the control characters `\n` / `\r` / `\t`. A raw newline terminates a backslash-style token early in BigQuery ("Unclosed string literal"); the other backslash dialects tolerate it but decode the named escapes to the same bytes, so escaping uniformly keeps values byte-exact. The escape set is deliberately those three control characters — `\0` and the Unicode line/paragraph separators are passed through, since there is no evidence they break these lexers.
+
+The contract is verified at two levels: `packages/malloy/src/dialect/escape.spec.ts` iterates `getDialects()` and asserts an adversarial corpus round-trips through each escape function (a new dialect is covered automatically the moment it is registered in `dialect_map.ts`), and `test/src/databases/all/escape.spec.ts` proves the output parses against the real engines. Extend the corpora when you add a character class the escapers must handle; you do not need to touch the spec to cover a new *dialect*.
 
 ### Table-path validation contract
 

--- a/packages/malloy/src/dialect/dialect.ts
+++ b/packages/malloy/src/dialect/dialect.ts
@@ -567,6 +567,50 @@ export abstract class Dialect {
   identifierEscapeStyle: EscapeStyleValue = EscapeStyle.Unset;
 
   /**
+   * Escape the body of a backslash-style quoted token — a string literal
+   * (`'…'`) or a quoted identifier (`` `…` ``) — for the dialects whose
+   * `EscapeStyle` is `Backslash` (BigQuery, Snowflake, MySQL, Databricks).
+   * Escapes the backslash, the closing delimiter `delim`, and the control
+   * characters newline / carriage-return / tab.
+   *
+   * The driving case is the raw newline: BigQuery rejects it outright
+   * ("Unclosed string literal"). The other three dialects tolerate a raw
+   * newline but decode `\n`/`\r`/`\t` to the same bytes, so escaping
+   * uniformly keeps the value byte-exact — ordered (`<` / `>`) comparisons
+   * against the original stay correct — and the generated SQL single-line.
+   *
+   * Scope is deliberately these three control characters: the ones seen to
+   * break real queries. Other non-printables (`\0`, U+2028, U+2029) are
+   * passed through — there is no evidence they terminate these dialects'
+   * lexers, and escaping bytes we have not verified risks corrupting values.
+   */
+  protected escapeBackslashStyle(body: string, delim: string): string {
+    let out = '';
+    for (const ch of body) {
+      switch (ch) {
+        case '\\':
+          out += '\\\\';
+          break;
+        case '\n':
+          out += '\\n';
+          break;
+        case '\r':
+          out += '\\r';
+          break;
+        case '\t':
+          out += '\\t';
+          break;
+        case delim:
+          out += '\\' + delim;
+          break;
+        default:
+          out += ch;
+      }
+    }
+    return out;
+  }
+
+  /**
    * Wrap an identifier in the dialect's quote character, escaping any
    * embedded quote characters per the dialect's `identifierEscapeStyle`.
    * This is the only safe way to render a user-controlled identifier
@@ -585,11 +629,7 @@ export abstract class Dialect {
       return q + identifier.split(q).join(q + q) + q;
     }
     if (this.identifierEscapeStyle === EscapeStyle.Backslash) {
-      const escaped = identifier
-        .replace(/\\/g, '\\\\')
-        .split(q)
-        .join('\\' + q);
-      return q + escaped + q;
+      return q + this.escapeBackslashStyle(identifier, q) + q;
     }
     throw new Error(
       `${this.name}: identifierEscapeStyle is not set. ` +
@@ -943,8 +983,10 @@ export abstract class Dialect {
       return "'" + literal.split("'").join("''") + "'";
     }
     if (this.stringLiteralStyle === 'backslash') {
-      const escaped = literal.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
-      return "'" + escaped + "'";
+      // Backslash-style literals must escape control characters; a raw
+      // newline terminates the literal early in BigQuery ("Unclosed string
+      // literal"). See escapeBackslashStyle for the full contract.
+      return "'" + this.escapeBackslashStyle(literal, "'") + "'";
     }
     throw new Error(
       `${this.name}: stringLiteralStyle is not set. ` +

--- a/packages/malloy/src/dialect/escape.spec.ts
+++ b/packages/malloy/src/dialect/escape.spec.ts
@@ -35,7 +35,13 @@ const ADVERSARIAL_STRINGS: {name: string; value: string}[] = [
   {name: 'line_comment', value: '-- injected'},
   {name: 'all_delims', value: '\'`"\\'},
   {name: 'newline', value: 'line1\nline2'},
+  {name: 'carriage_return', value: 'line1\rline2'},
+  {name: 'crlf', value: 'line1\r\nline2'},
   {name: 'tab', value: 'col\tval'},
+  // A multi-line text value with several embedded CRLFs — the shape that,
+  // emitted unescaped inside a generated string literal, made BigQuery
+  // report "Unclosed string literal". This is the case the fix exists for.
+  {name: 'multiline_blob', value: 'Order summary\r\nitem: widget\r\nqty: 3'},
 ];
 
 // ---------------------------------------------------------------------------
@@ -67,6 +73,15 @@ function parseStringLiteral(
         continue;
       }
       return {value, end: i + 1};
+    }
+    if (mode === 'backslash' && (c === '\n' || c === '\r')) {
+      // A backslash-style literal (BigQuery et al.) cannot span a raw
+      // newline: the lexer ends the literal at the line break, leaving it
+      // unterminated ("Unclosed string literal"). Model that here so an
+      // unescaped newline is caught as a parse failure rather than silently
+      // consumed — the permissive `value += c` path below would otherwise
+      // hide exactly the bug this corpus exists to catch.
+      return null;
     }
     if (mode === 'backslash' && c === '\\') {
       if (i + 1 >= sql.length) return null;
@@ -125,6 +140,13 @@ function parseQuotedIdent(
         continue;
       }
       return {value, end: i + 1};
+    }
+    if (mode === 'backslash' && (c === '\n' || c === '\r')) {
+      // Same rule as parseStringLiteral: a backslash-style quoted token
+      // cannot span a raw newline. Modelled here too so the identifier
+      // round-trip catches an unescaped newline rather than silently
+      // consuming it via the `value += c` path below.
+      return null;
     }
     value += c;
     i++;
@@ -248,6 +270,38 @@ for (const dialect of getDialects()) {
     });
   });
 }
+
+// Exact-encoding contract for backslash-style dialects.
+//
+// The round-trip tests above prove the value survives a decode; they do
+// not pin the *encoding*. This block asserts the literal output byte-for-
+// byte, so a regression to a different-but-still-decodable form (e.g.
+// `\x0a` or a raw byte) is caught. The byte-exact form is what keeps
+// generated SQL single-line and ordered (`<` / `>`) comparisons correct.
+describe('backslash-style exact encoding', () => {
+  // standardsql (BigQuery) is the canonical backslash-style dialect.
+  const bq = getDialects().find(d => d.name === 'standardsql')!;
+
+  it('escapes LF, CR, and TAB as named escapes', () => {
+    expect(bq.sqlLiteralString('a\nb\rc\td')).toBe("'a\\nb\\rc\\td'");
+  });
+
+  it('escapes the backslash and the closing quote', () => {
+    expect(bq.sqlLiteralString("a\\b'c")).toBe("'a\\\\b\\'c'");
+  });
+
+  it('emits no raw newline anywhere in the output', () => {
+    expect(bq.sqlLiteralString('x\r\ny')).not.toMatch(/[\n\r]/);
+  });
+
+  it('escapes control characters in quoted identifiers too', () => {
+    // sqlQuoteIdentifier shares the backslash-escape contract; a raw
+    // newline would break a backtick-quoted BigQuery identifier exactly
+    // as it breaks a string literal.
+    expect(bq.sqlQuoteIdentifier('col\nname')).toBe('`col\\nname`');
+    expect(bq.sqlQuoteIdentifier('col\nname')).not.toMatch(/[\n\r]/);
+  });
+});
 
 // Record-literal and field-reference smuggling tests.
 //

--- a/test/src/databases/all/escape.spec.ts
+++ b/test/src/databases/all/escape.spec.ts
@@ -33,6 +33,15 @@ const STRING_CORPUS: {name: string; value: string}[] = [
   {name: 'backslash', value: 'a\\b'},
   {name: 'trailing_backslash', value: 'foo\\'},
   {name: 'injection', value: "';DROP TABLE x;--"},
+  // Control characters. A raw newline broke BigQuery ("Unclosed string
+  // literal"); these prove the escaped output round-trips on the real
+  // engine, which the unit-test parser alone cannot. `multiline_blob`
+  // covers a value with several embedded CRLFs. (A lone `\r` is left to
+  // the unit corpus: some engines normalize a bare CR, which would make
+  // the assertion engine-dependent rather than a clean escape check.)
+  {name: 'newline', value: 'line1\nline2'},
+  {name: 'crlf', value: 'line1\r\nline2'},
+  {name: 'multiline_blob', value: 'Order summary\r\nitem: widget\r\nqty: 3'},
 ];
 
 // Regex patterns that exercise backslash semantics in backslash-style
@@ -56,7 +65,28 @@ const IDENT_CORPUS: {name: string; value: string}[] = [
 ];
 
 function toMalloyString(s: string): string {
-  return "'" + s.replace(/\\/g, '\\\\').replace(/'/g, "\\'") + "'";
+  // Mirror the dialect's backslash escaping so control-character values
+  // produce valid Malloy source. Malloy's lexer decodes \n/\r/\t back to
+  // the original bytes (malloy-tag parseString), so the value reaching the
+  // dialect — and the database — is exact. Backslash is escaped in the
+  // same pass, so this stays complete (not js/incomplete-sanitization).
+  const body = s.replace(/[\\'\n\r\t]/g, ch => {
+    switch (ch) {
+      case '\\':
+        return '\\\\';
+      case "'":
+        return "\\'";
+      case '\n':
+        return '\\n';
+      case '\r':
+        return '\\r';
+      case '\t':
+        return '\\t';
+      default:
+        return ch;
+    }
+  });
+  return "'" + body + "'";
 }
 
 // Render a JS string as a Malloy regex literal (r'...').


### PR DESCRIPTION
## Problem

Backslash-style dialects (BigQuery, Snowflake, MySQL, Databricks) render SQL string literals and quoted identifiers with C-style escapes, and such tokens **cannot contain a raw newline** — an embedded LF/CR terminates the token early and the engine reports `Syntax error: Unclosed string literal`.

The base `Dialect` escaped only the backslash and the closing delimiter:

```ts
const escaped = literal.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
```

So any value containing a newline, carriage return, or tab was emitted **raw** between the quotes, producing invalid SQL. A value with an embedded CRLF reaching a generated string literal hit exactly this against BigQuery (`Unclosed string literal`).

## Fix

Introduce a single helper, `escapeBackslashStyle(body, delim)`, that escapes the backslash, the closing delimiter, and the control characters `\n` / `\r` / `\t`. Both `sqlLiteralString` and `sqlQuoteIdentifier` route through it — the identifier path had the **identical** gap, since a raw newline breaks a backtick-quoted identifier the same way it breaks a string literal.

### Scope decisions

- **By character set, not by dialect.** Escaping is applied uniformly across all four backslash dialects, because all four decode `\n`/`\r`/`\t` to the same bytes. This is correct backslash-token encoding, not a BigQuery-only workaround: values stay byte-exact (ordered `<` / `>` comparisons remain correct) and generated SQL stays single-line. Carving out BigQuery would fragment the shared `EscapeStyle.Backslash` abstraction to emit *messier* raw-newline SQL elsewhere for no correctness gain.
- **Only the three confirmed control characters.** `\0` and the Unicode line/paragraph separators (U+2028 / U+2029) are passed through. There is no evidence they terminate these dialects' lexers, and escaping bytes we haven't verified risks corrupting values; if a concrete failure surfaces for one of them, it gets added with a test.
- **The `doubled`/ANSI branch is unchanged** (Postgres, DuckDB, Trino): those literals may span raw newlines and treat backslash as a literal character, so escaping there would corrupt data.

## Why the existing test didn't catch it

`escape.spec.ts` already had a `newline` case, but its simulated `parseStringLiteral` consumed raw newlines as ordinary characters (`value += c`), so backslash dialects round-tripped "successfully" while emitting SQL a real engine rejects. This PR:

- makes the simulated **literal and identifier** parsers reject a raw newline (matching real lexers);
- adds `carriage_return` / `crlf` / `multiline_blob` cases;
- adds an **exact-encoding** block that pins the literal and identifier output byte-for-byte, so a decodable-but-different form (e.g. `\x0a`) can't slip past round-trip alone.

A simulated parser is only ever as faithful as we make it, so the fix is also proven end-to-end: `test/src/databases/all/escape.spec.ts` adds `newline` / `crlf` / `multiline_blob` to the live-engine `STRING_CORPUS` (and teaches `toMalloyString` to escape control chars), validating the generated SQL against the real databases.

## Testing

- `jest --selectProjects malloy-core` — the `escape.spec.ts` round-trip + exact-encoding corpus across every registered dialect (729 tests passing).
- `test/src/databases/all/escape.spec.ts` runs against the live database matrix in CI. A lone `\r` is intentionally left to the unit corpus, since some engines normalize a bare CR, which would make a live assertion engine-dependent rather than a clean escape check.
