### PR TITLE
Hold @google-cloud/bigquery at v7 (8 breaks under jest via gaxios-7's ESM import)

### DIFF
--- a/.github/dependabot-pins.md
+++ b/.github/dependabot-pins.md
@@ -101,6 +101,28 @@ Cost: postgres connector held a few minors behind; no security advisory rides on
 Revisit when: issue #2928 — bump `pg` + `pg-cursor` + `pg-query-stream` together to
 compatible versions, verify `db-postgres` + the shared harness, then unpin.
 
+### BigQuery — `@google-cloud/bigquery` + `common` + `paginator` held at v7/v5
+Owned by `packages/malloy-db-bigquery`, exact-pinned to **best-v7** (`7.9.4` /
+`5.0.2` / `5.0.2`) as a coupled set. bigquery **8** pulls `@google-cloud/common@6`
+→ `google-auth-library@10` → `gaxios@7`, and gaxios 7 does an **ESM-only dynamic
+`import()`** in its token/request path. Under jest's CommonJS VM that throws
+`ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING_FLAG`, surfaced as "Unexpected Gaxios
+Error" → every bigquery test fails. The only thing that fixes jest is
+`NODE_OPTIONS=--experimental-vm-modules`; babel-transforming gaxios can't help (the
+import target is ESM-only, can't be `require`d). We don't take the flag: it can't
+be made invisible for a bare `npx jest FILE -t NAME` (no project-local
+`NODE_OPTIONS`), so it breaks the single-test workflow, and it's an experimental
+Node API applied suite-wide. **bigquery 8 itself is fine in plain node** — the
+break is jest-only.
+
+Cost: bigquery connector held on the v7 SDK line; whatever transitive security the
+v8 stack would clear stays open.
+
+Revisit when: issue #2932 — when the test runner handles the ESM-only import
+without the experimental flag (jest → vitest, or jest gains stable ESM), or gaxios
+drops the ESM-only `import()`. Then bump the trio together, confirm `db-bigquery`
+**and** the ci-core bigquery `streaming.spec` pass **without** the flag, and unpin.
+
 ## Not pins — context, so this list stays short
 
 - **Connector SDKs other than Snowflake** (`trino-client`, `@databricks/sql`,

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -48,6 +48,16 @@ updates:
       # (pg/pg-cursor/pg-query-stream move together); the real fix is issue #2928.
       - dependency-name: "pg"
       - dependency-name: "pg-query-stream"
+      # @google-cloud/bigquery + common + paginator held at v7/v5 (a coupled set).
+      # bigquery 8 -> common 6 -> google-auth-library 10 -> gaxios 7, and gaxios 7
+      # does an ESM-only dynamic import() that fails under jest without
+      # --experimental-vm-modules; that flag can't be made invisible for
+      # `npx jest FILE` and is experimental, so we hold v7. Pinned to best-v7 in
+      # malloy-db-bigquery/package.json. Unpin per issue #2932 (jest->vitest, or
+      # the ESM-only import going away).
+      - dependency-name: "@google-cloud/bigquery"
+      - dependency-name: "@google-cloud/common"
+      - dependency-name: "@google-cloud/paginator"
     groups:
       # Not for fragmentation (the per-platform node-bindings are transitive here,
       # so they never fan out). It's a deliberate callout: a duckdb bump has

--- a/package-lock.json
+++ b/package-lock.json
@@ -4627,14 +4627,15 @@
       }
     },
     "node_modules/@google-cloud/bigquery": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@google-cloud/bigquery/-/bigquery-7.3.0.tgz",
-      "integrity": "sha512-a/qQBOMlSRIVm262Kp3+Zg2+Et2fl+AwQv8mpVtvrpyk+wYQaY3dTK3U+RE6aWCiq/R1xo1vIXIYCRAQAoBsfw==",
+      "version": "7.9.4",
+      "resolved": "https://registry.npmjs.org/@google-cloud/bigquery/-/bigquery-7.9.4.tgz",
+      "integrity": "sha512-C7jeI+9lnCDYK3cRDujcBsPgiwshWKn/f0BiaJmClplfyosCLfWE83iGQ0eKH113UZzjR9c9q7aZQg0nU388sw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@google-cloud/common": "^5.0.0",
-        "@google-cloud/paginator": "^5.0.0",
+        "@google-cloud/paginator": "^5.0.2",
         "@google-cloud/precise-date": "^4.0.0",
-        "@google-cloud/promisify": "^4.0.0",
+        "@google-cloud/promisify": "4.0.0",
         "arrify": "^2.0.1",
         "big.js": "^6.0.0",
         "duplexify": "^4.0.0",
