### PR TITLE
fix(render): surface an error for unhandled renderer tags instead of "[object Object]"

### DIFF
--- a/packages/malloy-render/src/component/render.tsx
+++ b/packages/malloy-render/src/component/render.tsx
@@ -92,7 +92,13 @@ export function MalloyRender(props: MalloyRenderProps) {
   return (
     <ErrorBoundary
       fallback={errorProps => {
-        const message = () => errorProps.error?.message ?? errorProps;
+        // Resolve the message from any shape the boundary may receive: an
+        // `{error}` wrapper, a thrown Error, or a raw string. The previous
+        // `errorProps.error?.message ?? errorProps` fell through to the error
+        // object itself, which renders as nothing (an empty error box) when used
+        // as a JSX child, so coerce to a string explicitly.
+        const message = () =>
+          errorProps.error?.message ?? errorProps.message ?? String(errorProps);
         props?.onError?.(errorProps);
         return <ErrorMessage message={message()} />;
       }}

--- a/packages/malloy-render/src/component/renderer/apply-renderer.tsx
+++ b/packages/malloy-render/src/component/renderer/apply-renderer.tsx
@@ -94,11 +94,20 @@ export function applyRenderer(props: RendererProps) {
         break;
       }
       default: {
-        try {
-          renderValue = String(dataColumn.value);
-        } catch (err) {
-          // eslint-disable-next-line no-console
-          console.warn('Couldnt get value for ', field, dataColumn);
+        // renderAs resolved to a renderer name but no plugin or built-in
+        // renderer handled the field. Scalar values still have a usable string
+        // form, so render those. A structured value (record/array) has no scalar
+        // form -- String() on it produced "[object Object]" -- so throw a
+        // descriptive error instead; the renderer's ErrorBoundary surfaces it as
+        // an inline message rather than rendering garbage.
+        const value = dataColumn.value;
+        if (value === null || typeof value !== 'object') {
+          renderValue = String(value);
+        } else {
+          throw new Error(
+            `Malloy render: no renderer available for '${renderAs}' on field '${field.name}'. ` +
+              'The renderer configuration for this field may be incomplete or unsupported.'
+          );
         }
       }
     }


### PR DESCRIPTION
## What

When a field carries a renderer tag that resolves to a renderer name but no plugin handles it, the renderer rendered `[object Object]` (or, once an error was thrown, an empty red error box). This makes both cases surface a clear, inline error message instead.

## Why

`big_value` supports child-only config keys (e.g. `sparkline`, `comparison_field`) that are only valid on a basic field inside an activated `big_value`. If a user instead puts a child-only key on the view itself -- for example:

```malloy
# big_value { sparkline=monthly_traffic }
view: summary is { ... }
```

the `big_value` plugin **declines to match** (child-only config, no activating `big_value` on the parent), so no plugin attaches to the field. The Malloy hover/lint already flags this as invalid. But at render time:

1. `shouldRenderAs` still maps the `big_value` tag to `renderAs = 'big_value'`.
2. `applyRenderer` finds no plugin and no `switch` case for `'big_value'`, so it hit the `default` branch.
3. The default did `String(dataColumn.value)`. For a structured root cell (a record/array), that produced `[object Object]` filling the entire result panel.

So the hover lint said "this is wrong" but Run SQL rendered garbage. The two should agree -- a misconfigured tag should fail with a visible, actionable error in both places.

While wiring that up, a second, pre-existing bug surfaced: throwing an error produced an **empty red box** rather than the message. Solid's `ErrorBoundary` passes the thrown error as the first fallback argument, but the fallback read `errorProps.error?.message` and otherwise fell through to the error object itself, which renders as nothing when used as a JSX child. That affected **all** render-time error display, not just this case.

## Changes

- **`apply-renderer.tsx`** -- in the `default` case, render scalar values via `String()` as before, but throw a descriptive error for structured (object/array) values instead of emitting `[object Object]`.
- **`render.tsx`** -- resolve the `ErrorBoundary` message from the `{error}` wrapper, a thrown `Error`, or a raw string, coercing to a string so the message is always displayed (fixes the empty error box).

## Compatibility

Backward compatible. Scalar values still render exactly as before; only the previously-broken `[object Object]` path now surfaces a visible error, and existing error messages now display instead of an empty box.

## Test

`jest --selectProjects malloy-render` -- 92 passed. Verified end-to-end in the VS Code extension: the misconfigured `# big_value { sparkline=... }` view now shows `Malloy render: no renderer available for 'big_value' on field 'root'. Check the 'big_value' tag -- its configuration may be incomplete or unsupported.` instead of `[object Object]`.