### PR TITLE
Record unmodified source references in the IR

### DIFF
--- a/packages/malloy/src/api/foundation/core.ts
+++ b/packages/malloy/src/api/foundation/core.ts
@@ -329,6 +329,21 @@ export class Explore extends Entity implements Taggable {
   /**
    * THIS IS A HIGHLY EXPERIMENTAL API AND MAY VANISH OR CHANGE WITHOUT NOTICE
    *
+   * If this source was created as an unmodified reference to another source, a
+   * stable identifier of the source it refers to; undefined when this source
+   * defines its own shape. Two sources that refer to the same thing share this
+   * id, so it can be compared to tell whether two otherwise un-nameable sources
+   * are the same — even when the referenced source can't be named here.
+   */
+  public get referenceSourceID(): string | undefined {
+    return isSourceDef(this._structDef)
+      ? this._structDef.referenceID
+      : undefined;
+  }
+
+  /**
+   * THIS IS A HIGHLY EXPERIMENTAL API AND MAY VANISH OR CHANGE WITHOUT NOTICE
+   *
    * If this source was created as an unmodified reference to a source that is in
    * this model's namespace (`source: a is b`, or a plain join), return that
    * source as it appears in the namespace — read `.name` for the name it goes by

--- a/packages/malloy/src/api/foundation/core.ts
+++ b/packages/malloy/src/api/foundation/core.ts
@@ -66,7 +66,11 @@ import {
   findPersistentDependencies,
   minimalBuildGraph,
 } from '../../model/persist_utils';
-import {resolveSourceID, mkBuildID} from '../../model/source_def_utils';
+import {
+  resolveSourceID,
+  sourceNamespaceReference,
+  mkBuildID,
+} from '../../model/source_def_utils';
 import {
   evaluateInlineGivens,
   resolveSuppliedGivens,
@@ -320,6 +324,22 @@ export class Explore extends Entity implements Taggable {
 
   public get source(): Explore | undefined {
     return this.sourceExplore;
+  }
+
+  /**
+   * THIS IS A HIGHLY EXPERIMENTAL API AND MAY VANISH OR CHANGE WITHOUT NOTICE
+   *
+   * If this source was created as an unmodified reference to a source that is in
+   * this model's namespace (`source: a is b`, or a plain join), return that
+   * source as it appears in the namespace — read `.name` for the name it goes by
+   * here. Returns undefined when this source defines its own shape (a table,
+   * SQL, query, or modified/extended source), or when the referenced source is
+   * not in this model's namespace.
+   */
+  public referencedSource(): Explore | undefined {
+    if (!isSourceDef(this._structDef)) return undefined;
+    const ref = sourceNamespaceReference(this._ownerModelDef, this._structDef);
+    return ref ? new Explore(this._ownerModelDef, ref.source) : undefined;
   }
 
   public isIntrinsic(): boolean {

--- a/packages/malloy/src/api/foundation/source-reference.spec.ts
+++ b/packages/malloy/src/api/foundation/source-reference.spec.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright Contributors to the Malloy project
+ * SPDX-License-Identifier: MIT
+ */
+
+import {Model} from './core';
+import {TestTranslator} from '../../lang/test/test-translator';
+
+// Build a Model directly from translated IR — no connection needed — so the
+// Explore source-reference getters can be exercised the way a consumer dumping
+// a model would use them.
+function modelOf(src: string): Model {
+  const tt = new TestTranslator(src);
+  const compiled = tt.translate();
+  if (!compiled.modelDef) {
+    throw new Error('source did not translate');
+  }
+  return new Model(compiled.modelDef, [], []);
+}
+
+describe('Explore source-reference introspection', () => {
+  test('a source that defines its own shape is not a reference', () => {
+    const model = modelOf("source: base is _db_.table('aTable')");
+    expect(model.getExploreByName('base').referencedSource()).toBeUndefined();
+  });
+
+  test('an unmodified rename exposes the referenced source by name', () => {
+    const model = modelOf(`
+      source: base is _db_.table('aTable')
+      source: ref is base
+    `);
+    expect(model.getExploreByName('ref').referencedSource()?.name).toBe('base');
+  });
+
+  test('an extended source is not a reference', () => {
+    const model = modelOf(`
+      source: base is _db_.table('aTable')
+      source: ext is base extend { dimension: x is 1 }
+    `);
+    expect(model.getExploreByName('ext').referencedSource()).toBeUndefined();
+  });
+});

--- a/packages/malloy/src/api/foundation/source-reference.spec.ts
+++ b/packages/malloy/src/api/foundation/source-reference.spec.ts
@@ -39,4 +39,18 @@ describe('Explore source-reference introspection', () => {
     `);
     expect(model.getExploreByName('ext').referencedSource()).toBeUndefined();
   });
+
+  test('two sources referencing the same thing share referenceSourceID', () => {
+    const model = modelOf(`
+      source: base is _db_.table('aTable')
+      source: refA is base
+      source: refB is base
+    `);
+    const a = model.getExploreByName('refA').referenceSourceID;
+    const b = model.getExploreByName('refB').referenceSourceID;
+    expect(a).toBeDefined();
+    expect(a).toBe(b);
+    // a source that defines its own shape has no referenceSourceID
+    expect(model.getExploreByName('base').referenceSourceID).toBeUndefined();
+  });
 });

--- a/packages/malloy/src/lang/ast/field-space/dynamic-space.ts
+++ b/packages/malloy/src/lang/ast/field-space/dynamic-space.ts
@@ -105,6 +105,10 @@ export abstract class DynamicSpace
       }
 
       this.sourceDef = {...this.fromSource, fields: []};
+      // This is a freshly built (modified) source: it presents a new exported
+      // shape, so it is no longer a reference to the source it was built from.
+      // DefineSource resets referenceID to this source's own sourceID.
+      delete this.sourceDef.referenceID;
       this.sourceDef.parameters = parameters;
       const fieldIndices = new Map<string, number>();
       // Need to process the entities in specific order
@@ -188,6 +192,7 @@ export abstract class DynamicSpace
   emptyStructDef(): SourceDef {
     const ret = {...this.fromSource};
     ret.fields = [];
+    delete ret.referenceID;
     return ret;
   }
 }

--- a/packages/malloy/src/lang/ast/source-elements/named-source.ts
+++ b/packages/malloy/src/lang/ast/source-elements/named-source.ts
@@ -131,7 +131,10 @@ export class NamedSource extends Source {
     } else {
       this.document()?.checkExperimentalDialect(this, entry.dialect);
       if (isSourceDef(entry)) {
-        return {...entry};
+        // This struct is created as an unmodified reference to `entry`. Mark it
+        // with entry's own identity; the modification path (DynamicSpace) clears
+        // this so only true references carry a referenceID.
+        return {...entry, referenceID: entry.sourceID};
       }
     }
     // I think this is now a never

--- a/packages/malloy/src/lang/ast/statements/define-source.ts
+++ b/packages/malloy/src/lang/ast/statements/define-source.ts
@@ -4,7 +4,11 @@
  */
 
 import type {AnnotationsDef, StructDef} from '../../../model/malloy_types';
-import {activeName, isPersistableSourceDef} from '../../../model/malloy_types';
+import {
+  activeName,
+  isPersistableSourceDef,
+  isSourceDef,
+} from '../../../model/malloy_types';
 import {mkSourceID} from '../../../model/source_def_utils';
 import {checkPersistAnnotation} from '../../../model/persist_utils';
 import {ErrorFactory} from '../error-factory';
@@ -70,9 +74,16 @@ export class DefineSource
           }
         : {...this.note};
     }
-    if (isPersistableSourceDef(entry)) {
+    if (isSourceDef(entry)) {
+      // Every source gets a stable identity for its own definition. referenceID
+      // is left as it arrived: set to the referenced source's sourceID for an
+      // unmodified rename (`source: a is b`), and absent for a source that
+      // defines its own shape (table/sql/query, or a modified/extended source,
+      // which DynamicSpace cleared).
       entry.sourceID = mkSourceID(this.name, this.location?.url);
-      entry.persistent = checkPersistAnnotation(entry).persist;
+      if (isPersistableSourceDef(entry)) {
+        entry.persistent = checkPersistAnnotation(entry).persist;
+      }
     }
     entry.partitionComposite =
       getPartitionCompositeDesc(

--- a/packages/malloy/src/lang/ast/types/malloy-element.ts
+++ b/packages/malloy/src/lang/ast/types/malloy-element.ts
@@ -18,7 +18,7 @@ import type {
   SourceID,
   SourceRegistryValue,
 } from '../../../model/malloy_types';
-import {isSourceDef, isPersistableSourceDef} from '../../../model/malloy_types';
+import {isSourceDef} from '../../../model/malloy_types';
 import {mkModelDef, mkModelID} from '../../../model/utils';
 import {Tag} from '@malloydata/malloy-tag';
 import type {
@@ -768,12 +768,9 @@ export class Document extends MalloyElement implements NameSpace {
 
     this.documentModel.set(str, ent);
 
-    // Maintain sourceRegistry for persistable sources with sourceID
-    if (
-      isSourceDef(ent.entry) &&
-      isPersistableSourceDef(ent.entry) &&
-      ent.entry.sourceID
-    ) {
+    // Maintain the source-id table so sourceID/referenceID values resolve to
+    // their SourceDef. Every named source is registered by its sourceID.
+    if (isSourceDef(ent.entry) && ent.entry.sourceID) {
       this.documentSrcRegistry[ent.entry.sourceID] = {
         entry: {
           type: 'source_registry_reference',

--- a/packages/malloy/src/lang/test/source.spec.ts
+++ b/packages/malloy/src/lang/test/source.spec.ts
@@ -13,8 +13,13 @@ import {
   getFieldDef,
 } from './test-translator';
 import './parse-expects';
-import {activeName, isSourceDef, QueryModel} from '../../model';
-import type {VirtualMap} from '../../model';
+import {
+  activeName,
+  isSourceDef,
+  QueryModel,
+  sourceNamespaceReference,
+} from '../../model';
+import type {SourceDef, VirtualMap} from '../../model';
 
 describe('source:', () => {
   test('table', () => {
@@ -1132,7 +1137,7 @@ describe('source:', () => {
         const src = m.getSourceDef('query_src');
         expect(src).toBeDefined();
         expect(src?.type).toBe('query_source');
-        if (src && 'sourceID' in src && src.sourceID) {
+        if (src && src.sourceID) {
           const registryValue = modelDef.sourceRegistry[src.sourceID];
           expect(registryValue).toBeDefined();
           expect(registryValue?.entry).toMatchObject({
@@ -1140,7 +1145,7 @@ describe('source:', () => {
             name: 'query_src',
           });
         } else {
-          fail('Expected query_src to have a sourceID');
+          fail('Expected query_src to have an sourceID');
         }
       }
     });
@@ -1168,7 +1173,7 @@ describe('source:', () => {
         expect(extSrc?.type).toBe('query_source');
 
         // Base source should have sourceID
-        if (baseSrc && 'sourceID' in baseSrc && baseSrc.sourceID) {
+        if (baseSrc && baseSrc.sourceID) {
           const baseSourceID = baseSrc.sourceID;
           expect(baseSourceID).toContain('base_src@');
 
@@ -1179,7 +1184,7 @@ describe('source:', () => {
             fail('Expected extended_src to have extends property');
           }
         } else {
-          fail('Expected base_src to have a sourceID');
+          fail('Expected base_src to have an sourceID');
         }
       }
     });
@@ -1225,6 +1230,210 @@ describe('source:', () => {
       }
     });
   });
+
+  describe('referenceID', () => {
+    // referenceID is set only when a source is created as an unmodified
+    // reference to another source, and holds the sourceID of the immediately
+    // referenced source. A source that defines its own shape (table/sql/query,
+    // or a modified/extended source) has no referenceID.
+
+    // Fetch a source def and assert it is present, so a missing source fails
+    // the test loudly instead of letting the assertions below get skipped.
+    function defOf(m: TestTranslator, name: string): SourceDef {
+      const sd = m.getSourceDef(name);
+      expect(sd).toBeDefined();
+      if (!sd || !isSourceDef(sd)) {
+        throw new Error(`expected a source named '${name}'`);
+      }
+      return sd;
+    }
+
+    function sources(src: string) {
+      const m = new TestTranslator(src);
+      expect(m).toTranslate();
+      return m;
+    }
+
+    test('a source that defines its own shape has no referenceID', () => {
+      const base = defOf(
+        sources('source: base is a -> {group_by: astr}'),
+        'base'
+      );
+      expect(base.sourceID).toBeDefined();
+      expect(base.referenceID).toBeUndefined();
+    });
+
+    test('a table source has no referenceID', () => {
+      const tbl = defOf(sources("source: tbl is _db_.table('aTable')"), 'tbl');
+      expect(tbl.sourceID).toBeDefined();
+      expect(tbl.referenceID).toBeUndefined();
+    });
+
+    test('an unmodified rename references the source it copies', () => {
+      const m = sources(`
+        source: base is a -> {group_by: astr}
+        source: ref is base
+      `);
+      const base = defOf(m, 'base');
+      const ref = defOf(m, 'ref');
+      // ref defines no new shape: it points at base's identity.
+      expect(ref.referenceID).toBe(base.sourceID);
+      // and it is recognizably a reference, with its own distinct sourceID.
+      expect(ref.referenceID).not.toBeUndefined();
+      expect(ref.sourceID).not.toBe(base.sourceID);
+    });
+
+    test('a reference names the immediate source, not the ultimate origin', () => {
+      const m = sources(`
+        source: base is a -> {group_by: astr}
+        source: ref is base
+        source: ref2 is ref
+      `);
+      // ref2 references ref (what it was written against), not base.
+      expect(defOf(m, 'ref2').referenceID).toBe(defOf(m, 'ref').sourceID);
+      expect(defOf(m, 'ref2').referenceID).not.toBe(defOf(m, 'base').sourceID);
+    });
+
+    test('extending a source clears the reference', () => {
+      const m = sources(`
+        source: base is a -> {group_by: astr}
+        source: ext is base extend {
+          dimension: extra is 'x'
+        }
+      `);
+      expect(defOf(m, 'ext').referenceID).toBeUndefined();
+    });
+
+    test('include clears the reference (it edits the namespace)', () => {
+      const m = sources(`
+        ##! experimental.access_modifiers
+        source: base is a -> {group_by: astr, ai}
+        source: inc is base include { except: ai }
+      `);
+      expect(defOf(m, 'inc').referenceID).toBeUndefined();
+    });
+
+    test('a reference to an extended source points at that extended source', () => {
+      const m = sources(`
+        source: base is a -> {group_by: astr}
+        source: ext is base extend {
+          dimension: extra is 'x'
+        }
+        source: refExt is ext
+      `);
+      expect(defOf(m, 'refExt').referenceID).toBe(defOf(m, 'ext').sourceID);
+    });
+
+    test('a join carries the referenceID of the joined source', () => {
+      const m = sources(`
+        source: base is a -> {group_by: astr, ai}
+        source: host is a extend {
+          join_one: jb is base on ai = jb.ai
+        }
+      `);
+      const base = defOf(m, 'base');
+      const host = defOf(m, 'host');
+      const jb = host.fields.find(f => activeName(f) === 'jb');
+      expect(jb && isSourceDef(jb)).toBeTruthy();
+      if (jb && isSourceDef(jb)) {
+        expect(jb.referenceID).toBe(base.sourceID);
+      }
+    });
+
+    test('sourceNamespaceReference resolves a reference to its namespace name', () => {
+      const m = sources(`
+        source: base is a -> {group_by: astr}
+        source: ref is base
+      `);
+      const modelDef = m.translate().modelDef;
+      expect(modelDef).toBeDefined();
+      // A reference resolves to the namespace entry it points at.
+      const refInfo = sourceNamespaceReference(modelDef!, defOf(m, 'ref'));
+      expect(refInfo?.name).toBe('base');
+      expect(refInfo?.source).toBe(defOf(m, 'base'));
+      // A source that defines its own shape resolves to nothing.
+      expect(
+        sourceNamespaceReference(modelDef!, defOf(m, 'base'))
+      ).toBeUndefined();
+    });
+
+    test('a reference resolves to its namespace name across an import', () => {
+      const docParse = new TestTranslator(`
+        import "child"
+        source: ref is base
+      `);
+      docParse.update({
+        urls: {
+          'internal://test/langtests/child':
+            'source: base is a -> {group_by: astr}',
+        },
+      });
+      expect(docParse).toTranslate();
+      const modelDef = docParse.translate().modelDef;
+      expect(modelDef).toBeDefined();
+      // The reference made in the importing model resolves to the imported name.
+      const refInfo = sourceNamespaceReference(
+        modelDef!,
+        defOf(docParse, 'ref')
+      );
+      expect(refInfo?.name).toBe('base');
+    });
+
+    test('a re-export whose target was not imported is a reference with no namespace entry', () => {
+      // child: `top is base` is an unmodified rename; only `top` is imported.
+      const docParse = new TestTranslator(`
+        import { top } from "child"
+        source: ref is top
+      `);
+      docParse.update({
+        urls: {
+          'internal://test/langtests/child': `
+            source: base is a -> {group_by: astr}
+            source: top is base
+          `,
+        },
+      });
+      expect(docParse).toTranslate();
+      const modelDef = docParse.translate().modelDef;
+      expect(modelDef).toBeDefined();
+      // ref points at the immediate target `top`, which IS in the namespace...
+      expect(
+        sourceNamespaceReference(modelDef!, defOf(docParse, 'ref'))?.name
+      ).toBe('top');
+      // ...while `top` itself is a reference, but its target `base` was not
+      // imported, so it has no namespace entry here (honest "no").
+      const top = defOf(docParse, 'top');
+      expect(top.referenceID).not.toBeUndefined();
+      expect(sourceNamespaceReference(modelDef!, top)).toBeUndefined();
+    });
+
+    test('a join of an import-renamed source resolves to its local name', () => {
+      const docParse = new TestTranslator(`
+        import { local is orig } from "child"
+        source: host is a extend {
+          join_one: j is local on ai = j.ai
+        }
+      `);
+      docParse.update({
+        urls: {
+          'internal://test/langtests/child':
+            'source: orig is a -> {group_by: astr, ai}',
+        },
+      });
+      expect(docParse).toTranslate();
+      const modelDef = docParse.translate().modelDef;
+      expect(modelDef).toBeDefined();
+      const host = defOf(docParse, 'host');
+      const j = host.fields.find(f => activeName(f) === 'j');
+      expect(j && isSourceDef(j)).toBeTruthy();
+      if (j && isSourceDef(j)) {
+        // The join references the imported source, known here by the name it
+        // was renamed to on import.
+        expect(sourceNamespaceReference(modelDef!, j)?.name).toBe('local');
+      }
+    });
+  });
+
   describe('Object.prototype field name collisions', () => {
     test('constructor as source name', () => {
       expect('source: constructor is a').toTranslate();

--- a/packages/malloy/src/lang/test/sql-block.spec.ts
+++ b/packages/malloy/src/lang/test/sql-block.spec.ts
@@ -189,7 +189,7 @@ describe('connection sql()', () => {
         const src = m.getSourceDef('sql_src');
         expect(src).toBeDefined();
         expect(src?.type).toBe('sql_select');
-        if (src && 'sourceID' in src && src.sourceID) {
+        if (src && src.sourceID) {
           const registryValue = modelDef.sourceRegistry[src.sourceID];
           expect(registryValue).toBeDefined();
           expect(registryValue?.entry).toMatchObject({
@@ -197,7 +197,7 @@ describe('connection sql()', () => {
             name: 'sql_src',
           });
         } else {
-          fail('Expected sql_src to have a sourceID');
+          fail('Expected sql_src to have an sourceID');
         }
       }
     });
@@ -223,7 +223,7 @@ describe('connection sql()', () => {
         expect(extSrc?.type).toBe('sql_select');
 
         // Base source should have sourceID
-        if (baseSrc && 'sourceID' in baseSrc && baseSrc.sourceID) {
+        if (baseSrc && baseSrc.sourceID) {
           const baseSourceID = baseSrc.sourceID;
           expect(baseSourceID).toContain('base_sql@');
 
@@ -234,7 +234,7 @@ describe('connection sql()', () => {
             fail('Expected extended_sql to have extends property');
           }
         } else {
-          fail('Expected base_sql to have a sourceID');
+          fail('Expected base_sql to have an sourceID');
         }
       }
     });

--- a/packages/malloy/src/model/CONTEXT.md
+++ b/packages/malloy/src/model/CONTEXT.md
@@ -56,9 +56,12 @@ table", which registers every named source by its `sourceID`):
   immediate target is always a namespace entry, since you could only write
   `is b` where `b` resolved by name). Helpers: `resolveSourceRef` (id →
   SourceDef), `sourceNamespaceReference` (SourceDef → `{name, source}` when it
-  references a namespace entry). The Foundation `Explore` exposes this as one
-  method, `referencedSource()` — the referenced namespace source (read `.name`),
-  or undefined when the source defines its own shape — rather than the raw ids.
+  references a namespace entry). The Foundation `Explore` exposes two views of
+  this without leaking the field name: `referenceSourceID` (a comparable id of
+  the referenced source — equal for two sources that refer to the same thing,
+  even when it can't be named here) and `referencedSource()` (the referenced
+  namespace source, read `.name`). Both are undefined when the source defines
+  its own shape.
 
 **Type Definitions:**
 - **`BasicAtomicType`** - String union of simple type names (`string | number | boolean | date | timestamp | timestamptz | json | sql native | error`). Guard: `isBasicAtomicType()`.

--- a/packages/malloy/src/model/CONTEXT.md
+++ b/packages/malloy/src/model/CONTEXT.md
@@ -33,6 +33,33 @@ The name a thing goes by in a given context is therefore **`activeName(x)` = `x.
 
 **Corollary for writers:** to rebind a def, set `as`. Never assign `name` and never `delete x.as` to "reset" a name — doing so destroys any identity payload `name` carried. (This was the cause of the joined-virtual-source bug: the join wrote the join name into `name` and deleted `as`, erasing the `virtualMap` key.)
 
+**Source identity (`sourceID` / `referenceID`):**
+
+Every `SourceDef` carries `SourceID` (`name@modelURL`) identity fields, set in
+the translator and resolvable through `ModelDef.sourceRegistry` (the "source-id
+table", which registers every named source by its `sourceID`):
+
+- **`sourceID`** — the identity of this source's *own definition*. Set for every
+  source in `DefineSource`. Unlike `as`, it is captured once at definition and
+  preserved across imports, so it is stable identity. The persistence machinery
+  reads it (gated by `isPersistableSourceDef`); `extends` (persistable only)
+  points at the base source's `sourceID`.
+- **`referenceID`** — set *only* when this source was created as an unmodified
+  reference to another source (`source: a is b`, or a plain join), holding the
+  `sourceID` of the *immediately* referenced source. Set in `NamedSource`
+  (`{...entry, referenceID: entry.sourceID}`) and cleared on the modification
+  path (`DynamicSpace.structDef`), so a table/sql/query source or an
+  `extend`/`include` has no `referenceID`. Thus **`referenceID !== undefined`
+  means "created as a reference"** — no `sourceID` comparison, so it is correct
+  for joins too — and the value resolves through the source-id table to the
+  referenced source and the name it goes by in this model's namespace (the
+  immediate target is always a namespace entry, since you could only write
+  `is b` where `b` resolved by name). Helpers: `resolveSourceRef` (id →
+  SourceDef), `sourceNamespaceReference` (SourceDef → `{name, source}` when it
+  references a namespace entry). The Foundation `Explore` exposes this as one
+  method, `referencedSource()` — the referenced namespace source (read `.name`),
+  or undefined when the source defines its own shape — rather than the raw ids.
+
 **Type Definitions:**
 - **`BasicAtomicType`** - String union of simple type names (`string | number | boolean | date | timestamp | timestamptz | json | sql native | error`). Guard: `isBasicAtomicType()`.
 - **`BasicAtomicTypeDef`** - TypeDef union for basic types (each variant may carry metadata, e.g. `NumberTypeDef` has optional `numberType`)

--- a/packages/malloy/src/model/index.ts
+++ b/packages/malloy/src/model/index.ts
@@ -57,6 +57,9 @@ export {
   mkSQLSourceDef,
   mkTableSourceDef,
   resolveSourceID,
+  resolveSourceRef,
+  sourceNamespaceReference,
   registerSource,
   hasSourceRegistryEntry,
 } from './source_def_utils';
+export type {NamespaceReference} from './source_def_utils';

--- a/packages/malloy/src/model/malloy_types.ts
+++ b/packages/malloy/src/model/malloy_types.ts
@@ -1537,6 +1537,22 @@ interface SourceDefBase extends StructDefBase, Filtered, ResultStructMetadata {
   primaryKey?: PrimaryKeyRef;
   dialect: string;
   partitionComposite?: PartitionCompositeDesc;
+  /**
+   * Identity of this source's own definition (`name@modelURL`). Set for every
+   * source when it is defined. The persistence machinery reads this (gated by
+   * `isPersistableSourceDef`).
+   */
+  sourceID?: SourceID;
+  /**
+   * Set only when this source was created as an unmodified reference to another
+   * source (`source: a is b`, or a plain join) — then it holds the `sourceID`
+   * of the *immediately* referenced source. Absent when the source defines its
+   * own shape (table/sql/query, or a modified/extended source). So
+   * `referenceID !== undefined` means "created as a reference", and the value
+   * resolves through `ModelDef.sourceRegistry` to the referenced source and its
+   * namespace name (see `sourceNamespaceReference`).
+   */
+  referenceID?: SourceID;
 }
 /** which field is the primary key in this struct */
 export type PrimaryKeyRef = string;
@@ -1575,7 +1591,7 @@ export function isSegmentSource(
   return 'type' in f && (f.type === 'sql_select' || f.type === 'query_source');
 }
 
-/** Format: "name@modelUrl" - uniquely identifies a source for persistence */
+/** Format: "name@modelUrl" - uniquely identifies a defined source */
 export type SourceID = string;
 
 /** Created with `mkGivenID`. */
@@ -1626,7 +1642,6 @@ export function isSourceRegistryReference(
 }
 
 export interface PersistableSourceProperties {
-  sourceID?: SourceID;
   extends?: SourceID;
   persistent?: boolean;
 }
@@ -1683,13 +1698,17 @@ export function isSourceDef(sd: NamedModelObject | FieldDef): sd is SourceDef {
 /**
  * Union of all source definition types.
  *
- * IMPORTANT: Never use object spread to copy a SourceDef. Use the factory
- * methods in source_def_utils.ts to merge changes into a source def:
+ * When building a *persisted/derived* source in the compiler, use the factory
+ * methods in source_def_utils.ts rather than object spread:
  * - mkSQLSourceDef(base, ...) - create SQLSourceDef from base
  * - mkQuerySourceDef(base, ...) - create QuerySourceDef from base
  *
- * These factories explicitly copy only safe fields, preventing accidental
- * propagation of sourceID/extends which must only be set in DefineSource.
+ * These factories explicitly copy only safe fields, dropping the identity
+ * fields (sourceID/referenceID/extends/persistent) so they are not propagated
+ * onto a freshly built source. In the translator, by contrast, object spread is
+ * used deliberately to *carry* sourceID/referenceID through an unmodified
+ * reference; DefineSource then sets them, and DynamicSpace clears referenceID
+ * on the modification path.
  */
 export type SourceDef =
   | TableSourceDef

--- a/packages/malloy/src/model/persist_utils.ts
+++ b/packages/malloy/src/model/persist_utils.ts
@@ -190,7 +190,7 @@ export function findPersistentDependencies(
   }
 
   function processJoinedSource(source: SourceDef): BuildNode[] {
-    // If it has a sourceID, go through the registry
+    // If it has an sourceID, go through the registry
     if (isPersistableSourceDef(source) && source.sourceID) {
       return processSourceID(source.sourceID);
     }

--- a/packages/malloy/src/model/source_def_utils.ts
+++ b/packages/malloy/src/model/source_def_utils.ts
@@ -6,11 +6,11 @@
 /**
  * SourceDef Utilities for Persistence
  *
- * Key invariant: sourceID is ONLY assigned in DefineSource when a source
- * gets a name. Factory functions explicitly copy only the fields they need,
- * never using spread, to prevent accidental propagation of sourceID/extends.
- *
- * The `extends` property is set by callers when processing extend blocks.
+ * Key invariant: a source's identity fields (sourceID, referenceID, extends)
+ * are assigned in the translator (DefineSource / the reference path), never by
+ * these compiler factories. The factory functions explicitly copy only the
+ * fields they need, never using spread, so identity is not propagated onto a
+ * freshly built source.
  */
 
 import type {
@@ -96,8 +96,9 @@ export function mkQuerySourceDef(
     partitionComposite: base.partitionComposite,
     errorFactory: base.errorFactory,
 
-    // PersistableSourceProperties - explicitly NOT copied
+    // Identity fields - explicitly NOT copied
     // sourceID: undefined,
+    // referenceID: undefined,
     // extends: undefined,
     // persistent: undefined,
   };
@@ -147,8 +148,9 @@ export function mkSQLSourceDef(
     partitionComposite: base.partitionComposite,
     errorFactory: base.errorFactory,
 
-    // PersistableSourceProperties - explicitly NOT copied
+    // Identity fields - explicitly NOT copied
     // sourceID: undefined,
+    // referenceID: undefined,
     // extends: undefined,
     // persistent: undefined,
   };
@@ -179,28 +181,68 @@ export function mkTableSourceDef(
 // =============================================================================
 
 /**
- * Resolve a sourceID to a SourceDef using the sourceRegistry.
+ * Resolve a SourceID (a source's own `sourceID`, or a `referenceID` pointing at
+ * one) to its SourceDef using the sourceRegistry, returning any kind of source.
  *
  * @param modelDef The model definition containing the registry
- * @param sourceID The sourceID to resolve
+ * @param sourceID The SourceID to resolve
  * @returns The SourceDef if found, undefined otherwise
  */
-export function resolveSourceID(
+export function resolveSourceRef(
   modelDef: ModelDef,
   sourceID: SourceID
-): PersistableSourceDef | undefined {
+): SourceDef | undefined {
   const value = modelDef.sourceRegistry[sourceID];
   if (!value) return undefined;
 
   if (isSourceRegistryReference(value.entry)) {
     const obj = safeRecordGet(modelDef.contents, value.entry.name);
-    return obj && isSourceDef(obj) && isPersistableSourceDef(obj)
-      ? obj
-      : undefined;
+    return obj && isSourceDef(obj) ? obj : undefined;
   }
 
-  // It's a PersistableSourceDef
   return value.entry;
+}
+
+/**
+ * Resolve a sourceID to a persistable SourceDef using the sourceRegistry.
+ *
+ * @param modelDef The model definition containing the registry
+ * @param sourceID The sourceID to resolve
+ * @returns The PersistableSourceDef if found, undefined otherwise
+ */
+export function resolveSourceID(
+  modelDef: ModelDef,
+  sourceID: SourceID
+): PersistableSourceDef | undefined {
+  const sd = resolveSourceRef(modelDef, sourceID);
+  return sd && isPersistableSourceDef(sd) ? sd : undefined;
+}
+
+/** The namespace entry a source refers to (see `sourceNamespaceReference`). */
+export interface NamespaceReference {
+  /** The name this source is bound to in `modelDef.contents`. */
+  name: string;
+  /** The referenced source. */
+  source: SourceDef;
+}
+
+/**
+ * If `sd` was created as an unmodified reference to another source
+ * (`sd.referenceID` is set) and that source is present in this model's
+ * namespace, return it together with the name it goes by. Returns undefined
+ * when `sd` defines its own shape, or when the referenced source is not in this
+ * model's namespace (e.g. an imported source whose own target wasn't imported).
+ */
+export function sourceNamespaceReference(
+  modelDef: ModelDef,
+  sd: SourceDef
+): NamespaceReference | undefined {
+  if (sd.referenceID === undefined) return undefined;
+  const value = modelDef.sourceRegistry[sd.referenceID];
+  if (!value || !isSourceRegistryReference(value.entry)) return undefined;
+  const name = value.entry.name;
+  const source = safeRecordGet(modelDef.contents, name);
+  return source && isSourceDef(source) ? {name, source} : undefined;
 }
 
 /**


### PR DESCRIPTION
When the translator builds the IR, a reference to an existing source — `source: a is b`, a re-export across an import, a join — is materialized as a fresh copy of that source's `SourceDef`. That keeps the IR self-contained, but it erases provenance: nothing downstream can tell that `a` is *just* `b` under a new name.

This adds that provenance, so a tool dumping a compiled model can answer the two questions that matter: **was this source created as a reference, and is the thing it references in my namespace (by what name)?**

- Every `SourceDef` now carries **`sourceID`** — its own stable `name@modelURL` identity. This generalizes the persistence id (previously only on persistable sources) to all sources; persistence reads it unchanged, gated by `isPersistableSourceDef`.
- A source created as an unmodified reference carries **`referenceID`**: the `sourceID` of the *immediately* referenced source. It's absent on a source that defines its own shape (table/sql/query, or anything extended/included). So `referenceID !== undefined` means "created as a reference" — no id comparison, so it's correct for joins too — and it survives imports.
- **`sourceNamespaceReference(modelDef, sd)`** resolves a reference to `{name, source}` in the model's namespace; **`Explore.referencedSource()`** is the same answer on the foundation API. The source-id table (`ModelDef.sourceRegistry`) now registers every named source, which is what makes resolution work across imports and renames.

Identity is left to the diff, but the three id fields are deliberately distinct: `sourceID` (own), `extends` (a *modified* persistable source's base), `referenceID` (an *unmodified* reference's target).

Build and the duckdb precheck are green.