### PR TITLE
  fix(render): honor # label tags on chart axis, legend, and tooltip titles

### DIFF
--- a/packages/malloy-render/.npmignore
+++ b/packages/malloy-render/.npmignore
@@ -4,3 +4,4 @@ tsconfig*
 *.spec.*
 storybook-static
 CONTEXT.md
+dist/module/plugins/spec-test-support

--- a/packages/malloy-render/src/component/bar-chart/get-custom-tooltips-entries.ts
+++ b/packages/malloy-render/src/component/bar-chart/get-custom-tooltips-entries.ts
@@ -21,7 +21,7 @@ export function getCustomTooltipEntries({
   customTooltipFields.forEach(f => {
     records.forEach(rec => {
       customEntries.push({
-        label: f.name,
+        label: f.getLabel(),
         value: () =>
           applyRenderer({
             dataColumn: rec.__row.column(f.name),

--- a/packages/malloy-render/src/component/vega/measure-series-label-scale.ts
+++ b/packages/malloy-render/src/component/vega/measure-series-label-scale.ts
@@ -9,15 +9,12 @@ import type {NestField} from '@/data_tree';
 export const MEASURE_SERIES_LABEL_SCALE = 'measureSeriesLabel';
 
 /**
- * For a measure-series legend the color-domain values are the raw measure
- * field names; this ordinal scale maps them to their `# label` so the legend
- * entries match the axis and tooltip. Keeping the labels in scale data (not
- * in a parsed expression) renders any label verbatim. An explicit empty
- * `# label=""` intentionally renders a blank legend entry, the same way it
- * hides an axis title. Domain and range are deduped in lockstep via a Map
- * keyed by field name: d3 dedupes an ordinal scale's domain but keeps its
- * range verbatim, so a measure repeated in the y channel would otherwise
- * shift the indices and map a later measure to the wrong label.
+ * Maps the measure-series legend's domain (raw measure field names) to each
+ * field's `# label`. Labels live in scale data so they render verbatim: an
+ * explicit `# label=""` deliberately shows a blank legend entry, the same
+ * way it hides an axis title. Domain and range dedupe in lockstep because
+ * d3 dedupes an ordinal scale's domain but not its range; a repeated y
+ * measure would otherwise shift later labels onto the wrong measure.
  */
 export function getMeasureSeriesLabelScale(
   explore: NestField,

--- a/packages/malloy-render/src/component/vega/measure-series-label-scale.ts
+++ b/packages/malloy-render/src/component/vega/measure-series-label-scale.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright Contributors to the Malloy project
+ * SPDX-License-Identifier: MIT
+ */
+
+import type {Scale} from 'vega';
+import type {NestField} from '@/data_tree';
+
+export const MEASURE_SERIES_LABEL_SCALE = 'measureSeriesLabel';
+
+/**
+ * For a measure-series legend the color-domain values are the raw measure
+ * field names; this ordinal scale maps them to their `# label` so the legend
+ * entries match the axis and tooltip. Keeping the labels in scale data (not
+ * in a parsed expression) renders any label verbatim. An explicit empty
+ * `# label=""` intentionally renders a blank legend entry, the same way it
+ * hides an axis title. Domain and range are deduped in lockstep via a Map
+ * keyed by field name: d3 dedupes an ordinal scale's domain but keeps its
+ * range verbatim, so a measure repeated in the y channel would otherwise
+ * shift the indices and map a later measure to the wrong label.
+ */
+export function getMeasureSeriesLabelScale(
+  explore: NestField,
+  yFieldPaths: string[]
+): Scale {
+  const labelByName = new Map<string, string>();
+  for (const fieldPath of yFieldPaths) {
+    const field = explore.fieldAt(fieldPath);
+    labelByName.set(field.name, field.getLabel());
+  }
+  return {
+    name: MEASURE_SERIES_LABEL_SCALE,
+    type: 'ordinal',
+    domain: [...labelByName.keys()],
+    range: [...labelByName.values()],
+  };
+}

--- a/packages/malloy-render/src/plugins/bar-chart/bar-chart-plugin.tsx
+++ b/packages/malloy-render/src/plugins/bar-chart/bar-chart-plugin.tsx
@@ -38,12 +38,13 @@ import {
   barChartSettingsSchema,
 } from './bar-chart-settings';
 import {barChartSettingsToTag} from './settings-to-tag';
+import type {SyntheticSeriesField} from '@/plugins/synthetic-series-field';
 
 export interface BarChartPluginInstance extends CoreVizPluginInstance<BarChartPluginMetadata> {
   getTopNSeries?: (maxSeries: number) => (string | number | boolean)[];
   field: NestField;
   chartDisplay: ChartDisplayConfig;
-  syntheticSeriesField?: Field;
+  syntheticSeriesField?: SyntheticSeriesField;
   hasMultipleSeriesFields?: boolean;
 }
 
@@ -196,20 +197,12 @@ export const BarChartPluginFactory: RenderPluginFactory<BarChartPluginInstance> 
           }
 
           if (hasMultipleSeriesFields) {
-            // Create synthetic field
             pluginInstance.syntheticSeriesField = {
               name: seriesFields.map(f => f.name).join(' - '),
               getLabel: () => seriesFields.map(f => f.getLabel()).join(' - '),
               valueSet: concatenatedValues,
               referenceId: '__synthetic_concatenated_series__',
-              // Minimal Field interface implementation
-              isTime: () => false,
-              isDate: () => false,
-              isBasic: () => true,
-              isNumber: () => false,
-              isString: () => true,
-              isBoolean: () => false,
-            } as unknown as Field;
+            };
           }
         },
 

--- a/packages/malloy-render/src/plugins/bar-chart/bar-chart-plugin.tsx
+++ b/packages/malloy-render/src/plugins/bar-chart/bar-chart-plugin.tsx
@@ -199,6 +199,7 @@ export const BarChartPluginFactory: RenderPluginFactory<BarChartPluginInstance> 
             // Create synthetic field
             pluginInstance.syntheticSeriesField = {
               name: seriesFields.map(f => f.name).join(' - '),
+              getLabel: () => seriesFields.map(f => f.getLabel()).join(' - '),
               valueSet: concatenatedValues,
               referenceId: '__synthetic_concatenated_series__',
               // Minimal Field interface implementation

--- a/packages/malloy-render/src/plugins/bar-chart/generate-bar_chart-vega-spec.spec.ts
+++ b/packages/malloy-render/src/plugins/bar-chart/generate-bar_chart-vega-spec.spec.ts
@@ -7,32 +7,172 @@
 jest.mock('@/component/chart/chart-layout-settings', () =>
   jest.requireActual('@/plugins/spec-test-support/chart-layout-settings-stub')
 );
-jest.mock('@/component/bar-chart/get-custom-tooltips-entries', () =>
-  jest.requireActual(
-    '@/plugins/spec-test-support/get-custom-tooltips-entries-stub'
-  )
+jest.mock('@/component/renderer/apply-renderer', () =>
+  jest.requireActual('@/plugins/spec-test-support/apply-renderer-stub')
 );
+jest.mock('@/component/chart/chart-v2', () =>
+  jest.requireActual('@/plugins/spec-test-support/chart-v2-stub')
+);
+// ESM-only packages the plugin module imports but these tests never call.
+jest.mock('vega', () => ({}));
+jest.mock('vega-interpreter', () => ({}));
+jest.mock('solid-js/jsx-runtime', () => ({}));
 
-import type {Spec} from 'vega';
 import {
   describeChartLabelTests,
   runChartQuery,
+  fakeTooltipItem,
+  fakeTooltipView,
+  SOURCE,
+  SOURCE4,
 } from '@/plugins/spec-test-support/harness';
+import type {VegaChartProps} from '@/component/types';
 import {getBarChartSettings} from '@/plugins/bar-chart/get-bar_chart-settings';
 import {
   generateBarChartVegaSpecV2,
   type BarChartSpecInputs,
 } from '@/plugins/bar-chart/generate-bar_chart-vega-spec';
+import {BarChartPluginFactory} from '@/plugins/bar-chart/bar-chart-plugin';
 
-async function buildBarSpec(source: string, query: string): Promise<Spec> {
-  const {root, metadata} = await runChartQuery(source, query);
+async function buildBar(source: string, query: string) {
+  const {root, rootCell, metadata} = await runChartQuery(source, query);
   const settings = getBarChartSettings(root);
   const plugin: BarChartSpecInputs = {
     field: root,
     chartDisplay: {size: {}},
     getMetadata: () => ({type: 'bar', field: root, settings}),
   };
-  return generateBarChartVegaSpecV2(metadata, plugin).spec;
+  return {props: generateBarChartVegaSpecV2(metadata, plugin), rootCell};
 }
 
-describeChartLabelTests('bar_chart', buildBarSpec);
+async function buildBarProps(
+  source: string,
+  query: string
+): Promise<VegaChartProps> {
+  return (await buildBar(source, query)).props;
+}
+
+describeChartLabelTests('bar_chart', buildBarProps);
+
+describe('bar_chart honors # label tags in default tooltips', () => {
+  test('measure-series tooltip labels use the # label tags, not field names', async () => {
+    const props = await buildBarProps(
+      SOURCE,
+      `
+      # bar_chart
+      run: data -> {
+        group_by:
+          # label="Audience"
+          audience_name
+        aggregate:
+          # y
+          # label="Reach (HH)"
+          total_reach is reach.sum()
+          # y
+          # label="Avg Reach"
+          avg_reach is reach.avg()
+      }
+      `
+    );
+    const records = [
+      {x: 'Total Universe (HH)', y: 75, series: 'total_reach'},
+      {x: 'Total Universe (HH)', y: 30, series: 'avg_reach'},
+    ];
+    const tooltip = props.getTooltipData?.(
+      fakeTooltipItem('x_highlight', {x: 'Total Universe (HH)', v: records}),
+      fakeTooltipView()
+    );
+    expect(tooltip?.entries.map(e => e.label)).toEqual([
+      'Reach (HH)',
+      'Avg Reach',
+    ]);
+  }, 60000);
+
+  test('dimensional-series tooltip labels stay series values, not labels', async () => {
+    const props = await buildBarProps(
+      SOURCE,
+      `
+      # bar_chart
+      run: data -> {
+        group_by:
+          # label="Audience"
+          audience_name
+          # label="Quarter"
+          period
+        aggregate:
+          # label="Reach (HH)"
+          total_reach is reach.sum()
+      }
+      `
+    );
+    const records = [{x: 'Total Universe (HH)', y: 75, series: '1Q26'}];
+    const tooltip = props.getTooltipData?.(
+      fakeTooltipItem('x_highlight', {x: 'Total Universe (HH)', v: records}),
+      fakeTooltipView()
+    );
+    expect(tooltip?.entries.map(e => e.label)).toEqual(['1Q26']);
+  }, 60000);
+
+  test('custom # tooltip entries use the # label tag, not the field name', async () => {
+    const {props, rootCell} = await buildBar(
+      SOURCE,
+      `
+      # bar_chart
+      run: data -> {
+        group_by:
+          # label="Audience"
+          audience_name
+        aggregate:
+          # label="Reach (HH)"
+          total_reach is reach.sum()
+          # tooltip
+          # label="Avg Reach"
+          avg_reach is reach.avg()
+      }
+      `
+    );
+    const records = [
+      {
+        x: 'Total Universe (HH)',
+        y: 75,
+        series: 'total_reach',
+        __row: rootCell.rows[0],
+      },
+    ];
+    const tooltip = props.getTooltipData?.(
+      fakeTooltipItem('x_highlight', {x: 'Total Universe (HH)', v: records}),
+      fakeTooltipView()
+    );
+    expect(tooltip?.entries.map(e => e.label)).toEqual([
+      'Reach (HH)',
+      'Avg Reach',
+    ]);
+  }, 60000);
+});
+
+describe('bar_chart synthetic multi-series field', () => {
+  test('legend title joins the # label tags of the tagged series fields', async () => {
+    const {root, rootCell, metadata} = await runChartQuery(
+      SOURCE4,
+      `
+      # bar_chart
+      run: data4 -> {
+        group_by:
+          audience_name
+          # series
+          # label="Quarter"
+          period
+          # series
+          # label="Region"
+          region
+        aggregate: total_reach is reach.sum()
+      }
+      `
+    );
+    const plugin = BarChartPluginFactory.create(root);
+    plugin.processData?.(root, rootCell);
+    expect(plugin.syntheticSeriesField?.getLabel()).toBe('Quarter - Region');
+    const {spec} = generateBarChartVegaSpecV2(metadata, plugin);
+    expect(spec.legends?.[0]?.title).toBe('Quarter - Region');
+  }, 60000);
+});

--- a/packages/malloy-render/src/plugins/bar-chart/generate-bar_chart-vega-spec.spec.ts
+++ b/packages/malloy-render/src/plugins/bar-chart/generate-bar_chart-vega-spec.spec.ts
@@ -1,0 +1,149 @@
+/*
+ * Copyright Contributors to the Malloy project
+ * SPDX-License-Identifier: MIT
+ */
+
+// The bar-chart spec generator computes axis/legend titles directly from each
+// field's resolved label (`field.getLabel()`), independent of the chart layout
+// math. The layout math (`chart-layout-settings`) pulls in vega's `scale()` and
+// DOM text measurement, and the custom-tooltip path pulls in solid-js, neither
+// of which loads under the node test environment. Stub both so the generator
+// runs; the titles we assert on do not depend on them.
+jest.mock('@/component/chart/chart-layout-settings', () => ({
+  getChartLayoutSettings: () => ({
+    plotWidth: 300,
+    plotHeight: 200,
+    totalWidth: 400,
+    totalHeight: 300,
+    isSpark: false,
+    padding: {top: 0, left: 0, right: 0, bottom: 0},
+    xAxis: {labelAngle: 0, hidden: false},
+    yAxis: {hidden: false, tickCount: 5, width: 40, yTitleSize: 12},
+    yScale: {domain: [0, 100]},
+  }),
+  getXAxisSettings: () => ({}),
+}));
+jest.mock('@/component/bar-chart/get-custom-tooltips-entries', () => ({
+  getCustomTooltipEntries: () => [],
+}));
+
+import type {Spec} from 'vega';
+import {runtimeFor} from '../../../../../test/src/runtimes';
+import {API} from '@malloydata/malloy';
+import {RenderFieldMetadata} from '@/render-field-metadata';
+import {getDataTree} from '@/data_tree';
+import {getResultMetadata} from '@/component/render-result-metadata';
+import {getBarChartSettings} from '@/plugins/bar-chart/get-bar_chart-settings';
+import {generateBarChartVegaSpecV2} from '@/plugins/bar-chart/generate-bar_chart-vega-spec';
+import type {BarChartPluginInstance} from '@/plugins/bar-chart/bar-chart-plugin';
+
+const duckdb = runtimeFor('duckdb');
+
+afterAll(async () => {
+  await duckdb.connection.close();
+});
+
+// Compile + run the query, build field metadata (resolves `# label` tags at
+// setup time), build the data tree, then drive the bar-chart spec generator
+// with a minimal plugin instance, the same inputs the renderer would pass.
+async function buildBarSpec(sourceModel: string, query: string): Promise<Spec> {
+  const result = await duckdb.loadModel(sourceModel).loadQuery(query).run();
+  const malloyResult = API.util.wrapResult(result);
+  const rfm = new RenderFieldMetadata(malloyResult);
+  getDataTree(malloyResult, rfm);
+  const root = rfm.getRootField();
+  const settings = getBarChartSettings(root);
+  const plugin = {
+    name: 'bar',
+    field: root,
+    chartDisplay: {},
+    getMetadata: () => ({type: 'bar', field: root, settings}),
+  } as unknown as BarChartPluginInstance;
+  const metadata = getResultMetadata(root, {
+    renderFieldMetadata: rfm,
+    parentSize: {width: 400, height: 300},
+  });
+  return generateBarChartVegaSpecV2(metadata, plugin).spec;
+}
+
+const DATA =
+  'duckdb.sql("SELECT * FROM (VALUES ' +
+  "('Total Universe (HH)', 75, '1Q26'), " +
+  "('1Q26: High Income Earners', 28, '1Q26'), " +
+  "('1Q26: Auto Intenders', 25, '2Q26')) " +
+  'AS t(audience_name, reach, period)")';
+
+describe('bar chart honors # label tags on axis/legend titles', () => {
+  const SOURCE = `source: data is ${DATA}`;
+
+  test('x and y axis titles use the # label tag, not the field name', async () => {
+    const query = `
+      # bar_chart
+      run: data -> {
+        group_by:
+          # label="Audience"
+          audience_name
+        aggregate:
+          # label="Reach (HH)"
+          total_reach is reach.sum()
+        order_by: total_reach desc
+      }
+    `;
+    const spec = await buildBarSpec(SOURCE, query);
+    const xAxis = spec.axes?.find(a => a.scale === 'xscale');
+    const yAxis = spec.axes?.find(a => a.scale === 'yscale');
+    expect(xAxis?.title).toBe('Audience');
+    expect(yAxis?.title).toBe('Reach (HH)');
+  }, 60000);
+
+  test('legend title uses the # label tag of the series dimension', async () => {
+    const query = `
+      # bar_chart
+      run: data -> {
+        group_by:
+          # label="Audience"
+          audience_name
+          # label="Quarter"
+          period
+        aggregate:
+          # label="Reach (HH)"
+          total_reach is reach.sum()
+      }
+    `;
+    const spec = await buildBarSpec(SOURCE, query);
+    expect(spec.legends?.[0]?.title).toBe('Quarter');
+  }, 60000);
+
+  test('measure-series legend entries use the # label tags, not field names', async () => {
+    const query = `
+      # bar_chart
+      run: data -> {
+        group_by:
+          # label="Audience"
+          audience_name
+        aggregate:
+          # y
+          # label="Reach (HH)"
+          total_reach is reach.sum()
+          # y
+          # label=""
+          avg_reach is reach.avg()
+      }
+    `;
+    const spec = await buildBarSpec(SOURCE, query);
+    // Labels are mapped through an ordinal scale (data-driven), so they survive
+    // any label text and an explicit empty # label="" (no truthy fallback to
+    // the field name), and the legend references that scale.
+    const scale = (spec.scales ?? []).find(
+      s => s.name === 'measureSeriesLabel'
+    );
+    const range = scale && 'range' in scale ? scale.range : undefined;
+    const rangeArr: unknown[] = Array.isArray(range) ? range : [];
+    expect(rangeArr).toContain('Reach (HH)');
+    expect(rangeArr).toContain('');
+    expect(rangeArr).not.toContain('avg_reach');
+    expect(JSON.stringify(spec.legends?.[0] ?? {})).toContain(
+      'measureSeriesLabel'
+    );
+  }, 60000);
+});

--- a/packages/malloy-render/src/plugins/bar-chart/generate-bar_chart-vega-spec.spec.ts
+++ b/packages/malloy-render/src/plugins/bar-chart/generate-bar_chart-vega-spec.spec.ts
@@ -3,147 +3,36 @@
  * SPDX-License-Identifier: MIT
  */
 
-// The bar-chart spec generator computes axis/legend titles directly from each
-// field's resolved label (`field.getLabel()`), independent of the chart layout
-// math. The layout math (`chart-layout-settings`) pulls in vega's `scale()` and
-// DOM text measurement, and the custom-tooltip path pulls in solid-js, neither
-// of which loads under the node test environment. Stub both so the generator
-// runs; the titles we assert on do not depend on them.
-jest.mock('@/component/chart/chart-layout-settings', () => ({
-  getChartLayoutSettings: () => ({
-    plotWidth: 300,
-    plotHeight: 200,
-    totalWidth: 400,
-    totalHeight: 300,
-    isSpark: false,
-    padding: {top: 0, left: 0, right: 0, bottom: 0},
-    xAxis: {labelAngle: 0, hidden: false},
-    yAxis: {hidden: false, tickCount: 5, width: 40, yTitleSize: 12},
-    yScale: {domain: [0, 100]},
-  }),
-  getXAxisSettings: () => ({}),
-}));
-jest.mock('@/component/bar-chart/get-custom-tooltips-entries', () => ({
-  getCustomTooltipEntries: () => [],
-}));
+// These modules do not load under the node test env; the stubs document why.
+jest.mock('@/component/chart/chart-layout-settings', () =>
+  jest.requireActual('@/plugins/spec-test-support/chart-layout-settings-stub')
+);
+jest.mock('@/component/bar-chart/get-custom-tooltips-entries', () =>
+  jest.requireActual(
+    '@/plugins/spec-test-support/get-custom-tooltips-entries-stub'
+  )
+);
 
 import type {Spec} from 'vega';
-import {runtimeFor} from '../../../../../test/src/runtimes';
-import {API} from '@malloydata/malloy';
-import {RenderFieldMetadata} from '@/render-field-metadata';
-import {getDataTree} from '@/data_tree';
-import {getResultMetadata} from '@/component/render-result-metadata';
+import {
+  describeChartLabelTests,
+  runChartQuery,
+} from '@/plugins/spec-test-support/harness';
 import {getBarChartSettings} from '@/plugins/bar-chart/get-bar_chart-settings';
-import {generateBarChartVegaSpecV2} from '@/plugins/bar-chart/generate-bar_chart-vega-spec';
-import type {BarChartPluginInstance} from '@/plugins/bar-chart/bar-chart-plugin';
+import {
+  generateBarChartVegaSpecV2,
+  type BarChartSpecInputs,
+} from '@/plugins/bar-chart/generate-bar_chart-vega-spec';
 
-const duckdb = runtimeFor('duckdb');
-
-afterAll(async () => {
-  await duckdb.connection.close();
-});
-
-// Compile + run the query, build field metadata (resolves `# label` tags at
-// setup time), build the data tree, then drive the bar-chart spec generator
-// with a minimal plugin instance, the same inputs the renderer would pass.
-async function buildBarSpec(sourceModel: string, query: string): Promise<Spec> {
-  const result = await duckdb.loadModel(sourceModel).loadQuery(query).run();
-  const malloyResult = API.util.wrapResult(result);
-  const rfm = new RenderFieldMetadata(malloyResult);
-  getDataTree(malloyResult, rfm);
-  const root = rfm.getRootField();
+async function buildBarSpec(source: string, query: string): Promise<Spec> {
+  const {root, metadata} = await runChartQuery(source, query);
   const settings = getBarChartSettings(root);
-  const plugin = {
-    name: 'bar',
+  const plugin: BarChartSpecInputs = {
     field: root,
-    chartDisplay: {},
+    chartDisplay: {size: {}},
     getMetadata: () => ({type: 'bar', field: root, settings}),
-  } as unknown as BarChartPluginInstance;
-  const metadata = getResultMetadata(root, {
-    renderFieldMetadata: rfm,
-    parentSize: {width: 400, height: 300},
-  });
+  };
   return generateBarChartVegaSpecV2(metadata, plugin).spec;
 }
 
-const DATA =
-  'duckdb.sql("SELECT * FROM (VALUES ' +
-  "('Total Universe (HH)', 75, '1Q26'), " +
-  "('1Q26: High Income Earners', 28, '1Q26'), " +
-  "('1Q26: Auto Intenders', 25, '2Q26')) " +
-  'AS t(audience_name, reach, period)")';
-
-describe('bar chart honors # label tags on axis/legend titles', () => {
-  const SOURCE = `source: data is ${DATA}`;
-
-  test('x and y axis titles use the # label tag, not the field name', async () => {
-    const query = `
-      # bar_chart
-      run: data -> {
-        group_by:
-          # label="Audience"
-          audience_name
-        aggregate:
-          # label="Reach (HH)"
-          total_reach is reach.sum()
-        order_by: total_reach desc
-      }
-    `;
-    const spec = await buildBarSpec(SOURCE, query);
-    const xAxis = spec.axes?.find(a => a.scale === 'xscale');
-    const yAxis = spec.axes?.find(a => a.scale === 'yscale');
-    expect(xAxis?.title).toBe('Audience');
-    expect(yAxis?.title).toBe('Reach (HH)');
-  }, 60000);
-
-  test('legend title uses the # label tag of the series dimension', async () => {
-    const query = `
-      # bar_chart
-      run: data -> {
-        group_by:
-          # label="Audience"
-          audience_name
-          # label="Quarter"
-          period
-        aggregate:
-          # label="Reach (HH)"
-          total_reach is reach.sum()
-      }
-    `;
-    const spec = await buildBarSpec(SOURCE, query);
-    expect(spec.legends?.[0]?.title).toBe('Quarter');
-  }, 60000);
-
-  test('measure-series legend entries use the # label tags, not field names', async () => {
-    const query = `
-      # bar_chart
-      run: data -> {
-        group_by:
-          # label="Audience"
-          audience_name
-        aggregate:
-          # y
-          # label="Reach (HH)"
-          total_reach is reach.sum()
-          # y
-          # label=""
-          avg_reach is reach.avg()
-      }
-    `;
-    const spec = await buildBarSpec(SOURCE, query);
-    // Labels are mapped through an ordinal scale (data-driven), so they survive
-    // any label text and an explicit empty # label="" (no truthy fallback to
-    // the field name), and the legend references that scale.
-    const scale = (spec.scales ?? []).find(
-      s => s.name === 'measureSeriesLabel'
-    );
-    const range = scale && 'range' in scale ? scale.range : undefined;
-    const rangeArr: unknown[] = Array.isArray(range) ? range : [];
-    expect(rangeArr).toContain('Reach (HH)');
-    expect(rangeArr).toContain('');
-    expect(rangeArr).not.toContain('avg_reach');
-    expect(JSON.stringify(spec.legends?.[0] ?? {})).toContain(
-      'measureSeriesLabel'
-    );
-  }, 60000);
-});
+describeChartLabelTests('bar_chart', buildBarSpec);

--- a/packages/malloy-render/src/plugins/bar-chart/generate-bar_chart-vega-spec.ts
+++ b/packages/malloy-render/src/plugins/bar-chart/generate-bar_chart-vega-spec.ts
@@ -34,6 +34,10 @@ import {
   renderDateTimeField,
 } from '@/component/render-numeric-field';
 import {createMeasureAxis} from '@/component/vega/measure-axis';
+import {
+  MEASURE_SERIES_LABEL_SCALE,
+  getMeasureSeriesLabelScale,
+} from '@/component/vega/measure-series-label-scale';
 import {getCustomTooltipEntries} from '@/component/bar-chart/get-custom-tooltips-entries';
 import {getMarkName} from '@/component/vega/vega-utils';
 import type {CellValue, RecordCell} from '@/data_tree';
@@ -113,9 +117,23 @@ function getLimitedData({
   };
 }
 
+/**
+ * The slice of the bar chart plugin instance the spec generator reads,
+ * narrowed so tests can construct a real, fully typed value.
+ */
+export type BarChartSpecInputs = Pick<
+  BarChartPluginInstance,
+  | 'getMetadata'
+  | 'field'
+  | 'chartDisplay'
+  | 'getTopNSeries'
+  | 'syntheticSeriesField'
+  | 'hasMultipleSeriesFields'
+>;
+
 export function generateBarChartVegaSpecV2(
   metadata: RenderMetadata,
-  plugin: BarChartPluginInstance,
+  plugin: BarChartSpecInputs,
   vegaConfig?: Config
 ): VegaChartProps {
   const pluginMetadata = plugin.getMetadata();
@@ -797,27 +815,10 @@ export function generateBarChartVegaSpecV2(
     };
 
     (spec.padding as VegaPadding).right = legendSize;
-    // For a measure-series legend the color-domain values are the raw measure
-    // field names; map them to their # label via an ordinal scale so the legend
-    // entries match the axis and tooltip. Keeping the labels in scale data (not
-    // in a parsed expression) renders any label verbatim, including an explicit
-    // empty # label="".
     if (isMeasureSeries && !isDimensionalSeries) {
-      // Dedupe by field name so the ordinal scale's domain and range stay in
-      // lockstep: d3 dedupes an ordinal scale's domain but keeps its range
-      // verbatim, so a measure repeated in yChannel.fields would otherwise
-      // shift the indices and map a later measure to the wrong label.
-      const labelByName = new Map<string, string>();
-      for (const fieldPath of settings.yChannel.fields) {
-        const f = explore.fieldAt(fieldPath);
-        labelByName.set(f.name, f.getLabel());
-      }
-      spec.scales!.push({
-        name: 'measureSeriesLabel',
-        type: 'ordinal',
-        domain: [...labelByName.keys()],
-        range: [...labelByName.values()],
-      });
+      spec.scales!.push(
+        getMeasureSeriesLabelScale(explore, settings.yChannel.fields)
+      );
     }
     spec.legends!.push({
       fill: 'color',
@@ -839,7 +840,7 @@ export function generateBarChartVegaSpecV2(
           interactive: true,
           update: {
             ...(isMeasureSeries && !isDimensionalSeries
-              ? {text: {scale: 'measureSeriesLabel', field: 'value'}}
+              ? {text: {scale: MEASURE_SERIES_LABEL_SCALE, field: 'value'}}
               : {}),
             fillOpacity: [
               {

--- a/packages/malloy-render/src/plugins/bar-chart/generate-bar_chart-vega-spec.ts
+++ b/packages/malloy-render/src/plugins/bar-chart/generate-bar_chart-vega-spec.ts
@@ -272,7 +272,7 @@ export function generateBarChartVegaSpecV2(
     ? createMeasureAxis({
         type: 'y',
         title: settings.yChannel.fields
-          .map(f => explore.fieldAt(f).name)
+          .map(f => explore.fieldAt(f).getLabel())
           .join(', '),
         tickCount: chartSettings.yAxis.tickCount ?? 'ceil(height/40)',
         labelLimit: chartSettings.yAxis.width + 10,
@@ -715,7 +715,7 @@ export function generateBarChartVegaSpecV2(
       {
         orient: 'bottom',
         scale: 'xscale',
-        title: xField.name,
+        title: xField.getLabel(),
         labelOverlap: 'greedy',
         labelSeparation: 4,
         ...chartSettings.xAxis,
@@ -769,14 +769,14 @@ export function generateBarChartVegaSpecV2(
         (a, b) => Math.max(a, b?.toString().length ?? 1),
         0
       );
-      maxCharCt = Math.max(maxCharCt, seriesField!.name.length);
+      maxCharCt = Math.max(maxCharCt, seriesField!.getLabel().length);
     } else if (isDimensionalSeries) {
       // Legend size is by legend title or the longest legend value
       maxCharCt = seriesField!.maxString?.length ?? 0;
-      maxCharCt = Math.max(maxCharCt, seriesField!.name.length);
+      maxCharCt = Math.max(maxCharCt, seriesField!.getLabel().length);
     } else {
       maxCharCt = settings.yChannel.fields.reduce(
-        (max, f) => Math.max(max, f.length),
+        (max, f) => Math.max(max, explore.fieldAt(f).getLabel().length),
         maxCharCt
       );
     }
@@ -797,10 +797,32 @@ export function generateBarChartVegaSpecV2(
     };
 
     (spec.padding as VegaPadding).right = legendSize;
+    // For a measure-series legend the color-domain values are the raw measure
+    // field names; map them to their # label via an ordinal scale so the legend
+    // entries match the axis and tooltip. Keeping the labels in scale data (not
+    // in a parsed expression) renders any label verbatim, including an explicit
+    // empty # label="".
+    if (isMeasureSeries && !isDimensionalSeries) {
+      // Dedupe by field name so the ordinal scale's domain and range stay in
+      // lockstep: d3 dedupes an ordinal scale's domain but keeps its range
+      // verbatim, so a measure repeated in yChannel.fields would otherwise
+      // shift the indices and map a later measure to the wrong label.
+      const labelByName = new Map<string, string>();
+      for (const fieldPath of settings.yChannel.fields) {
+        const f = explore.fieldAt(fieldPath);
+        labelByName.set(f.name, f.getLabel());
+      }
+      spec.scales!.push({
+        name: 'measureSeriesLabel',
+        type: 'ordinal',
+        domain: [...labelByName.keys()],
+        range: [...labelByName.values()],
+      });
+    }
     spec.legends!.push({
       fill: 'color',
       // No title for measure list legends
-      title: seriesField ? seriesField.name : '',
+      title: seriesField ? seriesField.getLabel() : '',
       orient: 'right',
       ...legendSettings,
       values:
@@ -816,6 +838,9 @@ export function generateBarChartVegaSpecV2(
           name: 'legend_labels',
           interactive: true,
           update: {
+            ...(isMeasureSeries && !isDimensionalSeries
+              ? {text: {scale: 'measureSeriesLabel', field: 'value'}}
+              : {}),
             fillOpacity: [
               {
                 test: 'brushSeriesIn === datum.value',
@@ -1019,7 +1044,9 @@ export function generateBarChartVegaSpecV2(
         tooltipData = {
           title: [title],
           entries: records.map(rec => ({
-            label: rec.series,
+            label: isDimensionalSeries
+              ? rec.series
+              : explore.fieldAt([rec.series]).getLabel(),
             value: formatY(rec),
             highlight: false,
             color: colorScale(rec.series),
@@ -1045,7 +1072,9 @@ export function generateBarChartVegaSpecV2(
           title: [title],
           entries: records.map(rec => {
             return {
-              label: rec.series,
+              label: isDimensionalSeries
+                ? rec.series
+                : explore.fieldAt([rec.series]).getLabel(),
               value: formatY(rec),
               highlight: highlightedSeries === rec.series,
               color: colorScale(rec.series),

--- a/packages/malloy-render/src/plugins/bar-chart/generate-bar_chart-vega-spec.ts
+++ b/packages/malloy-render/src/plugins/bar-chart/generate-bar_chart-vega-spec.ts
@@ -45,6 +45,7 @@ import {Field} from '@/data_tree';
 import {NULL_SYMBOL} from '@/util';
 import type {RenderMetadata} from '@/component/render-result-metadata';
 import type {BarChartPluginInstance} from './bar-chart-plugin';
+import type {SyntheticSeriesField} from '@/plugins/synthetic-series-field';
 
 type BarDataRecord = {
   x: string | number;
@@ -78,7 +79,7 @@ function getLimitedData({
   xLimitSetting,
 }: {
   xField: Field;
-  seriesField?: Field | null;
+  seriesField?: Field | SyntheticSeriesField | null;
   maxSeries?: number;
   maxSizePerBar?: number;
   isGrouping: boolean;
@@ -156,7 +157,9 @@ export function generateBarChartVegaSpecV2(
   const xField = explore.fieldAt(xFieldPath);
   const xIsDateorTime = xField.isTime();
   const yField = explore.fieldAt(yFieldPath);
-  let seriesField = seriesFieldPath ? explore.fieldAt(seriesFieldPath) : null;
+  let seriesField: Field | SyntheticSeriesField | null = seriesFieldPath
+    ? explore.fieldAt(seriesFieldPath)
+    : null;
 
   // Use synthetic field if available (for multiple series)
   if (plugin.syntheticSeriesField) {
@@ -1029,6 +1032,10 @@ export function generateBarChartVegaSpecV2(
           ? renderNumericField(field, value)
           : String(value);
       };
+      const entryLabel = (rec: BarDataRecord) =>
+        isDimensionalSeries
+          ? rec.series
+          : explore.fieldAt([rec.series]).getLabel();
 
       // Tooltip records for the highlight bars
       if (getMarkName(item) === 'x_highlight') {
@@ -1045,9 +1052,7 @@ export function generateBarChartVegaSpecV2(
         tooltipData = {
           title: [title],
           entries: records.map(rec => ({
-            label: isDimensionalSeries
-              ? rec.series
-              : explore.fieldAt([rec.series]).getLabel(),
+            label: entryLabel(rec),
             value: formatY(rec),
             highlight: false,
             color: colorScale(rec.series),
@@ -1073,9 +1078,7 @@ export function generateBarChartVegaSpecV2(
           title: [title],
           entries: records.map(rec => {
             return {
-              label: isDimensionalSeries
-                ? rec.series
-                : explore.fieldAt([rec.series]).getLabel(),
+              label: entryLabel(rec),
               value: formatY(rec),
               highlight: highlightedSeries === rec.series,
               color: colorScale(rec.series),

--- a/packages/malloy-render/src/plugins/line-chart/generate-line_chart-vega-spec.spec.ts
+++ b/packages/malloy-render/src/plugins/line-chart/generate-line_chart-vega-spec.spec.ts
@@ -3,144 +3,37 @@
  * SPDX-License-Identifier: MIT
  */
 
-// See generate-bar_chart-vega-spec.spec.ts for why the layout math and custom
-// tooltip path are stubbed: they pull in vega's scale()/DOM measurement and
-// solid-js, which do not load under the node test environment. Axis/legend
-// titles are derived from field labels and are unaffected by the stubs.
-jest.mock('@/component/chart/chart-layout-settings', () => ({
-  getChartLayoutSettings: () => ({
-    plotWidth: 300,
-    plotHeight: 200,
-    totalWidth: 400,
-    totalHeight: 300,
-    isSpark: false,
-    padding: {top: 0, left: 0, right: 0, bottom: 0},
-    xAxis: {labelAngle: 0, hidden: false},
-    yAxis: {hidden: false, tickCount: 5, width: 40, yTitleSize: 12},
-    yScale: {domain: [0, 100]},
-  }),
-  getXAxisSettings: () => ({}),
-}));
-jest.mock('@/component/bar-chart/get-custom-tooltips-entries', () => ({
-  getCustomTooltipEntries: () => [],
-}));
+// These modules do not load under the node test env; the stubs document why.
+jest.mock('@/component/chart/chart-layout-settings', () =>
+  jest.requireActual('@/plugins/spec-test-support/chart-layout-settings-stub')
+);
+jest.mock('@/component/bar-chart/get-custom-tooltips-entries', () =>
+  jest.requireActual(
+    '@/plugins/spec-test-support/get-custom-tooltips-entries-stub'
+  )
+);
 
 import type {Spec} from 'vega';
-import {runtimeFor} from '../../../../../test/src/runtimes';
-import {API} from '@malloydata/malloy';
-import {RenderFieldMetadata} from '@/render-field-metadata';
-import {getDataTree} from '@/data_tree';
-import {getResultMetadata} from '@/component/render-result-metadata';
+import {
+  describeChartLabelTests,
+  runChartQuery,
+} from '@/plugins/spec-test-support/harness';
 import {getLineChartSettings} from '@/plugins/line-chart/get-line_chart-settings';
-import {generateLineChartVegaSpecV2} from '@/plugins/line-chart/generate-line_chart-vega-spec';
-import type {LineChartPluginInstance} from '@/plugins/line-chart/line-chart-plugin';
+import {
+  generateLineChartVegaSpecV2,
+  type LineChartSpecInputs,
+} from '@/plugins/line-chart/generate-line_chart-vega-spec';
 
-const duckdb = runtimeFor('duckdb');
-
-afterAll(async () => {
-  await duckdb.connection.close();
-});
-
-async function buildLineSpec(
-  sourceModel: string,
-  query: string
-): Promise<Spec> {
-  const result = await duckdb.loadModel(sourceModel).loadQuery(query).run();
-  const malloyResult = API.util.wrapResult(result);
-  const rfm = new RenderFieldMetadata(malloyResult);
-  getDataTree(malloyResult, rfm);
-  const root = rfm.getRootField();
+async function buildLineSpec(source: string, query: string): Promise<Spec> {
+  const {root, metadata} = await runChartQuery(source, query);
   const settings = getLineChartSettings(root);
-  const plugin = {
-    name: 'line',
+  const plugin: LineChartSpecInputs = {
     field: root,
-    chartDisplay: {},
+    chartDisplay: {size: {}},
+    getTopNSeries: () => [],
     getMetadata: () => ({type: 'line', field: root, settings}),
-  } as unknown as LineChartPluginInstance;
-  const metadata = getResultMetadata(root, {
-    renderFieldMetadata: rfm,
-    parentSize: {width: 400, height: 300},
-  });
+  };
   return generateLineChartVegaSpecV2(metadata, plugin).spec;
 }
 
-const DATA =
-  'duckdb.sql("SELECT * FROM (VALUES ' +
-  "('Jan', 75, '1Q26'), " +
-  "('Feb', 28, '1Q26'), " +
-  "('Mar', 25, '2Q26')) " +
-  'AS t(month_name, reach, period)")';
-
-describe('line chart honors # label tags on axis/legend titles', () => {
-  const SOURCE = `source: data is ${DATA}`;
-
-  test('x and y axis titles use the # label tag, not the field name', async () => {
-    const query = `
-      # line_chart
-      run: data -> {
-        group_by:
-          # label="Month"
-          month_name
-        aggregate:
-          # label="Reach (HH)"
-          total_reach is reach.sum()
-      }
-    `;
-    const spec = await buildLineSpec(SOURCE, query);
-    const xAxis = spec.axes?.find(a => a.scale === 'xscale');
-    const yAxis = spec.axes?.find(a => a.scale === 'yscale');
-    expect(xAxis?.title).toBe('Month');
-    expect(yAxis?.title).toBe('Reach (HH)');
-  }, 60000);
-
-  test('legend title uses the # label tag of the series dimension', async () => {
-    const query = `
-      # line_chart
-      run: data -> {
-        group_by:
-          # label="Month"
-          month_name
-          # label="Quarter"
-          period
-        aggregate:
-          # label="Reach (HH)"
-          total_reach is reach.sum()
-      }
-    `;
-    const spec = await buildLineSpec(SOURCE, query);
-    expect(spec.legends?.[0]?.title).toBe('Quarter');
-  }, 60000);
-
-  test('measure-series legend entries use the # label tags, not field names', async () => {
-    const query = `
-      # line_chart
-      run: data -> {
-        group_by:
-          # label="Month"
-          month_name
-        aggregate:
-          # y
-          # label="Reach (HH)"
-          total_reach is reach.sum()
-          # y
-          # label=""
-          avg_reach is reach.avg()
-      }
-    `;
-    const spec = await buildLineSpec(SOURCE, query);
-    // Labels are mapped through an ordinal scale (data-driven), so they survive
-    // any label text and an explicit empty # label="" (no truthy fallback to
-    // the field name), and the legend references that scale.
-    const scale = (spec.scales ?? []).find(
-      s => s.name === 'measureSeriesLabel'
-    );
-    const range = scale && 'range' in scale ? scale.range : undefined;
-    const rangeArr: unknown[] = Array.isArray(range) ? range : [];
-    expect(rangeArr).toContain('Reach (HH)');
-    expect(rangeArr).toContain('');
-    expect(rangeArr).not.toContain('avg_reach');
-    expect(JSON.stringify(spec.legends?.[0] ?? {})).toContain(
-      'measureSeriesLabel'
-    );
-  }, 60000);
-});
+describeChartLabelTests('line_chart', buildLineSpec);

--- a/packages/malloy-render/src/plugins/line-chart/generate-line_chart-vega-spec.spec.ts
+++ b/packages/malloy-render/src/plugins/line-chart/generate-line_chart-vega-spec.spec.ts
@@ -7,25 +7,35 @@
 jest.mock('@/component/chart/chart-layout-settings', () =>
   jest.requireActual('@/plugins/spec-test-support/chart-layout-settings-stub')
 );
-jest.mock('@/component/bar-chart/get-custom-tooltips-entries', () =>
-  jest.requireActual(
-    '@/plugins/spec-test-support/get-custom-tooltips-entries-stub'
-  )
+jest.mock('@/component/renderer/apply-renderer', () =>
+  jest.requireActual('@/plugins/spec-test-support/apply-renderer-stub')
 );
+jest.mock('@/component/chart/chart-v2', () =>
+  jest.requireActual('@/plugins/spec-test-support/chart-v2-stub')
+);
+// ESM-only packages the plugin module imports but these tests never call.
+jest.mock('vega', () => ({}));
+jest.mock('vega-interpreter', () => ({}));
+jest.mock('solid-js/jsx-runtime', () => ({}));
 
-import type {Spec} from 'vega';
 import {
   describeChartLabelTests,
   runChartQuery,
+  fakeTooltipItem,
+  fakeTooltipView,
+  SOURCE,
+  YOY_SOURCE,
 } from '@/plugins/spec-test-support/harness';
+import type {VegaChartProps} from '@/component/types';
 import {getLineChartSettings} from '@/plugins/line-chart/get-line_chart-settings';
 import {
   generateLineChartVegaSpecV2,
   type LineChartSpecInputs,
 } from '@/plugins/line-chart/generate-line_chart-vega-spec';
+import {LineChartPluginFactory} from '@/plugins/line-chart/line-chart-plugin';
 
-async function buildLineSpec(source: string, query: string): Promise<Spec> {
-  const {root, metadata} = await runChartQuery(source, query);
+async function buildLine(source: string, query: string) {
+  const {root, rootCell, metadata} = await runChartQuery(source, query);
   const settings = getLineChartSettings(root);
   const plugin: LineChartSpecInputs = {
     field: root,
@@ -33,7 +43,109 @@ async function buildLineSpec(source: string, query: string): Promise<Spec> {
     getTopNSeries: () => [],
     getMetadata: () => ({type: 'line', field: root, settings}),
   };
-  return generateLineChartVegaSpecV2(metadata, plugin).spec;
+  return {props: generateLineChartVegaSpecV2(metadata, plugin), rootCell};
 }
 
-describeChartLabelTests('line_chart', buildLineSpec);
+async function buildLineProps(
+  source: string,
+  query: string
+): Promise<VegaChartProps> {
+  return (await buildLine(source, query)).props;
+}
+
+describeChartLabelTests('line_chart', buildLineProps);
+
+describe('line_chart honors # label tags in default tooltips', () => {
+  test('measure-series tooltip labels use the # label tags, not field names', async () => {
+    const props = await buildLineProps(
+      SOURCE,
+      `
+      # line_chart
+      run: data -> {
+        group_by:
+          # label="Audience"
+          audience_name
+        aggregate:
+          # y
+          # label="Reach (HH)"
+          total_reach is reach.sum()
+          # y
+          # label="Avg Reach"
+          avg_reach is reach.avg()
+      }
+      `
+    );
+    const records = [
+      {x: 'Total Universe (HH)', y: 75, series: 'total_reach'},
+      {x: 'Total Universe (HH)', y: 30, series: 'avg_reach'},
+    ];
+    const tooltip = props.getTooltipData?.(
+      fakeTooltipItem('x_hit_target', {
+        datum: {x: 'Total Universe (HH)', v: records},
+      }),
+      fakeTooltipView()
+    );
+    expect(tooltip?.entries.map(e => e.label)).toEqual([
+      'Reach (HH)',
+      'Avg Reach',
+    ]);
+  }, 60000);
+
+  test('custom # tooltip entries use the # label tag, not the field name', async () => {
+    const {props, rootCell} = await buildLine(
+      SOURCE,
+      `
+      # line_chart
+      run: data -> {
+        group_by:
+          # label="Audience"
+          audience_name
+        aggregate:
+          # label="Reach (HH)"
+          total_reach is reach.sum()
+          # tooltip
+          # label="Avg Reach"
+          avg_reach is reach.avg()
+      }
+      `
+    );
+    const records = [
+      {
+        x: 'Total Universe (HH)',
+        y: 75,
+        series: 'total_reach',
+        __row: rootCell.rows[0],
+      },
+    ];
+    const tooltip = props.getTooltipData?.(
+      fakeTooltipItem('x_hit_target', {
+        datum: {x: 'Total Universe (HH)', v: records},
+      }),
+      fakeTooltipView()
+    );
+    expect(tooltip?.entries.map(e => e.label)).toEqual([
+      'Reach (HH)',
+      'Avg Reach',
+    ]);
+  }, 60000);
+});
+
+describe('line_chart YoY synthetic series field', () => {
+  test('legend title is the synthetic Year label in yoy mode', async () => {
+    const {root, rootCell, metadata} = await runChartQuery(
+      YOY_SOURCE,
+      `
+      # viz=line {mode=yoy}
+      run: yoy_data -> {
+        group_by: event_date
+        aggregate: total_sales is sales.sum()
+      }
+      `
+    );
+    const plugin = LineChartPluginFactory.create(root);
+    plugin.processData?.(root, rootCell);
+    expect(plugin.syntheticSeriesField?.getLabel()).toBe('Year');
+    const {spec} = generateLineChartVegaSpecV2(metadata, plugin);
+    expect(spec.legends?.[0]?.title).toBe('Year');
+  }, 60000);
+});

--- a/packages/malloy-render/src/plugins/line-chart/generate-line_chart-vega-spec.spec.ts
+++ b/packages/malloy-render/src/plugins/line-chart/generate-line_chart-vega-spec.spec.ts
@@ -1,0 +1,146 @@
+/*
+ * Copyright Contributors to the Malloy project
+ * SPDX-License-Identifier: MIT
+ */
+
+// See generate-bar_chart-vega-spec.spec.ts for why the layout math and custom
+// tooltip path are stubbed: they pull in vega's scale()/DOM measurement and
+// solid-js, which do not load under the node test environment. Axis/legend
+// titles are derived from field labels and are unaffected by the stubs.
+jest.mock('@/component/chart/chart-layout-settings', () => ({
+  getChartLayoutSettings: () => ({
+    plotWidth: 300,
+    plotHeight: 200,
+    totalWidth: 400,
+    totalHeight: 300,
+    isSpark: false,
+    padding: {top: 0, left: 0, right: 0, bottom: 0},
+    xAxis: {labelAngle: 0, hidden: false},
+    yAxis: {hidden: false, tickCount: 5, width: 40, yTitleSize: 12},
+    yScale: {domain: [0, 100]},
+  }),
+  getXAxisSettings: () => ({}),
+}));
+jest.mock('@/component/bar-chart/get-custom-tooltips-entries', () => ({
+  getCustomTooltipEntries: () => [],
+}));
+
+import type {Spec} from 'vega';
+import {runtimeFor} from '../../../../../test/src/runtimes';
+import {API} from '@malloydata/malloy';
+import {RenderFieldMetadata} from '@/render-field-metadata';
+import {getDataTree} from '@/data_tree';
+import {getResultMetadata} from '@/component/render-result-metadata';
+import {getLineChartSettings} from '@/plugins/line-chart/get-line_chart-settings';
+import {generateLineChartVegaSpecV2} from '@/plugins/line-chart/generate-line_chart-vega-spec';
+import type {LineChartPluginInstance} from '@/plugins/line-chart/line-chart-plugin';
+
+const duckdb = runtimeFor('duckdb');
+
+afterAll(async () => {
+  await duckdb.connection.close();
+});
+
+async function buildLineSpec(
+  sourceModel: string,
+  query: string
+): Promise<Spec> {
+  const result = await duckdb.loadModel(sourceModel).loadQuery(query).run();
+  const malloyResult = API.util.wrapResult(result);
+  const rfm = new RenderFieldMetadata(malloyResult);
+  getDataTree(malloyResult, rfm);
+  const root = rfm.getRootField();
+  const settings = getLineChartSettings(root);
+  const plugin = {
+    name: 'line',
+    field: root,
+    chartDisplay: {},
+    getMetadata: () => ({type: 'line', field: root, settings}),
+  } as unknown as LineChartPluginInstance;
+  const metadata = getResultMetadata(root, {
+    renderFieldMetadata: rfm,
+    parentSize: {width: 400, height: 300},
+  });
+  return generateLineChartVegaSpecV2(metadata, plugin).spec;
+}
+
+const DATA =
+  'duckdb.sql("SELECT * FROM (VALUES ' +
+  "('Jan', 75, '1Q26'), " +
+  "('Feb', 28, '1Q26'), " +
+  "('Mar', 25, '2Q26')) " +
+  'AS t(month_name, reach, period)")';
+
+describe('line chart honors # label tags on axis/legend titles', () => {
+  const SOURCE = `source: data is ${DATA}`;
+
+  test('x and y axis titles use the # label tag, not the field name', async () => {
+    const query = `
+      # line_chart
+      run: data -> {
+        group_by:
+          # label="Month"
+          month_name
+        aggregate:
+          # label="Reach (HH)"
+          total_reach is reach.sum()
+      }
+    `;
+    const spec = await buildLineSpec(SOURCE, query);
+    const xAxis = spec.axes?.find(a => a.scale === 'xscale');
+    const yAxis = spec.axes?.find(a => a.scale === 'yscale');
+    expect(xAxis?.title).toBe('Month');
+    expect(yAxis?.title).toBe('Reach (HH)');
+  }, 60000);
+
+  test('legend title uses the # label tag of the series dimension', async () => {
+    const query = `
+      # line_chart
+      run: data -> {
+        group_by:
+          # label="Month"
+          month_name
+          # label="Quarter"
+          period
+        aggregate:
+          # label="Reach (HH)"
+          total_reach is reach.sum()
+      }
+    `;
+    const spec = await buildLineSpec(SOURCE, query);
+    expect(spec.legends?.[0]?.title).toBe('Quarter');
+  }, 60000);
+
+  test('measure-series legend entries use the # label tags, not field names', async () => {
+    const query = `
+      # line_chart
+      run: data -> {
+        group_by:
+          # label="Month"
+          month_name
+        aggregate:
+          # y
+          # label="Reach (HH)"
+          total_reach is reach.sum()
+          # y
+          # label=""
+          avg_reach is reach.avg()
+      }
+    `;
+    const spec = await buildLineSpec(SOURCE, query);
+    // Labels are mapped through an ordinal scale (data-driven), so they survive
+    // any label text and an explicit empty # label="" (no truthy fallback to
+    // the field name), and the legend references that scale.
+    const scale = (spec.scales ?? []).find(
+      s => s.name === 'measureSeriesLabel'
+    );
+    const range = scale && 'range' in scale ? scale.range : undefined;
+    const rangeArr: unknown[] = Array.isArray(range) ? range : [];
+    expect(rangeArr).toContain('Reach (HH)');
+    expect(rangeArr).toContain('');
+    expect(rangeArr).not.toContain('avg_reach');
+    expect(JSON.stringify(spec.legends?.[0] ?? {})).toContain(
+      'measureSeriesLabel'
+    );
+  }, 60000);
+});

--- a/packages/malloy-render/src/plugins/line-chart/generate-line_chart-vega-spec.ts
+++ b/packages/malloy-render/src/plugins/line-chart/generate-line_chart-vega-spec.ts
@@ -12,6 +12,10 @@ import type {
 } from '@/component/types';
 import {getChartLayoutSettings} from '@/component/chart/chart-layout-settings';
 import {createMeasureAxis} from '@/component/vega/measure-axis';
+import {
+  MEASURE_SERIES_LABEL_SCALE,
+  getMeasureSeriesLabelScale,
+} from '@/component/vega/measure-series-label-scale';
 import type {
   Axis,
   Config,
@@ -85,9 +89,22 @@ export interface LineChartSettings {
   interactive: boolean;
 }
 
+/**
+ * The slice of the line chart plugin instance the spec generator reads,
+ * narrowed so tests can construct a real, fully typed value.
+ */
+export type LineChartSpecInputs = Pick<
+  LineChartPluginInstance,
+  | 'getMetadata'
+  | 'field'
+  | 'chartDisplay'
+  | 'getTopNSeries'
+  | 'syntheticSeriesField'
+>;
+
 export function generateLineChartVegaSpecV2(
   metadata: RenderMetadata,
-  plugin: LineChartPluginInstance,
+  plugin: LineChartSpecInputs,
   vegaConfig?: Config
 ): VegaChartProps {
   const pluginMetadata = plugin.getMetadata();
@@ -853,27 +870,10 @@ export function generateLineChartVegaSpecV2(
       offset: 4,
     };
     (spec.padding as VegaPadding).right = legendSize;
-    // For a measure-series legend the color-domain values are the raw measure
-    // field names; map them to their # label via an ordinal scale so the legend
-    // entries match the axis and tooltip. Keeping the labels in scale data (not
-    // in a parsed expression) renders any label verbatim, including an explicit
-    // empty # label="".
     if (isMeasureSeries && !isDimensionalSeries) {
-      // Dedupe by field name so the ordinal scale's domain and range stay in
-      // lockstep: d3 dedupes an ordinal scale's domain but keeps its range
-      // verbatim, so a measure repeated in yChannel.fields would otherwise
-      // shift the indices and map a later measure to the wrong label.
-      const labelByName = new Map<string, string>();
-      for (const fieldPath of settings.yChannel.fields) {
-        const f = explore.fieldAt(fieldPath);
-        labelByName.set(f.name, f.getLabel());
-      }
-      spec.scales!.push({
-        name: 'measureSeriesLabel',
-        type: 'ordinal',
-        domain: [...labelByName.keys()],
-        range: [...labelByName.values()],
-      });
+      spec.scales!.push(
+        getMeasureSeriesLabelScale(explore, settings.yChannel.fields)
+      );
     }
     spec.legends!.push({
       fill: 'color',
@@ -895,7 +895,7 @@ export function generateLineChartVegaSpecV2(
           interactive: true,
           update: {
             ...(isMeasureSeries && !isDimensionalSeries
-              ? {text: {scale: 'measureSeriesLabel', field: 'value'}}
+              ? {text: {scale: MEASURE_SERIES_LABEL_SCALE, field: 'value'}}
               : {}),
             fillOpacity: [
               {

--- a/packages/malloy-render/src/plugins/line-chart/generate-line_chart-vega-spec.ts
+++ b/packages/malloy-render/src/plugins/line-chart/generate-line_chart-vega-spec.ts
@@ -226,7 +226,7 @@ export function generateLineChartVegaSpecV2(
     ? createMeasureAxis({
         type: 'y',
         title: settings.yChannel.fields
-          .map(f => explore.fieldAt(f).name)
+          .map(f => explore.fieldAt(f).getLabel())
           .join(', '),
         tickCount: chartSettings.yAxis.tickCount ?? 'ceil(height/40)',
         labelLimit: chartSettings.yAxis.width + 10,
@@ -777,7 +777,7 @@ export function generateLineChartVegaSpecV2(
       {
         orient: 'bottom',
         scale: 'xscale',
-        title: xField.name,
+        title: xField.getLabel(),
         labelOverlap: 'greedy',
         labelSeparation: 4,
         ...chartSettings.xAxis,
@@ -828,11 +828,11 @@ export function generateLineChartVegaSpecV2(
           (a, b) => Math.max(a, b?.toString().length ?? 1),
           0
         );
-        maxCharCt = Math.max(maxCharCt, seriesField!.name.length);
+        maxCharCt = Math.max(maxCharCt, seriesField!.getLabel().length);
       }
     } else {
       maxCharCt = settings.yChannel.fields.reduce(
-        (max, f) => Math.max(max, f.length),
+        (max, f) => Math.max(max, explore.fieldAt(f).getLabel().length),
         maxCharCt
       );
     }
@@ -853,10 +853,32 @@ export function generateLineChartVegaSpecV2(
       offset: 4,
     };
     (spec.padding as VegaPadding).right = legendSize;
+    // For a measure-series legend the color-domain values are the raw measure
+    // field names; map them to their # label via an ordinal scale so the legend
+    // entries match the axis and tooltip. Keeping the labels in scale data (not
+    // in a parsed expression) renders any label verbatim, including an explicit
+    // empty # label="".
+    if (isMeasureSeries && !isDimensionalSeries) {
+      // Dedupe by field name so the ordinal scale's domain and range stay in
+      // lockstep: d3 dedupes an ordinal scale's domain but keeps its range
+      // verbatim, so a measure repeated in yChannel.fields would otherwise
+      // shift the indices and map a later measure to the wrong label.
+      const labelByName = new Map<string, string>();
+      for (const fieldPath of settings.yChannel.fields) {
+        const f = explore.fieldAt(fieldPath);
+        labelByName.set(f.name, f.getLabel());
+      }
+      spec.scales!.push({
+        name: 'measureSeriesLabel',
+        type: 'ordinal',
+        domain: [...labelByName.keys()],
+        range: [...labelByName.values()],
+      });
+    }
     spec.legends!.push({
       fill: 'color',
       // No title for measure list legends
-      title: seriesField ? seriesField.name : '',
+      title: seriesField ? seriesField.getLabel() : '',
       orient: 'right',
       ...legendSettings,
       values:
@@ -872,6 +894,9 @@ export function generateLineChartVegaSpecV2(
           name: 'legend_labels',
           interactive: true,
           update: {
+            ...(isMeasureSeries && !isDimensionalSeries
+              ? {text: {scale: 'measureSeriesLabel', field: 'value'}}
+              : {}),
             fillOpacity: [
               {
                 test: 'brushSeriesIn === datum.value',
@@ -1135,7 +1160,9 @@ export function generateLineChartVegaSpecV2(
         tooltipData = {
           title: [title],
           entries: sortedRecords.map(rec => ({
-            label: rec.series,
+            label: isDimensionalSeries
+              ? rec.series
+              : explore.fieldAt([rec.series]).getLabel(),
             value: formatY(rec),
             highlight: false,
             color: colorScale(rec.series),
@@ -1186,7 +1213,9 @@ export function generateLineChartVegaSpecV2(
           title: [title],
           entries: sortedRecords.map(rec => {
             return {
-              label: rec.series,
+              label: isDimensionalSeries
+                ? rec.series
+                : explore.fieldAt([rec.series]).getLabel(),
               value: formatY(rec),
               highlight: highlightedSeries === rec.series,
               color: colorScale(rec.series),

--- a/packages/malloy-render/src/plugins/line-chart/generate-line_chart-vega-spec.ts
+++ b/packages/malloy-render/src/plugins/line-chart/generate-line_chart-vega-spec.ts
@@ -41,6 +41,7 @@ import {Field} from '@/data_tree';
 import {NULL_SYMBOL, type RenderTimeStringOptions} from '@/util';
 import type {RenderMetadata} from '@/component/render-result-metadata';
 import type {LineChartPluginInstance} from '@/plugins/line-chart/line-chart-plugin';
+import type {SyntheticSeriesField} from '@/plugins/synthetic-series-field';
 
 type LineDataRecord = {
   x: string | number;
@@ -135,7 +136,9 @@ export function generateLineChartVegaSpecV2(
   };
 
   const yField = explore.fieldAt(yFieldPath);
-  let seriesField = seriesFieldPath ? explore.fieldAt(seriesFieldPath) : null;
+  let seriesField: Field | SyntheticSeriesField | null = seriesFieldPath
+    ? explore.fieldAt(seriesFieldPath)
+    : null;
 
   // Use synthetic series field for YoY mode
   if (settings.mode === 'yoy' && plugin.syntheticSeriesField) {
@@ -1126,6 +1129,10 @@ export function generateLineChartVegaSpecV2(
           ? renderNumericField(field, value)
           : String(value);
       };
+      const entryLabel = (rec: LineDataRecord) =>
+        isDimensionalSeries
+          ? rec.series
+          : explore.fieldAt([rec.series]).getLabel();
 
       // Tooltip records for the highlighted points
       if (['x_hit_target', 'ref_line_targets'].includes(markName)) {
@@ -1160,9 +1167,7 @@ export function generateLineChartVegaSpecV2(
         tooltipData = {
           title: [title],
           entries: sortedRecords.map(rec => ({
-            label: isDimensionalSeries
-              ? rec.series
-              : explore.fieldAt([rec.series]).getLabel(),
+            label: entryLabel(rec),
             value: formatY(rec),
             highlight: false,
             color: colorScale(rec.series),
@@ -1213,9 +1218,7 @@ export function generateLineChartVegaSpecV2(
           title: [title],
           entries: sortedRecords.map(rec => {
             return {
-              label: isDimensionalSeries
-                ? rec.series
-                : explore.fieldAt([rec.series]).getLabel(),
+              label: entryLabel(rec),
               value: formatY(rec),
               highlight: highlightedSeries === rec.series,
               color: colorScale(rec.series),

--- a/packages/malloy-render/src/plugins/line-chart/line-chart-plugin.tsx
+++ b/packages/malloy-render/src/plugins/line-chart/line-chart-plugin.tsx
@@ -196,6 +196,7 @@ export const LineChartPluginFactory: RenderPluginFactory<LineChartPluginInstance
             // Create synthetic series field
             pluginInstance.syntheticSeriesField = {
               name: 'Year',
+              getLabel: () => 'Year',
               valueSet: yearValues,
               referenceId: '__synthetic_year__',
               // Add minimal Field interface properties that might be used

--- a/packages/malloy-render/src/plugins/line-chart/line-chart-plugin.tsx
+++ b/packages/malloy-render/src/plugins/line-chart/line-chart-plugin.tsx
@@ -39,6 +39,7 @@ import {
   lineChartSettingsSchema,
 } from './line-chart-settings';
 import {lineChartSettingsToTag} from './settings-to-tag';
+import type {SyntheticSeriesField} from '@/plugins/synthetic-series-field';
 
 interface LineChartPluginMetadata {
   type: 'line';
@@ -57,7 +58,7 @@ interface LineChartPluginInstance extends CoreVizPluginInstance<LineChartPluginM
   chartDisplay: ChartDisplayConfig;
   seriesStats: Map<string, SeriesStats>;
   getTopNSeries: (maxSeries: number) => (string | number | boolean)[];
-  syntheticSeriesField?: Field;
+  syntheticSeriesField?: SyntheticSeriesField;
 }
 
 export const LineChartPluginFactory: RenderPluginFactory<LineChartPluginInstance> =
@@ -193,20 +194,12 @@ export const LineChartPluginFactory: RenderPluginFactory<LineChartPluginInstance
               yearValues.add(year);
             }
 
-            // Create synthetic series field
             pluginInstance.syntheticSeriesField = {
               name: 'Year',
               getLabel: () => 'Year',
               valueSet: yearValues,
               referenceId: '__synthetic_year__',
-              // Add minimal Field interface properties that might be used
-              isTime: () => false,
-              isDate: () => false,
-              isBasic: () => true,
-              isNumber: () => false,
-              isString: () => true,
-              isBoolean: () => false,
-            } as unknown as Field;
+            };
 
             // Calculate series stats for YoY mode
             for (const row of cell.rows) {

--- a/packages/malloy-render/src/plugins/scatter-chart/generate-scatter_chart-spec.spec.ts
+++ b/packages/malloy-render/src/plugins/scatter-chart/generate-scatter_chart-spec.spec.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright Contributors to the Malloy project
+ * SPDX-License-Identifier: MIT
+ */
+
+// The builder reaches ESM-only vega through @/html/vega_spec but never calls it.
+jest.mock('vega', () => ({}));
+
+import * as lite from 'vega-lite';
+import type {LoggerInterface} from 'vega';
+import {
+  runChartQuery,
+  closeChartTestRuntime,
+  SOURCE4,
+} from '@/plugins/spec-test-support/harness';
+import {generateScatterChartSpec} from '@/plugins/scatter-chart/generate-scatter_chart-spec';
+
+afterAll(async () => {
+  await closeChartTestRuntime();
+});
+
+describe('scatter_chart honors # label tags on channel titles', () => {
+  test('x/y axis and color/size/shape legend titles use the # label tags', async () => {
+    const {root, rootCell} = await runChartQuery(
+      SOURCE4,
+      `
+      # scatter_chart
+      run: data4 -> {
+        group_by:
+          # label="Audience"
+          audience_name
+        aggregate:
+          # label="Reach (HH)"
+          total_reach is reach.sum()
+        group_by:
+          # label="Quarter"
+          period
+        aggregate:
+          # label="Avg Reach"
+          avg_reach is reach.avg()
+        group_by:
+          # label="Region"
+          region
+      }
+      `
+    );
+    // Quiet logger: the spec's pre-existing `zero: false` on a nominal x
+    // channel makes vega-lite warn that zero is dropped for point scales.
+    const quietLogger = {
+      level() {
+        return this;
+      },
+      error() {
+        return this;
+      },
+      warn() {
+        return this;
+      },
+      info() {
+        return this;
+      },
+      debug() {
+        return this;
+      },
+    } as unknown as LoggerInterface;
+    const compiled = lite.compile(generateScatterChartSpec(rootCell, root), {
+      logger: quietLogger,
+    }).spec;
+
+    const axisTitle = (scaleName: string) =>
+      (compiled.axes ?? []).find(a => a.scale === scaleName && a.title)?.title;
+    expect(axisTitle('x')).toBe('Audience');
+    expect(axisTitle('y')).toBe('Reach (HH)');
+
+    const legendTitles = (compiled.legends ?? []).map(l => l.title);
+    expect(legendTitles).toContain('Quarter');
+    expect(legendTitles).toContain('Avg Reach');
+    expect(legendTitles).toContain('Region');
+
+    const allTitles = [
+      ...(compiled.axes ?? []).map(a => a.title),
+      ...legendTitles,
+    ];
+    for (const rawName of [
+      'audience_name',
+      'total_reach',
+      'period',
+      'avg_reach',
+      'region',
+    ]) {
+      expect(allTitles).not.toContain(rawName);
+    }
+  }, 60000);
+});

--- a/packages/malloy-render/src/plugins/scatter-chart/generate-scatter_chart-spec.ts
+++ b/packages/malloy-render/src/plugins/scatter-chart/generate-scatter_chart-spec.ts
@@ -1,0 +1,128 @@
+/*
+ * Copyright Contributors to the Malloy project
+ * SPDX-License-Identifier: MIT
+ */
+
+import type {Field, Cell, RecordCell, RepeatedRecordCell} from '@/data_tree';
+import type * as lite from 'vega-lite';
+import {mergeVegaConfigs} from '@/component/vega/merge-vega-configs';
+import {DEFAULT_SPEC} from '@/html/vega_spec';
+import {getColorScale, normalizeToTimezone} from '@/html/utils';
+
+function getDataType(
+  field: Field
+): 'temporal' | 'ordinal' | 'quantitative' | 'nominal' {
+  if (field.isTime()) return 'temporal';
+  if (field.isString()) return 'nominal';
+  if (field.isNumber()) return 'quantitative';
+  throw new Error('Invalid field type for scatter chart.');
+}
+
+function getDataValue(data: Cell): Date | string | number | null {
+  if (data.isNull()) return null;
+  if (data.isTime() || data.isString()) return data.value;
+  if (data.isNumber()) return data.value;
+  throw new Error('Invalid field type for scatter chart.');
+}
+
+function mapData(
+  rows: RecordCell[],
+  timezone: string | undefined
+): Record<string, unknown>[] {
+  return rows.map(row => {
+    const mapped: Record<string, unknown> = {};
+    for (const f of row.field.fields) {
+      let value = getDataValue(row.column(f.name));
+      if (value instanceof Date) {
+        value = normalizeToTimezone(value, timezone);
+      }
+      mapped[f.name] = value;
+    }
+    return mapped;
+  });
+}
+
+function getSize(field: Field): {height: number; width: number} {
+  return field.isRoot() ? {height: 350, width: 500} : {height: 175, width: 250};
+}
+
+export function generateScatterChartSpec(
+  data: RepeatedRecordCell,
+  field: Field,
+  vegaConfigOverride: Record<string, unknown> = {}
+): lite.TopLevelSpec {
+  const fields = data.field.fields;
+  const xField = fields[0];
+  const yField = fields[1];
+  const colorField = fields[2];
+  const sizeField = fields[3];
+  const shapeField = fields[4];
+
+  const xType = getDataType(xField);
+  const yType = getDataType(yField);
+  const colorType = colorField ? getDataType(colorField) : undefined;
+  const sizeType = sizeField ? getDataType(sizeField) : undefined;
+  const shapeType = shapeField ? getDataType(shapeField) : undefined;
+
+  const timezone = field.root().queryTimezone;
+
+  const colorDef =
+    colorField !== undefined
+      ? {
+          field: colorField.name,
+          type: colorType,
+          legend: {title: colorField.getLabel()},
+          scale: getColorScale(colorType, false),
+        }
+      : {value: '#4285F4'};
+
+  const sizeDef = sizeField
+    ? {
+        field: sizeField.name,
+        type: sizeType,
+        legend: {title: sizeField.getLabel()},
+      }
+    : undefined;
+
+  const shapeDef = shapeField
+    ? {
+        field: shapeField.name,
+        type: shapeType,
+        legend: {title: shapeField.getLabel()},
+      }
+    : undefined;
+
+  const xSort = xType === 'nominal' ? null : undefined;
+  const ySort = yType === 'nominal' ? null : undefined;
+
+  const spec: lite.TopLevelSpec = {
+    ...DEFAULT_SPEC,
+    ...getSize(field),
+    data: {values: mapData(data.rows, timezone)},
+    mark: 'point',
+    encoding: {
+      x: {
+        field: xField.name,
+        type: xType,
+        sort: xSort,
+        axis: {title: xField.getLabel()},
+        scale: {zero: false},
+      },
+      y: {
+        field: yField.name,
+        type: yType,
+        sort: ySort,
+        axis: {title: yField.getLabel()},
+        scale: {zero: false},
+      },
+      size: sizeDef,
+      color: colorDef,
+      shape: shapeDef,
+    },
+    background: 'transparent',
+  };
+
+  spec.config = mergeVegaConfigs(spec.config ?? {}, vegaConfigOverride);
+
+  return spec;
+}

--- a/packages/malloy-render/src/plugins/scatter-chart/scatter-chart-plugin.tsx
+++ b/packages/malloy-render/src/plugins/scatter-chart/scatter-chart-plugin.tsx
@@ -9,55 +9,16 @@ import type {
   DOMRenderPluginInstance,
   RendererValidationSpec,
 } from '@/api/plugin-types';
-import {type Field, type Cell, type RecordCell, FieldType} from '@/data_tree';
+import {type Field, FieldType} from '@/data_tree';
 import type {Tag} from '@malloydata/malloy-tag';
 import * as lite from 'vega-lite';
 import * as vega from 'vega';
-import {mergeVegaConfigs} from '@/component/vega/merge-vega-configs';
-import {DEFAULT_SPEC} from '@/html/vega_spec';
-import {getColorScale, normalizeToTimezone} from '@/html/utils';
+import {generateScatterChartSpec} from './generate-scatter_chart-spec';
 import type {
   GetResultMetadataOptions,
   RenderMetadata,
 } from '@/component/render-result-metadata';
 import type {RenderLogCollector} from '@/component/render-log-collector';
-
-function getDataType(
-  field: Field
-): 'temporal' | 'ordinal' | 'quantitative' | 'nominal' {
-  if (field.isTime()) return 'temporal';
-  if (field.isString()) return 'nominal';
-  if (field.isNumber()) return 'quantitative';
-  throw new Error('Invalid field type for scatter chart.');
-}
-
-function getDataValue(data: Cell): Date | string | number | null {
-  if (data.isNull()) return null;
-  if (data.isTime() || data.isString()) return data.value;
-  if (data.isNumber()) return data.value;
-  throw new Error('Invalid field type for scatter chart.');
-}
-
-function mapData(
-  rows: RecordCell[],
-  timezone: string | undefined
-): Record<string, unknown>[] {
-  return rows.map(row => {
-    const mapped: Record<string, unknown> = {};
-    for (const f of row.field.fields) {
-      let value = getDataValue(row.column(f.name));
-      if (value instanceof Date) {
-        value = normalizeToTimezone(value, timezone);
-      }
-      mapped[f.name] = value;
-    }
-    return mapped;
-  });
-}
-
-function getSize(field: Field): {height: number; width: number} {
-  return field.isRoot() ? {height: 350, width: 500} : {height: 175, width: 250};
-}
 
 export const ScatterChartPluginFactory: RenderPluginFactory<DOMRenderPluginInstance> =
   {
@@ -107,79 +68,11 @@ export const ScatterChartPluginFactory: RenderPluginFactory<DOMRenderPluginInsta
             );
           }
 
-          const data = props.dataColumn;
-          const fields = data.field.fields;
-          const xField = fields[0];
-          const yField = fields[1];
-          const colorField = fields[2];
-          const sizeField = fields[3];
-          const shapeField = fields[4];
-
-          const xType = getDataType(xField);
-          const yType = getDataType(yField);
-          const colorType = colorField ? getDataType(colorField) : undefined;
-          const sizeType = sizeField ? getDataType(sizeField) : undefined;
-          const shapeType = shapeField ? getDataType(shapeField) : undefined;
-
-          const timezone = field.root().queryTimezone;
-
-          const colorDef =
-            colorField !== undefined
-              ? {
-                  field: colorField.name,
-                  type: colorType,
-                  axis: {title: colorField.getLabel()},
-                  scale: getColorScale(colorType, false),
-                }
-              : {value: '#4285F4'};
-
-          const sizeDef = sizeField
-            ? {
-                field: sizeField.name,
-                type: sizeType,
-                axis: {title: sizeField.getLabel()},
-              }
-            : undefined;
-
-          const shapeDef = shapeField
-            ? {
-                field: shapeField.name,
-                type: shapeType,
-                axis: {title: shapeField.getLabel()},
-              }
-            : undefined;
-
-          const xSort = xType === 'nominal' ? null : undefined;
-          const ySort = yType === 'nominal' ? null : undefined;
-
-          const spec: lite.TopLevelSpec = {
-            ...DEFAULT_SPEC,
-            ...getSize(field),
-            data: {values: mapData(data.rows, timezone)},
-            mark: 'point',
-            encoding: {
-              x: {
-                field: xField.name,
-                type: xType,
-                sort: xSort,
-                axis: {title: xField.getLabel()},
-                scale: {zero: false},
-              },
-              y: {
-                field: yField.name,
-                type: yType,
-                sort: ySort,
-                axis: {title: yField.getLabel()},
-                scale: {zero: false},
-              },
-              size: sizeDef,
-              color: colorDef,
-              shape: shapeDef,
-            },
-            background: 'transparent',
-          };
-
-          spec.config = mergeVegaConfigs(spec.config ?? {}, vegaConfigOverride);
+          const spec = generateScatterChartSpec(
+            props.dataColumn,
+            field,
+            vegaConfigOverride
+          );
 
           const vegaSpec = lite.compile(spec).spec;
           const view = new vega.View(vega.parse(vegaSpec), {

--- a/packages/malloy-render/src/plugins/scatter-chart/scatter-chart-plugin.tsx
+++ b/packages/malloy-render/src/plugins/scatter-chart/scatter-chart-plugin.tsx
@@ -128,7 +128,7 @@ export const ScatterChartPluginFactory: RenderPluginFactory<DOMRenderPluginInsta
               ? {
                   field: colorField.name,
                   type: colorType,
-                  axis: {title: colorField.name},
+                  axis: {title: colorField.getLabel()},
                   scale: getColorScale(colorType, false),
                 }
               : {value: '#4285F4'};
@@ -137,7 +137,7 @@ export const ScatterChartPluginFactory: RenderPluginFactory<DOMRenderPluginInsta
             ? {
                 field: sizeField.name,
                 type: sizeType,
-                axis: {title: sizeField.name},
+                axis: {title: sizeField.getLabel()},
               }
             : undefined;
 
@@ -145,7 +145,7 @@ export const ScatterChartPluginFactory: RenderPluginFactory<DOMRenderPluginInsta
             ? {
                 field: shapeField.name,
                 type: shapeType,
-                axis: {title: shapeField.name},
+                axis: {title: shapeField.getLabel()},
               }
             : undefined;
 
@@ -162,14 +162,14 @@ export const ScatterChartPluginFactory: RenderPluginFactory<DOMRenderPluginInsta
                 field: xField.name,
                 type: xType,
                 sort: xSort,
-                axis: {title: xField.name},
+                axis: {title: xField.getLabel()},
                 scale: {zero: false},
               },
               y: {
                 field: yField.name,
                 type: yType,
                 sort: ySort,
-                axis: {title: yField.name},
+                axis: {title: yField.getLabel()},
                 scale: {zero: false},
               },
               size: sizeDef,

--- a/packages/malloy-render/src/plugins/spec-test-support/apply-renderer-stub.ts
+++ b/packages/malloy-render/src/plugins/spec-test-support/apply-renderer-stub.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright Contributors to the Malloy project
+ * SPDX-License-Identifier: MIT
+ */
+
+// Stands in for apply-renderer, whose solid-js rendering does not load under
+// the node test environment; custom-tooltip values are lazy and never rendered
+// in these tests.
+export const applyRenderer = () => ({renderAs: '', renderValue: null});

--- a/packages/malloy-render/src/plugins/spec-test-support/chart-layout-settings-stub.ts
+++ b/packages/malloy-render/src/plugins/spec-test-support/chart-layout-settings-stub.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Contributors to the Malloy project
+ * SPDX-License-Identifier: MIT
+ */
+
+// Test stand-in for chart-layout-settings, whose real implementation needs
+// vega's scale() and DOM text measurement; fixed dimensions are fine because
+// the chart spec tests assert titles, not layout.
+export const getChartLayoutSettings = () => ({
+  plotWidth: 300,
+  plotHeight: 200,
+  totalWidth: 400,
+  totalHeight: 300,
+  isSpark: false,
+  padding: {top: 0, left: 0, right: 0, bottom: 0},
+  xAxis: {labelAngle: 0, hidden: false},
+  yAxis: {hidden: false, tickCount: 5, width: 40, yTitleSize: 12},
+  yScale: {domain: [0, 100]},
+});
+
+export const getXAxisSettings = () => ({});

--- a/packages/malloy-render/src/plugins/spec-test-support/chart-v2-stub.ts
+++ b/packages/malloy-render/src/plugins/spec-test-support/chart-v2-stub.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Contributors to the Malloy project
+ * SPDX-License-Identifier: MIT
+ */
+
+// Stands in for chart-v2, whose solid-js JSX and `chart.css?raw` import do not
+// load under the node test environment; tests never render the component.
+export const ChartV2 = () => null;

--- a/packages/malloy-render/src/plugins/spec-test-support/get-custom-tooltips-entries-stub.ts
+++ b/packages/malloy-render/src/plugins/spec-test-support/get-custom-tooltips-entries-stub.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Contributors to the Malloy project
+ * SPDX-License-Identifier: MIT
+ */
+
+// Test stand-in for get-custom-tooltips-entries, whose real implementation
+// pulls in solid-js; the chart spec tests assert titles, not tooltips.
+export const getCustomTooltipEntries = () => [];

--- a/packages/malloy-render/src/plugins/spec-test-support/get-custom-tooltips-entries-stub.ts
+++ b/packages/malloy-render/src/plugins/spec-test-support/get-custom-tooltips-entries-stub.ts
@@ -1,8 +1,0 @@
-/*
- * Copyright Contributors to the Malloy project
- * SPDX-License-Identifier: MIT
- */
-
-// Test stand-in for get-custom-tooltips-entries, whose real implementation
-// pulls in solid-js; the chart spec tests assert titles, not tooltips.
-export const getCustomTooltipEntries = () => [];

--- a/packages/malloy-render/src/plugins/spec-test-support/harness.ts
+++ b/packages/malloy-render/src/plugins/spec-test-support/harness.ts
@@ -22,8 +22,8 @@ export interface ChartQueryResult {
 }
 
 /**
- * Compile and run a query, returning the data-tree root (with `# label` tags
- * resolved) and the render metadata a spec generator takes as input.
+ * Runs a query, returning the data-tree root (`# label`s resolved) and the
+ * render metadata a spec generator consumes.
  */
 export async function runChartQuery(
   source: string,
@@ -50,10 +50,7 @@ const DATA =
 
 const SOURCE = `source: data is ${DATA}`;
 
-/**
- * The label-honoring cases shared by the bar and line chart specs,
- * parametrized by chart tag and each chart's spec builder.
- */
+/** The label-honoring cases shared by the bar and line chart specs. */
 export function describeChartLabelTests(
   chartTag: 'bar_chart' | 'line_chart',
   buildSpec: (source: string, query: string) => Promise<Spec>
@@ -123,8 +120,7 @@ export function describeChartLabelTests(
         }
         `
       );
-      // The labels ride a data-driven ordinal scale, so an explicit empty
-      // # label="" survives verbatim instead of falling back to the name.
+      // Labels ride a data-driven scale, so an empty # label="" survives.
       const scale = (spec.scales ?? []).find(
         s => s.name === MEASURE_SERIES_LABEL_SCALE
       );

--- a/packages/malloy-render/src/plugins/spec-test-support/harness.ts
+++ b/packages/malloy-render/src/plugins/spec-test-support/harness.ts
@@ -1,0 +1,141 @@
+/*
+ * Copyright Contributors to the Malloy project
+ * SPDX-License-Identifier: MIT
+ */
+
+import type {Spec} from 'vega';
+import {API} from '@malloydata/malloy';
+import {runtimeFor} from '../../../../../test/src/runtimes';
+import {RenderFieldMetadata} from '@/render-field-metadata';
+import {getDataTree, type RootField} from '@/data_tree';
+import {
+  getResultMetadata,
+  type RenderMetadata,
+} from '@/component/render-result-metadata';
+import {MEASURE_SERIES_LABEL_SCALE} from '@/component/vega/measure-series-label-scale';
+
+const duckdb = runtimeFor('duckdb');
+
+export interface ChartQueryResult {
+  root: RootField;
+  metadata: RenderMetadata;
+}
+
+/**
+ * Compile and run a query, returning the data-tree root (with `# label` tags
+ * resolved) and the render metadata a spec generator takes as input.
+ */
+export async function runChartQuery(
+  source: string,
+  query: string
+): Promise<ChartQueryResult> {
+  const result = await duckdb.loadModel(source).loadQuery(query).run();
+  const malloyResult = API.util.wrapResult(result);
+  const rfm = new RenderFieldMetadata(malloyResult);
+  getDataTree(malloyResult, rfm);
+  const root = rfm.getRootField();
+  const metadata = getResultMetadata(root, {
+    renderFieldMetadata: rfm,
+    parentSize: {width: 400, height: 300},
+  });
+  return {root, metadata};
+}
+
+const DATA =
+  'duckdb.sql("SELECT * FROM (VALUES ' +
+  "('Total Universe (HH)', 75, '1Q26'), " +
+  "('1Q26: High Income Earners', 28, '1Q26'), " +
+  "('1Q26: Auto Intenders', 25, '2Q26')) " +
+  'AS t(audience_name, reach, period)")';
+
+const SOURCE = `source: data is ${DATA}`;
+
+/**
+ * The label-honoring cases shared by the bar and line chart specs,
+ * parametrized by chart tag and each chart's spec builder.
+ */
+export function describeChartLabelTests(
+  chartTag: 'bar_chart' | 'line_chart',
+  buildSpec: (source: string, query: string) => Promise<Spec>
+) {
+  afterAll(async () => {
+    await duckdb.connection.close();
+  });
+
+  describe(`${chartTag} honors # label tags on axis/legend titles`, () => {
+    test('x and y axis titles use the # label tag, not the field name', async () => {
+      const spec = await buildSpec(
+        SOURCE,
+        `
+        # ${chartTag}
+        run: data -> {
+          group_by:
+            # label="Audience"
+            audience_name
+          aggregate:
+            # label="Reach (HH)"
+            total_reach is reach.sum()
+        }
+        `
+      );
+      const xAxis = spec.axes?.find(a => a.scale === 'xscale');
+      const yAxis = spec.axes?.find(a => a.scale === 'yscale');
+      expect(xAxis?.title).toBe('Audience');
+      expect(yAxis?.title).toBe('Reach (HH)');
+    }, 60000);
+
+    test('legend title uses the # label tag of the series dimension', async () => {
+      const spec = await buildSpec(
+        SOURCE,
+        `
+        # ${chartTag}
+        run: data -> {
+          group_by:
+            # label="Audience"
+            audience_name
+            # label="Quarter"
+            period
+          aggregate:
+            # label="Reach (HH)"
+            total_reach is reach.sum()
+        }
+        `
+      );
+      expect(spec.legends?.[0]?.title).toBe('Quarter');
+    }, 60000);
+
+    test('measure-series legend entries use the # label tags, not field names', async () => {
+      const spec = await buildSpec(
+        SOURCE,
+        `
+        # ${chartTag}
+        run: data -> {
+          group_by:
+            # label="Audience"
+            audience_name
+          aggregate:
+            # y
+            # label="Reach (HH)"
+            total_reach is reach.sum()
+            # y
+            # label=""
+            avg_reach is reach.avg()
+        }
+        `
+      );
+      // The labels ride a data-driven ordinal scale, so an explicit empty
+      // # label="" survives verbatim instead of falling back to the name.
+      const scale = (spec.scales ?? []).find(
+        s => s.name === MEASURE_SERIES_LABEL_SCALE
+      );
+      const range = scale && 'range' in scale ? scale.range : undefined;
+      const rangeArr: unknown[] = Array.isArray(range) ? range : [];
+      expect(rangeArr).toContain('Reach (HH)');
+      expect(rangeArr).toContain('');
+      expect(rangeArr).not.toContain('avg_reach');
+      expect(JSON.stringify(spec.legends?.[0] ?? {})).toContain(
+        MEASURE_SERIES_LABEL_SCALE
+      );
+    }, 60000);
+  });
+}

--- a/packages/malloy-render/src/plugins/spec-test-support/harness.ts
+++ b/packages/malloy-render/src/plugins/spec-test-support/harness.ts
@@ -3,27 +3,34 @@
  * SPDX-License-Identifier: MIT
  */
 
-import type {Spec} from 'vega';
+import type {Item, View} from 'vega';
 import {API} from '@malloydata/malloy';
 import {runtimeFor} from '../../../../../test/src/runtimes';
 import {RenderFieldMetadata} from '@/render-field-metadata';
 import {getDataTree, type RootField} from '@/data_tree';
+import type {RepeatedRecordCell} from '@/data_tree';
 import {
   getResultMetadata,
   type RenderMetadata,
 } from '@/component/render-result-metadata';
+import type {VegaChartProps} from '@/component/types';
 import {MEASURE_SERIES_LABEL_SCALE} from '@/component/vega/measure-series-label-scale';
 
 const duckdb = runtimeFor('duckdb');
 
+export async function closeChartTestRuntime() {
+  await duckdb.connection.close();
+}
+
 export interface ChartQueryResult {
   root: RootField;
+  rootCell: RepeatedRecordCell;
   metadata: RenderMetadata;
 }
 
 /**
- * Runs a query, returning the data-tree root (`# label`s resolved) and the
- * render metadata a spec generator consumes.
+ * Runs a query, returning the data-tree root (`# label`s resolved), its data
+ * cell, and the render metadata a spec generator consumes.
  */
 export async function runChartQuery(
   source: string,
@@ -32,13 +39,26 @@ export async function runChartQuery(
   const result = await duckdb.loadModel(source).loadQuery(query).run();
   const malloyResult = API.util.wrapResult(result);
   const rfm = new RenderFieldMetadata(malloyResult);
-  getDataTree(malloyResult, rfm);
+  const rootCell = getDataTree(malloyResult, rfm);
   const root = rfm.getRootField();
   const metadata = getResultMetadata(root, {
     renderFieldMetadata: rfm,
     parentSize: {width: 400, height: 300},
   });
-  return {root, metadata};
+  return {root, rootCell, metadata};
+}
+
+/**
+ * Builds the minimal scenegraph item shape getTooltipData reads. Real items
+ * only exist inside a running vega View, which the node test env cannot load
+ * (vega 6 is ESM-only), hence the cast at this third-party boundary.
+ */
+export function fakeTooltipItem(markName: string, datum: unknown): Item {
+  return {datum, mark: {name: markName}} as unknown as Item;
+}
+
+export function fakeTooltipView(): View {
+  return {scale: () => () => '#4285F4'} as unknown as View;
 }
 
 const DATA =
@@ -48,20 +68,37 @@ const DATA =
   "('1Q26: Auto Intenders', 25, '2Q26')) " +
   'AS t(audience_name, reach, period)")';
 
-const SOURCE = `source: data is ${DATA}`;
+export const SOURCE = `source: data is ${DATA}`;
+
+const DATA4 =
+  'duckdb.sql("SELECT * FROM (VALUES ' +
+  "('Total Universe (HH)', 75, '1Q26', 'East'), " +
+  "('1Q26: High Income Earners', 28, '1Q26', 'West'), " +
+  "('1Q26: Auto Intenders', 25, '2Q26', 'East')) " +
+  'AS t(audience_name, reach, period, region)")';
+
+export const SOURCE4 = `source: data4 is ${DATA4}`;
+
+const YOY_DATA =
+  'duckdb.sql("SELECT * FROM (VALUES ' +
+  "(DATE '2024-01-15', 10), (DATE '2024-04-15', 20), " +
+  "(DATE '2025-01-15', 12), (DATE '2025-04-15', 24)) " +
+  'AS t(event_date, sales)")';
+
+export const YOY_SOURCE = `source: yoy_data is ${YOY_DATA}`;
 
 /** The label-honoring cases shared by the bar and line chart specs. */
 export function describeChartLabelTests(
   chartTag: 'bar_chart' | 'line_chart',
-  buildSpec: (source: string, query: string) => Promise<Spec>
+  buildProps: (source: string, query: string) => Promise<VegaChartProps>
 ) {
   afterAll(async () => {
-    await duckdb.connection.close();
+    await closeChartTestRuntime();
   });
 
   describe(`${chartTag} honors # label tags on axis/legend titles`, () => {
     test('x and y axis titles use the # label tag, not the field name', async () => {
-      const spec = await buildSpec(
+      const {spec} = await buildProps(
         SOURCE,
         `
         # ${chartTag}
@@ -82,7 +119,7 @@ export function describeChartLabelTests(
     }, 60000);
 
     test('legend title uses the # label tag of the series dimension', async () => {
-      const spec = await buildSpec(
+      const {spec} = await buildProps(
         SOURCE,
         `
         # ${chartTag}
@@ -102,7 +139,7 @@ export function describeChartLabelTests(
     }, 60000);
 
     test('measure-series legend entries use the # label tags, not field names', async () => {
-      const spec = await buildSpec(
+      const {spec} = await buildProps(
         SOURCE,
         `
         # ${chartTag}

--- a/packages/malloy-render/src/plugins/synthetic-series-field.ts
+++ b/packages/malloy-render/src/plugins/synthetic-series-field.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Contributors to the Malloy project
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+ * The slice of `Field` the chart spec generators read off a series field,
+ * so the bar and line plugins' synthetic series fields stay honestly typed.
+ */
+export interface SyntheticSeriesField {
+  name: string;
+  getLabel: () => string;
+  valueSet: ReadonlySet<string | number | boolean>;
+  referenceId: string;
+  // Never set by synthetics; the bar generator's legend-sizing read needs it.
+  maxString?: string;
+}

--- a/packages/malloy-render/src/stories/label_tags.stories.malloy
+++ b/packages/malloy-render/src/stories/label_tags.stories.malloy
@@ -1,0 +1,77 @@
+source: sample is duckdb.sql("""
+  SELECT * FROM (VALUES
+    ('Total Universe', '1Q26', 75, 3, 120),
+    ('High Income', '1Q26', 28, 5, 220),
+    ('Auto Intenders', '2Q26', 25, 4, 90),
+    ('Sports Fans', '2Q26', 22, 6, 250)
+  ) AS t(audience_name, period, reach, frequency, spend)
+""") extend {
+  measure:
+    # label="Reach (HH)"
+    total_reach is reach.sum()
+    # label="Total Spend"
+    total_spend is spend.sum()
+    # label="Avg Frequency"
+    avg_frequency is frequency.avg()
+
+  #(story)
+  # bar_chart
+  view: bar_axis_labels is {
+    group_by:
+      # label="Audience"
+      audience_name
+    aggregate: total_reach
+  }
+
+  #(story)
+  # bar_chart
+  view: bar_series_labels is {
+    group_by:
+      # label="Audience"
+      audience_name
+      # label="Quarter"
+      period
+    aggregate: total_reach
+  }
+
+  #(story)
+  # line_chart
+  view: line_labels is {
+    group_by:
+      # label="Audience"
+      audience_name
+      # label="Quarter"
+      period
+    aggregate: total_reach
+  }
+
+  #(story)
+  # scatter_chart
+  view: scatter_labels is {
+    group_by:
+      # label="Frequency"
+      frequency
+    aggregate:
+      # label="Total Spend"
+      total_spend
+      # label="Reach (HH)"
+      total_reach
+    group_by:
+      # label="Audience"
+      audience_name
+  }
+
+  #(story)
+  # bar_chart
+  view: tooltip_label is {
+    group_by:
+      # label="Audience"
+      audience_name
+    aggregate:
+      # label="Reach (HH)"
+      total_reach
+      # tooltip
+      # label="Avg Frequency"
+      avg_frequency
+  }
+}


### PR DESCRIPTION
## Summary

Bar, line, and scatter charts rendered their axis, legend, and tooltip titles from the raw field name instead of the field's `# label`, so a dimension or measure tagged with `# label="..."` showed e.g. `audience_name` on the axis instead of `Audience`. The table and dashboard renderers already honor the label; this brings the charts in line.

Before:
<img width="2000" height="1280" alt="chart-labels-before-bug" src="https://github.com/user-attachments/assets/06a6a97f-5a35-412c-84fe-20274e524c13" />


After:
<img width="2000" height="1280" alt="chart-labels-after-fixed" src="https://github.com/user-attachments/assets/eaa92b3f-a127-49d4-a0ed-c1fb9e66469a" />

## Root cause

`getLabel()` (which resolves the `# label` tag at setup time) was added to the field abstraction and adopted by the table and dashboard renderers, but the chart plugins still read `.name` for their display text.

## What changed

- Bar, line, and scatter charts use `field.getLabel()` for axis titles, legend titles, and (bar/line) tooltip labels, covering both the custom `# tooltip` entries and the default measure row.
- Every `.name` used as a data reference (vega `field:` paths, `row.column(...)` lookups) is left unchanged, as are dimensional-series tooltip entries, whose value is the series value rather than a field name.
- The bar and line synthetic series fields gain a `getLabel()` so the multi-series legend path keeps working.
- For a multi-measure (measure-series) chart, the color-legend entries are the raw measure field names from the fold transform; they are relabeled to their `# label` through an ordinal scale, so the legend matches the axis and tooltip and an explicit `# label=""` renders blank.

## Before / after

Before: x-axis `audience_name`, y-axis `reach`. After: x-axis `Audience`, y-axis `Reach (HH)`.

## Testing

- Added bar and line spec tests asserting the axis, legend, and measure-series legend titles come from the labels, and that an explicit empty `# label=""` is preserved.
- Verified in Storybook across bar, line, and scatter; single and multi-measure; dimensional and measure series; empty labels; and custom and default tooltips.
- Reproduced the original behavior on the pre-fix baseline (raw field names) and confirmed it is resolved.
