### PR TITLE
Restore BigQuery default-project qualification on table sources

### DIFF
--- a/packages/malloy-db-bigquery/src/bigquery.spec.ts
+++ b/packages/malloy-db-bigquery/src/bigquery.spec.ts
@@ -224,6 +224,80 @@ describe('db:BigQuery', () => {
     });
   });
 
+  describe('table path project qualification', () => {
+    // The default project (BigQuery's defaultProjectId / connection
+    // `projectId`) must end up in the stored tablePath so it lands in the
+    // emitted SQL. Otherwise an unqualified `dataset.table` resolves against
+    // the job's billing/ambient project rather than the default project.
+    const emptySchema = {
+      schema: {fields: []},
+      needsTableSuffixPseudoColumn: false,
+      needsPartitionTimePseudoColumn: false,
+      needsPartitionDatePseudoColumn: false,
+    };
+
+    function makeConnection(
+      projectId = 'my-default-project'
+    ): BigQueryConnection {
+      const conn = new BigQueryConnection({name: 'qualify_test', projectId});
+      jest.spyOn(conn, 'getTableFieldSchema').mockResolvedValue(emptySchema);
+      return conn;
+    }
+
+    async function tablePathOf(
+      conn: BigQueryConnection,
+      tablePath: string
+    ): Promise<string> {
+      const tableDef = await conn.fetchTableSchema('t', tablePath);
+      if (typeof tableDef === 'string') {
+        throw new Error(tableDef);
+      }
+      return tableDef.tablePath;
+    }
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('prepends the default project to a 2-part table path', async () => {
+      expect(await tablePathOf(makeConnection(), 'malloytest.carriers')).toBe(
+        'my-default-project.malloytest.carriers'
+      );
+    });
+
+    it('leaves a fully-qualified 3-part table path unchanged', async () => {
+      expect(
+        await tablePathOf(makeConnection(), 'other-project.malloytest.carriers')
+      ).toBe('other-project.malloytest.carriers');
+    });
+
+    it('prepends the project but leaves a quoted segment verbatim', async () => {
+      // The user's text is pasted as written; we only add the project in front.
+      expect(
+        await tablePathOf(makeConnection(), 'malloytest.`weird table`')
+      ).toBe('my-default-project.malloytest.`weird table`');
+    });
+
+    it('quotes a project id that BigQuery requires quoted', async () => {
+      // A legacy domain-scoped project id is not a bare identifier, so the one
+      // segment we render ourselves gets backtick-quoted.
+      expect(
+        await tablePathOf(
+          makeConnection('google.com:acme'),
+          'malloytest.carriers'
+        )
+      ).toBe('`google.com:acme`.malloytest.carriers');
+    });
+
+    it('leaves a whole-backtick path verbatim (one segment, not two)', async () => {
+      // `\`dataset.table\`` decodes to a single quoted segment, so the
+      // two-segment rule does not fire and we touch nothing.
+      expect(await tablePathOf(makeConnection(), '`my dataset.events_*`')).toBe(
+        '`my dataset.events_*`'
+      );
+    });
+  });
+
   describe('Caching', () => {
     let getTableFieldSchema: jest.SpyInstance;
     let getSQLBlockSchema: jest.SpyInstance;

--- a/packages/malloy-db-bigquery/src/bigquery_connection.ts
+++ b/packages/malloy-db-bigquery/src/bigquery_connection.ts
@@ -353,16 +353,20 @@ export class BigQueryConnection
     };
   }
 