@@ -4660,17 +4661,18 @@
       }
     },
     "node_modules/@google-cloud/common": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-5.0.1.tgz",
-      "integrity": "sha512-7NBC5vD0au75nkctVs2vEGpdUPFs1BaHTMpeI+RVEgQSMe5/wEU6dx9p0fmZA0bj4HgdpobMKeegOcLUiEoxng==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-5.0.2.tgz",
+      "integrity": "sha512-V7bmBKYQyu0eVG2BFejuUjlBt+zrya6vtsKdY+JxMM/dNntPF41vZ9+LhOshEUH01zOHEqBSvI7Dad7ZS6aUeA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@google-cloud/projectify": "^4.0.0",
         "@google-cloud/promisify": "^4.0.0",
         "arrify": "^2.0.1",
         "duplexify": "^4.1.1",
-        "ent": "^2.2.0",
         "extend": "^3.0.2",
         "google-auth-library": "^9.0.0",
+        "html-entities": "^2.5.2",
         "retry-request": "^7.0.0",
         "teeny-request": "^9.0.0"
       },
@@ -4678,10 +4680,27 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@google-cloud/common/node_modules/html-entities": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
+      "integrity": "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mdevils"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/mdevils"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@google-cloud/paginator": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-5.0.0.tgz",
-      "integrity": "sha512-87aeg6QQcEPxGCOthnpUjvw4xAZ57G7pL8FS0C4e/81fr3FjkpUpibf1s2v5XGyGhUVGF4Jfg7yEcxqn2iUw1w==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-5.0.2.tgz",
+      "integrity": "sha512-DJS3s0OVH4zFDB1PzjxAsHqJT6sKVbRwwML0ZBP9PbU7Yebtu/7SWMRzvO2J3nUi9pRNITCfu4LJeooM2w4pjg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "arrify": "^2.0.0",
         "extend": "^3.0.2"
@@ -29787,9 +29806,9 @@
       "version": "0.0.416",
       "license": "MIT",
       "dependencies": {
-        "@google-cloud/bigquery": "^7.3.0",
-        "@google-cloud/common": "^5.0.1",
-        "@google-cloud/paginator": "^5.0.0",
+        "@google-cloud/bigquery": "7.9.4",
+        "@google-cloud/common": "5.0.2",
+        "@google-cloud/paginator": "5.0.2",
         "@malloydata/malloy": "0.0.416",
         "gaxios": "^4.2.0"
       },

--- a/packages/malloy-db-bigquery/package.json
+++ b/packages/malloy-db-bigquery/package.json
@@ -23,9 +23,9 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@google-cloud/bigquery": "^7.3.0",
-    "@google-cloud/common": "^5.0.1",
-    "@google-cloud/paginator": "^5.0.0",
+    "@google-cloud/bigquery": "7.9.4",
+    "@google-cloud/common": "5.0.2",
+    "@google-cloud/paginator": "5.0.2",
     "@malloydata/malloy": "0.0.416",
     "gaxios": "^4.2.0"
   }


### PR DESCRIPTION
The connectors-group bump to `@google-cloud/bigquery@8` fails CI. Root cause: 8 pulls `@google-cloud/common@6` → `google-auth-library@10` → `gaxios@7`, and gaxios 7 does an **ESM-only dynamic `import()`** in its token/request path. Under jest's CommonJS VM that throws `ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING_FLAG`, surfaced as "Unexpected Gaxios Error" → every bigquery test fails (823 in the live `db-bigquery` job).

**bigquery 8 is fine in plain node** — verified, it authenticates and runs requests cleanly. The break is **jest-only**. The single thing that fixes jest is `NODE_OPTIONS=--experimental-vm-modules` (verified: 7/7 tests pass with it); babel-transforming gaxios can't help because the import target is ESM-only and can't be `require`d. We don't take the flag — it can't be made invisible for a bare `npx jest FILE -t NAME` (no project-local `NODE_OPTIONS`), so it breaks the repo's single-test workflow, and it's an experimental Node API applied suite-wide.

So we **defer**, properly pinned (not just ignored, so the green state can't drift):
- push the v7 line to its best version and **exact-pin the coupled trio** in `packages/malloy-db-bigquery/package.json`: `@google-cloud/bigquery` 7.9.4 / `common` 5.0.2 / `paginator` 5.0.2 (verified: build clean, 7/7 bigquery tests pass)
- `ignore` all three in `.github/dependabot.yml`
- record it in `.github/dependabot-pins.md`

Real fix + unpin condition (jest → vitest, or the ESM-only import going away) tracked in **#2932**.