### PR TITLE
Defer table schema requests until the connection dialect is resolved

### DIFF
--- a/packages/malloy/src/api/asynchronous.spec.ts
+++ b/packages/malloy/src/api/asynchronous.spec.ts
@@ -74,16 +74,9 @@ describe('api', () => {
       expect(result).toMatchObject(expected);
     });
 
-    // Regression: the renderer storybook compiles
-    // `duckdb.table('static/data/products.parquet')`. The path is a valid
-    // DuckDB file-path table whose canonical SQL form is the input wrapped
-    // in single quotes (`'static/data/products.parquet'`). On the first
-    // translate round the connection's dialect isn't resolved yet, so the
-    // path can't be canonicalized — the translator must NOT request the
-    // schema for the raw path. The async loop fetches table schemas through
-    // `wrapLegacyInfoConnection.fetchSchemaForTable`, which throws on a
-    // non-canonical path; if the raw path goes out before the dialect is
-    // known, that throw escapes `fetchNeeds` and crashes the whole compile.
+    // A DuckDB file-path table (canonical form is single-quoted) compiles
+    // through the stateless API even though its dialect isn't known on the
+    // first round and the path can't be canonicalized until it is.
     test('file-path table is deferred until its dialect resolves', async () => {
       const legacy: LegacyInfoConnection = {
         get name() {
@@ -308,9 +301,7 @@ ORDER BY 1 asc NULLS LAST
         },
       };
       expect(result).toMatchObject(expected);
-      // Sanity-check the timing envelope without pinning the round structure
-      // (how many connection/schema round-trips the compile takes is an
-      // implementation detail and changes with dialect-resolution ordering).
+      // Check the timing envelope, not the round structure.
       expect(result.timing_info).toMatchObject({
         name: 'run_query',
         duration_ms: expect.any(Number),

--- a/packages/malloy/src/api/asynchronous.spec.ts
+++ b/packages/malloy/src/api/asynchronous.spec.ts
@@ -6,6 +6,9 @@
 import {compileModel, compileQuery, runQuery} from './asynchronous';
 import type * as Malloy from '@malloydata/malloy-interfaces';
 import type {Connection, InfoConnection, LookupConnection} from './connection';
+import type {InfoConnection as LegacyInfoConnection} from '../connection';
+import {wrapLegacyInfoConnection} from './util';
+import type {TableSourceDef} from '../model';
 import type {URLReader} from '../runtime_types';
 
 describe('api', () => {
@@ -69,6 +72,67 @@ describe('api', () => {
         },
       };
       expect(result).toMatchObject(expected);
+    });
+
+    // Regression: the renderer storybook compiles
+    // `duckdb.table('static/data/products.parquet')`. The path is a valid
+    // DuckDB file-path table whose canonical SQL form is the input wrapped
+    // in single quotes (`'static/data/products.parquet'`). On the first
+    // translate round the connection's dialect isn't resolved yet, so the
+    // path can't be canonicalized — the translator must NOT request the
+    // schema for the raw path. The async loop fetches table schemas through
+    // `wrapLegacyInfoConnection.fetchSchemaForTable`, which throws on a
+    // non-canonical path; if the raw path goes out before the dialect is
+    // known, that throw escapes `fetchNeeds` and crashes the whole compile.
+    test('file-path table is deferred until its dialect resolves', async () => {
+      const legacy: LegacyInfoConnection = {
+        get name() {
+          return 'duckdb';
+        },
+        get dialectName() {
+          return 'duckdb';
+        },
+        getDigest: () => 'duckdb-digest',
+        fetchSchemaForSQLStruct: async () => {
+          throw new Error('not implemented');
+        },
+        fetchSchemaForTables: async (tables: Record<string, string>) => {
+          const schemas: Record<string, TableSourceDef> = {};
+          for (const [key, tablePath] of Object.entries(tables)) {
+            schemas[key] = {
+              type: 'table',
+              name: tablePath,
+              dialect: 'duckdb',
+              connection: 'duckdb',
+              tablePath,
+              fields: [{name: 'category', type: 'string'}],
+            };
+          }
+          return {schemas, errors: {}};
+        },
+      };
+      const connection = wrapLegacyInfoConnection(legacy);
+      const urls: URLReader = {
+        readURL: async (_url: URL) => {
+          return "source: products is duckdb.table('static/data/products.parquet')";
+        },
+      };
+      const connections: LookupConnection<InfoConnection> = {
+        lookupConnection: async (_name: string) => {
+          return connection;
+        },
+      };
+      const result = await compileModel(
+        {
+          model_url: 'file://test.malloy',
+        },
+        {urls, connections}
+      );
+      expect(result.logs ?? []).toEqual([]);
+      expect(result.model).toBeDefined();
+      expect(result.model?.entries).toMatchObject([
+        {kind: 'source', name: 'products'},
+      ]);
     });
   });
   describe('compile query', () => {
@@ -244,40 +308,14 @@ ORDER BY 1 asc NULLS LAST
         },
       };
       expect(result).toMatchObject(expected);
-      expect(result).toMatchObject({
-        timing_info: {
-          name: 'run_query',
-          duration_ms: expect.any(Number),
-          detailed_timing: [
-            {name: 'compile_model'},
-            {name: 'read_url'},
-            {name: 'compile_model', detailed_timing: [{name: 'parse_malloy'}]},
-            {name: 'lookup_connection'},
-            {name: 'lookup_connection'},
-            {name: 'fetch_table_schemas'},
-            {
-              name: 'compile_model',
-              detailed_timing: [
-                {
-                  name: 'generate_ast',
-                  detailed_timing: [{name: 'parse_compiler_flags'}],
-                },
-                {name: 'compile_malloy'},
-              ],
-            },
-            {name: 'parse_compiler_flags'},
-            {name: 'parse_malloy'},
-            {
-              name: 'generate_ast',
-              detailed_timing: [{name: 'parse_compiler_flags'}],
-            },
-            {name: 'compile_malloy'},
-            {name: 'generate_sql'},
-            {name: 'lookup_connection'},
-            {name: 'run_sql'},
-          ],
-        },
+      // Sanity-check the timing envelope without pinning the round structure
+      // (how many connection/schema round-trips the compile takes is an
+      // implementation detail and changes with dialect-resolution ordering).
+      expect(result.timing_info).toMatchObject({
+        name: 'run_query',
+        duration_ms: expect.any(Number),
       });
+      expect(result.timing_info?.detailed_timing?.length).toBeGreaterThan(0);
     });
 
     test('bigint field type propagates through stable API schema (table source)', async () => {

--- a/packages/malloy/src/api/sessioned.spec.ts
+++ b/packages/malloy/src/api/sessioned.spec.ts
@@ -14,9 +14,8 @@ interface SessionFixtures {
   sqls?: Record<string, Malloy.Schema>; // `${connection}:${selectStr}` -> schema
 }
 
-// Answer one round of compiler needs from the fixtures. We don't care which
-// needs arrive in which round — whatever is asked for, we fill from the same
-// flat fixture set. Unknown items get no payload (the compiler will error).
+// Fill one round of compiler needs from the fixtures, in whatever order they
+// arrive. Unknown items get no payload.
 function fulfill(
   needs: Malloy.CompilerNeeds,
   fx: SessionFixtures
@@ -49,10 +48,8 @@ function fulfill(
   return out;
 }
 
-// Drive a stateful compile to completion, answering whatever the compiler asks
-// for from `fx` each round — regardless of how many rounds it takes or which
-// order dialects, tables, and files are requested in. `step` runs one compile
-// call given the needs to feed and the session to resume.
+// Drive a stateful compile to completion, answering needs from `fx` each
+// round. `step` runs one compile call given the needs to feed and the session.
 function runToCompletion<
   R extends {compiler_needs?: Malloy.CompilerNeeds; session_id?: string},
 >(
@@ -286,8 +283,7 @@ ORDER BY 1 asc NULLS LAST
           }
         );
         expect(result.session_id).toBe(session_id);
-        // The session is mid-flight; capture wherever it is without caring
-        // which needs the compiler asked for.
+        // Capture wherever the mid-flight session is.
         const midFlight = result.compiler_needs;
         expect(midFlight).toBeDefined();
         // Now asking for a different file should NOT purge the original session

--- a/packages/malloy/src/api/sessioned.spec.ts
+++ b/packages/malloy/src/api/sessioned.spec.ts
@@ -6,75 +6,99 @@
 import {compileModel, compileQuery, compileSource} from './sessioned';
 import type * as Malloy from '@malloydata/malloy-interfaces';
 
+// Everything the driver can hand back to the compiler, indexed by request.
+interface SessionFixtures {
+  files?: Record<string, string>; // url -> contents
+  dialects?: Record<string, string>; // connection name -> dialect
+  tables?: Record<string, Malloy.Schema>; // `${connection}:${table}` -> schema
+  sqls?: Record<string, Malloy.Schema>; // `${connection}:${selectStr}` -> schema
+}
+
+// Answer one round of compiler needs from the fixtures. We don't care which
+// needs arrive in which round — whatever is asked for, we fill from the same
+// flat fixture set. Unknown items get no payload (the compiler will error).
+function fulfill(
+  needs: Malloy.CompilerNeeds,
+  fx: SessionFixtures
+): Malloy.CompilerNeeds {
+  const out: Malloy.CompilerNeeds = {};
+  if (needs.files) {
+    out.files = needs.files.map(f => ({
+      ...f,
+      contents: fx.files?.[f.url] ?? '',
+    }));
+  }
+  if (needs.connections) {
+    out.connections = needs.connections.map(c => ({
+      ...c,
+      dialect: fx.dialects?.[c.name],
+    }));
+  }
+  if (needs.table_schemas) {
+    out.table_schemas = needs.table_schemas.map(t => ({
+      ...t,
+      schema: fx.tables?.[`${t.connection_name}:${t.name}`],
+    }));
+  }
+  if (needs.sql_schemas) {
+    out.sql_schemas = needs.sql_schemas.map(s => ({
+      ...s,
+      schema: fx.sqls?.[`${s.connection_name}:${s.sql}`],
+    }));
+  }
+  return out;
+}
+
+// Drive a stateful compile to completion, answering whatever the compiler asks
+// for from `fx` each round — regardless of how many rounds it takes or which
+// order dialects, tables, and files are requested in. `step` runs one compile
+// call given the needs to feed and the session to resume.
+function runToCompletion<
+  R extends {compiler_needs?: Malloy.CompilerNeeds; session_id?: string},
+>(
+  step: (
+    needs: Malloy.CompilerNeeds | undefined,
+    session_id: string | undefined
+  ) => R,
+  fx: SessionFixtures
+): R {
+  let needs: Malloy.CompilerNeeds | undefined;
+  let session_id: string | undefined;
+  for (let round = 0; round < 20; round++) {
+    const result = step(needs, session_id);
+    session_id = result.session_id;
+    if (result.compiler_needs === undefined) return result;
+    needs = fulfill(result.compiler_needs, fx);
+  }
+  throw new Error('runToCompletion: compile did not converge in 20 rounds');
+}
+
 describe('api', () => {
   describe('compile model', () => {
     test('compile model with table dependency', () => {
-      let result = compileModel({
-        model_url: 'file://test.malloy',
-      });
-      let expected: Malloy.CompileModelResponse & {session_id?: string} = {
-        compiler_needs: {
-          files: [
-            {
-              url: 'file://test.malloy',
-            },
-          ],
+      const fx: SessionFixtures = {
+        files: {
+          'file://test.malloy':
+            "# someannotation=foo\n source: flights is connection.table('flights')",
         },
-      };
-      expect(result).toMatchObject(expected);
-      result = compileModel(
-        {
-          model_url: 'file://test.malloy',
-          compiler_needs: {
-            files: [
-              {
-                url: 'file://test.malloy',
-                contents:
-                  "# someannotation=foo\n source: flights is connection.table('flights')",
-              },
+        dialects: {connection: 'duckdb'},
+        tables: {
+          'connection:flights': {
+            fields: [
+              {kind: 'dimension', name: 'carrier', type: {kind: 'string_type'}},
             ],
           },
         },
-        {session_id: result.session_id}
-      );
-      expected = {
-        compiler_needs: {
-          table_schemas: [
-            {
-              connection_name: 'connection',
-              name: 'flights',
-            },
-          ],
-          connections: [{name: 'connection'}],
-        },
-        session_id: result.session_id,
       };
-      expect(result).toMatchObject(expected);
-      result = compileModel(
-        {
-          model_url: 'file://test.malloy',
-          compiler_needs: {
-            table_schemas: [
-              {
-                connection_name: 'connection',
-                name: 'flights',
-                schema: {
-                  fields: [
-                    {
-                      kind: 'dimension',
-                      name: 'carrier',
-                      type: {kind: 'string_type'},
-                    },
-                  ],
-                },
-              },
-            ],
-            connections: [{name: 'connection', dialect: 'duckdb'}],
-          },
-        },
-        {session_id: result.session_id}
+      const result = runToCompletion(
+        (compiler_needs, session_id) =>
+          compileModel(
+            {model_url: 'file://test.malloy', compiler_needs},
+            session_id === undefined ? undefined : {session_id}
+          ),
+        fx
       );
-      expected = {
+      expect(result).toMatchObject({
         model: {
           entries: [
             {
@@ -89,101 +113,46 @@ describe('api', () => {
                   },
                 ],
               },
-              annotations: [
-                {
-                  value: '# someannotation=foo\n',
-                },
-              ],
+              annotations: [{value: '# someannotation=foo\n'}],
             },
           ],
           anonymous_queries: [],
         },
-        session_id: result.session_id,
-      };
-      expect(result).toMatchObject(expected);
-      expect(result).toMatchObject({
-        timing_info: {
-          name: 'compile_model',
-          duration_ms: expect.any(Number),
-          detailed_timing: [
-            {name: 'session_wait'},
-            {name: 'parse_malloy'},
-            {name: 'session_wait'},
-            {
-              name: 'generate_ast',
-              detailed_timing: [{name: 'parse_compiler_flags'}],
-            },
-            {name: 'compile_malloy'},
-          ],
-        },
       });
     });
     test('compile source basic test', () => {
-      let result = compileSource({
-        model_url: 'file://test.malloy',
-        name: 'flights',
-        compiler_needs: {
-          files: [
-            {
-              url: 'file://test.malloy',
-              contents: "source: flights is connection.table('flights')",
-            },
-          ],
+      const fx: SessionFixtures = {
+        files: {
+          'file://test.malloy':
+            "source: flights is connection.table('flights')",
         },
-      });
-      let expected: Malloy.CompileSourceResponse & {session_id?: string} = {
-        compiler_needs: {
-          table_schemas: [
-            {
-              connection_name: 'connection',
-              name: 'flights',
-            },
-          ],
-          connections: [{name: 'connection'}],
-        },
-      };
-      expect(result).toMatchObject(expected);
-      result = compileSource(
-        {
-          model_url: 'file://test.malloy',
-          name: 'flights',
-          compiler_needs: {
-            table_schemas: [
-              {
-                connection_name: 'connection',
-                name: 'flights',
-                schema: {
-                  fields: [
-                    {
-                      kind: 'dimension',
-                      name: 'carrier',
-                      type: {kind: 'string_type'},
-                    },
-                  ],
-                },
-              },
+        dialects: {connection: 'duckdb'},
+        tables: {
+          'connection:flights': {
+            fields: [
+              {kind: 'dimension', name: 'carrier', type: {kind: 'string_type'}},
             ],
-            connections: [{name: 'connection', dialect: 'duckdb'}],
           },
         },
-        {session_id: result.session_id}
+      };
+      const result = runToCompletion(
+        (compiler_needs, session_id) =>
+          compileSource(
+            {model_url: 'file://test.malloy', name: 'flights', compiler_needs},
+            session_id === undefined ? undefined : {session_id}
+          ),
+        fx
       );
-      expected = {
+      expect(result).toMatchObject({
         source: {
           name: 'flights',
           schema: {
             fields: [
-              {
-                kind: 'dimension',
-                name: 'carrier',
-                type: {kind: 'string_type'},
-              },
+              {kind: 'dimension', name: 'carrier', type: {kind: 'string_type'}},
             ],
           },
         },
-        session_id: result.session_id,
-      };
-      expect(result).toMatchObject(expected);
+      });
     });
   });
   describe('compile query', () => {
@@ -205,73 +174,29 @@ describe('api', () => {
           },
         },
       };
-      let result = compileQuery({
-        model_url: 'file://test.malloy',
-        query,
-      });
-      let expected: Malloy.CompileQueryResponse & {session_id?: string} = {
-        compiler_needs: {
-          files: [
-            {
-              url: 'file://test.malloy',
-            },
-          ],
+      const fx: SessionFixtures = {
+        files: {
+          'file://test.malloy':
+            "source: flights is connection.table('flights')",
         },
-      };
-      expect(result).toMatchObject(expected);
-      result = compileQuery(
-        {
-          model_url: 'file://test.malloy',
-          query,
-          compiler_needs: {
-            files: [
-              {
-                url: 'file://test.malloy',
-                contents: "source: flights is connection.table('flights')",
-              },
+        dialects: {connection: 'duckdb'},
+        tables: {
+          'connection:flights': {
+            fields: [
+              {kind: 'dimension', name: 'carrier', type: {kind: 'string_type'}},
             ],
           },
         },
-        {session_id: result.session_id}
-      );
-      expected = {
-        compiler_needs: {
-          table_schemas: [
-            {
-              connection_name: 'connection',
-              name: 'flights',
-            },
-          ],
-          connections: [{name: 'connection'}],
-        },
       };
-      expect(result).toMatchObject(expected);
-      result = compileQuery(
-        {
-          model_url: 'file://test.malloy',
-          query,
-          compiler_needs: {
-            table_schemas: [
-              {
-                connection_name: 'connection',
-                name: 'flights',
-                schema: {
-                  fields: [
-                    {
-                      kind: 'dimension',
-                      name: 'carrier',
-                      type: {kind: 'string_type'},
-                    },
-                  ],
-                },
-              },
-            ],
-            connections: [{name: 'connection', dialect: 'duckdb'}],
-          },
-        },
-        {session_id: result.session_id}
+      const result = runToCompletion(
+        (compiler_needs, session_id) =>
+          compileQuery(
+            {model_url: 'file://test.malloy', query, compiler_needs},
+            session_id === undefined ? undefined : {session_id}
+          ),
+        fx
       );
-      expected = {
+      expect(result).toMatchObject({
         result: {
           connection_name: 'connection',
           sql: `SELECT \n\
@@ -282,17 +207,11 @@ ORDER BY 1 asc NULLS LAST
 `,
           schema: {
             fields: [
-              {
-                kind: 'dimension',
-                name: 'carrier',
-                type: {kind: 'string_type'},
-              },
+              {kind: 'dimension', name: 'carrier', type: {kind: 'string_type'}},
             ],
           },
         },
-        session_id: result.session_id,
-      };
-      expect(result).toMatchObject(expected);
+      });
     });
   });
   describe('sessions', () => {
@@ -346,16 +265,8 @@ ORDER BY 1 asc NULLS LAST
           }
         );
         const session_id = result.session_id;
-        let expected: Malloy.CompileModelResponse & {session_id?: string} = {
-          compiler_needs: {
-            files: [
-              {
-                url: 'file://test.malloy',
-              },
-            ],
-          },
-        };
-        expect(result).toMatchObject(expected);
+        expect(result.compiler_needs).toBeDefined();
+        // Advance the session one round and push its TTL into the future.
         result = compileModel(
           {
             model_url: 'file://test.malloy',
@@ -374,25 +285,19 @@ ORDER BY 1 asc NULLS LAST
             ttl: {seconds: 100000},
           }
         );
-        expected = {
-          compiler_needs: {
-            table_schemas: [
-              {
-                connection_name: 'connection',
-                name: 'flights',
-              },
-            ],
-            connections: [{name: 'connection'}],
-          },
-          session_id,
-        };
-        expect(result).toMatchObject(expected);
+        expect(result.session_id).toBe(session_id);
+        // The session is mid-flight; capture wherever it is without caring
+        // which needs the compiler asked for.
+        const midFlight = result.compiler_needs;
+        expect(midFlight).toBeDefined();
         // Now asking for a different file should NOT purge the original session
         compileModel({
           model_url: 'file://some_other_model.malloy',
         });
+        // Re-entering the session resumes exactly where it left off.
         result = compileModel({model_url: 'file://test.malloy'}, {session_id});
-        expect(result).toMatchObject(expected);
+        expect(result.session_id).toBe(session_id);
+        expect(result.compiler_needs).toEqual(midFlight);
       });
     });
     test('getting an error should kill session', () => {

--- a/packages/malloy/src/lang/parse-malloy.ts
+++ b/packages/malloy/src/lang/parse-malloy.ts
@@ -263,47 +263,51 @@ class ImportsAndTablesStep implements TranslationStep {
 
     let allMissing: DataRequestResponse = {};
 
-    // Validate each table reference against its dialect's grammar (if
-    // the dialect is resolved) and register the canonical entry. Bad
-    // paths are silently dropped — the AST step re-validates and logs
-    // an error at the precise source range. Entries whose dialect
-    // isn't resolved yet are preserved unchanged and re-processed on a
-    // later step.
-    {
-      const refs = this.parseReferences.tables;
-      const canonical: typeof refs = {};
-      for (const rawKey in refs) {
-        const info = refs[rawKey];
-        let {tablePath} = info;
-        const dialectName = that.root.connectionDialectZone.get(
-          info.connectionName
-        );
-        if (dialectName !== undefined) {
-          const result =
-            getDialect(dialectName).sqlValidateTableName(tablePath);
-          if (!result.ok) continue;
-          tablePath = result.canonical;
-        }
-        const key = `${info.connectionName}:${tablePath}`;
-        canonical[key] = {...info, tablePath};
-        that.root.schemaZone.reference(key, {
-          url: that.sourceURL,
-          range: info.firstReference,
-        });
-      }
-      this.parseReferences.tables = canonical;
+    // Register a schema request for every table reference whose dialect is
+    // known, keyed by the dialect's canonical form of the path. We re-scan
+    // the full (immutable) reference list every round:
+    //   - dialect not resolved yet  -> skip; we can't canonicalize the path,
+    //     and requesting the raw path is wrong (consumers reject non-canonical
+    //     paths). The connection's dialect is always requested (the
+    //     missingDialects block below), so a later round re-runs this loop
+    //     with the dialect known.
+    //   - canonicalization fails    -> skip; the AST step re-validates and
+    //     logs an error at the precise source range.
+    // `tableRequests` maps each canonical schema key back to its request info,
+    // for the missing-table loop just below. Re-registering an already-known
+    // key is idempotent, so re-scanning resolved entries each round is safe.
+    const tableRequests: Record<
+      string,
+      {connectionName: string; tablePath: string}
+    > = {};
+    for (const rawKey in this.parseReferences.tables) {
+      const info = this.parseReferences.tables[rawKey];
+      const dialectName = that.root.connectionDialectZone.get(
+        info.connectionName
+      );
+      if (dialectName === undefined) continue;
+      const result = getDialect(dialectName).sqlValidateTableName(
+        info.tablePath
+      );
+      if (!result.ok) continue;
+      const key = `${info.connectionName}:${result.canonical}`;
+      tableRequests[key] = {
+        connectionName: info.connectionName,
+        tablePath: result.canonical,
+      };
+      that.root.schemaZone.reference(key, {
+        url: that.sourceURL,
+        range: info.firstReference,
+      });
     }
 
     const missingTables = that.root.schemaZone.getUndefined();
     if (missingTables) {
       const tables = {};
       for (const key of missingTables) {
-        const info = this.parseReferences.tables[key];
-        if (info === undefined) continue;
-        tables[key] = {
-          connectionName: info.connectionName,
-          tablePath: info.tablePath,
-        };
+        const request = tableRequests[key];
+        if (request === undefined) continue;
+        tables[key] = request;
       }
       if (Object.keys(tables).length > 0) {
         allMissing = {tables};

--- a/packages/malloy/src/lang/parse-malloy.ts
+++ b/packages/malloy/src/lang/parse-malloy.ts
@@ -263,19 +263,10 @@ class ImportsAndTablesStep implements TranslationStep {
 
     let allMissing: DataRequestResponse = {};
 
-    // Register a schema request for every table reference whose dialect is
-    // known, keyed by the dialect's canonical form of the path. We re-scan
-    // the full (immutable) reference list every round:
-    //   - dialect not resolved yet  -> skip; we can't canonicalize the path,
-    //     and requesting the raw path is wrong (consumers reject non-canonical
-    //     paths). The connection's dialect is always requested (the
-    //     missingDialects block below), so a later round re-runs this loop
-    //     with the dialect known.
-    //   - canonicalization fails    -> skip; the AST step re-validates and
-    //     logs an error at the precise source range.
-    // `tableRequests` maps each canonical schema key back to its request info,
-    // for the missing-table loop just below. Re-registering an already-known
-    // key is idempotent, so re-scanning resolved entries each round is safe.
+    // A path can only be canonicalized once its dialect is known; references
+    // whose dialect isn't resolved yet are skipped and re-scanned next round.
+    // Invalid paths are dropped here and re-reported by the AST step.
+    // tableRequests feeds the missing-table loop below.
     const tableRequests: Record<
       string,
       {connectionName: string; tablePath: string}


### PR DESCRIPTION
Reported by @whscullin: the renderer storybook crashed on every file-path table, e.g. `duckdb.table('static/data/products.parquet')`.

The path is valid, but its canonical SQL form is single-quoted — and the translator can't produce that without first knowing the connection's dialect. It was requesting the table schema with the raw path before the dialect came back. The `Runtime` tolerated that (soft-errors a non-canonical path and retries), but the stateless API's single-table fetch wrapper throws, so the bad request took down the whole compile.

Now a table reference whose dialect isn't resolved yet is skipped and re-scanned on a later round once the dialect (always requested separately) arrives, so the only schema request that ever goes out is the canonical one. While here, `parseReferences.tables` no longer gets rewritten each round.

The API tests pinned the per-round needs by hand; they now answer whatever the compiler asks for via a small driver, so they don't care how resolution is ordered.