### PR TITLE
Shorter, readable parser error messages

### DIFF
--- a/packages/malloy/femto-config.motly
+++ b/packages/malloy/femto-config.motly
@@ -16,6 +16,16 @@ parser: {
   ]
 }
 
+tokenNames: {
+  deps = [lexer]
+  inputs = [
+    "src/lang/grammar/MalloyLexer.g4",
+    "src/lang/grammar/build_token_names.js"
+  ]
+  outputs = ["src/lang/lib/Malloy/keyword-display-names.ts"]
+  commands = ["node src/lang/grammar/build_token_names.js"]
+}
+
 codegen: {
-  deps = [parser]
+  deps = [parser, tokenNames]
 }

--- a/packages/malloy/src/lang/grammar/MalloyLexer.g4
+++ b/packages/malloy/src/lang/grammar/MalloyLexer.g4
@@ -31,6 +31,13 @@ lexer grammar MalloyLexer;
 
 fragment SPACE_CHAR: [ \u000B\t\r\n\u00A0];
 
+// KEYWORDS-BEGIN
+// Every rule between the markers is a keyword whose spelling is harvested by
+// build_token_names.js to produce readable parser-error names. Keep this
+// section to plain keyword rules: case-insensitive letter fragments, one-char
+// literals ('_', ':'), SPACE_CHAR, and ?/* quantifiers only. Anything fancier
+// (literals, patterns, punctuation) belongs below the closing marker.
+
 // colon keywords ...
 ACCEPT: A C C E P T SPACE_CHAR* ':';
 AGGREGATE: A G G R E G A T E SPACE_CHAR* ':';
@@ -140,6 +147,7 @@ WHEN: W H E N ;
 WITH: W I T H ;
 YEAR: Y E A R S?;
 VIRTUAL: V I R T U A L;
+// KEYWORDS-END
 
 fragment SQ: '\'';
 fragment BQ: '`';

