### PR TITLE
fix(duckdb): accept more URL-shaped table paths in connection.table()

### DIFF
--- a/packages/malloy/src/dialect/duckdb/table-path-parser.ts
+++ b/packages/malloy/src/dialect/duckdb/table-path-parser.ts
@@ -18,12 +18,14 @@
 //      base `validateDottedTablePath` helper with the standard ANSI
 //      identifier rules DuckDB inherits via `PostgresBase`.
 //
-//   3. File-path convenience: a non-empty run of
-//      `[A-Za-z0-9._\-/:?*]` characters. The char set is deliberately
-//      narrow — single quotes, whitespace, parentheses, and semicolons
-//      are excluded so the convenience form can't carry a SQL payload.
-//      Canonical form wraps the input in single quotes so it becomes a
-//      DuckDB string-literal table name.
+//   3. File-path / URL convenience: a non-empty run of URL-shaped
+//      characters — the RFC 3986 set, minus the four that could carry a
+//      SQL payload (`'`, `(`, `)`, `;`) and whitespace, plus `%` for
+//      percent-encoding. This admits remote references DuckDB resolves
+//      directly (e.g. `hf://…`, `https://…?a=b&c=d`, `s3://…`) while
+//      keeping the injection guard: because `'` can never enter the set,
+//      the canonical form (the input wrapped in single quotes, making it
+//      a DuckDB string-literal table name) can't be broken out of.
 //
 // Branches 2 and 3 aren't LL(1)-distinguishable by first character (a
 // letter can start either), so we try (2) first and fall back to (3)
@@ -32,7 +34,7 @@
 import type {ValidateTablePathResult} from '../table-path';
 import {validateDottedTablePath} from '../table-path';
 
-const DUCKDB_FILE_PATH_RE = /^[A-Za-z0-9._\-/:?*]+$/;
+const DUCKDB_FILE_PATH_RE = /^[A-Za-z0-9._~:/?#@!$&*+,=%-]+$/;
 const DUCKDB_SINGLE_QUOTED_RE = /^'(?:[^']|'')*'$/;
 
 export function validateDuckDBTablePath(
@@ -70,7 +72,7 @@ export function validateDuckDBTablePath(
     dialectName: 'DuckDB',
   });
   if (id.ok) return id;
-  // Branch 3: file-path convenience.
+  // Branch 3: file-path / URL convenience.
   if (DUCKDB_FILE_PATH_RE.test(input)) {
     return {ok: true, canonical: `'${input}'`};
   }
@@ -79,8 +81,8 @@ export function validateDuckDBTablePath(
     error:
       `Invalid DuckDB table path: ${JSON.stringify(input)} — expected an ` +
       'identifier path, a quoted identifier path, a single-quoted ' +
-      "literal ('foo.csv'), or a file-path-shaped string of letters, " +
-      'digits, and `._-/:?*`. For table-valued function calls (e.g. ' +
+      "literal ('foo.csv'), or a simple file/URL path (some file/URL " +
+      'paths require quoting). For table-valued function calls (e.g. ' +
       "read_parquet('foo.parquet')) or other table expressions, use a " +
       'SQL block instead: connection.sql("""SELECT * FROM …""").',
   };

--- a/packages/malloy/src/lang/test/table-path-validation.spec.ts
+++ b/packages/malloy/src/lang/test/table-path-validation.spec.ts
@@ -9,6 +9,50 @@
 
 import './parse-expects';
 import {errorMessage} from './test-translator';
+import {validateDuckDBTablePath} from '../../dialect/duckdb/table-path-parser';
+
+describe('validateDuckDBTablePath (unit)', () => {
+  // Remote references DuckDB resolves directly. These reach the file-path /
+  // URL branch and come back quoted as a string-literal table name.
+  test.each([
+    'hf://datasets/An-j96/SuperstoreData@convert%2fparquet/default/train/0000.parquet',
+    'https://huggingface.co/datasets/An-j96/SuperstoreData/resolve/refs%2Fconvert%2Fparquet/default/train/0000.parquet',
+    'https://host/data.parquet?download=true&token=abc123',
+    's3://bucket/path/file.parquet',
+    'data/local.parquet',
+  ])('accepts and quotes URL/file path %s', input => {
+    expect(validateDuckDBTablePath(input)).toEqual({
+      ok: true,
+      canonical: `'${input}'`,
+    });
+  });
+
+  test('leaves a bare identifier path unquoted', () => {
+    expect(validateDuckDBTablePath('my_schema.my_table')).toEqual({
+      ok: true,
+      canonical: 'my_schema.my_table',
+    });
+  });
+
+  test('keeps an explicit single-quoted literal verbatim', () => {
+    expect(validateDuckDBTablePath("'hf://datasets/foo@bar%2fbaz'")).toEqual({
+      ok: true,
+      canonical: "'hf://datasets/foo@bar%2fbaz'",
+    });
+  });
+
+  // The injection guard survives the wider URL char set: the SQL-payload
+  // characters ' ( ) ; and whitespace are still excluded.
+  test.each([
+    "foo'; drop table x; --",
+    "x'),(select 1)",
+    "read_parquet('foo.parquet')",
+    'a b.parquet',
+    'foo; bar',
+  ])('rejects SQL-payload-shaped input %s', input => {
+    expect(validateDuckDBTablePath(input).ok).toBe(false);
+  });
+});
 
 describe('connection.table() path validation', () => {
   test('rejects Bobby Tables on a DuckDB-shaped connection', () => {


### PR DESCRIPTION
Fixes #2865.

We are now more permissive when we do the "looks like a URL reference, we will auto quote it" heuristic the DuckDB dialect offers.

If the user has a file or URL name which does not pass this, they will need to quote it in the `.table()` statement.
