### PR TITLE
Resolve inline given references to a declared default

### DIFF
--- a/packages/malloy/src/lang/ast/statements/define-given.ts
+++ b/packages/malloy/src/lang/ast/statements/define-given.ts
@@ -203,6 +203,26 @@ export class GivenDeclaration
               operators: [...bad].sort().join(', '),
             });
           }
+          // An inline default may fold an unsupplied `$REF` to that
+          // given's declared default, so every reachable regular default
+          // must also be inline-reducible. The closure is flat; inline
+          // members self-validate at their own declaration, so only
+          // regular ones need checking here.
+          for (const g of givenUsage ?? []) {
+            const refDecl = doc.documentGivens.get(g.id);
+            if (!refDecl || refDecl.inline || refDecl.default === undefined) {
+              continue;
+            }
+            const refBad = new Set<string>();
+            collectInlineBadOps(refDecl.default, refBad);
+            if (refBad.size > 0) {
+              this.default.logError('inline-bad-operator-in-ref', {
+                name: this.name,
+                refName: refDecl.name,
+                operators: [...refBad].sort().join(', '),
+              });
+            }
+          }
         }
       }
     }

--- a/packages/malloy/src/lang/parse-log.ts
+++ b/packages/malloy/src/lang/parse-log.ts
@@ -321,6 +321,11 @@ type MessageParameterTypes = {
   'in-given-type-mismatch': {lhsType: string; elementType: string};
   'inline-no-default': {name: string};
   'inline-bad-operator': {name: string; operators: string};
+  'inline-bad-operator-in-ref': {
+    name: string;
+    refName: string;
+    operators: string;
+  };
   'invalid-given-modifier': {modifier: string};
   'illegal-filter-type': string;
   'invalid-source-from-given': string;
@@ -495,6 +500,8 @@ export const MESSAGE_FORMATTERS: PartialErrorCodeMessageMap = {
     `inline given \`${e.name}\` must have a value — there is nothing to inline without one`,
   'inline-bad-operator': e =>
     `inline given \`${e.name}\` uses operator(s) not allowed in inline expressions: ${e.operators}`,
+  'inline-bad-operator-in-ref': e =>
+    `inline given \`${e.name}\` references \`${e.refName}\`, whose default uses operator(s) not allowed in inline expressions: ${e.operators}`,
   'invalid-given-modifier': e =>
     `Unknown modifier \`${e.modifier}\` on \`given:\` declaration; the only modifier allowed here is \`inline\``,
   'restricted-construct-forbidden': e => ({

--- a/packages/malloy/src/lang/test/givens.spec.ts
+++ b/packages/malloy/src/lang/test/givens.spec.ts
@@ -1793,6 +1793,28 @@ describe('inline givens', () => {
     `).toTranslate();
   });
 
+  test('inline referencing a regular given with a reducible default translates cleanly', () => {
+    expect(givensModel`
+      given:
+        REV_REC_METHOD :: string[] is ['__NO_METHOD__']
+        inline NO_METHOD_RESTRICTIONS :: boolean is '__NO_METHOD__' in $REV_REC_METHOD
+    `).toTranslate();
+  });
+
+  test('inline reaching a non-reducible default through a reference is a translate-time error', () => {
+    // `N`'s default `1 + 1` isn't inline-reducible; an inline gate that
+    // can fall back to it is rejected, naming the reference.
+    expect(givensModel`
+      given:
+        N :: number is 1 + 1
+        inline BIG :: boolean is $N > 0
+    `).toLog(
+      errorMessage(
+        /inline given `BIG` references `N`, whose default uses operator\(s\) not allowed/
+      )
+    );
+  });
+
   test('inline given filtered out of Model.givens introspection', () => {
     const t = givensModel`
       given:

--- a/packages/malloy/src/model/expression_compiler.ts
+++ b/packages/malloy/src/model/expression_compiler.ts
@@ -62,6 +62,7 @@ import {isBasicScalar} from './query_node';
 import type {QueryStruct, QueryField} from './query_node';
 import type {Dialect, QueryInfo} from '../dialect';
 import {MalloyCompileError} from './malloy_compile_error';
+import {lookupGivenValue} from './given_binding';
 
 const NUMERIC_DECIMAL_PRECISION = 9;
 
@@ -872,10 +873,12 @@ export function generateParameterFragment(
  * and the `'inGiven'` SQL-emit case ($ARR in `expr in $ARR`).
  */
 function resolveGivenBoundExpr(context: QueryStruct, ref: GivenRefNode): Expr {
-  const supplied = context.prepareResultOptions?.resolvedGivens?.get(ref.id);
-  if (supplied !== undefined) return supplied;
-  const decl = context.getModel().givens[ref.id];
-  if (decl?.default !== undefined) return decl.default;
+  const value = lookupGivenValue(
+    context.prepareResultOptions?.resolvedGivens,
+    context.getModel().givens,
+    ref.id
+  );
+  if (value !== undefined) return value;
   throw new MalloyCompileError(
     unsatisfiedGivenMessage(ref.refName),
     'compiler-given-no-value',

--- a/packages/malloy/src/model/given_binding.ts
+++ b/packages/malloy/src/model/given_binding.ts
@@ -10,6 +10,7 @@ import {isRepeatedRecord, mkSafeRecord, TD} from './malloy_types';
 import type {
   AtomicTypeDef,
   Expr,
+  Given,
   GivenID,
   GivenTypeDef,
   GivenValue,
@@ -17,6 +18,22 @@ import type {
   SafeRecord,
 } from './malloy_types';
 import {MalloyCompileError} from './malloy_compile_error';
+
+/**
+ * The one definition of "what value does a given reference stand for":
+ * the caller-supplied value if one is bound, otherwise the declaration
+ * default. Returns undefined when neither exists — callers decide how to
+ * report that, since the right diagnostic differs by site (a bind-time
+ * inline fold vs. SQL emission). Shared by `evaluateInlineGivens` here
+ * and `resolveGivenBoundExpr` in the compiler.
+ */
+export function lookupGivenValue(
+  bound: Map<GivenID, Expr> | undefined,
+  givens: Record<GivenID, Given> | undefined,
+  id: GivenID
+): Expr | undefined {
+  return bound?.get(id) ?? givens?.[id]?.default;
+}
 
 export function resolveSuppliedGivens(
   supplied: Record<string, GivenValue> | undefined,
@@ -75,9 +92,12 @@ export function resolveSuppliedGivens(
  * `inline-no-default` error at declaration time.
  *
  * Iteration follows `modelDef.contents` insertion order, which (by
- * Malloy's no-forward-refs rule) is also topological order: if inline
- * A's default references inline B, B's declaration came first and is
- * already in the map by the time A runs.
+ * Malloy's no-forward-refs rule) is also topological order. An inline
+ * default that references another inline given relies on this: the
+ * referenced one was declared first, so it is already folded into
+ * `bound` by the time this one reads it. A reference to a regular given
+ * resolves straight to its supplied value or declaration default (see
+ * `resolveGiven`), which needs no ordering.
  */
 export function evaluateInlineGivens(
   bound: Map<GivenID, Expr>,
@@ -85,13 +105,26 @@ export function evaluateInlineGivens(
 ): Map<GivenID, Expr> {
   if (!modelDef) return bound;
   const givens = modelDef.givens ?? {};
+  // A `$REF` in an inline default resolves to its supplied value, else
+  // its declaration default; a reference with neither is a caller error.
+  // `bound` is read live, so a given folded earlier in the loop is
+  // visible to one folded later.
+  const resolveGiven = (id: GivenID, refName: string): Expr => {
+    const v = lookupGivenValue(bound, givens, id);
+    if (v !== undefined) return v;
+    throw new MalloyCompileError(
+      `Inline given depends on '${refName}', which has no supplied value and no default. Supply a value for '${refName}' or give it a declaration default.`,
+      'runtime-given-unsatisfied-inline',
+      undefined
+    );
+  };
   for (const [, entry] of Object.entries(modelDef.contents)) {
     if (entry.type !== 'given') continue;
     if (bound.has(entry.id)) continue;
     const decl = givens[entry.id];
     if (!decl?.inline) continue;
     if (decl.default === undefined) continue;
-    bound.set(entry.id, inlineExpr(decl.default, bound));
+    bound.set(entry.id, inlineExpr(decl.default, resolveGiven));
   }
   return bound;
 }

--- a/packages/malloy/src/model/inline_expr.ts
+++ b/packages/malloy/src/model/inline_expr.ts
@@ -50,16 +50,25 @@ export const INLINE_LEAVES: ReadonlySet<string> = new Set<string>([
 ]);
 
 /**
- * Bind-time evaluator for `inline` given defaults. Walks the Expr tree,
- * recursing on bound values for given-refs, and returns a literal Expr
- * (string/number/boolean/null/arrayLiteral).
+ * Bind-time evaluator for `inline` given defaults. Walks the Expr tree
+ * and returns a literal Expr (string/number/boolean/null/arrayLiteral).
+ *
+ * A pure folder: it does not know how given references get their values.
+ * `resolveGiven` is handed a given reference's id and surface name (both
+ * a `$NAME` ref and the array of an `expr in $NAME`) and returns the Expr
+ * that reference stands for — caller-supplied value, declaration default,
+ * or a thrown error if neither. That policy lives with the caller
+ * (`given_binding.ts`), not here — see `lookupGivenValue`.
  *
  * Throws on any node outside `INLINE_OPS ∪ INLINE_LEAVES`. The
  * translator's pre-flight check should have rejected such defaults
  * already, so a throw here flags a compiler bug rather than a caller
  * error.
  */
-export function inlineExpr(e: Expr, bound: Map<GivenID, Expr>): Expr {
+export function inlineExpr(
+  e: Expr,
+  resolveGiven: (id: GivenID, refName: string) => Expr
+): Expr {
   switch (e.node) {
     case 'stringLiteral':
     case 'numberLiteral':
@@ -68,25 +77,18 @@ export function inlineExpr(e: Expr, bound: Map<GivenID, Expr>): Expr {
     case 'null':
     case 'arrayLiteral':
       return e;
-    case 'given': {
-      const v = bound.get(e.id);
-      if (v === undefined) {
-        throw new Error(
-          `inlineExpr: given '${e.refName}' has no bound value and no default — translator should have caught this earlier`
-        );
-      }
-      return inlineExpr(v, bound);
-    }
+    case 'given':
+      return inlineExpr(resolveGiven(e.id, e.refName), resolveGiven);
     case '()':
-      return inlineExpr(e.e, bound);
+      return inlineExpr(e.e, resolveGiven);
     case 'not': {
-      const inner = inlineExpr(e.e, bound);
+      const inner = inlineExpr(e.e, resolveGiven);
       return toBoolLiteral(!exprAsBool(inner));
     }
     case 'and':
     case 'or': {
-      const left = exprAsBool(inlineExpr(e.kids.left, bound));
-      const right = exprAsBool(inlineExpr(e.kids.right, bound));
+      const left = exprAsBool(inlineExpr(e.kids.left, resolveGiven));
+      const right = exprAsBool(inlineExpr(e.kids.right, resolveGiven));
       return toBoolLiteral(e.node === 'and' ? left && right : left || right);
     }
     case '=':
@@ -95,28 +97,26 @@ export function inlineExpr(e: Expr, bound: Map<GivenID, Expr>): Expr {
     case '<':
     case '>=':
     case '<=': {
-      const left = inlineExpr(e.kids.left, bound);
-      const right = inlineExpr(e.kids.right, bound);
+      const left = inlineExpr(e.kids.left, resolveGiven);
+      const right = inlineExpr(e.kids.right, resolveGiven);
       return toBoolLiteral(compareLiterals(e.node, left, right));
     }
     case 'inGiven': {
-      const lhs = inlineExpr(e.e, bound);
-      const arrBound = bound.get(e.givenRef.id);
-      if (arrBound === undefined) {
-        throw new Error(
-          `inlineExpr: given '${e.givenRef.refName}' has no bound value and no default — translator should have caught this earlier`
-        );
-      }
-      if (arrBound.node === 'null') {
+      const lhs = inlineExpr(e.e, resolveGiven);
+      const arr = inlineExpr(
+        resolveGiven(e.givenRef.id, e.givenRef.refName),
+        resolveGiven
+      );
+      if (arr.node === 'null') {
         return toBoolLiteral(e.not);
       }
-      if (arrBound.node !== 'arrayLiteral') {
+      if (arr.node !== 'arrayLiteral') {
         throw new Error(
-          `inlineExpr: 'inGiven' bound to '${arrBound.node}', expected 'arrayLiteral'`
+          `inlineExpr: 'inGiven' resolved to '${arr.node}', expected 'arrayLiteral'`
         );
       }
-      const found = arrBound.kids.values.some(v =>
-        compareLiterals('=', lhs, inlineExpr(v, bound))
+      const found = arr.kids.values.some(v =>
+        compareLiterals('=', lhs, inlineExpr(v, resolveGiven))
       );
       return toBoolLiteral(e.not ? !found : found);
     }

--- a/test/src/core/givens.spec.ts
+++ b/test/src/core/givens.spec.ts
@@ -1032,4 +1032,39 @@ describe('givens — `inline` (Pattern A)', () => {
       .run({givens: {ROLE: 'viewer', CAPS: []}});
     expect(denied.data.toObject().length).toBe(0);
   });
+
+  test('inline gate falls back to a referenced regular given default when unsupplied', async () => {
+    const model = runtime.loadModel(`
+      ##! experimental.givens
+      given:
+        REV_REC_METHOD :: string[] is ['__NO_METHOD__']
+        inline NO_METHOD_RESTRICTIONS :: boolean is '__NO_METHOD__' in $REV_REC_METHOD
+      query: q is duckdb.table('malloytest.state_facts') -> {
+        where: $NO_METHOD_RESTRICTIONS
+        group_by: state
+      }
+    `);
+    // REV_REC_METHOD is NOT supplied → must fall back to its declared
+    // default ['__NO_METHOD__'] → inline gate is true → rows come through.
+    const result = await model.loadQueryByName('q').run();
+    expect(result.data.toObject().length).toBeGreaterThan(0);
+  });
+
+  test('inline gate referencing an unsupplied no-default given is a clear runtime error', async () => {
+    // CAP is surfaced with no default → satisfiability passes, but
+    // omitting it at run time leaves the inline gate nothing to fold.
+    const model = runtime.loadModel(`
+      ##! experimental.givens
+      given:
+        CAP :: string[]
+        inline CAN_READ :: boolean is 'read' in $CAP
+      query: q is duckdb.table('malloytest.state_facts') -> {
+        where: $CAN_READ
+        group_by: state
+      }
+    `);
+    await expect(model.loadQueryByName('q').run()).rejects.toThrow(
+      /Inline given depends on 'CAP', which has no supplied value and no default/
+    );
+  });
 });


### PR DESCRIPTION
An inline given whose default references a regular given crashed at run time with an "Internal compiler error (likely a Malloy bug)" whenever that regular given wasn't supplied and fell back to its declared default — even though the model is perfectly valid. The inline gate simply couldn't resolve the reference to the other given's default.

Three user-visible consequences:

- Referencing a normal given from an inline given now works when it falls back to its declared default
- A reference with neither a supplied value nor a default is now a clear caller error ("supply a value for X"), not a compiler-bug throw.
- A referenced given whose default can't fold to a literal (e.g. `1 + 1`) is now rejected at compile time, naming the reference, instead of detonating at bind time on the unsupplied path. An inline gate has to fold in every case, including not-supplied, and the default is the not-supplied value.
