### PR TITLE
handle expr DOT timeframe when the user mean expr DOT `timeframe`

### DIFF
--- a/packages/malloy/src/lang/ast/expressions/expr-granular-time.ts
+++ b/packages/malloy/src/lang/ast/expressions/expr-granular-time.ts
@@ -8,7 +8,12 @@ import type {
   TemporalTypeDef,
   TimestampUnit,
 } from '../../../model/malloy_types';
-import {isDateUnit, mkTemporal, TD} from '../../../model/malloy_types';
+import {
+  isBasicAtomicType,
+  isDateUnit,
+  mkTemporal,
+  TD,
+} from '../../../model/malloy_types';
 
 import {errorFor} from '../ast-utils';
 import * as TDU from '../typedesc-utils';
@@ -93,10 +98,29 @@ export class ExprGranularTime extends ExpressionDef {
       return tsVal;
     }
     if (exprVal.type !== 'error') {
-      this.logError(
-        'unsupported-type-for-time-truncation',
-        `Cannot do time truncation on type '${exprVal.type}'`
-      );
+      if (!isBasicAtomicType(exprVal.type)) {
+        // The truncation target has fields (a join/struct/record/array), so it
+        // can't be a time value. The likely intent is a field whose name is a
+        // time unit (e.g. `flight.year`); since `.year` parses as a truncation
+        // and time units are reserved words, that field has to be quoted.
+        const ref = this.expr.drillExpression();
+        const lhs =
+          ref?.kind === 'field_reference'
+            ? [...(ref.path ?? []), ref.name].join('.')
+            : undefined;
+        const quoted = lhs ? `${lhs}.\`${timeframe}\`` : `\`${timeframe}\``;
+        this.logError(
+          'unsupported-type-for-time-truncation',
+          `'.${timeframe}' is a time truncation, but ${
+            lhs ? `'${lhs}'` : 'the left side'
+          } is type '${exprVal.type}', not a time value. If '${timeframe}' is a field name it must be quoted, because it is a reserved word: ${quoted}`
+        );
+      } else {
+        this.logError(
+          'unsupported-type-for-time-truncation',
+          `Cannot do time truncation on type '${exprVal.type}'`
+        );
+      }
     }
     const returnType = {...exprVal};
     if (exprVal.type === 'error') {

--- a/packages/malloy/src/lang/grammar/MalloyParser.g4
+++ b/packages/malloy/src/lang/grammar/MalloyParser.g4
@@ -570,7 +570,33 @@ ordering
   ;
 
 orderBySpec
-  : (INTEGER_LITERAL | fieldName) ( ASC | DESC ) ?
+  : (INTEGER_LITERAL | possibleBadPath) ( ASC | DESC ) ?
+  ;
+
+// order_by names a single (unquoted) output column, but we accept a more
+// permissive reference -- a dotted path and/or reserved-word segments like time
+// units (`flights.dep_year`) -- and let the visitor decide: a lone ordinary
+// name is fine, a lone reserved word must be quoted, a dotted path is never
+// legal here. Reusable wherever a single name is required and a path or a bare
+// keyword is a likely mistake worth a good error. See visitOrderBySpec.
+possibleBadPath
+  : badWord (DOT badWord)*
+  ;
+
+// A name segment that the parser accepts but that may be reserved. `fieldName`
+// is a legal name; everything else is a reserved word the user would have to
+// quote. Keep in sync with the bare keywords in MalloyLexer.g4 -- MINUS `ASC`
+// and `DESC`, which are the order_by direction suffix (allowing them here would
+// make `order_by: foo asc` ambiguous). `timeframe` covers the time units.
+badWord
+  : fieldName
+  | timeframe
+  | ALL | AND | AS | AVG | BOOLEAN | BY | CASE | CAST | COUNT | COMPOSE | DATE
+  | DISTINCT | ELSE | END | EXCLUDE | EXPORT | EXTEND | FALSE | FILTER | FULL
+  | FOR | FROM | HAS | IMPORT | INCLUDE | INNER | IS | IN | INTERNAL_KW | JSON
+  | LEFT | LIKE | MAX | MIN | NOT | NOW | NULL | NUMBER | ON | OR | PICK
+  | PRIVATE_KW | PUBLIC_KW | RIGHT | STRING | SOURCE_KW | SUM | SQL | TABLE
+  | THEN | THIS | TIMESTAMPTZ | TIMESTAMP | TO | TRUE | WHEN | WITH | VIRTUAL
   ;
 
 limitStatement

--- a/packages/malloy/src/lang/malloy-to-ast.ts
+++ b/packages/malloy/src/lang/malloy-to-ast.ts
@@ -1390,11 +1390,34 @@ export class MalloyToAST
     if (ncx) {
       return new ast.OrderBy(this.getNumber(ncx), dir);
     }
-    const fieldCx = pcx.fieldName();
-    if (fieldCx) {
-      return new ast.OrderBy(this.getFieldName(fieldCx), dir);
+    const pathCx = pcx.possibleBadPath();
+    if (!pathCx) {
+      throw this.internalError(pcx, "can't parse order_by specification");
     }
-    throw this.internalError(pcx, "can't parse order_by specification");
+    const words = pathCx.badWord();
+    const firstField = words[0].fieldName();
+    if (words.length === 1 && firstField) {
+      // A lone ordinary identifier -- the normal, valid order_by target.
+      return new ast.OrderBy(this.getFieldName(firstField), dir);
+    }
+    // Otherwise illegal: a dotted path, and/or a reserved-word segment that
+    // would have to be quoted. Logging an error here prevents translation, so
+    // the throwaway OrderBy below is never evaluated -- it only satisfies the
+    // visitor's contract.
+    const last = words[words.length - 1];
+    const lastFieldCx = last.fieldName();
+    const lastName = lastFieldCx ? lastFieldCx.text : '`' + last.text + '`';
+    const message =
+      words.length > 1
+        ? `order_by takes the name of a field in the query output, not a path ('${pathCx.text}'). ` +
+          `To order by '${last.text}', make it an output field and order by its name` +
+          (lastFieldCx === undefined
+            ? `, quoting it because '${last.text}' is a reserved word: ${lastName}`
+            : `: ${lastName}`) +
+          '.'
+        : `'${last.text}' is a reserved word, so to order by it you must quote it: ${lastName}`;
+    this.contextError(pathCx, 'order-by-bad-reference', message);
+    return new ast.OrderBy(new ast.FieldName('internal_error'), dir);
   }
 
   visitOrdering(pcx: parse.OrderingContext): ast.Ordering {

--- a/packages/malloy/src/lang/malloy-to-stable-query.ts
+++ b/packages/malloy/src/lang/malloy-to-stable-query.ts
@@ -385,17 +385,22 @@ export class MalloyToQuery
     for (const spec of specs) {
       if (spec.INTEGER_LITERAL()) {
         this.notAllowed(spec, 'Indexed order by statements');
-      } else if (spec.fieldName()) {
-        const fieldName = getId(spec.fieldName()!);
-        const direction = spec.ASC() ? 'asc' : spec.DESC() ? 'desc' : undefined;
-        orders.push({
-          kind: 'order_by',
-          direction,
-          field_reference: {name: fieldName},
-        });
-      } else {
+        continue;
+      }
+      // A valid order_by target is a single ordinary name; a dotted path or a
+      // bare reserved word is not representable as a stable query.
+      const words = spec.possibleBadPath()?.badWord() ?? [];
+      const firstField = words.length === 1 ? words[0].fieldName() : undefined;
+      if (!firstField) {
         return null;
       }
+      const fieldName = getId(firstField);
+      const direction = spec.ASC() ? 'asc' : spec.DESC() ? 'desc' : undefined;
+      orders.push({
+        kind: 'order_by',
+        direction,
+        field_reference: {name: fieldName},
+      });
     }
     return orders;
   }

--- a/packages/malloy/src/lang/parse-log.ts
+++ b/packages/malloy/src/lang/parse-log.ts
@@ -236,6 +236,7 @@ type MessageParameterTypes = {
   'aggregate-in-where': string;
   'order-by-not-found-in-output': string;
   'order-by-analytic': string;
+  'order-by-bad-reference': string;
   'illegal-index-operation': string;
   'illegal-project-operation': string;
   'illegal-grouping-operation': string;

--- a/packages/malloy/src/lang/test/expressions.spec.ts
+++ b/packages/malloy/src/lang/test/expressions.spec.ts
@@ -54,6 +54,19 @@ describe('expressions', () => {
     test.each(diffable)('timestamp difference - %s', unit => {
       expect(new BetaExpression(`${unit}(ats to @2030)`)).toParse();
     });
+
+    describe('truncation of a non-time value', () => {
+      test('a join/struct suggests quoting the colliding field', () =>
+        expect(model`run: a -> { select: x is aninline.year }`).toLogAtLeast(
+          errorMessage(
+            "'.year' is a time truncation, but 'aninline' is type 'record', not a time value. If 'year' is a field name it must be quoted, because it is a reserved word: aninline.`year`"
+          )
+        ));
+      test('a scalar keeps the generic error', () =>
+        expect(model`run: a -> { select: x is astr.year }`).toLogAtLeast(
+          errorMessage("Cannot do time truncation on type 'string'")
+        ));
+    });
   });
 
   test('field name', () => {

--- a/packages/malloy/src/lang/test/query.spec.ts
+++ b/packages/malloy/src/lang/test/query.spec.ts
@@ -1046,6 +1046,24 @@ describe('query:', () => {
         expect('run: a -> { order_by: af; group_by: astr }').toLog(
           errorMessage('Unknown field af in output space')
         ));
+      test('order by rejects a dotted path with a helpful error', () =>
+        expect('run: a -> { group_by: astr; order_by: aninline.column }').toLog(
+          errorMessage(
+            "order_by takes the name of a field in the query output, not a path ('aninline.column'). To order by 'column', make it an output field and order by its name: column."
+          )
+        ));
+      test('order by dotted path suggests quoting a reserved segment', () =>
+        expect('run: a -> { group_by: astr; order_by: aninline.year }').toLog(
+          errorMessage(
+            "order_by takes the name of a field in the query output, not a path ('aninline.year'). To order by 'year', make it an output field and order by its name, quoting it because 'year' is a reserved word: `year`."
+          )
+        ));
+      test('order by a bare reserved word suggests quoting', () =>
+        expect('run: a -> { group_by: astr; order_by: year }').toLog(
+          errorMessage(
+            "'year' is a reserved word, so to order by it you must quote it: `year`"
+          )
+        ));
       test('order by asc', () => {
         expect('run: a->{ order_by: astr asc; group_by: astr }').toTranslate();
       });


### PR DESCRIPTION
Common mistake when data has colums like `year`  or `hours` which are reserved words in Malloy.

Not possible to fix in all cases, this fixes a couple of common ones and gernates much more helpful errors.

### `event.year` on a join/struct

`.year` on a struct parses as a time truncation, so it died deep in the type checker with `Cannot do time truncation on type 'table'` — which mentions neither `year`, the field, nor quoting. Now, when the truncation target has fields (join/struct/record/array), it says:

> `'.year' is a time truncation, but 'event' is type 'table', not a time value. If 'year' is a field name it must be quoted, because it is a reserved word: event.`year``

Scalars (`astr.year`) keep the old generic message.

### `order_by: tournament.year`

`order_by` only accepted a single bare name, so a dotted path failed in the parser with `extraneous input '.'` and a ~60-token expected-token dump. The grammar now carries a permissive `possibleBadPath` (a dotted reference whose segments may be reserved words), and the visitor decides:

- a lone ordinary name → valid (unchanged)
- a lone reserved word → `'year' is a reserved word, so to order by it you must quote it: `year``
- a dotted path → `order_by takes the name of a field in the query output, not a path ('tournament.year'). To order by 'year', make it an output field and order by its name, quoting it because 'year' is a reserved word: `year`.`
