### PR TITLE
Pin @databricks/sql to 1.15.0 (last pre-native release)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -120,6 +120,10 @@ Each database has its own package with connection handling and dialect-specific 
 - `malloy-db-trino/` - Trino/Presto adapter
 - `malloy-db-publisher/` - Publishing/caching layer
 
+#### Native-dependency pins (do not loosen casually)
+
+`snowflake-sdk` (`2.3.1`) and `@databricks/sql` (`1.15.0`) are pinned to exact, pre-native versions, not `^` ranges. Why isn't visible here: downstream clients (the VS Code extension, `malloy-cli`) bundle with esbuild, which can't bundle native `.node` binaries. Newer driver releases ship them, so an unpinned range floats one in and breaks those builds — caught only in their CI. Bumping past these requires externalize-and-ship work in each client first (their `check-native` guard trips otherwise).
+
 ### Supporting Libraries
 - `malloy-interfaces/` - TypeScript interfaces and Thrift-generated types
 - `malloy-render/` - Data visualization and rendering (see [packages/malloy-render/CONTEXT.md](packages/malloy-render/CONTEXT.md))

--- a/package-lock.json
+++ b/package-lock.json
@@ -3709,10 +3709,10 @@
       }
     },
     "node_modules/@databricks/sql": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@databricks/sql/-/sql-1.13.0.tgz",
-      "integrity": "sha512-xBuxCKmq3gR2fXnCzHsWkPujd5Vi/QxtHAyZXlj180v0fAqucIrG3SckSS5bpbF/NOH7uPLjolBUiZWDJ8E4xQ==",
-      "license": "Apache 2.0",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@databricks/sql/-/sql-1.15.0.tgz",
+      "integrity": "sha512-bbKxXB+A6KhXUGtjRFtXXLGBmFahcI6clzHLozr0WcddRFbLtrFgPtt7fYV9G237/OadIa5F0hLZKgSpKpaY9w==",
+      "license": "Apache-2.0",
       "dependencies": {
         "apache-arrow": "^13.0.0",
         "commander": "^9.3.0",
@@ -28864,7 +28864,7 @@
       "version": "0.0.412",
       "license": "MIT",
       "dependencies": {
-        "@databricks/sql": "^1.8.4",
+        "@databricks/sql": "1.15.0",
         "@malloydata/malloy": "0.0.412",
         "@types/node": "^22.7.4"
       },

--- a/packages/malloy-db-databricks/package.json
+++ b/packages/malloy-db-databricks/package.json
@@ -22,7 +22,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@databricks/sql": "^1.8.4",
+    "@databricks/sql": "1.15.0",
     "@malloydata/malloy": "0.0.412",
     "@types/node": "^22.7.4"
   }


### PR DESCRIPTION
`@databricks/sql` 1.16.0 introduced a native `.node` kernel (eight `@databricks/databricks-sql-kernel-*` binaries) that esbuild can't bundle, which broke the vscode-extension and malloy-cli builds. `db-databricks` declared a floating `^1.8.4` range, so the bump rode in on its own the moment 1.16.0 published — no malloy change asked for it.

Pin to `1.15.0`, the last pre-native release, exactly mirroring the `snowflake-sdk: "2.3.1"` pin already in `db-snowflake`. Unlike snowflake — whose native form is genuinely unworkable (it loads via `eval('require')`, invisible to esbuild) — databricks' kernel *is* externalizable, so this is a soft freeze: if the 1.16 native Arrow path is ever wanted downstream, the duckdb-style externalize-and-ship treatment is the way to take it. No reason to pay for that now.

Followup:
- [ ] After release, re-do the `@malloydata/*` bump in the vscode extension and malloy-cli (their 0.0.411 update PRs were closed over this).
