### PR TITLE
fix(render): add import/require export conditions for ESM consumers

### DIFF
--- a/packages/malloy-render/package.json
+++ b/packages/malloy-render/package.json
@@ -15,6 +15,8 @@
   "exports": {
     ".": {
       "types": "./dist/module/index.d.ts",
+      "import": "./dist/module/index.mjs",
+      "require": "./dist/module/index.umd.js",
       "default": "./dist/module/index.umd.js"
     }
   },


### PR DESCRIPTION
The renderer's exports map only declared a default condition, so ESM consumers resolving the package by named import (e.g. @malloydata/malloy-explorer) could not pick up the ES build. Add explicit import and require conditions pointing at the existing index.mjs and index.umd.js outputs the vite lib build already emits.