### PR TITLE
Enforce the deferred Dependabot pins, group the connectors, clear render build noise

### DIFF
--- a/.github/dependabot-pins.md
+++ b/.github/dependabot-pins.md
@@ -42,6 +42,23 @@ Holds open: `uuid` — 2×medium.
 
 Revisit when: a deliberate uuid migration, or a high/critical uuid advisory lands.
 
+### duckdb-wasm — `@motherduck/wasm-client` held at `^0.6.6`
+Owned by `packages/malloy-db-duckdb` (the duckdb-wasm browser connector,
+`src/duckdb_wasm_connection_browser.ts`). Held because that code is written
+against the old 0.6 API: `0.8` renamed the type exports (`DuckDBDate`,
+`DuckDBDecimal`, `DuckDBList`, the `DuckDBTimestamp*` family, …) and reshaped
+`SpecialDuckDBValue`, so the bump fails `tsc`. It rode the minor/patch group as a
+"minor" — the **0.x trap**, where a 0.x minor is allowed to break — and broke the
+#2911 group build. Now ignored for **all** versions in `dependabot.yml`, matching
+the `@dependabot ignore @motherduck/wasm-client` comment on #2911. (That comment
+lives only in Dependabot's memory; this row + the `ignore` are the durable record.)
+
+Cost: the duckdb-wasm connector can't take `@motherduck/wasm-client` updates, and
+latest is `1.5.3-r.2` — so it's far behind, and the gap grows.
+
+Revisit when: a deliberate migration of `duckdb_wasm_connection_browser.ts` to the
+new `@motherduck/wasm-client` API.
+
 ## Not pins — context, so this list stays short
 
 - **Connector SDKs other than Snowflake** (`trino-client`, `@databricks/sql`,

--- a/.github/dependabot-pins.md
+++ b/.github/dependabot-pins.md
@@ -8,12 +8,22 @@ and when we'd revisit it. Reviewed monthly (see [CONTEXT.md](./CONTEXT.md)): for
 each pin, is its "Revisit when" now true, and has its cost escalated (a new
 critical behind it)?
 
+**Two surfaces per pin.** A pinned *direct* dependency (`snowflake-sdk`,
+`vega-lite`, `@motherduck/wasm-client`, `vscode-textmate`, `uuid`) emits its own
+recurring version-update PR, so each is `ignore`d in `dependabot.yml` to stop it
+squatting the PR limit — and exact-pinned in its `package.json` where the existing
+range would otherwise let a fresh `npm install` resolve the bad version. The
+*transitive* advisories a pin holds open are alert-only (no PR); those are what's
+listed under each entry.
+
 ## Pins (deliberate holds)
 
 ### Snowflake — `snowflake-sdk` pinned exactly at `2.3.1`
 Owned by `packages/malloy-db-snowflake` (see its CONTEXT.md). The exact pin (no
 caret) is intentional: floating the SDK thrashes the native connector chain, so
-bumps are made deliberately, not by a lockfile range.
+bumps are made deliberately, not by a lockfile range. Now also `ignore`d in
+`dependabot.yml` so Dependabot stops proposing bumps (it would otherwise pull
+snowflake-sdk into the connectors group).
 
 Holds open (alert-only — no PR):
 - `fast-xml-parser` — 2×critical, 4×high *(also pulled by BigQuery's
@@ -26,10 +36,13 @@ Snowflake CI env. Not a lockfile bump.
 
 ### Renderer — Vega held at v5 (via `vega-lite ^5`)
 Owned by `packages/malloy-render` (see its CONTEXT.md). The fix is Vega 6, a major
-across the whole render stack.
+across the whole render stack. `vega-lite` is a *direct* dep, so its major opens a
+recurring monthly PR — its **major** is `ignore`d in `dependabot.yml` so it stops
+squatting the limit; the v5 minors still flow.
 
-Holds open: `vega`, `vega-functions`, `vega-expression` — 3×high. Render-owned
-only (nothing else pulls them), so the renderer is the sole place that clears them.
+Holds open: `vega`, `vega-functions`, `vega-expression` — 3×high (transitive,
+alert-only). Render-owned only (nothing else pulls them), so the renderer is the
+sole place that clears them.
 
 Revisit when: the renderer's Vega 5→6 upgrade.
 
@@ -59,13 +72,29 @@ latest is `1.5.3-r.2` — so it's far behind, and the gap grows.
 Revisit when: a deliberate migration of `duckdb_wasm_connection_browser.ts` to the
 new `@motherduck/wasm-client` API.
 
+### syntax-highlight — `vscode-textmate` held at `9.0.0`
+Owned by `packages/malloy-syntax-highlight`. Unlike the others, the dep isn't the
+problem — *our code is*. `scripts/generateMonarchGrammar.ts` deep-imports internal
+paths (`vscode-textmate/release/theme`, `/rawGrammar`) and relies on
+`TextMateBeginEndRule`'s private shape. `9.3.2` — an **in-range minor** — stopped
+exporting those internals, breaking the syntax-highlight codegen in the #2911
+group. Exact-pinned to `9.0.0` (the `^9.0.0` range would otherwise resolve the
+breaker) and `ignore`d in `dependabot.yml`.
+
+Cost: held one minor behind; no security advisory rides on it.
+
+Revisit when: issue #2918 — stop deep-importing vscode-textmate internals, then
+unpin. (Relates to the textmate-grammar-rebuild work.)
+
 ## Not pins — context, so this list stays short
 
 - **Connector SDKs other than Snowflake** (`trino-client`, `@databricks/sql`,
-  `@google-cloud/*`) aren't pinned — just not-yet-upgraded. Their transitive
-  advisories (`axios`, `thrift`, `fast-xml-parser`, `uuid`) clear by a deliberate
-  per-dialect SDK bump, each verified against that dialect's live CI env. Tracked
-  as connector maintenance, not here.
+  `@google-cloud/*`, `mysql2`, `pg`, …) aren't pinned — just not-yet-upgraded.
+  Their transitive advisories (`axios`, `thrift`, `fast-xml-parser`, `uuid`) clear
+  by a deliberate per-dialect SDK bump, each verified against that dialect's live
+  CI env. They're collected into the `connectors` group in `dependabot.yml` so a
+  bump lands as its own deliberate PR instead of riding the routine minor/patch
+  merge. Tracked as connector maintenance, not here.
 - **Dev/build tooling is the majority of the alert count and never ships.** `tar`,
   `shell-quote`, `ws`, `tmp`, `minimatch`, `js-yaml`, `markdown-it`, `basic-ftp`,
   `@babel/*` and friends arrive transitively via lerna/nx/storybook/karma/eslint/

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,13 @@ updates:
       # unmergeable security PR. The alert stays visible; see dependabot-pins.md.
       - dependency-name: "uuid"
         update-types: ["version-update:semver-major"]
+      # @motherduck/wasm-client held at ^0.6.6: the duckdb-wasm connector
+      # (packages/malloy-db-duckdb) is written against the old 0.6 API. The 0.8
+      # "minor" reshaped the type exports / SpecialDuckDBValue — a 0.x minor that
+      # breaks — so it broke the #2911 group build; latest is 1.5.3-r.2, so moving
+      # it is a deliberate connector migration. No update-types = hold all
+      # versions (matches the @dependabot ignore comment). See dependabot-pins.md.
+      - dependency-name: "@motherduck/wasm-client"
     groups:
       # Not for fragmentation (the per-platform node-bindings are transitive here,
       # so they never fan out). It's a deliberate callout: a duckdb bump has

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,23 @@ updates:
       # it is a deliberate connector migration. No update-types = hold all
       # versions (matches the @dependabot ignore comment). See dependabot-pins.md.
       - dependency-name: "@motherduck/wasm-client"
+      # vscode-textmate held at 9.0.0: our generateMonarchGrammar.ts deep-imports
+      # internal paths (vscode-textmate/release/theme, /rawGrammar) and rule types
+      # that 9.3.2 — an in-range MINOR — stopped exporting, breaking the
+      # syntax-highlight codegen in #2911. Also exact-pinned in
+      # malloy-syntax-highlight/package.json (^9.0.0 would resolve the breaker on a
+      # fresh install). The real fix is issue #2918; see dependabot-pins.md.
+      - dependency-name: "vscode-textmate"
+      # snowflake-sdk is exact-pinned (2.3.1) in malloy-db-snowflake; ignore here
+      # so Dependabot stops proposing bumps that would otherwise ride the
+      # connectors group. Deliberate bumps happen by hand against live Snowflake
+      # CI. See dependabot-pins.md.
+      - dependency-name: "snowflake-sdk"
+      # vega-lite held at v5 (the renderer's Vega 5->6 upgrade is deferred). It's a
+      # direct dep, so its major opens a recurring monthly PR; ignore the major so
+      # it stops squatting the limit. v5 minors still flow. See dependabot-pins.md.
+      - dependency-name: "vega-lite"
+        update-types: ["version-update:semver-major"]
     groups:
       # Not for fragmentation (the per-platform node-bindings are transitive here,
       # so they never fan out). It's a deliberate callout: a duckdb bump has
@@ -40,6 +57,24 @@ updates:
           - "prettier"
         update-types:
           - "major"
+      # Connector SDKs are high-blast-radius — native bits, dialect-specific, only
+      # meaningfully verified against their live DB CI. Group them so any connector
+      # bump lands as its own deliberate PR instead of riding the routine
+      # minor/patch merge (which is how a @databricks/sql bump slipped in, and how
+      # the motherduck/vscode-textmate breakers poisoned #2911). Held connectors
+      # (snowflake-sdk, @motherduck/*) are also in the ignore list, so they won't
+      # appear here. Placed before minor-and-patch so connector deps match here first.
+      connectors:
+        patterns:
+          - "@google-cloud/*"
+          - "@databricks/*"
+          - "@prestodb/*"
+          - "trino-client"
+          - "snowflake-sdk"
+          - "@motherduck/*"
+          - "mysql2"
+          - "pg"
+          - "pg-query-stream"
       minor-and-patch:
         patterns:
           - "*"

--- a/package-lock.json
+++ b/package-lock.json
@@ -28977,7 +28977,7 @@
         "@duckdb/duckdb-wasm": "1.33.1-dev45.0",
         "@duckdb/node-api": "1.5.3-r.2",
         "@malloydata/malloy": "0.0.416",
-        "@motherduck/wasm-client": "^0.6.6",
+        "@motherduck/wasm-client": "0.6.6",
         "apache-arrow": "^17.0.0",
         "web-worker": "^1.5.0"
       },
