### PR TITLE
Decode file:// URL workingDirectory to a path for DuckDB

### DIFF
--- a/packages/malloy-db-duckdb/src/duckdb_config.spec.ts
+++ b/packages/malloy-db-duckdb/src/duckdb_config.spec.ts
@@ -6,6 +6,7 @@
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+import {pathToFileURL} from 'url';
 import type {ConnectionConfig} from '@malloydata/malloy';
 import {
   buildDuckDBShareKey,
@@ -72,6 +73,17 @@ describe('normalizeDuckDBConfig', () => {
     expect(() =>
       normalizeDuckDBConfig(baseConfig({workingDirectory: ''}))
     ).toThrow('workingDirectory is invalid: path must not be empty');
+  });
+
+  it('accepts a file:// URL workingDirectory and resolves it to a path', () => {
+    // `workingDirectory` defaults to `config.rootDirectory`, which the config
+    // stack carries as a URL string — make sure it lands as a real OS path and
+    // not a `file:`-prefixed segment joined to the process cwd.
+    const normalized = normalizeDuckDBConfig(
+      baseConfig({workingDirectory: pathToFileURL(workingDirectory).toString()})
+    );
+
+    expect(normalized.workingDirectory).toEqual(canonical(workingDirectory));
   });
 
   it('does not invent allowedDirectories outside sandboxed mode', () => {

--- a/packages/malloy-db-duckdb/src/duckdb_config.ts
+++ b/packages/malloy-db-duckdb/src/duckdb_config.ts
@@ -4,6 +4,7 @@
  */
 
 import path from 'path';
+import {fileURLToPath} from 'url';
 import {makeDigest} from '@malloydata/malloy';
 import type {
   ConnectionConfig,
@@ -568,13 +569,36 @@ function canonicalizeDatabasePath(databasePath: string): string {
   return canonicalizeConfigPath(databasePath, 'databasePath');
 }
 
+// A config path can arrive as a `file://` URL rather than a plain path —
+// notably `workingDirectory`, which defaults to `config.rootDirectory` (the
+// config stack carries it as a URL string). Left as a URL, `path.resolve`
+// treats `file:` as a relative segment and joins it to the process cwd,
+// silently breaking relative `read_parquet`/glob resolution. Decode file URLs
+// to a real path so every downstream consumer (FILE_SEARCH_PATH,
+// allowed_directories, …) sees one. Plain paths and non-file schemes pass
+// through untouched; a malformed file URL throws and surfaces as the caller's
+// field-specific validation error.
+function maybeFileURLToPath(input: string): string {
+  // Cheap guard so plain paths (the common case) skip URL parsing entirely.
+  if (!/^[a-z][a-z0-9+.-]*:/i.test(input)) {
+    return input;
+  }
+  let url: URL;
+  try {
+    url = new URL(input);
+  } catch {
+    return input; // not a URL — treat as a plain path
+  }
+  return url.protocol === 'file:' ? fileURLToPath(url) : input;
+}
+
 function canonicalizeConfigPath(
   input: string,
   fieldName: string,
   options: pathSecurity.CanonicalPathOptions = {}
 ): string {
   try {
-    return pathSecurity.canonicalizePath(input, options);
+    return pathSecurity.canonicalizePath(maybeFileURLToPath(input), options);
   } catch (error) {
     throw new DuckDBConfigValidationError(
       `${fieldName} is invalid: ${errorMessage(error)}`

--- a/packages/malloy-db-duckdb/src/duckdb_config_lookup.spec.ts
+++ b/packages/malloy-db-duckdb/src/duckdb_config_lookup.spec.ts
@@ -3,6 +3,10 @@
  * SPDX-License-Identifier: MIT
  */
 
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import {pathToFileURL} from 'url';
 import {MalloyConfig} from '@malloydata/malloy';
 import {DuckDBConnection} from './duckdb_connection';
 import './native';
@@ -10,6 +14,35 @@ import './native';
 describe('DuckDB config lookup validation', () => {
   afterEach(() => {
     DuckDBConnection.closeAllInstances();
+  });
+
+  // Regression: `workingDirectory` defaults to `{config: 'rootDirectory'}`, and
+  // the config stack carries rootDirectory as a `file://` URL string. That URL
+  // must reach DuckDB as a real OS path — otherwise `SET FILE_SEARCH_PATH` gets
+  // a `file:`-prefixed value, DuckDB treats it as relative to the process cwd,
+  // and every relative `read_parquet`/glob silently resolves nothing.
+  it('resolves relative files against a file:// rootDirectory default', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'malloy-duckdb-root-'));
+    fs.mkdirSync(path.join(root, 'data'));
+    fs.writeFileSync(path.join(root, 'data', 'marker.txt'), 'hi');
+    const canonicalRoot = fs.realpathSync.native(root);
+
+    const config = new MalloyConfig(
+      {connections: {duckdb: {is: 'duckdb'}}},
+      {rootDirectory: pathToFileURL(root).toString()}
+    );
+
+    const connection = await config.connections.lookupConnection('duckdb');
+    const {rows} = await connection.runSQL(
+      "SELECT current_setting('file_search_path') AS search_path"
+    );
+    expect(rows[0]['search_path']).toBe(canonicalRoot);
+
+    // The behavior that actually matters: a relative glob finds the file.
+    const globbed = await connection.runSQL("SELECT file FROM glob('data/*')");
+    expect(globbed.rows.map(r => r['file'])).toEqual([
+      path.join(canonicalRoot, 'data', 'marker.txt'),
+    ]);
   });
 
   it('rejects reference-shaped securityPolicy before DuckDB construction', async () => {

--- a/packages/malloy-db-duckdb/src/duckdb_wasm_connection.spec.ts
+++ b/packages/malloy-db-duckdb/src/duckdb_wasm_connection.spec.ts
@@ -149,6 +149,27 @@ FROM read_parquet("inventory_items2.parquet")
   });
 });
 
+describe('workingDirectory file:// URL handling', () => {
+  // `workingDirectory` defaults to `config.rootDirectory`, a URL string. It must
+  // reach DuckDB-Wasm's FILE_SEARCH_PATH as a plain virtual-FS path, not a
+  // `file:` URL — otherwise relative reads resolve against nothing.
+  const connection = new DuckDBWASMConnection({
+    name: 'duckdb',
+    workingDirectory: 'file:///work/data%20dir',
+  });
+
+  afterAll(async () => {
+    await connection.close();
+  });
+
+  it('decodes the file:// URL into the FILE_SEARCH_PATH', async () => {
+    const result = await connection.runSQL(
+      "SELECT current_setting('file_search_path') AS search_path"
+    );
+    expect(result.rows[0]['search_path']).toBe('/work/data dir');
+  });
+});
+
 /**
  * Tests for reading numeric values through Malloy queries (WASM path)
  */

--- a/packages/malloy-db-duckdb/src/duckdb_wasm_connection.ts
+++ b/packages/malloy-db-duckdb/src/duckdb_wasm_connection.ts
@@ -226,6 +226,23 @@ export interface DuckDBWasmOptions extends ConnectionConfig {
   workingDirectory?: string;
   setupSQL?: string;
 }
+// `workingDirectory` defaults to `config.rootDirectory`, which the config
+// stack carries as a URL string. DuckDB-Wasm's virtual filesystem wants a plain
+// POSIX path; a `file://` URL left intact becomes a bogus FILE_SEARCH_PATH and
+// breaks relative reads. Decode file URLs to their path. Browser-safe — uses
+// the WHATWG `URL` (the native connection's Node `fileURLToPath` is unavailable
+// here). Plain paths and non-file schemes pass through untouched.
+function fileURLToVirtualPath(input: string): string {
+  if (!/^file:\/\//i.test(input)) {
+    return input;
+  }
+  const decoded = decodeURIComponent(new URL(input).pathname);
+  // Drop a trailing separator but keep the filesystem root '/'.
+  return decoded.length > 1 && decoded.endsWith('/')
+    ? decoded.slice(0, -1)
+    : decoded;
+}
+
 export abstract class DuckDBWASMConnection extends DuckDBCommon {
   private additionalExtensions: string[] = [];
   public readonly name: string;
@@ -260,7 +277,7 @@ export abstract class DuckDBWASMConnection extends DuckDBCommon {
         this.databasePath = arg2;
       }
       if (typeof workingDirectory === 'string') {
-        this.workingDirectory = workingDirectory;
+        this.workingDirectory = fileURLToVirtualPath(workingDirectory);
       }
       if (queryOptions) {
         this.queryOptions = queryOptions;
@@ -274,7 +291,7 @@ export abstract class DuckDBWASMConnection extends DuckDBCommon {
         this.databasePath = arg.databasePath;
       }
       if (typeof arg.workingDirectory === 'string') {
-        this.workingDirectory = arg.workingDirectory;
+        this.workingDirectory = fileURLToVirtualPath(arg.workingDirectory);
       }
       if (typeof arg.motherDuckToken === 'string') {
         this.motherDuckToken = arg.motherDuckToken;


### PR DESCRIPTION
A DuckDB source over a glob of relative files — `read_parquet('data/*.parquet')` — finds nothing under the default connection, even when the files sit right under the project root the connection is supposed to resolve against.

The DuckDB `workingDirectory` defaults to `config.rootDirectory`, which the config stack carries as a `file://` URL string. That URL was fed verbatim into `SET FILE_SEARCH_PATH`. DuckDB doesn't read `file:` there, treats the value as a relative path, and joins it to the process cwd — so every relative read resolves against a directory that doesn't exist.

The fix decodes a `file://` URL to a real path before it reaches DuckDB. Both connections were affected and both are fixed: the native connection at its path-canonicalization boundary (Node `fileURLToPath`), and the wasm connection at its constructor boundary (WHATWG `URL`, since that layer runs in a browser).
