### PR TITLE
Hold the pg cluster until it's bumped as a coupled set

### DIFF
--- a/.github/dependabot-pins.md
+++ b/.github/dependabot-pins.md
@@ -86,6 +86,21 @@ Cost: held one minor behind; no security advisory rides on it.
 Revisit when: issue #2918 — stop deep-importing vscode-textmate internals, then
 unpin. (Relates to the textmate-grammar-rebuild work.)
 
+### Postgres — `pg` + `pg-query-stream` held as a coupled set
+Owned by `packages/malloy-db-postgres`. `pg-query-stream` pulls `pg-cursor`, which
+**deep-imports `pg`'s internal `lib/result.js`**. The connectors-group PR #2923
+bumped `pg` 8.7→8.22, skewing those versions, and `pg-cursor` could no longer
+resolve the internal path — which broke module resolution in **every** dialect's
+test suite (the shared harness loads the postgres path), not just postgres. `pg`,
+`pg-cursor`, and `pg-query-stream` are a **coupled set** that must move together
+(like the gts/eslint cluster). `pg` is exact-pinned to `8.7.3` in `package.json`
+(the `^8.7.1` range admitted the breaker on a fresh install); both are `ignore`d.
+
+Cost: postgres connector held a few minors behind; no security advisory rides on it.
+
+Revisit when: issue #2928 — bump `pg` + `pg-cursor` + `pg-query-stream` together to
+compatible versions, verify `db-postgres` + the shared harness, then unpin.
+
 ## Not pins — context, so this list stays short
 
 - **Connector SDKs other than Snowflake** (`trino-client`, `@databricks/sql`,

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,6 +39,15 @@ updates:
       # it stops squatting the limit. v5 minors still flow. See dependabot-pins.md.
       - dependency-name: "vega-lite"
         update-types: ["version-update:semver-major"]
+      # pg + pg-query-stream held: pg-query-stream pulls pg-cursor, which
+      # deep-imports pg's internal lib/result.js. Bumping pg (8.7->8.22 in the
+      # connectors group, #2923) skewed those versions and broke module resolution
+      # in EVERY dialect's test suite (the shared harness loads the postgres path).
+      # pg is also exact-pinned (8.7.3) in malloy-db-postgres/package.json since
+      # ^8.7.1 would resolve the breaker on a fresh install. They're a coupled set
+      # (pg/pg-cursor/pg-query-stream move together); the real fix is issue #2928.
+      - dependency-name: "pg"
+      - dependency-name: "pg-query-stream"
     groups:
       # Not for fragmentation (the per-platform node-bindings are transitive here,
       # so they never fan out). It's a deliberate callout: a duckdb bump has

--- a/package-lock.json
+++ b/package-lock.json
@@ -29921,7 +29921,7 @@
       "dependencies": {
         "@malloydata/malloy": "0.0.416",
         "@types/pg": "^8.6.1",
-        "pg": "^8.7.1",
+        "pg": "8.7.3",
         "pg-query-stream": "4.2.3"
       },
       "engines": {

--- a/packages/malloy-db-postgres/package.json
+++ b/packages/malloy-db-postgres/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@malloydata/malloy": "0.0.416",
     "@types/pg": "^8.6.1",
-    "pg": "^8.7.1",
+    "pg": "8.7.3",
     "pg-query-stream": "4.2.3"
   }
 }


### PR DESCRIPTION
The connectors-group PR #2923 went red across **every dialect** (not just postgres) with:

```
Cannot find module 'pg/lib/result.js' from 'node_modules/pg-cursor/index.js'
```

It bumped `pg` 8.7→8.22, skewing it against the `pg-cursor` that `pg-query-stream` pulls — `pg-cursor` **deep-imports `pg`'s internal `lib/result.js`**, and the bump broke that resolution. Because the shared test harness loads the postgres path, the broken require failed module resolution at load time for all dialects.

This makes the hold durable instead of a silent `@dependabot ignore` comment:
- **exact-pin `pg` to 8.7.3** in `packages/malloy-db-postgres/package.json` — the `^8.7.1` range admitted the breaker on a fresh `npm install` (`pg-query-stream` was already exact)
- **`ignore` `pg` + `pg-query-stream`** in `.github/dependabot.yml`
- **record the coupled-set hold** in `.github/dependabot-pins.md`

`pg` / `pg-cursor` / `pg-query-stream` are a must-move-together set (like gts/eslint). The real fix — bumping all three to compatible versions and removing the hold — is **#2928**.