-  // The whole-backtick form `` `proj.dataset.table` `` parses as one
-  // quoted segment, but the metadata API still wants the parts
-  // separately — split its decoded body on `.` to recover them.
-  private decodeTablePathSegments(tablePath: string): string[] {
-    const result = decodeDottedTablePath(tablePath, {
+  private decodeTablePath(tablePath: string) {
+    return decodeDottedTablePath(tablePath, {
       quoteChar: '`',
       escapeStyle: 'backslash',
       bareIdentRegex: this.dialect.tablePathBareIdentRegex,
       dialectName: 'BigQuery',
     });
+  }
+
+  // The whole-backtick form `` `proj.dataset.table` `` parses as one
+  // quoted segment, but the metadata API still wants the parts
+  // separately — split its decoded body on `.` to recover them.
+  private decodeTablePathSegments(tablePath: string): string[] {
+    const result = this.decodeTablePath(tablePath);
     if (!result.ok) return [tablePath];
     if (result.segments.length === 1 && result.segments[0].quoted) {
       return result.segments[0].value.split('.');
@@ -585,21 +589,46 @@ export class BigQueryConnection
     }
   }
 
+  // tablePath is pasted into the FROM clause verbatim — we never edit the
+  // characters the user wrote. The default project is the one sanctioned
+  // addition: BigQuery resolves an unqualified `dataset.table` against the
+  // job's billing/ambient project, so when the user omits the project we
+  // prepend it as a new leading segment. We do this exactly when the user
+  // wrote a two-segment path; anything else (a single segment, an already-
+  // qualified path, or a path wrapped entirely in backticks — which decodes
+  // to one segment) is left as written, and the user supplies the project.
+  // The project is the one segment we render ourselves, so we quote it if
+  // BigQuery requires it (e.g. a legacy `domain.com:project` id).
+  private qualifyTablePath(tablePath: string): string {
+    const decoded = this.decodeTablePath(tablePath);
+    if (!decoded.ok || decoded.segments.length !== 2) {
+      return tablePath;
+    }
+    return `${this.encodeProjectSegment(this.projectId)}.${tablePath}`;
+  }
+
+  private encodeProjectSegment(project: string): string {
+    // Leave it bare only if the whole id is a bare table-path segment (the
+    // regex anchors the start, so require it to match end to end); otherwise
+    // quote it the way BigQuery would any other identifier.
+    const bare = this.dialect.tablePathBareIdentRegex.exec(project);
+    if (bare && bare[0] === project) {
+      return project;
+    }
+    return this.dialect.sqlQuoteIdentifier(project);
+  }
+
   async fetchTableSchema(
     tableName: string,
     tablePath: string
   ): Promise<TableSourceDef | string> {
-    // Keep the canonical tablePath (which may be backtick-wrapped for
-    // wildcard tables) for downstream SQL emission. The metadata lookup
-    // wants the unwrapped form, which `getTableFieldSchema` handles via
-    // `normalizeTablePath`.
     try {
       const tableFieldSchema = await this.getTableFieldSchema(tablePath);
       const tableDef: TableSourceDef = {
         type: 'table',
         name: tableName,
         dialect: this.dialectName,
-        tablePath,
+        tablePath: this.qualifyTablePath(tablePath),
         connection: this.name,
         fields: [],
       };


### PR DESCRIPTION
A BigQuery connection configured with a default project (`defaultProjectId` in Publisher, `projectId` on the connection) is supposed to let you write `dataset.table` and have the project filled in. Since `@malloydata/db-bigquery ^0.0.405` it stopped doing that: the table resolves against the job's billing/ambient project instead, which for ADC-only runtimes is the runtime's own project, not yours.

The cause is a side-effect of #2813. That PR removed the `normalizeTablePath` call at the top of `fetchTableSchema`, so the two-segment path is now stored on `TableSourceDef.tablePath` unqualified and pasted into the `FROM` clause verbatim. The project qualification survived only for the metadata API lookup, not for the SQL we actually run.

The fix restores qualification on the stored path while staying inside the contract #2813 established — *we don't edit the characters the user wrote*. We only ever prepend the default project as a new leading segment, and only when the path decodes to exactly two segments. Anything else — a single segment, an already-qualified path, or a path the user wrapped entirely in backticks (which decodes to one segment) — is left exactly as written, and the user supplies the project. The project is the one segment we render ourselves, so it's quoted via the dialect's identifier quoter when BigQuery would require it (e.g. a legacy `domain.com:project` id).

What this deliberately does **not** do is reach inside a user's backticks to re-quote their text — that would need BigQuery's position-aware quoting rules, which #2813 explicitly deferred. The one shape not auto-served (a whole-backtick two-part name *and* reliance on the default project) is a one-line fix in the user's own model.

Verified with `ci-bigquery` (live BigQuery), plus unit coverage for: bare two-part → prepended, three-part → unchanged, quoted segment → project added with the user's quoting preserved, legacy project id → quoted, whole-backtick → untouched.