--- a/packages/malloy/src/lang/grammar/build_token_names.js
+++ b/packages/malloy/src/lang/grammar/build_token_names.js
@@ -1,0 +1,194 @@
+/*
+ * Copyright Contributors to the Malloy project
+ * SPDX-License-Identifier: MIT
+ */
+
+// Reconstructs the spelling of Malloy's keyword tokens from the marked section
+// of MalloyLexer.g4, so parse errors can say `aggregate:` instead of the
+// SHOUTING symbolic name ANTLR gives keywords built from letter fragments
+// (`AGGREGATE: A G G R E G A T E SPACE_CHAR* ':'`). The trailing colon is part
+// of the rule, so it comes through for free.
+//
+// Membership is declared, not guessed: every rule inside the section must
+// reconstruct to a clean keyword, or the build FAILS. Keep anything fancier
+// (literals, patterns, punctuation) outside the markers.
+
+/* eslint-disable no-console */
+
+const {readFileSync, writeFileSync} = require('fs');
+const path = require('path');
+
+const grammarDir = __dirname;
+const lexerFile = path.join(grammarDir, 'MalloyLexer.g4');
+const outFile = path.join(
+  path.dirname(grammarDir),
+  'lib',
+  'Malloy',
+  'keyword-display-names.ts'
+);
+
+// Markers must stand alone on their own comment line, so a passing prose
+// mention of the marker name never gets mistaken for the delimiter.
+const BEGIN = /^[ \t]*\/\/[ \t]*KEYWORDS-BEGIN[ \t]*$/m;
+const END = /^[ \t]*\/\/[ \t]*KEYWORDS-END[ \t]*$/m;
+
+function fail(message) {
+  console.error(`build_token_names: ${message}`);
+  process.exit(1);
+}
+
+function keywordSection(grammarText) {
+  const begin = grammarText.match(BEGIN);
+  const end = grammarText.match(END);
+  if (!begin || !end || end.index < begin.index) {
+    fail(
+      'could not find // KEYWORDS-BEGIN .. // KEYWORDS-END in MalloyLexer.g4'
+    );
+  }
+  // Drop comments so only grammar rules remain. No keyword body contains a
+  // block comment or a `;`, so a plain split is safe within the section.
+  return grammarText
+    .slice(begin.index + begin[0].length, end.index)
+    .replace(/\/\*[\s\S]*?\*\//g, ' ')
+    .replace(/\/\/[^\n]*/g, ' ');
+}
+
+// Break a keyword rule body into atoms. Returns null for anything the scanner
+// cannot classify, which the caller turns into a hard failure.
+function tokenizeBody(body) {
+  const atoms = [];
+  let i = 0;
+  const n = body.length;
+  while (i < n) {
+    const c = body[i];
+    if (/\s/.test(c)) {
+      i++;
+      continue;
+    }
+    if (c === "'") {
+      let j = i + 1;
+      let raw = '';
+      while (j < n && body[j] !== "'") {
+        if (body[j] === '\\') {
+          raw += body[j + 1];
+          j += 2;
+        } else {
+          raw += body[j];
+          j++;
+        }
+      }
+      if (j >= n) return null;
+      atoms.push({kind: 'literal', text: raw});
+      i = j + 1;
+      continue;
+    }
+    if (/[A-Za-z_]/.test(c)) {
+      let j = i;
+      while (j < n && /[A-Za-z0-9_]/.test(body[j])) j++;
+      atoms.push({kind: 'name', text: body.slice(i, j)});
+      i = j;
+      continue;
+    }
+    if ('?*'.includes(c)) {
+      atoms.push({kind: 'quant', text: c});
+      i++;
+      continue;
+    }
+    return null;
+  }
+  return atoms;
+}
+
+// A single-letter `name` is a case-insensitive letter fragment; `SPACE_CHAR` is
+// the inter-token whitespace fragment; one-char literals carry `_` and `:`.
+function roleOf(atom) {
+  if (atom.kind === 'name') {
+    if (atom.text.length === 1) return 'letter';
+    if (atom.text === 'SPACE_CHAR') return 'spaceChar';
+    return 'other';
+  }
+  if (atom.kind === 'literal') {
+    return atom.text.length === 1 ? 'oneCharLiteral' : 'other';
+  }
+  if (atom.kind === 'quant') return 'quant';
+  return 'other';
+}
+
+function reconstruct(name, body) {
+  const atoms = tokenizeBody(body);
+  if (atoms === null) {
+    fail(`rule ${name}: cannot parse body — unrecognized grammar syntax`);
+  }
+  const roles = atoms.map(roleOf);
+  const bad = atoms.find((_, k) => roles[k] === 'other');
+  if (bad) {
+    fail(
+      `rule ${name}: unexpected '${bad.text}' in keyword section — keep ` +
+        'non-keyword rules outside KEYWORDS-BEGIN..KEYWORDS-END'
+    );
+  }
+  // A letter (or SPACE_CHAR) immediately followed by `?`/`*` is optional and
+  // dropped (handles plurals like `DAYS?`); SPACE_CHAR is never part of the
+  // spelling; one-char literals contribute `_` and `:`.
+  let word = '';
+  for (let k = 0; k < atoms.length; k++) {
+    const role = roles[k];
+    const optional = roles[k + 1] === 'quant';
+    if (role === 'quant' || role === 'spaceChar' || optional) continue;
+    if (role === 'letter') word += atoms[k].text.toLowerCase();
+    else if (role === 'oneCharLiteral') word += atoms[k].text;
+  }
+  if (!/^[a-z][a-z0-9_]*:?$/.test(word)) {
+    fail(`rule ${name}: reconstructed "${word}" is not a clean keyword`);
+  }
+  return word;
+}
+
+function extractKeywords(grammarText) {
+  const section = keywordSection(grammarText);
+  const result = {};
+  for (const rawRule of section.split(';')) {
+    const rule = rawRule.trim();
+    if (rule === '') continue;
+    const colon = rule.indexOf(':');
+    if (colon < 0) {
+      fail(`malformed entry in keyword section: "${rule}"`);
+    }
+    const name = rule.slice(0, colon).trim();
+    if (!/^[A-Z][A-Z0-9_]*$/.test(name)) {
+      fail(`keyword section contains a non-token-name rule head: "${name}"`);
+    }
+    result[name] = reconstruct(name, rule.slice(colon + 1));
+  }
+  return result;
+}
+
+const grammarText = readFileSync(lexerFile, 'utf-8');
+const table = extractKeywords(grammarText);
+const names = Object.keys(table).sort();
+if (names.length === 0) fail('no keywords harvested — is the section empty?');
+
+const lines = names.map(n => `  ${n}: ${JSON.stringify(table[n])},`);
+const banner = `/*
+ * Copyright Contributors to the Malloy project
+ * SPDX-License-Identifier: MIT
+ */
+
+// GENERATED by src/lang/grammar/build_token_names.js from the
+// KEYWORDS-BEGIN..KEYWORDS-END section of MalloyLexer.g4. Do not edit by hand.
+// Maps a keyword token's symbolic name to the spelling a user types (including
+// the trailing colon for statement keywords), for parser error messages.
+// Run \`npm run codegen\` to regenerate.
+
+export const KEYWORD_DISPLAY_NAMES: Record<string, string> = {
+${lines.join('\n')}
+};
+`;
+
+writeFileSync(outFile, banner);
+console.log(
+  `build_token_names: wrote ${names.length} keyword names to ${path.relative(
+    process.cwd(),
+    outFile
+  )}`
+);

--- a/packages/malloy/src/lang/syntax-errors/malloy-error-strategy.ts
+++ b/packages/malloy/src/lang/syntax-errors/malloy-error-strategy.ts
@@ -3,15 +3,65 @@
  * SPDX-License-Identifier: MIT
  */
 
+import type {InputMismatchException, Parser} from 'antlr4ts';
 import {DefaultErrorStrategy} from 'antlr4ts';
+import {describeExpected} from './token-names';
+
+function unexpected(offending: string, clause: string | undefined): string {
+  return clause
+    ? `unexpected ${offending}, expected ${clause}`
+    : `unexpected ${offending}`;
+}
 
 /**
- * Custom error strategy for the Malloy Parser.
+ * Overrides the three DefaultErrorStrategy methods that paste the parser's
+ * expected-token set into the message: tokens are named the way the user types
+ * them (via describeExpected) and the set is dropped once too large to be a hint.
  *
- * This class does not currently override default ANTLR error handling.
- *
- * For more details, read the documentation in DefaultErrorStrategy.d.ts
- * or reference the superclass at:
- * https://github.com/tunnelvisionlabs/antlr4ts/blob/master/src/DefaultErrorStrategy.ts
+ * Fallback only — MalloyParserErrorListener's custom-error cases run first and
+ * override these when they match.
  */
-export class MalloyErrorStrategy extends DefaultErrorStrategy {}
+export class MalloyErrorStrategy extends DefaultErrorStrategy {
+  protected reportInputMismatch(
+    recognizer: Parser,
+    e: InputMismatchException
+  ): void {
+    const offending = this.getTokenErrorDisplay(
+      e.getOffendingToken(recognizer)
+    );
+    const expected = e.expectedTokens?.toArray() ?? [];
+    const clause = describeExpected(expected, recognizer.vocabulary);
+    this.notifyErrorListeners(recognizer, unexpected(offending, clause), e);
+  }
+
+  protected reportUnwantedToken(recognizer: Parser): void {
+    if (this.inErrorRecoveryMode(recognizer)) {
+      return;
+    }
+    this.beginErrorCondition(recognizer);
+    const t = recognizer.currentToken;
+    const offending = this.getTokenErrorDisplay(t);
+    const expected = this.getExpectedTokens(recognizer).toArray();
+    const clause = describeExpected(expected, recognizer.vocabulary);
+    recognizer.notifyErrorListeners(
+      unexpected(offending, clause),
+      t,
+      undefined
+    );
+  }
+
+  protected reportMissingToken(recognizer: Parser): void {
+    if (this.inErrorRecoveryMode(recognizer)) {
+      return;
+    }
+    this.beginErrorCondition(recognizer);
+    const t = recognizer.currentToken;
+    const offending = this.getTokenErrorDisplay(t);
+    const expected = this.getExpectedTokens(recognizer).toArray();
+    const clause = describeExpected(expected, recognizer.vocabulary);
+    const msg = clause
+      ? `missing ${clause} before ${offending}`
+      : `something is missing before ${offending}`;
+    recognizer.notifyErrorListeners(msg, t, undefined);
+  }
+}

--- a/packages/malloy/src/lang/syntax-errors/token-names.ts
+++ b/packages/malloy/src/lang/syntax-errors/token-names.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright Contributors to the Malloy project
+ * SPDX-License-Identifier: MIT
+ */
+
+import type {Vocabulary} from 'antlr4ts';
+import {Token} from 'antlr4ts';
+import {KEYWORD_DISPLAY_NAMES} from '../lib/Malloy/keyword-display-names';
+
+// Pattern tokens have neither a literal nor a keyword spelling to show, so they
+// get hand-written prose instead of their SHOUTING symbolic name.
+const CLASS_TOKEN_DISPLAY_NAMES: Record<string, string> = {
+  IDENTIFIER: 'a name',
+  BQ_STRING: 'a `quoted` name',
+  SQ_STRING: 'a quoted string',
+  DQ_STRING: 'a quoted string',
+  NUMERIC_LITERAL: 'a number',
+  INTEGER_LITERAL: 'a number',
+  PERCENT_LITERAL: 'a percentage',
+  GIVEN_REF: 'a $given reference',
+};
+
+// Past this many alternatives the expected-set is the parser's follow-set, not
+// a hint, so describeExpected drops it.
+const MAX_EXPECTED_NAMED = 3;
+
+export function describeToken(type: number, vocabulary: Vocabulary): string {
+  if (type === Token.EOF) return 'end of input';
+  const symbolic = vocabulary.getSymbolicName(type);
+  if (symbolic !== undefined) {
+    const prose = CLASS_TOKEN_DISPLAY_NAMES[symbolic];
+    if (prose !== undefined) return prose;
+    const keyword = KEYWORD_DISPLAY_NAMES[symbolic];
+    if (keyword !== undefined) return `'${keyword}'`;
+  }
+  // Punctuation already carries a quoted literal name, e.g. "'{'".
+  const literal = vocabulary.getLiteralName(type);
+  if (literal !== undefined) return literal;
+  return symbolic ?? `<token ${type}>`;
+}
+
+function joinOr(items: string[]): string {
+  if (items.length === 1) return items[0];
+  return `${items.slice(0, -1).join(', ')} or ${items[items.length - 1]}`;
+}
+
+export function describeExpected(
+  types: number[],
+  vocabulary: Vocabulary
+): string | undefined {
+  const displays: string[] = [];
+  const seen = new Set<string>();
+  for (const type of types) {
+    if (type < Token.MIN_USER_TOKEN_TYPE && type !== Token.EOF) continue;
+    const display = describeToken(type, vocabulary);
+    if (!seen.has(display)) {
+      seen.add(display);
+      displays.push(display);
+    }
+  }
+  if (displays.length === 0 || displays.length > MAX_EXPECTED_NAMED) {
+    return undefined;
+  }
+  return joinOr(displays);
+}

--- a/packages/malloy/src/lang/test/givens.spec.ts
+++ b/packages/malloy/src/lang/test/givens.spec.ts
@@ -286,13 +286,13 @@ describe('$NAME references in expressions', () => {
 describe('given: parse-time errors', () => {
   test('missing type is a parse error', () => {
     expect('given: TENANT').toLog(
-      errorMessage(/extraneous|missing|mismatched|no viable/i)
+      errorMessage(/extraneous|missing|mismatched|no viable|unexpected/i)
     );
   });
 
   test('missing name is a parse error', () => {
     expect('given: :: string').toLog(
-      errorMessage(/extraneous|missing|mismatched/i)
+      errorMessage(/extraneous|missing|mismatched|unexpected/i)
     );
   });
 
@@ -312,7 +312,7 @@ describe('given: parse-time errors', () => {
     // as a given type. The parser reports a syntax error rather than
     // accepting and later rejecting.
     expect('given: J :: json').toLog(
-      errorMessage(/extraneous|missing|mismatched|no viable/i)
+      errorMessage(/extraneous|missing|mismatched|no viable|unexpected/i)
     );
   });
 });

--- a/packages/malloy/src/lang/test/syntax-errors.spec.ts
+++ b/packages/malloy/src/lang/test/syntax-errors.spec.ts
@@ -63,7 +63,7 @@ describe('custom error messages', () => {
       expect(`
         source: x is a extend
           primary_key: id
-      `).toLogAtLeast(errorMessage("missing '{' at 'primary_key:'"));
+      `).toLogAtLeast(errorMessage("missing '{' before 'primary_key:'"));
     });
 
     test('use of the distinct keyword in a count', () => {
@@ -143,7 +143,7 @@ describe('custom error messages', () => {
           }
         }
         `).toLogAtLeast(
-        errorMessage("extraneous input '{' expecting {BQ_STRING, IDENTIFIER}")
+        errorMessage("unexpected '{', expected a `quoted` name or a name")
       );
     });
 

--- a/packages/malloy/src/lang/test/token-names.spec.ts
+++ b/packages/malloy/src/lang/test/token-names.spec.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright Contributors to the Malloy project
+ * SPDX-License-Identifier: MIT
+ */
+
+import {readFileSync} from 'fs';
+import path from 'path';
+import {Token} from 'antlr4ts';
+import {MalloyLexer} from '../lib/Malloy/MalloyLexer';
+import {KEYWORD_DISPLAY_NAMES} from '../lib/Malloy/keyword-display-names';
+import {describeExpected, describeToken} from '../syntax-errors/token-names';
+
+const vocab = MalloyLexer.VOCABULARY;
+
+describe('describeToken', () => {
+  test('statement keywords keep their colon', () => {
+    expect(describeToken(MalloyLexer.AGGREGATE, vocab)).toBe("'aggregate:'");
+    expect(describeToken(MalloyLexer.DIMENSION, vocab)).toBe("'dimension:'");
+    expect(describeToken(MalloyLexer.GROUP_BY, vocab)).toBe("'group_by:'");
+  });
+
+  test('bare keywords have no colon', () => {
+    expect(describeToken(MalloyLexer.IS, vocab)).toBe("'is'");
+    expect(describeToken(MalloyLexer.AND, vocab)).toBe("'and'");
+  });
+
+  test('class tokens read as prose', () => {
+    expect(describeToken(MalloyLexer.IDENTIFIER, vocab)).toBe('a name');
+    expect(describeToken(MalloyLexer.BQ_STRING, vocab)).toBe('a `quoted` name');
+    expect(describeToken(MalloyLexer.NUMERIC_LITERAL, vocab)).toBe('a number');
+  });
+
+  test('punctuation uses its literal name', () => {
+    expect(describeToken(MalloyLexer.OCURLY, vocab)).toBe("'{'");
+    expect(describeToken(MalloyLexer.COMMA, vocab)).toBe("','");
+  });
+
+  test('end of input', () => {
+    expect(describeToken(Token.EOF, vocab)).toBe('end of input');
+  });
+});
+
+describe('describeExpected', () => {
+  test('a short set is named, in order', () => {
+    expect(
+      describeExpected([MalloyLexer.OCURLY, MalloyLexer.IDENTIFIER], vocab)
+    ).toBe("'{' or a name");
+  });
+
+  test('a single expected token', () => {
+    expect(describeExpected([MalloyLexer.IDENTIFIER], vocab)).toBe('a name');
+  });
+
+  test('token types that share a display are merged', () => {
+    expect(
+      describeExpected([MalloyLexer.SQ_STRING, MalloyLexer.DQ_STRING], vocab)
+    ).toBe('a quoted string');
+  });
+
+  test('a large follow-set is suppressed', () => {
+    const many = [
+      MalloyLexer.AGGREGATE,
+      MalloyLexer.DIMENSION,
+      MalloyLexer.MEASURE,
+      MalloyLexer.GROUP_BY,
+      MalloyLexer.WHERE,
+    ];
+    expect(describeExpected(many, vocab)).toBeUndefined();
+  });
+
+  test('an empty set yields no clause', () => {
+    expect(describeExpected([], vocab)).toBeUndefined();
+  });
+});
+
+// Drift guard, independent of the build: every keyword rule in the marked
+// section of the grammar must have a generated display name. If someone adds a
+// keyword but the table was not regenerated (`npm run codegen`), this fails.
+describe('KEYWORD_DISPLAY_NAMES stays in sync with the grammar', () => {
+  const grammar = readFileSync(
+    path.join(__dirname, '..', 'grammar', 'MalloyLexer.g4'),
+    'utf-8'
+  );
+  const begin = grammar.match(/^[ \t]*\/\/[ \t]*KEYWORDS-BEGIN[ \t]*$/m);
+  const end = grammar.match(/^[ \t]*\/\/[ \t]*KEYWORDS-END[ \t]*$/m);
+  const section =
+    begin && end ? grammar.slice(begin.index, end.index) : undefined;
+  const ruleNames = [
+    ...(section ?? '').matchAll(/^([A-Z][A-Z0-9_]*)\s*:/gm),
+  ].map(m => m[1]);
+
+  test('the markers and rules are found', () => {
+    expect(section).toBeDefined();
+    expect(ruleNames.length).toBeGreaterThan(50);
+  });
+
+  test('every keyword rule has exactly one display entry', () => {
+    expect(ruleNames.length).toBe(Object.keys(KEYWORD_DISPLAY_NAMES).length);
+    for (const name of ruleNames) {
+      expect(KEYWORD_DISPLAY_NAMES[name]).toBeDefined();
+    }
+  });
+
+  test('every display name is a clean keyword spelling', () => {
+    for (const spelling of Object.values(KEYWORD_DISPLAY_NAMES)) {
+      expect(spelling).toMatch(/^[a-z][a-z0-9_]*:?$/);
+    }
+  });
+});


### PR DESCRIPTION
Cleans up what you see when the parser hits a syntax error.

Previously a parse error appended ANTLR's full set of legal next tokens — often dozens of ALL-CAPS token names — which buried the one useful fact (the token that was actually wrong) and frequently misframed the problem.

Now:
- When only a few tokens are valid next, they're named the way you type them — `'aggregate:'`, `'group_by:'`, `a name`, `a \`quoted\` name` — e.g. `unexpected '{', expected a \`quoted\` name or a name`.
- When many tokens are valid next, the list is dropped entirely, leaving just the offending token: `unexpected '.'`.

Example — `order_by: tournament.year`:

Before:
```
extraneous input '.' expecting {AGGREGATE, CALCULATE, DECLARE, DIMENSION, DRILL,
EXCEPT, EXTENDQ, GIVEN, GROUP_BY, HAVING, INDEX, … IDENTIFIER, NUMERIC_LITERAL,
INTEGER_LITERAL, '"""'}
```

After:
```
unexpected '.'
```

Existing targeted syntax-error messages are unaffected — they still take precedence; this only changes the generic fallback.