### PR TITLE
Highlight Malloy tags as MOTLY (embed source.motly)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@malloydata/db-bigquery": "*",
         "@malloydata/db-mysql": "*",
         "@malloydata/malloy": "*",
-        "@malloydata/motly-ts-parser": "^0.7.1",
+        "@malloydata/motly-ts-parser": "^0.9.0",
         "@malloydata/render": "*",
         "@types/fs-extra": "^9.0.13",
         "@types/jest": "^29.0.3",
@@ -6394,10 +6394,9 @@
       "link": true
     },
     "node_modules/@malloydata/motly-ts-parser": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@malloydata/motly-ts-parser/-/motly-ts-parser-0.7.1.tgz",
-      "integrity": "sha512-zL08Dkbzlx+m2Br4lAlcaV/xHlxnLRsJWcAfTNpjuI5Amy5cYBJwPEvkEAUaXCU8JVT5XuR2MtEyJufYaw5pjw==",
-      "dev": true,
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@malloydata/motly-ts-parser/-/motly-ts-parser-0.9.0.tgz",
+      "integrity": "sha512-r3OneNVn3734XV3C4NS4xg/VbVDIVaF3/zxorBCuNUihpPV+JHe2KyfDcFVBJligJxGKkHiFtEu0uw98B9budA==",
       "license": "MIT"
     },
     "node_modules/@malloydata/render": {
@@ -30515,7 +30514,7 @@
       "version": "0.0.409",
       "license": "MIT",
       "dependencies": {
-        "@malloydata/motly-ts-parser": "^0.8.0",
+        "@malloydata/motly-ts-parser": "^0.9.0",
         "assert": "^2.0.0"
       },
       "devDependencies": {
@@ -30525,12 +30524,6 @@
       "engines": {
         "node": ">=20"
       }
-    },
-    "packages/malloy-tag/node_modules/@malloydata/motly-ts-parser": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@malloydata/motly-ts-parser/-/motly-ts-parser-0.8.0.tgz",
-      "integrity": "sha512-8XMLGd0EDH1llOpwHrmV3hW/xZDXVkK+sbxZe8mKD7d2f4X8RZMsqBXPQk+Yve8OKsxSm9Y1eI8ViAOPLxQSjQ==",
-      "license": "MIT"
     },
     "packages/malloy-tag/node_modules/glob": {
       "version": "11.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -30491,6 +30491,7 @@
       "version": "0.0.409",
       "license": "MIT",
       "devDependencies": {
+        "@malloydata/motly-ts-parser": "^0.9.0",
         "@types/jasmine": "^4.3.5",
         "http-server": "^14.1.1",
         "jasmine-core": "^5.1.1",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "@malloydata/db-bigquery": "*",
     "@malloydata/db-mysql": "*",
     "@malloydata/malloy": "*",
-    "@malloydata/motly-ts-parser": "^0.7.1",
+    "@malloydata/motly-ts-parser": "^0.9.0",
     "@malloydata/render": "*",
     "@types/fs-extra": "^9.0.13",
     "@types/jest": "^29.0.3",

--- a/packages/malloy-syntax-highlight/grammars/malloy/corpus.json
+++ b/packages/malloy-syntax-highlight/grammars/malloy/corpus.json
@@ -91,6 +91,17 @@
       ]
     },
     {
+      "name": "bare backtick is a quoted identifier, not a string",
+      "code": "dimension: `weird name` is 1",
+      "expect": [
+        {
+          "text": "`weird name`",
+          "lexer": "BQ_STRING",
+          "scope": "variable.other.quoted.malloy"
+        }
+      ]
+    },
+    {
       "name": "regex literal r'...' and /'...'",
       "code": "where: state ~ r'C.' | /'N.'",
       "expect": [

--- a/packages/malloy-syntax-highlight/grammars/malloy/corpus.json
+++ b/packages/malloy-syntax-highlight/grammars/malloy/corpus.json
@@ -236,28 +236,28 @@
         {
           "text": "bar_chart",
           "lexer": "ANNOTATION",
-          "scope": "entity.name.tag.malloy"
+          "scope": "entity.name.tag.motly"
         }
       ]
     },
     {
-      "name": "annotation: key=value (bare value shares the tag-name scope in v1)",
+      "name": "annotation: key=value (MOTLY distinguishes key from unquoted-string value)",
       "code": "# size=large",
       "expect": [
         {
           "text": "size",
           "lexer": "ANNOTATION",
-          "scope": "entity.name.tag.malloy"
+          "scope": "entity.name.tag.motly"
         },
         {
           "text": "=",
           "lexer": "ANNOTATION",
-          "scope": "keyword.operator.assignment.malloy"
+          "scope": "keyword.operator.assignment.motly"
         },
         {
           "text": "large",
           "lexer": "ANNOTATION",
-          "scope": "entity.name.tag.malloy"
+          "scope": "string.unquoted.motly"
         }
       ]
     },
