### PR TITLE
Recognize all .sql() SQL-block forms

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "profile": "ts-node scripts/profiler",
     "malloyc": "ts-node scripts/malloy-to-json",
     "build-duckdb-db": "ts-node scripts/build_duckdb_test_database",
+    "setup-new-checkout": "scripts/setup-new-checkout.sh",
     "ping-db": "ts-node ./test/bin/ping_db.ts"
   },
   "devDependencies": {

--- a/packages/malloy-syntax-highlight/grammars/malloy/corpus.json
+++ b/packages/malloy-syntax-highlight/grammars/malloy/corpus.json
@@ -169,6 +169,62 @@
       ]
     },
     {
+      "name": "SQL block: backtick-quoted connection (connectionId is an `id` = IDENTIFIER | BQ_STRING)",
+      "code": "run: `my conn`.sql(\"SELECT 1\")",
+      "expect": [
+        {
+          "text": "`my conn`",
+          "lexer": "BQ_STRING",
+          "scope": "variable.other.malloy"
+        },
+        {
+          "text": "SELECT 1",
+          "lexer": "DQ_STRING",
+          "scope": "meta.embedded.block.sql.malloy"
+        }
+      ]
+    },
+    {
+      "name": "SQL block: Unicode connection name (ID_CHAR is [\\p{Alphabetic}_], not just A-Z)",
+      "code": "run: café.sql('SELECT 1')",
+      "expect": [
+        {
+          "text": "café",
+          "lexer": "IDENTIFIER",
+          "scope": "variable.other.malloy"
+        }
+      ]
+    },
+    {
+      "name": "SQL block: a raw s'...' string argument is SQL too",
+      "note": "The s prefix is consumed; the quote opens the SQL string. Lexer sees one RAW_SQ.",
+      "code": "run: duckdb.sql(s'SELECT 1')",
+      "expect": [
+        {
+          "text": "SELECT 1",
+          "lexer": "RAW_SQ",
+          "scope": "meta.embedded.block.sql.malloy"
+        }
+      ]
+    },
+    {
+      "name": "SQL block: the string may sit on a different line from .sql(",
+      "note": "Newlines/whitespace between .sql(, the string, and ) — the nested rule spans lines.",
+      "code": "foo.sql(\n\"SELECT * FROM STUFF\"\n)",
+      "expect": [
+        {
+          "text": "foo",
+          "lexer": "IDENTIFIER",
+          "scope": "variable.other.malloy"
+        },
+        {
+          "text": "SELECT * FROM STUFF",
+          "lexer": "DQ_STRING",
+          "scope": "meta.embedded.block.sql.malloy"
+        }
+      ]
+    },
+    {
       "name": "bare \"\"\" is a MULTI-LINE STRING, not SQL",
       "note": "Bare \"\"\" is a string, not SQL; the lexer over-fires SQL_BEGIN, so scope follows the parser.",
       "code": "dimension: doc is \"\"\"line one\nline two\"\"\"",

--- a/packages/malloy-syntax-highlight/grammars/malloy/malloy.monarch.ts
+++ b/packages/malloy-syntax-highlight/grammars/malloy/malloy.monarch.ts
@@ -13,7 +13,6 @@ export const monarch: Monaco.IMonarchLanguage = {
   tokenizer: {
     root: [{include: '@malloy_language'}],
     malloy_language: [
-      {include: '@sql_string'},
       {include: '@comments'},
       {include: '@strings'},
       {include: '@given'},
@@ -28,80 +27,6 @@ export const monarch: Monaco.IMonarchLanguage = {
       {include: '@constants'},
       {include: '@timeframes'},
       {include: '@identifiers_unquoted'},
-    ],
-    sql_string: [
-      [
-        /(\b[A-Za-z_][A-Za-z_0-9]*)(\s*\.\s*)((?:sql))(\s*\(\s*)(""")/,
-        [
-          'variable.other.malloy',
-          '',
-          'keyword.control.sql.malloy',
-          '',
-          {
-            next: '@sql_end_0',
-            nextEmbedded: 'sql',
-            token: 'punctuation.definition.string.begin.sql.malloy',
-          },
-        ],
-      ],
-      [
-        /(\b[A-Za-z_][A-Za-z_0-9]*)(\s*\.\s*)((?:sql))(\s*\(\s*)(")/,
-        [
-          'variable.other.malloy',
-          '',
-          'keyword.control.sql.malloy',
-          '',
-          {
-            next: '@sql_end_1',
-            nextEmbedded: 'sql',
-            token: 'punctuation.definition.string.begin.sql.malloy',
-          },
-        ],
-      ],
-      [
-        /(\b[A-Za-z_][A-Za-z_0-9]*)(\s*\.\s*)((?:sql))(\s*\(\s*)(')/,
-        [
-          'variable.other.malloy',
-          '',
-          'keyword.control.sql.malloy',
-          '',
-          {
-            next: '@sql_end_2',
-            nextEmbedded: 'sql',
-            token: 'punctuation.definition.string.begin.sql.malloy',
-          },
-        ],
-      ],
-    ],
-    sql_end_0: [
-      [
-        /"""/,
-        {
-          next: '@pop',
-          nextEmbedded: '@pop',
-          token: 'punctuation.definition.string.end.sql.malloy',
-        },
-      ],
-    ],
-    sql_end_1: [
-      [
-        /"/,
-        {
-          next: '@pop',
-          nextEmbedded: '@pop',
-          token: 'punctuation.definition.string.end.sql.malloy',
-        },
-      ],
-    ],
-    sql_end_2: [
-      [
-        /'/,
-        {
-          next: '@pop',
-          nextEmbedded: '@pop',
-          token: 'punctuation.definition.string.end.sql.malloy',
-        },
-      ],
     ],
     comments: [
       [/\/\*/, {next: '@comment_block_end', token: 'comment.block'}],

--- a/packages/malloy-syntax-highlight/grammars/malloy/malloy.tmGrammar.json
+++ b/packages/malloy-syntax-highlight/grammars/malloy/malloy.tmGrammar.json
@@ -93,34 +93,42 @@
       ]
     },
     "sql-string": {
-      "comment": "SQL-ness is the .sql() context, not the delimiter — any string argument to connection.sql(...) is SQL. ONE combined rule, not three per-quote siblings: vscode-textmate's begin scanner drops shorter begins that share a prefix with a longer one, so separate \"\"\"/\"/' rules leave only \"\"\" working. The opening quote is captured (group 5) and the end back-references it (\\5), so all three close correctly. #malloy-in-sql gives \"\"\" blocks their %{ } interpolation; it also (harmlessly) applies inside short SQL strings, where %{ } is not real interpolation but is vanishingly rare.",
+      "comment": "SQL-ness is the .sql() CONTEXT, not the delimiter — any string argument to connection.sql(...) is SQL (grammar: connectionId DOT SQL OPAREN (sqlString|shortString) CPAREN; connectionId is an `id`). Two NESTED rules so the string can sit on a different line from `.sql(` — a single begin regex cannot span the newline. The OUTER rule opens at `connection.sql(` and closes at the matching `)`; the INNER rule matches the string argument wherever it lands. connection matches an `id`: a Unicode identifier ([\\p{Alphabetic}_]… mirrors the lexer's ID_CHAR) or a backtick-quoted name. The inner quote absorbs an optional raw `s` prefix but captures only the quote, so the \\1 end back-reference closes all of '…', \"…\", s'…', s\"…\", and \"\"\"…\"\"\". #malloy-in-sql gives blocks their %{ } interpolation (harmless inside short/raw strings, where it is vanishingly rare).",
       "patterns": [
         {
-          "begin": "(\\b[A-Za-z_][A-Za-z_0-9]*)(\\s*\\.\\s*)((?i:sql))(\\s*\\(\\s*)(\"\"\"|\"|')",
-          "end": "\\5",
+          "begin": "(`[^`]*`|[\\p{Alphabetic}_][\\p{Alphabetic}_0-9]*)(\\s*\\.\\s*)((?i:sql))(\\s*\\(\\s*)",
+          "end": "\\)",
           "beginCaptures": {
             "1": {
               "name": "variable.other.malloy"
             },
             "3": {
               "name": "keyword.control.sql.malloy"
-            },
-            "5": {
-              "name": "punctuation.definition.string.begin.sql.malloy"
-            }
-          },
-          "endCaptures": {
-            "0": {
-              "name": "punctuation.definition.string.end.sql.malloy"
             }
           },
           "name": "meta.embedded.block.sql.malloy",
           "patterns": [
             {
-              "include": "#malloy-in-sql"
-            },
-            {
-              "include": "source.sql"
+              "begin": "(?:[sS]\\s*)?(\"\"\"|\"|')",
+              "end": "\\1",
+              "beginCaptures": {
+                "1": {
+                  "name": "punctuation.definition.string.begin.sql.malloy"
+                }
+              },
+              "endCaptures": {
+                "0": {
+                  "name": "punctuation.definition.string.end.sql.malloy"
+                }
+              },
+              "patterns": [
+                {
+                  "include": "#malloy-in-sql"
+                },
+                {
+                  "include": "source.sql"
+                }
+              ]
             }
           ]
         }

--- a/packages/malloy-syntax-highlight/grammars/malloy/tokenizations/darkPlus.ts
+++ b/packages/malloy-syntax-highlight/grammars/malloy/tokenizations/darkPlus.ts
@@ -1405,7 +1405,11 @@ export default [
           ],
           color: '#D4D4D4',
         },
-        {startIndex: 3, type: ['source.malloy'], color: '#000000'},
+        {
+          startIndex: 3,
+          type: ['source.malloy', 'meta.embedded.block.sql.malloy'],
+          color: '#D4D4D4',
+        },
       ],
     },
   ],

--- a/packages/malloy-syntax-highlight/scripts/generateMonarchGrammar.ts
+++ b/packages/malloy-syntax-highlight/scripts/generateMonarchGrammar.ts
@@ -520,9 +520,16 @@ function generateMonarchRules(
   const patterns = scope.patterns ? scope.patterns : [scope];
   for (const pattern of patterns) {
     if (pattern.include) {
-      // Annotations are Monarch-divergent — routed/column-matched tags need
-      // cross-state backreferences Monarch lacks — so #tags is not generated.
-      if (pattern.include === '#tags') continue;
+      // Some rules are Monarch-divergent and are not generated:
+      //  - #tags: routed/column-matched annotations need cross-state
+      //    backreferences Monarch lacks.
+      //  - #sql-string: the .sql(...) embedding is a nested begin/end (the
+      //    string may sit on a different line from the `(`) whose multi-line
+      //    embedding Monarch can't express. Both are exercised only in
+      //    monarchDivergentTestInput.
+      if (pattern.include === '#tags' || pattern.include === '#sql-string') {
+        continue;
+      }
       state.push({
         include: textmateToMonarchInclude(pattern.include),
       });

--- a/scripts/setup-new-checkout.sh
+++ b/scripts/setup-new-checkout.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+#
+# Set up a fresh checkout or `git worktree` for development:
+#   1. install dependencies
+#   2. build all workspace packages (so jest can resolve @malloydata/* and
+#      generated code exists)
+#   3. create the gitignored DuckDB test-fixture database
+#      (test/data/duckdb/duckdb_test.db) the duckdb test suites need
+#
+# A new git worktree shares .git but NOT node_modules or gitignored fixtures,
+# so run this once after `git worktree add` (or after a fresh clone).
+#
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+echo "==> [1/3] npm install"
+npm install
+
+echo "==> [2/3] npm run build"
+npm run build
+
+echo "==> [3/3] npm run build-duckdb-db"
+npm run build-duckdb-db
+
+echo "==> setup complete"


### PR DESCRIPTION
We overlooked some forms of SQL embedding in #2882 when we updated the TextMate grammar. With this change we recognize that a `.sql()` expression might span multiple lines, and that not all SQL strings are triple-quoted.
