### PR TITLE
ci: bump artifact actions to Node 24

### DIFF
--- a/.github/workflows/db-bigquery.yaml
+++ b/.github/workflows/db-bigquery.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: workspace
       - name: Extract workspace

--- a/.github/workflows/db-databricks.yaml
+++ b/.github/workflows/db-databricks.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: workspace
       - name: Extract workspace

--- a/.github/workflows/db-duckdb-wasm.yaml
+++ b/.github/workflows/db-duckdb-wasm.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: workspace
       - name: Extract workspace

--- a/.github/workflows/db-duckdb.yaml
+++ b/.github/workflows/db-duckdb.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: workspace
       - name: Extract workspace

--- a/.github/workflows/db-motherduck.yaml
+++ b/.github/workflows/db-motherduck.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: workspace
       - name: Extract workspace

--- a/.github/workflows/db-mysql.yaml
+++ b/.github/workflows/db-mysql.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: workspace
       - name: Extract workspace

--- a/.github/workflows/db-postgres.yaml
+++ b/.github/workflows/db-postgres.yaml
@@ -22,7 +22,7 @@ jobs:
           - 5432:5432
 
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: workspace
       - name: Extract workspace

--- a/.github/workflows/db-presto.yaml
+++ b/.github/workflows/db-presto.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: workspace
       - name: Extract workspace
@@ -39,7 +39,7 @@ jobs:
       #     docker logs --since=1h trino-malloy
       # - name: Archive production artifacts
       #   if: always()
-      #   uses: actions/upload-artifact@v4
+      #   uses: actions/upload-artifact@v7
       #   with:
       #     name: trino-logs
       #     path: |

--- a/.github/workflows/db-publisher.yaml
+++ b/.github/workflows/db-publisher.yaml
@@ -15,7 +15,7 @@ jobs:
           - 8000:8000
 
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: workspace
       - name: Extract workspace

--- a/.github/workflows/db-snowflake.yaml
+++ b/.github/workflows/db-snowflake.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: workspace
       - name: Extract workspace

--- a/.github/workflows/db-trino.yaml
+++ b/.github/workflows/db-trino.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: workspace
       - name: Extract workspace
@@ -38,7 +38,7 @@ jobs:
       #     docker logs --since=1h trino-malloy
       # - name: Archive production artifacts
       #   if: always()
-      #   uses: actions/upload-artifact@v4
+      #   uses: actions/upload-artifact@v7
       #   with:
       #     name: trino-logs
       #     path: |

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -30,7 +30,7 @@ jobs:
           - 5432:5432
 
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: workspace
       - name: Extract workspace

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
           npm run build-duckdb-db
       - name: Tar workspace
         run: tar --exclude='./.git' --use-compress-program='zstd -3 -T0' -cf /tmp/workspace.tzst .
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: workspace
           path: /tmp/workspace.tzst
@@ -30,7 +30,7 @@ jobs:
     needs: pull_and_build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: workspace
       - name: Extract workspace
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           ssh-key: ${{ secrets.MALLOY_GHAPI }}
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: workspace
       - name: Extract workspace

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -43,7 +43,7 @@ jobs:
           npm run build-duckdb-db
       - name: Tar workspace
         run: tar --exclude='./.git' --use-compress-program='zstd -3 -T0' -cf /tmp/workspace.tzst .
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: workspace
           path: /tmp/workspace.tzst


### PR DESCRIPTION
GitHub is deprecating Node.js 20 actions (forced to Node 24 on 2026-06-16, removed 2026-09-16). `actions/upload-artifact@v4` and `actions/download-artifact@v4` still run on Node 20 and were throwing deprecation warnings on every job that uploads or downloads the workspace artifact.

Bumps both to their current majors across all workflows: `upload-artifact@v7`, `download-artifact@v8`. `setup-node@v5`, `checkout@v5`, and `auth@v3` are already on Node 24.