@@ -268,12 +268,12 @@
         {
           "text": "-",
           "lexer": "ANNOTATION",
-          "scope": "keyword.operator.negation.malloy"
+          "scope": "keyword.operator.negation.motly"
         },
         {
           "text": "hidden",
           "lexer": "ANNOTATION",
-          "scope": "entity.name.tag.malloy"
+          "scope": "entity.name.tag.motly"
         }
       ]
     },
@@ -284,12 +284,12 @@
         {
           "text": "title",
           "lexer": "ANNOTATION",
-          "scope": "entity.name.tag.malloy"
+          "scope": "entity.name.tag.motly"
         },
         {
           "text": "\"Hi There\"",
           "lexer": "ANNOTATION",
-          "scope": "string.quoted.double.malloy"
+          "scope": "string.quoted.double.motly"
         }
       ]
     },
@@ -305,7 +305,7 @@
         {
           "text": "dialect",
           "lexer": "DOC_ANNOTATION",
-          "scope": "entity.name.tag.malloy"
+          "scope": "entity.name.tag.motly"
         }
       ]
     },
@@ -321,7 +321,7 @@
         {
           "text": "internal",
           "lexer": "DOC_ANNOTATION",
-          "scope": "entity.name.tag.malloy"
+          "scope": "entity.name.tag.motly"
         }
       ]
     },
