### PR TITLE
Emit single-group-set nested queries without the group_set fan-out

### DIFF
--- a/packages/malloy/src/dialect/databricks/databricks.ts
+++ b/packages/malloy/src/dialect/databricks/databricks.ts
@@ -33,7 +33,7 @@ import type {
   OrderByRequest,
   QueryInfo,
 } from '../dialect';
-import {Dialect, EscapeStyle, qtz} from '../dialect';
+import {Dialect, EscapeStyle, qtz, turtleGroupSetCondition} from '../dialect';
 import type {DialectFunctionOverloadDef} from '../functions';
 import {expandBlueprintMap, expandOverrideMap} from '../functions';
 import {DATABRICKS_DIALECT_FUNCTIONS} from './dialect_functions';
@@ -213,15 +213,16 @@ export class DatabricksDialect extends Dialect {
   }
 
   sqlAggregateTurtle(
-    groupSet: number,
+    groupSet: number | undefined,
     fieldList: DialectFieldList,
     orderBy: CompiledOrderBy[] | undefined,
     limit?: number,
     filterSQL?: string
   ): string {
     const namedStruct = this.buildNamedStructExpression(fieldList);
-    const filter = filterSQL ? ` AND ${filterSQL}` : '';
-    const collectExpr = `COLLECT_LIST(${namedStruct}) FILTER (WHERE group_set=${groupSet}${filter})`;
+    const cond = turtleGroupSetCondition(groupSet, filterSQL);
+    const filterClause = cond ? ` FILTER (WHERE ${cond})` : '';
+    const collectExpr = `COLLECT_LIST(${namedStruct})${filterClause}`;
     // COLLECT_LIST is unordered, so ordering is done post-aggregation via
     // ARRAY_SORT — the limit must slice the *ordered* array.
     const ordered =

--- a/packages/malloy/src/dialect/dialect.ts
+++ b/packages/malloy/src/dialect/dialect.ts
@@ -137,6 +137,27 @@ export function qtz(qi: QueryInfo): string | undefined {
   return tz;
 }
 
+/**
+ * The per-element condition for an aggregate turtle (sqlAggregateTurtle). On
+ * the normal path it gates each row by its group_set (and a projection's own
+ * `where:`). On the single-group-set fast path `groupSet` is `undefined` --
+ * there is no group_set column, every row is in the one group -- so the
+ * condition is just the `where:`, or `undefined` to include unconditionally.
+ * Callers wrap the result in whatever form the dialect uses (`FILTER (WHERE
+ * ...)`, `CASE WHEN ... THEN`, `IF(...)`).
+ */
+export function turtleGroupSetCondition(
+  groupSet: number | undefined,
+  filterSQL: string | undefined
+): string | undefined {
+  if (groupSet === undefined) {
+    return filterSQL;
+  }
+  return filterSQL
+    ? `group_set=${groupSet} AND ${filterSQL}`
+    : `group_set=${groupSet}`;
+}
+
 export type OrderByClauseType = 'output_name' | 'ordinal' | 'expression';
 export type OrderByRequest = 'query' | 'turtle' | 'analytical';
 export type BooleanTypeSupport = 'supported' | 'simulated' | 'none';
@@ -441,8 +462,12 @@ export abstract class Dialect {
   // `filterSQL`, when set, is a projection nest's `where:` as a boolean SQL
   // expression; it folds into the per-element group_set condition (a projection
   // rides its enclosing group_set, so a scan-level WHERE can't isolate it).
+  // `groupSet` is `undefined` on the single-group-set fast path: there is no
+  // group_set column to filter on (every row is in the one group), so the
+  // array-agg omits its `FILTER (WHERE group_set=N)` and keeps only a
+  // projection's own `where:` (filterSQL), if any.
   abstract sqlAggregateTurtle(
-    groupSet: number,
+    groupSet: number | undefined,
     fieldList: DialectFieldList,
     orderBy: CompiledOrderBy[] | undefined,
     limit?: number,

--- a/packages/malloy/src/dialect/duckdb/duckdb.ts
+++ b/packages/malloy/src/dialect/duckdb/duckdb.ts
@@ -31,7 +31,14 @@ import type {
   FieldReferenceType,
   IntegerTypeMapping,
 } from '../dialect';
-import {inDays, MIN_INT32, MAX_INT32, MIN_INT128, MAX_INT128} from '../dialect';
+import {
+  inDays,
+  MIN_INT32,
+  MAX_INT32,
+  MIN_INT128,
+  MAX_INT128,
+  turtleGroupSetCondition,
+} from '../dialect';
 import {PostgresBase} from '../pg_impl';
 import {DUCKDB_DIALECT_FUNCTIONS} from './dialect_functions';
 import {DUCKDB_MALLOY_STANDARD_OVERLOADS} from './function_overrides';
@@ -127,7 +134,7 @@ export class DuckDBDialect extends PostgresBase {
   }
 
   sqlAggregateTurtle(
-    groupSet: number,
+    groupSet: number | undefined,
     fieldList: DialectFieldList,
     orderBy: CompiledOrderBy[] | undefined,
     limit?: number,
@@ -137,8 +144,10 @@ export class DuckDBDialect extends PostgresBase {
       .map(f => `\n  ${f.sqlOutputName}: ${f.sqlExpression}`)
       .join(', ');
     const orderByClause = orderBy ? this.sqlTurtleOrderByClause(orderBy) : '';
-    const filter = filterSQL ? ` AND ${filterSQL}` : '';
-    const list = `LIST({${fields}} ${orderByClause}) FILTER (WHERE group_set=${groupSet}${filter})`;
+    const cond = turtleGroupSetCondition(groupSet, filterSQL);
+    const list =
+      `LIST({${fields}} ${orderByClause})` +
+      (cond ? ` FILTER (WHERE ${cond})` : '');
     // A projection nest's limit is applied by slicing the aggregated array
     // (duckdb lists are 1-based, inclusive).
     const limited = limit !== undefined ? `(${list})[1:${limit}]` : list;

--- a/packages/malloy/src/dialect/mysql/mysql.ts
+++ b/packages/malloy/src/dialect/mysql/mysql.ts
@@ -37,7 +37,7 @@ import type {
   OrderByClauseType,
   QueryInfo,
 } from '../dialect';
-import {Dialect, EscapeStyle, qtz} from '../dialect';
+import {Dialect, EscapeStyle, qtz, turtleGroupSetCondition} from '../dialect';
 import type {DialectFunctionOverloadDef} from '../functions';
 import {expandBlueprintMap, expandOverrideMap} from '../functions';
 import {MYSQL_DIALECT_FUNCTIONS} from './dialect_functions';
@@ -202,7 +202,7 @@ export class MySQLDialect extends Dialect {
   }
 
   sqlAggregateTurtle(
-    groupSet: number,
+    groupSet: number | undefined,
     fieldList: DialectFieldList,
     orderBy: CompiledOrderBy[] | undefined,
     _limit?: number,
@@ -210,12 +210,16 @@ export class MySQLDialect extends Dialect {
   ): string {
     const separator = ',';
     const orderByClause = orderBy ? this.sqlTurtleOrderByClause(orderBy) : '';
-    const filter = filterSQL ? ` AND ${filterSQL}` : '';
-    let gc = `GROUP_CONCAT(
-      IF(group_set=${groupSet}${filter},
-        JSON_OBJECT(${this.mapFields(fieldList)})
+    const cond = turtleGroupSetCondition(groupSet, filterSQL);
+    const json = `JSON_OBJECT(${this.mapFields(fieldList)})`;
+    const element = cond
+      ? `IF(${cond},
+        ${json}
         , null
-        )
+        )`
+      : json;
+    let gc = `GROUP_CONCAT(
+      ${element}
       ${orderByClause}
       SEPARATOR '${separator}'
     )`;

--- a/packages/malloy/src/dialect/postgres/postgres.ts
+++ b/packages/malloy/src/dialect/postgres/postgres.ts
@@ -26,6 +26,7 @@ import type {DialectFunctionOverloadDef} from '../functions';
 import {expandOverrideMap, expandBlueprintMap} from '../functions';
 import {
   qtz,
+  turtleGroupSetCondition,
   type CompiledOrderBy,
   type DialectFieldList,
   type FieldReferenceType,
@@ -131,7 +132,7 @@ export class PostgresDialect extends PostgresBase {
   }
 
   sqlAggregateTurtle(
-    groupSet: number,
+    groupSet: number | undefined,
     fieldList: DialectFieldList,
     orderBy: CompiledOrderBy[] | undefined,
     limit?: number,
@@ -139,8 +140,9 @@ export class PostgresDialect extends PostgresBase {
   ): string {
     const fields = this.mapFields(fieldList);
     const orderByClause = orderBy ? this.sqlTurtleOrderByClause(orderBy) : '';
-    const filter = filterSQL ? ` AND ${filterSQL}` : '';
-    const arrayAgg = `(ARRAY_AGG((SELECT TO_JSONB(__x) FROM (SELECT ${fields}\n  ) as __x) ${orderByClause} ) FILTER (WHERE group_set=${groupSet}${filter}))`;
+    const cond = turtleGroupSetCondition(groupSet, filterSQL);
+    const filterClause = cond ? ` FILTER (WHERE ${cond})` : '';
+    const arrayAgg = `(ARRAY_AGG((SELECT TO_JSONB(__x) FROM (SELECT ${fields}\n  ) as __x) ${orderByClause} )${filterClause})`;
     // Slice the native ARRAY (1-based, inclusive) before TO_JSONB turns it into
     // a single jsonb value — a jsonb scalar can't be range-sliced.
     const limited = limit !== undefined ? `${arrayAgg}[1:${limit}]` : arrayAgg;

--- a/packages/malloy/src/dialect/snowflake/snowflake.ts
+++ b/packages/malloy/src/dialect/snowflake/snowflake.ts
@@ -43,6 +43,7 @@ import {
   qtz,
   MIN_DECIMAL38,
   MAX_DECIMAL38,
+  turtleGroupSetCondition,
 } from '../dialect';
 import {SNOWFLAKE_DIALECT_FUNCTIONS} from './dialect_functions';
 import {SNOWFLAKE_MALLOY_STANDARD_OVERLOADS} from './function_overrides';
@@ -153,7 +154,7 @@ export class SnowflakeDialect extends Dialect {
   }
 
   sqlAggregateTurtle(
-    groupSet: number,
+    groupSet: number | undefined,
     fieldList: DialectFieldList,
     orderBy: CompiledOrderBy[] | undefined,
     limit?: number,
@@ -163,8 +164,10 @@ export class SnowflakeDialect extends Dialect {
     const orderByClause = orderBy
       ? ` WITHIN GROUP (${this.sqlTurtleOrderByClause(orderBy)})`
       : '';
-    const filter = filterSQL ? ` AND ${filterSQL}` : '';
-    const aggClause = `ARRAY_AGG(CASE WHEN group_set=${groupSet}${filter} THEN OBJECT_CONSTRUCT_KEEP_NULL(${fields}) END)${orderByClause}`;
+    const cond = turtleGroupSetCondition(groupSet, filterSQL);
+    const struct = `OBJECT_CONSTRUCT_KEEP_NULL(${fields})`;
+    const element = cond ? `CASE WHEN ${cond} THEN ${struct} END` : struct;
+    const aggClause = `ARRAY_AGG(${element})${orderByClause}`;
     // ARRAY_SLICE is 0-based, end-exclusive, so (0, n) keeps the first n.
     const limited =
       limit !== undefined

--- a/packages/malloy/src/dialect/standardsql/standardsql.ts
+++ b/packages/malloy/src/dialect/standardsql/standardsql.ts
@@ -39,6 +39,7 @@ import {
   EscapeStyle,
   MIN_INT64,
   MAX_INT64,
+  turtleGroupSetCondition,
   type LateralJoinExpression,
 } from '../dialect';
 import {STANDARDSQL_DIALECT_FUNCTIONS} from './dialect_functions';
@@ -213,7 +214,7 @@ export class StandardSQLDialect extends Dialect {
 
   // can array agg or any_value a struct...
   sqlAggregateTurtle(
-    groupSet: number,
+    groupSet: number | undefined,
     fieldList: DialectFieldList,
     orderBy: CompiledOrderBy[] | undefined,
     limit?: number,
@@ -225,8 +226,10 @@ export class StandardSQLDialect extends Dialect {
     const orderByClause = orderBy ? this.sqlTurtleOrderByClause(orderBy) : '';
     // BigQuery ARRAY_AGG takes LIMIT as its final sub-clause, after ORDER BY.
     const limitClause = limit !== undefined ? ` LIMIT ${limit}` : '';
-    const filter = filterSQL ? ` AND ${filterSQL}` : '';
-    return `ARRAY_AGG(CASE WHEN group_set=${groupSet}${filter} THEN STRUCT(${fields}\n  ) END IGNORE NULLS ${orderByClause}${limitClause})`;
+    const cond = turtleGroupSetCondition(groupSet, filterSQL);
+    const struct = `STRUCT(${fields}\n  )`;
+    const element = cond ? `CASE WHEN ${cond} THEN ${struct} END` : struct;
+    return `ARRAY_AGG(${element} IGNORE NULLS ${orderByClause}${limitClause})`;
   }
 
   sqlAnyValueTurtle(groupSet: number, fieldList: DialectFieldList): string {

--- a/packages/malloy/src/dialect/trino/trino.ts
+++ b/packages/malloy/src/dialect/trino/trino.ts
@@ -34,6 +34,7 @@ import type {
   OrderByClauseType,
   QueryInfo,
 } from '../dialect';
+import {turtleGroupSetCondition} from '../dialect';
 import {PostgresBase, timeExtractMap} from '../pg_impl';
 import {
   PRESTO_DIALECT_FUNCTIONS,
@@ -174,7 +175,7 @@ export class TrinoDialect extends PostgresBase {
   }
   // can array agg or any_value a struct...
   sqlAggregateTurtle(
-    groupSet: number,
+    groupSet: number | undefined,
     fieldList: DialectFieldList,
     orderBy: CompiledOrderBy[] | undefined,
     limit?: number,
@@ -183,8 +184,9 @@ export class TrinoDialect extends PostgresBase {
     const expressions = fieldList.map(f => f.sqlExpression).join(',\n ');
     const definitions = this.buildTypeExpression(fieldList);
     const orderByClause = orderBy ? this.sqlTurtleOrderByClause(orderBy) : '';
-    const filter = filterSQL ? ` AND ${filterSQL}` : '';
-    const arrayAgg = `ARRAY_AGG(CAST(ROW(${expressions}) AS ROW(${definitions})) ${orderByClause}) FILTER (WHERE group_set=${groupSet}${filter})`;
+    const cond = turtleGroupSetCondition(groupSet, filterSQL);
+    const filterClause = cond ? ` FILTER (WHERE ${cond})` : '';
+    const arrayAgg = `ARRAY_AGG(CAST(ROW(${expressions}) AS ROW(${definitions})) ${orderByClause})${filterClause}`;
     // SLICE(array, start, length) is 1-based; length n keeps the first n.
     return limit !== undefined ? `SLICE(${arrayAgg}, 1, ${limit})` : arrayAgg;
   }

--- a/packages/malloy/src/model/CONTEXT.md
+++ b/packages/malloy/src/model/CONTEXT.md
@@ -202,6 +202,17 @@ nest); per group_set, scalars become `CASE WHEN group_set=N …` and nests an ar
 numbers — a `reduce` nest recurses and gets its own group_set; a `project` nest rides
 the enclosing group_set (it's grain-preserving, one element per in-scope row).
 
+**One group set, no fan-out.** When the only nests are single-stage grain-preserving
+projections — no `reduce` nest, ungrouping, or total, so `maxGroupSet === 0` — there is
+nothing to demux: the cross-join, the `group_set` column, the `FILTER`/`CASE WHEN
+group_set=N`, and the combine stage are all degenerate. `canUseSingleGroupSetSQL` detects
+this and routes to `generateSimpleSQL` (the emitter a non-nested query uses, extended to
+emit each projection nest as an array-agg in the one `SELECT`). That array-agg passes
+`groupSet: undefined` to `sqlAggregateTurtle` (no `FILTER (WHERE group_set=N)`), and
+`FieldInstanceResultRoot.emitsGroupSet = false` keeps aggregate/window expressions from
+gating on a `group_set` column that isn't there. The output is the single `GROUP BY` a
+person would write by hand — no CTE, no fan-out.
+
 **The trap:** grouped stages emit columns named `name__groupSet` (`f1__0`, `m__0`) plus
 a literal `group_set` column; only the final combine stage renames them to user names
 (`"f1__0" as "f1"`). So a follow-on stage must reference the names the prior stage

--- a/packages/malloy/src/model/expression_compiler.ts
+++ b/packages/malloy/src/model/expression_compiler.ts
@@ -189,7 +189,7 @@ function compileExpr<T extends Expr>(
             `Internal Error: Unknown aggregate function ${expr.function}`
           );
         }
-        if (resultSet.root().isComplexQuery) {
+        if (resultSet.root().isComplexQuery && resultSet.root().emitsGroupSet) {
           let groupSet = resultSet.groupSet;
           if (state.totalGroupSet !== -1) {
             groupSet = state.totalGroupSet;
@@ -551,7 +551,8 @@ function generateAnalyticFragment(
   partitionByFields?: string[],
   funcOrdering?: string
 ): string {
-  const isComplex = resultStruct.root().isComplexQuery;
+  const isComplex =
+    resultStruct.root().isComplexQuery && resultStruct.root().emitsGroupSet;
   const partitionFields = getAnalyticPartitions(
     resultStruct,
     partitionByFields

--- a/packages/malloy/src/model/field_instance.ts
+++ b/packages/malloy/src/model/field_instance.ts
@@ -599,6 +599,11 @@ export class FieldInstanceResultRoot extends FieldInstanceResult {
   joins = new Map<string, JoinInstance>();
   havings = new AndChain();
   isComplexQuery = false;
+  // True when the query emits a `group_set` column to demux fanned-out rows
+  // (the general path). The single-group-set fast path (generateSingleGroupSetSQL)
+  // sets this false: there is no group_set column, so aggregate and window
+  // expressions must not wrap themselves in `CASE WHEN group_set=N`.
+  emitsGroupSet = true;
   queryUsesPartitioning = false;
   computeOnlyGroups: number[] = [];
   elimatedComputeGroups = false;

--- a/packages/malloy/src/model/query_query.ts
+++ b/packages/malloy/src/model/query_query.ts
@@ -1299,16 +1299,37 @@ export class QueryQuery extends QueryField {
     return s;
   }
 
+  /**
+   * The single-scan form, with no `group_set` fan-out: one `SELECT` over the
+   * scan, grouped by the dimensions. Used both for a query with no nests and --
+   * via canUseSingleGroupSetSQL -- for one whose only nests are single-stage
+   * grain-preserving projections, which become an array-agg in the same SELECT.
+   * That array-agg needs no `FILTER (WHERE group_set=N)` (every row is in the
+   * one group), and aggregate/window expressions must not gate themselves by
+   * group_set either, so emitsGroupSet is cleared (see FieldInstanceResultRoot).
+   */
   generateSimpleSQL(stageWriter: StageWriter): string {
+    this.rootResult.emitsGroupSet = false;
     let s = '';
     s += 'SELECT \n';
     const fields: string[] = [];
+    const outputPipelinedSQL: OutputPipelinedSQL[] = [];
 
-    for (const [name, field] of this.rootResult.allFields) {
-      const fi = field as FieldInstanceField;
+    for (const [name, fi] of this.rootResult.allFields) {
       const sqlName = this.parent.dialect.sqlQuoteIdentifier(name);
-      if (fi.fieldUsage.type === 'result') {
-        fields.push(` ${fi.generateExpression()} as ${sqlName}`);
+      if (fi instanceof FieldInstanceField) {
+        if (fi.fieldUsage.type === 'result') {
+          fields.push(` ${fi.generateExpression()} as ${sqlName}`);
+        }
+      } else if (fi instanceof FieldInstanceResult) {
+        const turtle = this.generateTurtleSQL(
+          fi,
+          stageWriter,
+          sqlName,
+          outputPipelinedSQL,
+          true
+        );
+        fields.push(` ${turtle} as ${sqlName}`);
       }
     }
     s += indent(fields.join(',\n')) + '\n';
@@ -1343,7 +1364,48 @@ export class QueryQuery extends QueryField {
       s += `LIMIT ${this.firstSegment.limit}\n`;
     }
     this.resultStage = stageWriter.addStage(s);
+    // Consumes any pipelined turtle output. The nests that reach here are
+    // single-stage (canUseSingleGroupSetSQL), so outputPipelinedSQL is empty and
+    // this is a no-op; kept so the function stays correct if that guard widens.
+    this.resultStage = this.generatePipelinedStages(
+      outputPipelinedSQL,
+      this.resultStage,
+      stageWriter,
+      []
+    );
     return this.resultStage;
+  }
+
+  /**
+   * Can this query take the single-group-set fast path? True when the query
+   * needs no group-set fan-out: it has nests (so it's "complex") but every one
+   * is a single-stage grain-preserving projection riding group_set 0, and there
+   * are no reduce nests, ungroupings, or totals (all of which would mint a
+   * second group set and push maxGroupSet above 0). Anything outside that shape
+   * falls back to the general demux path, which is correct for every case.
+   */
+  canUseSingleGroupSetSQL(): boolean {
+    if (this.maxGroupSet !== 0) return false;
+    if (this.firstSegment.type !== 'reduce') return false;
+    for (const [, fi] of this.rootResult.allFields) {
+      if (fi instanceof FieldInstanceResult) {
+        if (fi.firstSegment.type !== 'project') return false;
+        if (fi.turtleDef.pipeline.length !== 1) return false;
+        if (fi.getRepeatedResultType() !== 'nested') return false;
+        // A `calculate:` inside a `select:` would put a window function inside
+        // the array-agg, which no dialect allows; leave it on the general path.
+        for (const [, nestField] of fi.allFields) {
+          if (
+            nestField instanceof FieldInstanceField &&
+            hasExpression(nestField.f.fieldDef) &&
+            expressionIsAnalytic(nestField.f.fieldDef.expressionType)
+          ) {
+            return false;
+          }
+        }
+      }
+    }
+    return true;
   }
 
   // This probably should be generated in a dialect independat way.
@@ -2111,7 +2173,12 @@ export class QueryQuery extends QueryField {
     resultStruct: FieldInstanceResult,
     stageWriter: StageWriter,
     sqlFieldName: string,
-    outputPipelinedSQL: OutputPipelinedSQL[]
+    outputPipelinedSQL: OutputPipelinedSQL[],
+    // The single-group-set fast path (generateSingleGroupSetSQL) has no
+    // group_set column to filter on: every row is in the one group. The
+    // array-agg drops its `FILTER (WHERE group_set=N)` and keeps only a
+    // projection's own `where:`.
+    omitGroupSetFilter = false
   ): string {
     // How to emit this nest's first stage — and the last line of defense before
     // broken SQL for IR that didn't pass through the translator (cached,
@@ -2201,7 +2268,7 @@ export class QueryQuery extends QueryField {
       }
       // (capability is guarded by nestStrategy at the top of this method)
       ret = this.parent.dialect.sqlAggregateTurtle(
-        resultStruct.groupSet,
+        omitGroupSetFilter ? undefined : resultStruct.groupSet,
         dialectFieldList,
         orderBy,
         limit,
@@ -2322,11 +2389,13 @@ export class QueryQuery extends QueryField {
     this.rootResult.assignFieldsToGroups();
 
     this.rootResult.isComplexQuery ||= this.maxDepth > 0 || r.isComplex;
-    if (this.rootResult.isComplexQuery) {
+    // A complex query needs the group-set fan-out unless it has just one group
+    // set (only single-stage projection nests), in which case generateSimpleSQL
+    // emits the same no-fan-out form a non-nested query gets.
+    if (this.rootResult.isComplexQuery && !this.canUseSingleGroupSetSQL()) {
       return this.generateComplexSQL(stageWriter);
-    } else {
-      return this.generateSimpleSQL(stageWriter);
     }
+    return this.generateSimpleSQL(stageWriter);
   }
 
   generateSQLFromPipeline(stageWriter: StageWriter): {

--- a/packages/malloy/src/model/query_query.ts
+++ b/packages/malloy/src/model/query_query.ts
@@ -102,6 +102,14 @@ function usesShaveLimit(result: FieldInstanceResult): boolean {
   return !isNestedProjection;
 }
 
+/** Is this an analytic (window) field -- a `calculate:`? */
+function fieldIsAnalytic(fi: FieldInstanceField): boolean {
+  return (
+    hasExpression(fi.f.fieldDef) &&
+    expressionIsAnalytic(fi.f.fieldDef.expressionType)
+  );
+}
+
 interface OutputPipelinedSQL {
   sqlFieldName: string;
   pipelineSQL: string;
@@ -1388,7 +1396,12 @@ export class QueryQuery extends QueryField {
     if (this.maxGroupSet !== 0) return false;
     if (this.firstSegment.type !== 'reduce') return false;
     for (const [, fi] of this.rootResult.allFields) {
-      if (fi instanceof FieldInstanceResult) {
+      if (fi instanceof FieldInstanceField) {
+        // A root-level `calculate:` (window) needs the general path's analytic
+        // handling: on dialects that can't partition a window on an expression
+        // (BigQuery) it rides a lateral-join bag this path doesn't build.
+        if (fieldIsAnalytic(fi)) return false;
+      } else if (fi instanceof FieldInstanceResult) {
         if (fi.firstSegment.type !== 'project') return false;
         if (fi.turtleDef.pipeline.length !== 1) return false;
         if (fi.getRepeatedResultType() !== 'nested') return false;
@@ -1397,8 +1410,7 @@ export class QueryQuery extends QueryField {
         for (const [, nestField] of fi.allFields) {
           if (
             nestField instanceof FieldInstanceField &&
-            hasExpression(nestField.f.fieldDef) &&
-            expressionIsAnalytic(nestField.f.fieldDef.expressionType)
+            fieldIsAnalytic(nestField)
           ) {
             return false;
           }

--- a/test/src/databases/all/nested-select.spec.ts
+++ b/test/src/databases/all/nested-select.spec.ts
@@ -50,6 +50,23 @@ runtimes.runtimeMap.forEach((runtime, databaseName) => {
       });
     });
 
+    test('single-group-set nest emits no group_set fan-out', async () => {
+      // The point of the single-group-set path: a top-level group_by whose only
+      // nests are projections needs no demux, so the SQL carries no `group_set`
+      // column/FILTER/CASE and no cross-join. The result assertions here pass on
+      // the general fan-out path too, so this pins the *shape* the change exists
+      // to produce -- without it, a revert to the fan-out path goes unnoticed.
+      const sql = await runtime
+        .loadQuery(
+          `run: ${table} -> {
+            group_by: f is substr(popular_name, 1, 1)
+            nest: names is { select: popular_name }
+          }`
+        )
+        .getSQL();
+      expect(sql).not.toMatch(/group_set/);
+    });
+
     test('depth-3 projection nest is populated', async () => {
       await expect(`
         run: ${table} -> {


### PR DESCRIPTION
The nested `select:` work in #2897 left a top-level `group_by` whose only nests are projections on the full group_set fan-out — a cross-join against a one-row group_set table, the `FILTER`/`CASE WHEN group_set=N` demux, and a second combine stage — even though the query has a single grouping grain and needs none of it. Lloyd flagged the generated SQL as more complex than it should be. These queries now emit the single `GROUP BY` a person would write by hand.

The behavior was already correct; this changes only the shape of the SQL. The general fan-out path is untouched — only a query with `maxGroupSet === 0` (no `reduce` nest, ungrouping, or total) takes the new route, where the no-fan-out emitter grew to handle a projection nest as an array-agg.