@@ -30670,7 +30670,7 @@
         "karma-spec-reporter": "^0.0.36",
         "monaco-editor": "^0.41.0",
         "vscode-oniguruma": "^1.7.0",
-        "vscode-textmate": "^9.0.0"
+        "vscode-textmate": "9.0.0"
       },
       "engines": {
         "node": ">=20"

--- a/packages/malloy-db-duckdb/package.json
+++ b/packages/malloy-db-duckdb/package.json
@@ -62,7 +62,7 @@
     "@duckdb/duckdb-wasm": "1.33.1-dev45.0",
     "@duckdb/node-api": "1.5.3-r.2",
     "@malloydata/malloy": "0.0.416",
-    "@motherduck/wasm-client": "^0.6.6",
+    "@motherduck/wasm-client": "0.6.6",
     "apache-arrow": "^17.0.0",
     "web-worker": "^1.5.0"
   }

--- a/packages/malloy-render/tsconfig.json
+++ b/packages/malloy-render/tsconfig.json
@@ -7,7 +7,7 @@
     "noImplicitReturns": true,
     "jsx": "react-jsx",
     "jsxImportSource": "solid-js",
-    "lib": ["dom", "es2021"],
+    "lib": ["dom", "es2021", "es2022.array", "es2022.string"],
     "paths": {
       "@/*": ["./src/*"]
     },

