### PR TITLE
fix(render): surface render-tag validation errors instead of "[object Object]"

### DIFF
--- a/packages/malloy-render/src/component/renderer/apply-renderer.tsx
+++ b/packages/malloy-render/src/component/renderer/apply-renderer.tsx
@@ -14,6 +14,7 @@ import type {RendererProps} from '@/component/types';
 import {PluginRenderContainer} from '@/component/renderer/plugin-render-container';
 import {renderCellValue} from '@/component/cell-utils';
 import type {CellFormatConfig} from '@/component/tag-configs';
+import {ErrorMessage} from '@/component/error-message/error-message';
 
 export function applyRenderer(props: RendererProps) {
   const {dataColumn, customProps = {}} = props;
@@ -94,11 +95,18 @@ export function applyRenderer(props: RendererProps) {
         break;
       }
       default: {
-        try {
-          renderValue = String(dataColumn.value);
-        } catch (err) {
-          // eslint-disable-next-line no-console
-          console.warn('Couldnt get value for ', field, dataColumn);
+        const validationErrors = field.getValidationErrors();
+        if (validationErrors.length > 0) {
+          // No renderer matched (e.g. a misconfigured # big_value); surface the
+          // validation error instead of stringifying to '[object Object]'.
+          renderValue = <ErrorMessage message={validationErrors.join(' ')} />;
+        } else {
+          try {
+            renderValue = String(dataColumn.value);
+          } catch (err) {
+            // eslint-disable-next-line no-console
+            console.warn('Couldnt get value for ', field, dataColumn);
+          }
         }
       }
     }

--- a/packages/malloy-render/src/data_tree/fields/base.ts
+++ b/packages/malloy-render/src/data_tree/fields/base.ts
@@ -41,6 +41,7 @@ export abstract class FieldBase {
   private _tagConfig: unknown = undefined;
   private _resolvedLabel: string | undefined;
   private _columnConfig: unknown = undefined;
+  private _validationErrors: string[] = [];
 
   // Get the plugins registered for this field
   getPlugins(): RenderPluginInstance[] {
@@ -93,6 +94,16 @@ export abstract class FieldBase {
 
   setColumnConfig(config: unknown): void {
     this._columnConfig = config;
+  }
+
+  // Validation errors recorded at setup (validateFieldTags) so applyRenderer can
+  // surface them instead of stringifying an unrenderable value to '[object Object]'.
+  addValidationError(message: string): void {
+    this._validationErrors.push(message);
+  }
+
+  getValidationErrors(): string[] {
+    return this._validationErrors;
   }
 
   renderAs(): string {

--- a/packages/malloy-render/src/render-field-metadata.ts
+++ b/packages/malloy-render/src/render-field-metadata.ts
@@ -10,6 +10,7 @@ import type {
   RenderFieldRegistry,
 } from '@/registry/types';
 import {RenderLogCollector} from '@/component/render-log-collector';
+import type {Tag} from '@malloydata/malloy-tag';
 import {resolveBuiltInTags} from '@/component/tag-configs';
 import {getBuiltInRendererValidationSpec} from '@/component/renderer-validation-specs';
 import {convertLegacyToVizTag} from '@/component/tag-utils';
@@ -185,7 +186,16 @@ export class RenderFieldMetadata {
   private validateFieldTags(field: Field): void {
     const tag = field.tag;
     const fieldType = getFieldType(field);
-    const log = this.logCollector;
+    // Errors are also recorded on the field so applyRenderer can surface them;
+    // warnings stay on the logs surface only.
+    const collector = this.logCollector;
+    const log = {
+      warn: (message: string, t?: Tag): void => collector.warn(message, t),
+      error: (message: string, t?: Tag): void => {
+        collector.error(message, t);
+        field.addValidationError(message);
+      },
+    };
 
     // --- Renderer tags on wrong field types ---
 

--- a/packages/malloy-render/src/stories/big_value.stories.malloy
+++ b/packages/malloy-render/src/stories/big_value.stories.malloy
@@ -344,4 +344,25 @@ source: big_value_orders is duckdb.table("static/data/order_items.parquet") exte
       limit: 24
     }
   }
+
+  // MISCONFIGURED: a child-only `# big_value { sparkline=... }` placed on the
+  // view itself, with no activating `# big_value`. The renderer declines to
+  // match it, so it used to render as "[object Object]". It now surfaces the
+  // validation error instead.
+  #(story)
+  # big_value { sparkline=mis_trend }
+  view: misconfigured_big_value is {
+    aggregate:
+      # label="Total Sales"
+      total_sales
+
+    # line_chart { size=spark }
+    # hidden
+    nest: mis_trend is {
+      group_by: order_month
+      aggregate: total_sales
+      order_by: order_month
+      limit: 24
+    }
+  }
 }

--- a/test/src/render/render-validator.spec.ts
+++ b/test/src/render/render-validator.spec.ts
@@ -383,6 +383,23 @@ describe('render tag validation', () => {
       expectError(logs, 'only valid on basic fields');
       expectNoWarnings(logs);
     });
+
+    it('errors when a child-only big_value (sparkline) is on the view itself', async () => {
+      // The exact shape that rendered as "[object Object]" in Publisher: a
+      // child-only `# big_value { sparkline=... }` placed on a view with no
+      // activating big_value. The renderer declines to match it, so this error
+      // must surface (now recorded on the field and rendered, see apply-renderer).
+      const logs = await getValidationLogs(`
+        source: s is duckdb.sql("SELECT 1 as val") extend {
+          # big_value { sparkline=trend }
+          view: q is {
+            aggregate: total is count()
+          }
+        }
+        query: q is s -> q
+      `);
+      expectError(logs, 'only valid on basic fields');
+    });
   });
 
   describe('chart y-channel must be numeric', () => {


### PR DESCRIPTION
A child-only renderer config such as `# big_value { sparkline=... }` placed on a view with no activating `# big_value` leaves no matching renderer (the big_value plugin correctly declines since #2719). The render dispatch then falls through to `String(value)`, which on a record cell produces the literal text `[object Object]`. `RenderFieldMetadata` already detects and logs the misconfiguration, but that error never reached the rendered output.

This records error-severity validation findings on the field during setup and has `applyRenderer`'s fallback render them via the existing `ErrorMessage` component instead of stringifying an unrenderable value. The message the renderer already computes (e.g. "Tag 'big_value' on field 'root' is only valid on basic fields inside big_value.") now shows in place of the garbage.

## Before / after

<img width="1608" height="848" alt="pr_before_after" src="https://github.com/user-attachments/assets/2d2bdd09-2f3a-4dc9-a836-6df184706b8a" />

## Changes

- `FieldBase` stores error-severity validation messages (`addValidationError` / `getValidationErrors`), matching the existing resolve-at-setup / read-at-render pattern (`setPlugins`, `setTagConfig`).
- `RenderFieldMetadata.validateFieldTags` records error-severity logs on the field in addition to the log collector; warnings stay on the logs surface only.
- `applyRenderer`'s `default` case renders an `ErrorMessage` when the field has validation errors; the existing `String(value)` fallback is otherwise unchanged.

## Testing

- Added a `misconfigured_big_value` Storybook story and verified the rendered output (error box, no `[object Object]`); confirmed valid table / line / bar / dashboard / list / pivot / big_value stories are unaffected.
- Added a `render-validator` test for the exact view-level `# big_value { sparkline=... }` shape.

A companion change in malloydata/publisher validates these tags at package-load time so a misconfigured tag also fails publish with a clear error rather than only surfacing at render time.
