### PR TITLE
Resolve relative DuckDB databasePath against workingDirectory

### DIFF
--- a/packages/malloy-db-duckdb/src/duckdb_config.spec.ts
+++ b/packages/malloy-db-duckdb/src/duckdb_config.spec.ts
@@ -86,6 +86,64 @@ describe('normalizeDuckDBConfig', () => {
     expect(normalized.workingDirectory).toEqual(canonical(workingDirectory));
   });
 
+  it('resolves a relative databasePath against workingDirectory', () => {
+    const normalized = normalizeDuckDBConfig(
+      baseConfig({workingDirectory, databasePath: 'analytics.duckdb'})
+    );
+
+    expect(normalized.databasePath).toEqual(
+      path.join(canonical(workingDirectory), 'analytics.duckdb')
+    );
+  });
+
+  it('resolves a relative databasePath against a file:// URL workingDirectory', () => {
+    const normalized = normalizeDuckDBConfig(
+      baseConfig({
+        workingDirectory: pathToFileURL(workingDirectory).toString(),
+        databasePath: 'nested/analytics.duckdb',
+      })
+    );
+
+    expect(normalized.databasePath).toEqual(
+      path.join(canonical(workingDirectory), 'nested', 'analytics.duckdb')
+    );
+  });
+
+  it('leaves an absolute databasePath untouched by workingDirectory', () => {
+    // A real file so the result is the path verbatim (no missing-leaf
+    // canonicalization) — proving an absolute path passes through and is not
+    // re-anchored under workingDirectory.
+    const absolute = path.join(allowedA, 'analytics.duckdb');
+    fs.writeFileSync(absolute, '');
+    const normalized = normalizeDuckDBConfig(
+      baseConfig({workingDirectory, databasePath: absolute})
+    );
+
+    expect(normalized.databasePath).toEqual(canonical(absolute));
+    expect(normalized.databasePath).not.toContain(canonical(workingDirectory));
+  });
+
+  it('falls back to cwd for a relative databasePath with no workingDirectory', () => {
+    const normalized = normalizeDuckDBConfig(
+      baseConfig({databasePath: 'analytics.duckdb'})
+    );
+
+    expect(normalized.databasePath).toEqual(
+      path.join(canonical(process.cwd()), 'analytics.duckdb')
+    );
+  });
+
+  it('does not resolve :memory: or remote databasePaths against workingDirectory', () => {
+    expect(
+      normalizeDuckDBConfig(baseConfig({workingDirectory})).databasePath
+    ).toEqual(':memory:');
+    expect(
+      normalizeDuckDBConfig(
+        baseConfig({workingDirectory, databasePath: 'md:malloy'})
+      ).databasePath
+    ).toEqual('md:malloy');
+  });
+
   it('does not invent allowedDirectories outside sandboxed mode', () => {
     const normalized = normalizeDuckDBConfig(baseConfig());
 

--- a/packages/malloy-db-duckdb/src/duckdb_config.ts
+++ b/packages/malloy-db-duckdb/src/duckdb_config.ts
@@ -224,7 +224,10 @@ export function normalizeDuckDBConfig(
     );
   }
 
-  const databasePath = canonicalizeDatabasePath(rawDatabasePath);
+  const databasePath = canonicalizeDatabasePath(
+    rawDatabasePath,
+    workingDirectory
+  );
   const isMotherDuck = isMotherDuckPath(databasePath);
   if (restricted && !isAllowedClosedNetworkDatabasePath(databasePath)) {
     throw new DuckDBConfigValidationError(
@@ -562,11 +565,22 @@ function deriveRestrictedSecretDirectory({
   );
 }
 
-function canonicalizeDatabasePath(databasePath: string): string {
+// A relative `databasePath` resolves against `workingDirectory` (which itself
+// defaults to the project root via `{config: 'rootDirectory'}`), keeping a
+// config file portable — `databasePath: "analytics.duckdb"` names the database
+// alongside the project regardless of where the host process is launched.
+// `:memory:` and remote schemes are taken as-is; absolute paths ignore the
+// base; with no `workingDirectory` set, a relative path falls back to the cwd.
+function canonicalizeDatabasePath(
+  databasePath: string,
+  workingDirectory: string | undefined
+): string {
   if (databasePath === ':memory:' || isLikelyRemoteDatabasePath(databasePath)) {
     return databasePath;
   }
-  return canonicalizeConfigPath(databasePath, 'databasePath');
+  return canonicalizeConfigPath(databasePath, 'databasePath', {
+    baseDirectory: workingDirectory,
+  });
 }
 
 // A config path can arrive as a `file://` URL rather than a plain path —

--- a/packages/malloy-db-duckdb/src/path_security.ts
+++ b/packages/malloy-db-duckdb/src/path_security.ts
@@ -8,6 +8,10 @@ import path from 'path';
 
 export interface CanonicalPathOptions {
   mustExist?: boolean;
+  // Anchor for relative inputs. Defaults to the process cwd (plain
+  // `path.resolve`). Absolute inputs ignore it. Lets a config path resolve
+  // against the project root rather than wherever the host happens to run.
+  baseDirectory?: string;
 }
 
 export function isPosixHost(): boolean {
@@ -16,13 +20,16 @@ export function isPosixHost(): boolean {
 
 export function canonicalizePath(
   input: string,
-  {mustExist = false}: CanonicalPathOptions = {}
+  {mustExist = false, baseDirectory}: CanonicalPathOptions = {}
 ): string {
   if (input.trim() === '') {
     throw new Error('path must not be empty');
   }
 
-  const resolved = path.resolve(input);
+  const resolved =
+    baseDirectory !== undefined
+      ? path.resolve(baseDirectory, input)
+      : path.resolve(input);
   const canonical = (() => {
     try {
       return fs.realpathSync.native(resolved);


### PR DESCRIPTION
A relative `databasePath` in a DuckDB connection config resolved against the process working directory, so the same `malloy-config.json` behaved differently depending on where the host was launched and could not point at a database file relative to the project.

This resolves a relative `databasePath` against `workingDirectory` instead — which already defaults to the project root via `{config: 'rootDirectory'}`, and is how every other DuckDB config path (`tempDirectory`, `extensionDirectory`, `allowedDirectories`) already resolves. So `databasePath: "analytics.duckdb"` now names the database alongside the project regardless of the launch directory.

Absolute paths, `:memory:`, and remote schemes (MotherDuck, `scheme://`) are unaffected; with no `workingDirectory` configured a relative path still falls back to the process cwd, preserving today's behavior where there's no project root to anchor to.

The base resolution is threaded through an optional `baseDirectory` on the shared path canonicalizer rather than special-cased at the databasePath site, which keeps a single canonicalization entry point and makes the same anchoring trivial to extend to the other DuckDB paths later.

WASM is deliberately untouched — the virtual filesystem makes "resolve against a directory" a different question, and there's no user asking for it yet.