--- a/packages/malloy-syntax-highlight/package.json
+++ b/packages/malloy-syntax-highlight/package.json
@@ -40,6 +40,6 @@
     "karma-spec-reporter": "^0.0.36",
     "monaco-editor": "^0.41.0",
     "vscode-oniguruma": "^1.7.0",
-    "vscode-textmate": "^9.0.0"
+    "vscode-textmate": "9.0.0"
   }
 }


### PR DESCRIPTION
Follow-up to #2910. That PR made Dependabot useful and *documented* the dependencies we deliberately hold; this one makes the holds real, splits the connectors out of the routine pile, and clears the build noise the rollout surfaced.

**Enforce the pins.** #2910 recorded the deferred deps in the ledger, but only `uuid` and `@types/node` were actually told to Dependabot — the rest would keep opening PRs, and `snowflake-sdk`/`vega-lite` would squat the limit every month. Now every held dep is `ignore`d in `dependabot.yml` and, where its range still allowed the bad version, exact-pinned in `package.json`:
- `snowflake-sdk`, `vega-lite` (major only), `@motherduck/wasm-client`, `vscode-textmate`, alongside the existing `uuid` / `@types/node`.
- `@motherduck/wasm-client` and `vscode-textmate` are both #2911 group breakers — the 0.x trap (a "minor" that broke) and a reach-into-a-dep's-internals fragility, respectively. The latter is a real bug in our code, tracked as #2918.

**Group the connectors.** DB-SDK bumps (`@google-cloud/*`, `@databricks/*`, `trino-client`, `mysql2`, `pg`, …) now land as their own deliberate PR — verified against the dialect's live DB CI — instead of riding the routine minor/patch merge, which is how a `@databricks/sql` bump slipped into #2911.

**Clear the build noise.** `malloy-render`'s tsconfig dropped `es2022` from its `lib`, lighting up false `.at()` `TS2550` errors on every `vite build`. Restored; the full build is now TS-error-clean. Chasing it surfaced a deeper gap — render's types aren't gated in CI at all — filed separately as #2920.

The pin ledger (`.github/dependabot-pins.md`) is corrected: a pinned *direct* dep emits its own (now-suppressed) version PR; only the transitive advisories it holds open are alert-only.