### PR TITLE
fix(render): surface an error for misconfigured/unhandled renderer tags instead of "[object Object]"

### DIFF
--- a/packages/malloy-render/docs/validation.md
+++ b/packages/malloy-render/docs/validation.md
@@ -51,6 +51,8 @@ getLogs()
 
 4. **Unread-tag detection** — After validation, any tag property the user wrote that no resolver, validator, or ownership spec touched becomes a warning. This is the safety net for misspellings and unknown tags.
 
+**Render-time surfacing.** A producer-#1 error on a field that then ends up with no matching renderer (it would otherwise stringify to `[object Object]` in the result panel) is also shown inline at render time, using the same `ErrorMessage` UI as producer #3's red tile (`apply-renderer`'s `default` branch reads `field.getValidationErrors()`). This is the decline-side counterpart to a plugin throw: when a renderer *declines* a field a validator has flagged, the user sees the error in the render, not only in the Problems panel. Fields that render fine (scalars, the `none` chart-child case, built-in renderers) are untouched.
+
 ### Tag ownership
 
 A renderer "owns" a tag when removing the renderer would make the tag meaningless (e.g., `viz.x` only matters when a chart is active). Ownership is declared on the factory:

--- a/packages/malloy-render/src/component/render.tsx
+++ b/packages/malloy-render/src/component/render.tsx
@@ -92,7 +92,10 @@ export function MalloyRender(props: MalloyRenderProps) {
   return (
     <ErrorBoundary
       fallback={errorProps => {
-        const message = () => errorProps.error?.message ?? errorProps;
+        // Solid hands the thrown value to the fallback directly; show its
+        // message or stringify it. The old code let the raw object fall through
+        // as a JSX child, which rendered as an empty error box.
+        const message = () => errorProps?.message ?? String(errorProps);
         props?.onError?.(errorProps);
         return <ErrorMessage message={message()} />;
       }}

--- a/packages/malloy-render/src/component/renderer/apply-renderer.tsx
+++ b/packages/malloy-render/src/component/renderer/apply-renderer.tsx
@@ -14,6 +14,7 @@ import type {RendererProps} from '@/component/types';
 import {PluginRenderContainer} from '@/component/renderer/plugin-render-container';
 import {renderCellValue} from '@/component/cell-utils';
 import type {CellFormatConfig} from '@/component/tag-configs';
+import {ErrorMessage} from '@/component/error-message/error-message';
 
 export function applyRenderer(props: RendererProps) {
   const {dataColumn, customProps = {}} = props;
@@ -94,11 +95,29 @@ export function applyRenderer(props: RendererProps) {
         break;
       }
       default: {
-        try {
-          renderValue = String(dataColumn.value);
-        } catch (err) {
-          // eslint-disable-next-line no-console
-          console.warn('Couldnt get value for ', field, dataColumn);
+        // A renderer tag resolved but no plugin/built-in handled the field.
+        const validationErrors = field.getValidationErrors();
+        const value = dataColumn.value;
+        if (validationErrors.length > 0) {
+          // The validator flagged this field (e.g. a misconfigured # big_value):
+          // show the specific reason rather than stringifying to '[object Object]'.
+          renderValue = <ErrorMessage message={validationErrors.join(' ')} />;
+        } else if (
+          renderAs === 'none' ||
+          value === null ||
+          typeof value !== 'object'
+        ) {
+          // 'none' (a record a parent renderer consumes, e.g. a chart child) and
+          // scalars keep the existing string fallback.
+          renderValue = String(value);
+        } else {
+          // A structured value with no renderer would stringify to
+          // '[object Object]'; surface it inline (not thrown).
+          renderValue = (
+            <ErrorMessage
+              message={`Malloy render: no renderer handled '${renderAs}' on field '${field.name}'. Check that the renderer tag is supported and applies to this field's shape.`}
+            />
+          );
         }
       }
     }

--- a/packages/malloy-render/src/data_tree/fields/base.ts
+++ b/packages/malloy-render/src/data_tree/fields/base.ts
@@ -41,6 +41,7 @@ export abstract class FieldBase {
   private _tagConfig: unknown = undefined;
   private _resolvedLabel: string | undefined;
   private _columnConfig: unknown = undefined;
+  private _validationErrors: string[] = [];
 
   // Get the plugins registered for this field
   getPlugins(): RenderPluginInstance[] {
@@ -93,6 +94,16 @@ export abstract class FieldBase {
 
   setColumnConfig(config: unknown): void {
     this._columnConfig = config;
+  }
+
+  // Validation errors recorded at setup (validateFieldTags) so applyRenderer can
+  // surface them instead of stringifying an unrenderable value to '[object Object]'.
+  addValidationError(message: string): void {
+    this._validationErrors.push(message);
+  }
+
+  getValidationErrors(): string[] {
+    return this._validationErrors;
   }
 
   renderAs(): string {

--- a/packages/malloy-render/src/render-field-metadata.ts
+++ b/packages/malloy-render/src/render-field-metadata.ts
@@ -10,6 +10,7 @@ import type {
   RenderFieldRegistry,
 } from '@/registry/types';
 import {RenderLogCollector} from '@/component/render-log-collector';
+import type {Tag} from '@malloydata/malloy-tag';
 import {resolveBuiltInTags} from '@/component/tag-configs';
 import {getBuiltInRendererValidationSpec} from '@/component/renderer-validation-specs';
 import {convertLegacyToVizTag} from '@/component/tag-utils';
@@ -185,7 +186,16 @@ export class RenderFieldMetadata {
   private validateFieldTags(field: Field): void {
     const tag = field.tag;
     const fieldType = getFieldType(field);
-    const log = this.logCollector;
+    // Errors are also recorded on the field so applyRenderer can surface them;
+    // warnings stay on the logs surface only.
+    const collector = this.logCollector;
+    const log = {
+      warn: (message: string, t?: Tag): void => collector.warn(message, t),
+      error: (message: string, t?: Tag): void => {
+        collector.error(message, t);
+        field.addValidationError(message);
+      },
+    };
 
     // --- Renderer tags on wrong field types ---
 

--- a/packages/malloy-render/src/stories/big_value.stories.malloy
+++ b/packages/malloy-render/src/stories/big_value.stories.malloy
@@ -344,4 +344,25 @@ source: big_value_orders is duckdb.table("static/data/order_items.parquet") exte
       limit: 24
     }
   }
+
+  // MISCONFIGURED: a child-only `# big_value { sparkline=... }` placed on the
+  // view itself, with no activating `# big_value`. The renderer declines to
+  // match it, so it used to render as "[object Object]". It now surfaces the
+  // validation error instead.
+  #(story)
+  # big_value { sparkline=mis_trend }
+  view: misconfigured_big_value is {
+    aggregate:
+      # label="Total Sales"
+      total_sales
+
+    # line_chart { size=spark }
+    # hidden
+    nest: mis_trend is {
+      group_by: order_month
+      aggregate: total_sales
+      order_by: order_month
+      limit: 24
+    }
+  }
 }

--- a/test/src/render/render-validator.spec.ts
+++ b/test/src/render/render-validator.spec.ts
@@ -383,6 +383,23 @@ describe('render tag validation', () => {
       expectError(logs, 'only valid on basic fields');
       expectNoWarnings(logs);
     });
+
+    it('errors when a child-only big_value (sparkline) is on the view itself', async () => {
+      // The exact shape that rendered as "[object Object]" in Publisher: a
+      // child-only `# big_value { sparkline=... }` placed on a view with no
+      // activating big_value. The renderer declines to match it, so this error
+      // must surface (now recorded on the field and rendered, see apply-renderer).
+      const logs = await getValidationLogs(`
+        source: s is duckdb.sql("SELECT 1 as val") extend {
+          # big_value { sparkline=trend }
+          view: q is {
+            aggregate: total is count()
+          }
+        }
+        query: q is s -> q
+      `);
+      expectError(logs, 'only valid on basic fields');
+    });
   });
 
   describe('chart y-channel must be numeric', () => {


### PR DESCRIPTION
Combines #2874 (Sagar) and #2875 (Monty) into one change, closing both.

A field whose renderer tag resolves to a renderer name that no plugin handles fell through `apply-renderer`'s `default` branch to `String(value)`. For a structured (record/array) value that produced the literal `[object Object]` filling the result panel. A common case: a child-only `# big_value { sparkline=... }` placed on a view with no activating `# big_value` (the plugin correctly declines to match since #2719). The Malloy lint already flags this, but render time showed garbage. Separately, once an error was thrown the ErrorBoundary rendered an empty red box rather than the message.

## Changes

- When the validator has already flagged the field (e.g. the big_value case), surface its specific message ("Tag 'big_value' on field 'root' is only valid on basic fields inside big_value.") so the user sees exactly what is wrong. `FieldBase` records error-severity `validateFieldTags` findings; `apply-renderer`'s `default` reads them.
- For any other structured value with no matching renderer, surface a generic "no renderer handled '<renderer>' on field '<name>'" message inline. Scalars and the `none` renderAs keep the existing string fallback, so a chart-child record is not mistaken for an error and one unhandled field does not blank the whole panel.
- `render.tsx`: the ErrorBoundary fallback now resolves the message from a thrown `Error` or a raw string, fixing a pre-existing bug where thrown render errors showed an empty red box (affects all render-time error display).
- `docs/validation.md`: documents the new inline render-time surfacing of producer-#1 errors.

## Before / after

<img width="1608" height="848" alt="pr_before_after" src="https://github.com/user-attachments/assets/c9611461-4259-4820-ac4f-7ff2939f1faa" />

## Testing

- `jest --selectProjects malloy-render` passes; added a `render-validator` test for the exact view-level `# big_value { sparkline=... }` shape.
- Added a `misconfigured_big_value` Storybook story; verified via headless screenshots that the misconfig shows the specific error and that table / line / bar / dashboard / list / pivot / valid big_value stories are unaffected (the generic branch never false-fires on legit renderers or the `none` chart-child case).

## Note for reviewers

This surfaces the error two ways depending on how the renderer fails: a plugin *throw* still routes to `ErrorPlugin` (unchanged); a plugin *decline* that leaves a field with no renderer but which the validator has flagged now shows that logged error inline rather than `[object Object]`. I considered rerouting the decline case through a plugin throw or a setup-time `ErrorPlugin` injection instead, but the throw path loses `validateFieldTags` coverage for "renders + one setting wrong" cases (e.g. `# big_value { size=lg sparkline=x }`, which should render and log, not red-box), and a setup-time injection would have to mirror the built-in renderer list to avoid replacing valid cell/dashboard renders. Flagging since it touches the validation contract; happy to take the decline case down a different route if you'd prefer.

A companion change in malloydata/publisher validates these tags at package-load time so a misconfigured tag also fails publish with a clear error rather than only surfacing at render time.