@@ -338,7 +338,7 @@
         {
           "text": "size",
           "lexer": "BLOCK_ANNOTATION_TEXT",
-          "scope": "entity.name.tag.malloy"
+          "scope": "entity.name.tag.motly"
         },
         {
           "text": "|#",

--- a/packages/malloy-syntax-highlight/grammars/malloy/corpus.spec.ts
+++ b/packages/malloy-syntax-highlight/grammars/malloy/corpus.spec.ts
@@ -105,7 +105,7 @@ describe('syntax-highlight corpus — TextMate scopes', () => {
   for (const c of corpus.cases) {
     describe(c.name, () => {
       for (const e of c.expect) {
-        test(`${JSON.stringify(e.text)} → ${e.scope}`, () => {
+        it(`${JSON.stringify(e.text)} → ${e.scope}`, () => {
           const scopes = scopesAt(grammar, c.code, e.text);
           expect(scopes).toBeDefined();
           expect(scopes).toContain(e.scope);

--- a/packages/malloy-syntax-highlight/grammars/malloy/corpus.spec.ts
+++ b/packages/malloy-syntax-highlight/grammars/malloy/corpus.spec.ts
@@ -39,6 +39,12 @@ interface Corpus {
 }
 
 const grammarPath = pathJoin(__dirname, 'malloy.tmGrammar.json');
+// MOTLY is embedded in annotation (tag) bodies; load the real grammar shipped
+// by @malloydata/motly-ts-parser so the embed resolves while tokenizing.
+const motlyGrammarPath = pathJoin(
+  __dirname,
+  '../../../../node_modules/@malloydata/motly-ts-parser/grammar/source.motly.tmGrammar.json'
+);
 const corpusPath = pathJoin(__dirname, 'corpus.json');
 const corpus: Corpus = JSON.parse(readFileSync(corpusPath, 'utf8'));
 
@@ -62,7 +68,13 @@ async function loadMalloyGrammar(): Promise<IGrammar> {
       if (scopeName === 'source.malloy') {
         return parseRawGrammar(readFileSync(grammarPath, 'utf8'), grammarPath);
       }
-      return null; // embedded grammars (source.sql) not bundled for this test
+      if (scopeName === 'source.motly') {
+        return parseRawGrammar(
+          readFileSync(motlyGrammarPath, 'utf8'),
+          motlyGrammarPath
+        );
+      }
+      return null; // other embedded grammars (source.sql) not bundled for this test
     },
   });
   const grammar = await registry.loadGrammar('source.malloy');

--- a/packages/malloy-syntax-highlight/grammars/malloy/malloy.monarch.ts
+++ b/packages/malloy-syntax-highlight/grammars/malloy/malloy.monarch.ts
@@ -287,7 +287,7 @@ export const monarch: Monaco.IMonarchLanguage = {
         'constant.numeric.date',
       ],
     ],
-    identifiers_quoted: [[/`[^`]*`/, 'variable.other.quoted']],
+    identifiers_quoted: [[/`[^`]*`/, 'variable.other.quoted.malloy']],
     types: [
       [
         /\b(boolean|date|json|number|string|timestamp|timestamptz)\b/,

--- a/packages/malloy-syntax-highlight/grammars/malloy/malloy.tmGrammar.json
+++ b/packages/malloy-syntax-highlight/grammars/malloy/malloy.tmGrammar.json
@@ -245,7 +245,7 @@
       ]
     },
     "tags": {
-      "comment": "Malloy annotations are ROUTED (annotation-prefix.ts parsePrefix; docs.malloydata.dev/documentation/language/tags). The sigil is ##? then an optional block '|'; the route follows it (up to first whitespace) and decides how the content reads. Tag routes — empty (MOTLY) and the claimed sigils ! @ : — carry tag property-language → tag styling. The documentation route (\") and app-defined bracketed routes ( () <> [] {} ) carry prose/markdown/JSON → documentation styling. Routes apply identically to single-line (#/##) and block (#|/##|) forms. The doc-route fragment is repeated per rule because TextMate has no regex variables; (?!docroute) on the tag rules both implements the split and keeps the prefix-sharing begin scanner from dropping the shorter tag begins. v1: bare tag values share the tag-name scope; tag-route block bodies get tag-content treatment.",
+      "comment": "Malloy annotations are ROUTED (annotation-prefix.ts parsePrefix; docs.malloydata.dev/documentation/language/tags). The sigil is ##? then an optional block '|'; the route follows it (up to first whitespace) and decides how the content reads. Tag routes — empty (MOTLY) and the claimed sigils ! @ : — carry tag property-language → tag styling. The documentation route (\") and app-defined bracketed routes ( () <> [] {} ) carry prose/markdown/JSON → documentation styling. Routes apply identically to single-line (#/##) and block (#|/##|) forms. The doc-route fragment is repeated per rule because TextMate has no regex variables; (?!docroute) on the tag rules both implements the split and keeps the prefix-sharing begin scanner from dropping the shorter tag begins. Tag-route bodies (line and block alike) embed source.motly — the MOTLY tag-property language (@malloydata/motly-ts-parser) — so keys, values, references, @-literals, arrays, and nested blocks highlight as MOTLY.",
       "patterns": [
         {
           "begin": "^([ \\t]*)(##\\|(?:\"|\\([^\\s)]*\\)|<[^\\s>]*>|\\[[^\\s\\]]*\\]|\\{[^\\s}]*\\}))",
@@ -278,7 +278,7 @@
           "name": "meta.annotation.block.malloy",
           "patterns": [
             {
-              "include": "#tag-content"
+              "include": "source.motly"
             }
           ]
         },
@@ -313,7 +313,7 @@
           "name": "meta.annotation.block.malloy",
           "patterns": [
             {
-              "include": "#tag-content"
+              "include": "source.motly"
             }
           ]
         },
@@ -338,37 +338,11 @@
           "name": "meta.annotation.line.malloy",
           "patterns": [
             {
-              "include": "#tag-content"
+              "include": "source.motly"
             }
           ]
         }
-      ],
-      "repository": {
-        "tag-content": {
-          "patterns": [
-            {
-              "match": "\"[^\"#]*\"",
-              "name": "string.quoted.double.malloy"
-            },
-            {
-              "match": "=",
-              "name": "keyword.operator.assignment.malloy"
-            },
-            {
-              "match": "-(?=[A-Za-z_])",
-              "name": "keyword.operator.negation.malloy"
-            },
-            {
-              "match": "[0-9][A-Za-z_0-9.]*",
-              "name": "constant.numeric.malloy"
-            },
-            {
-              "match": "[A-Za-z_][A-Za-z_0-9.]*",
-              "name": "entity.name.tag.malloy"
-            }
-          ]
-        }
-      }
+      ]
     },
     "strings": {
       "comment": "Order matters: f-/s-/r- prefixed forms begin one char earlier than a bare quote so they win by start position; among same-start ties the triple forms are listed before the single/double forms. Filter (f...) and raw (s...) bodies are opaque in v1 — no inner patterns. The bare triple string has NO interpolation pattern, so %{ } inside it stays plain string text (interpolation is only legal inside .sql(), handled by #sql-string).",

--- a/packages/malloy-syntax-highlight/grammars/malloy/malloy.tmGrammar.json
+++ b/packages/malloy-syntax-highlight/grammars/malloy/malloy.tmGrammar.json
@@ -173,7 +173,7 @@
       "patterns": [
         {
           "match": "`[^`]*`",
-          "name": "variable.other.quoted"
+          "name": "variable.other.quoted.malloy"
         }
       ]
     },

--- a/packages/malloy-syntax-highlight/grammars/malloy/tokenizations/darkPlus.ts
+++ b/packages/malloy-syntax-highlight/grammars/malloy/tokenizations/darkPlus.ts
@@ -589,7 +589,7 @@ export default [
         {startIndex: 14, type: ['source.malloy'], color: '#000000'},
         {
           startIndex: 15,
-          type: ['source.malloy', 'variable.other.quoted'],
+          type: ['source.malloy', 'variable.other.quoted.malloy'],
           color: '#9CDCFE',
         },
         {startIndex: 40, type: ['source.malloy'], color: '#000000'},
@@ -649,7 +649,7 @@ export default [
       tokens: [
         {
           startIndex: 0,
-          type: ['source.malloy', 'variable.other.quoted'],
+          type: ['source.malloy', 'variable.other.quoted.malloy'],
           color: '#9CDCFE',
         },
         {startIndex: 19, type: ['source.malloy'], color: '#000000'},
@@ -697,7 +697,7 @@ export default [
         {startIndex: 60, type: ['source.malloy'], color: '#000000'},
         {
           startIndex: 63,
-          type: ['source.malloy', 'variable.other.quoted'],
+          type: ['source.malloy', 'variable.other.quoted.malloy'],
           color: '#9CDCFE',
         },
         {startIndex: 67, type: ['source.malloy'], color: '#000000'},
@@ -773,7 +773,7 @@ export default [
       tokens: [
         {
           startIndex: 0,
-          type: ['source.malloy', 'variable.other.quoted'],
+          type: ['source.malloy', 'variable.other.quoted.malloy'],
           color: '#9CDCFE',
         },
         {startIndex: 6, type: ['source.malloy'], color: '#000000'},

--- a/packages/malloy-syntax-highlight/grammars/malloy/tokenizations/darkPlus.ts
+++ b/packages/malloy-syntax-highlight/grammars/malloy/tokenizations/darkPlus.ts
@@ -1437,7 +1437,7 @@ export default [
           type: [
             'source.malloy',
             'meta.annotation.block.malloy',
-            'entity.name.tag.malloy',
+            'entity.name.tag.motly',
           ],
           color: '#569CD6',
         },
@@ -1446,7 +1446,7 @@ export default [
           type: [
             'source.malloy',
             'meta.annotation.block.malloy',
-            'keyword.operator.assignment.malloy',
+            'keyword.operator.assignment.motly',
           ],
           color: '#D4D4D4',
         },
@@ -1455,9 +1455,9 @@ export default [
           type: [
             'source.malloy',
             'meta.annotation.block.malloy',
-            'entity.name.tag.malloy',
+            'string.unquoted.motly',
           ],
-          color: '#569CD6',
+          color: '#CE9178',
         },
         {
           startIndex: 20,
@@ -1469,7 +1469,7 @@ export default [
           type: [
             'source.malloy',
             'meta.annotation.block.malloy',
-            'entity.name.tag.malloy',
+            'entity.name.tag.motly',
           ],
           color: '#569CD6',
         },
@@ -1478,7 +1478,7 @@ export default [
           type: [
             'source.malloy',
             'meta.annotation.block.malloy',
-            'keyword.operator.assignment.malloy',
+            'keyword.operator.assignment.motly',
           ],
           color: '#D4D4D4',
         },
@@ -1487,9 +1487,9 @@ export default [
           type: [
             'source.malloy',
             'meta.annotation.block.malloy',
-            'entity.name.tag.malloy',
+            'string.unquoted.motly',
           ],
-          color: '#569CD6',
+          color: '#CE9178',
         },
       ],
     },
@@ -1564,7 +1564,7 @@ export default [
           type: [
             'source.malloy',
             'meta.annotation.block.malloy',
-            'entity.name.tag.malloy',
+            'entity.name.tag.motly',
           ],
           color: '#569CD6',
         },
@@ -1573,7 +1573,7 @@ export default [
           type: [
             'source.malloy',
             'meta.annotation.block.malloy',
-            'keyword.operator.assignment.malloy',
+            'keyword.operator.assignment.motly',
           ],
           color: '#D4D4D4',
         },
@@ -1582,9 +1582,9 @@ export default [
           type: [
             'source.malloy',
             'meta.annotation.block.malloy',
-            'entity.name.tag.malloy',
+            'string.unquoted.motly',
           ],
-          color: '#569CD6',
+          color: '#CE9178',
         },
       ],
     },
@@ -1631,7 +1631,7 @@ export default [
           type: [
             'source.malloy',
             'meta.annotation.block.malloy',
-            'entity.name.tag.malloy',
+            'entity.name.tag.motly',
           ],
           color: '#569CD6',
         },
@@ -1645,7 +1645,7 @@ export default [
           type: [
             'source.malloy',
             'meta.annotation.block.malloy',
-            'entity.name.tag.malloy',
+            'entity.name.tag.motly',
           ],
           color: '#569CD6',
         },
@@ -1659,7 +1659,7 @@ export default [
           type: [
             'source.malloy',
             'meta.annotation.block.malloy',
-            'entity.name.tag.malloy',
+            'entity.name.tag.motly',
           ],
           color: '#569CD6',
         },
@@ -1673,7 +1673,7 @@ export default [
           type: [
             'source.malloy',
             'meta.annotation.block.malloy',
-            'entity.name.tag.malloy',
+            'entity.name.tag.motly',
           ],
           color: '#569CD6',
         },
@@ -1687,12 +1687,21 @@ export default [
           type: [
             'source.malloy',
             'meta.annotation.block.malloy',
-            'entity.name.tag.malloy',
+            'entity.name.tag.motly',
           ],
           color: '#569CD6',
         },
         {
           startIndex: 25,
+          type: [
+            'source.malloy',
+            'meta.annotation.block.malloy',
+            'punctuation.separator.motly',
+          ],
+          color: '#000000',
+        },
+        {
+          startIndex: 26,
           type: ['source.malloy', 'meta.annotation.block.malloy'],
           color: '#000000',
         },
@@ -1701,7 +1710,7 @@ export default [
           type: [
             'source.malloy',
             'meta.annotation.block.malloy',
-            'entity.name.tag.malloy',
+            'entity.name.tag.motly',
           ],
           color: '#569CD6',
         },
@@ -1720,12 +1729,21 @@ export default [
           type: [
             'source.malloy',
             'meta.annotation.block.malloy',
-            'entity.name.tag.malloy',
+            'entity.name.tag.motly',
           ],
           color: '#569CD6',
         },
         {
           startIndex: 8,
+          type: [
+            'source.malloy',
+            'meta.annotation.block.malloy',
+            'keyword.operator.assignment.motly',
+          ],
+          color: '#D4D4D4',
+        },
+        {
+          startIndex: 9,
           type: ['source.malloy', 'meta.annotation.block.malloy'],
           color: '#000000',
         },
@@ -1734,7 +1752,7 @@ export default [
           type: [
             'source.malloy',
             'meta.annotation.block.malloy',
-            'entity.name.tag.malloy',
+            'entity.name.tag.motly',
           ],
           color: '#569CD6',
         },
@@ -1748,7 +1766,7 @@ export default [
           type: [
             'source.malloy',
             'meta.annotation.block.malloy',
-            'entity.name.tag.malloy',
+            'entity.name.tag.motly',
           ],
           color: '#569CD6',
         },
@@ -1762,7 +1780,7 @@ export default [
           type: [
             'source.malloy',
             'meta.annotation.block.malloy',
-            'entity.name.tag.malloy',
+            'entity.name.tag.motly',
           ],
           color: '#569CD6',
         },
@@ -1781,7 +1799,7 @@ export default [
           type: [
             'source.malloy',
             'meta.annotation.block.malloy',
-            'entity.name.tag.malloy',
+            'entity.name.tag.motly',
           ],
           color: '#569CD6',
         },
@@ -1795,7 +1813,7 @@ export default [
           type: [
             'source.malloy',
             'meta.annotation.block.malloy',
-            'entity.name.tag.malloy',
+            'entity.name.tag.motly',
           ],
           color: '#569CD6',
         },
@@ -1809,7 +1827,7 @@ export default [
           type: [
             'source.malloy',
             'meta.annotation.block.malloy',
-            'entity.name.tag.malloy',
+            'entity.name.tag.motly',
           ],
           color: '#569CD6',
         },
@@ -1823,7 +1841,7 @@ export default [
           type: [
             'source.malloy',
             'meta.annotation.block.malloy',
-            'entity.name.tag.malloy',
+            'entity.name.tag.motly',
           ],
           color: '#569CD6',
         },
@@ -1838,27 +1856,13 @@ export default [
           color: '#000000',
         },
         {
-          startIndex: 5,
+          startIndex: 2,
           type: [
             'source.malloy',
             'meta.annotation.block.malloy',
-            'entity.name.tag.malloy',
+            'comment.line.number-sign.motly',
           ],
-          color: '#569CD6',
-        },
-        {
-          startIndex: 9,
-          type: ['source.malloy', 'meta.annotation.block.malloy'],
-          color: '#000000',
-        },
-        {
-          startIndex: 10,
-          type: [
-            'source.malloy',
-            'meta.annotation.block.malloy',
-            'entity.name.tag.malloy',
-          ],
-          color: '#569CD6',
+          color: '#6A9955',
         },
       ],
     },
@@ -1869,6 +1873,15 @@ export default [
           startIndex: 0,
           type: ['source.malloy', 'meta.annotation.block.malloy'],
           color: '#000000',
+        },
+        {
+          startIndex: 5,
+          type: [
+            'source.malloy',
+            'meta.annotation.block.malloy',
+            'comment.line.number-sign.motly',
+          ],
+          color: '#6A9955',
         },
       ],
     },

--- a/packages/malloy-syntax-highlight/package.json
+++ b/packages/malloy-syntax-highlight/package.json
@@ -27,6 +27,7 @@
   },
   "license": "MIT",
   "devDependencies": {
+    "@malloydata/motly-ts-parser": "^0.9.0",
     "@types/jasmine": "^4.3.5",
     "http-server": "^14.1.1",
     "jasmine-core": "^5.1.1",

--- a/packages/malloy-syntax-highlight/test/config/textmate/malloyDarkPlusConfig.ts
+++ b/packages/malloy-syntax-highlight/test/config/textmate/malloyDarkPlusConfig.ts
@@ -12,7 +12,18 @@ const malloyDarkPlusConfig: TextmateTestConfig = {
     id: 'malloy',
     scopeName: 'source.malloy',
     definition: '../grammars/malloy/malloy.tmGrammar.json',
-    embeddedLanguages: [stubEmbeddedTextmateLanguage('sql', 'source.sql')],
+    embeddedLanguages: [
+      stubEmbeddedTextmateLanguage('sql', 'source.sql'),
+      // MOTLY is the tag-property language embedded in annotation bodies. Unlike
+      // the SQL stub, we register the real grammar so the snapshot reflects its
+      // actual scopes. Path is relative to test/ (where the loader resolves it).
+      {
+        id: 'motly',
+        scopeName: 'source.motly',
+        definition:
+          '../../../node_modules/@malloydata/motly-ts-parser/grammar/source.motly.tmGrammar.json',
+      },
+    ],
   },
   theme: {
     id: 'vs-dark-plus',

--- a/packages/malloy-syntax-highlight/tsconfig.json
+++ b/packages/malloy-syntax-highlight/tsconfig.json
@@ -13,6 +13,5 @@
     "test/config/**/*.ts",
     "test/testUtils.ts",
     "test/generateMonarchTokenizations.ts"
-  ],
-  "exclude": ["**/*.spec.ts"],
+  ]
 }

--- a/packages/malloy-tag/package.json
+++ b/packages/malloy-tag/package.json
@@ -29,7 +29,7 @@
     "generate-flow": "node ../../scripts/femto-build.js flow"
   },
   "dependencies": {
-    "@malloydata/motly-ts-parser": "^0.8.0",
+    "@malloydata/motly-ts-parser": "^0.9.0",
     "assert": "^2.0.0"
   },
   "devDependencies": {

--- a/scripts/femto-build.js
+++ b/scripts/femto-build.js
@@ -97,7 +97,8 @@ if (errors.length > 0) {
   }
   process.exit(1);
 }
-const allConfig = session.getMot({env: process.env});
+const result = session.finish();
+const allConfig = result.getMot({env: process.env});
 
 function validateTarget(name) {
   const config = allConfig.get(name);


### PR DESCRIPTION
Update MOTLY and pick up the new MOTLY tmGrammar, weave it into the main grammar so tags will highlight

Two smaller fixes ride along:
- The quoted-identifier scope gains the `.malloy` suffix the rest of the grammar uses (`variable.other.quoted` → `variable.other.quoted.malloy`).
- Dropping a `**/*.spec.ts` tsconfig exclude in the syntax-highlight package, so the spec files type-check under `npm run build` and resolve in the editor (the exclude had let a Jasmine-vs-Jest global error slip past the build).
