### PR TITLE
Friendlier errors for now() and reserved words used as names

### DIFF
--- a/packages/malloy/src/lang/grammar/MalloyParser.g4
+++ b/packages/malloy/src/lang/grammar/MalloyParser.g4
@@ -691,7 +691,7 @@ literal
   | (TRUE | FALSE)                              # exprBool
   | HACKY_REGEX                                 # exprRegex
   | filterString                                # filterString_stub
-  | NOW                                         # exprNow
+  | NOW (OPAREN CPAREN)?                         # exprNow
   ;
 
 dateLiteral

--- a/packages/malloy/src/lang/malloy-to-ast.ts
+++ b/packages/malloy/src/lang/malloy-to-ast.ts
@@ -1630,7 +1630,16 @@ export class MalloyToAST
     return new ast.ExprRegEx(malloyRegex.slice(2, -1));
   }
 
-  visitExprNow(_pcx: parse.ExprNowContext): ast.ExprNow {
+  visitExprNow(pcx: parse.ExprNowContext): ast.ExprNow {
+    if (pcx.OPAREN()) {
+      // `now` is a value, not a function; accept `now()`, warn, compile as `now`.
+      this.contextError(
+        pcx,
+        'now-is-not-a-function',
+        "'now' is a value, not a function; the parentheses are unnecessary. Write 'now'.",
+        {severity: 'warn'}
+      );
+    }
     return new ast.ExprNow();
   }
 

--- a/packages/malloy/src/lang/parse-log.ts
+++ b/packages/malloy/src/lang/parse-log.ts
@@ -237,6 +237,7 @@ type MessageParameterTypes = {
   'order-by-not-found-in-output': string;
   'order-by-analytic': string;
   'order-by-bad-reference': string;
+  'now-is-not-a-function': string;
   'illegal-index-operation': string;
   'illegal-project-operation': string;
   'illegal-grouping-operation': string;

--- a/packages/malloy/src/lang/syntax-errors/malloy-error-strategy.ts
+++ b/packages/malloy/src/lang/syntax-errors/malloy-error-strategy.ts
@@ -3,9 +3,13 @@
  * SPDX-License-Identifier: MIT
  */
 
-import type {InputMismatchException, Parser} from 'antlr4ts';
+import type {
+  InputMismatchException,
+  NoViableAltException,
+  Parser,
+} from 'antlr4ts';
 import {DefaultErrorStrategy} from 'antlr4ts';
-import {describeExpected} from './token-names';
+import {describeExpected, reservedNameMessage} from './token-names';
 
 function unexpected(offending: string, clause: string | undefined): string {
   return clause
@@ -14,9 +18,12 @@ function unexpected(offending: string, clause: string | undefined): string {
 }
 
 /**
- * Overrides the three DefaultErrorStrategy methods that paste the parser's
+ * Overrides the DefaultErrorStrategy methods that paste the parser's
  * expected-token set into the message: tokens are named the way the user types
  * them (via describeExpected) and the set is dropped once too large to be a hint.
+ *
+ * Each path also checks reservedNameMessage first, so a reserved word used where
+ * a name was expected (`group_by: year`) says "quote it".
  *
  * Fallback only — MalloyParserErrorListener's custom-error cases run first and
  * override these when they match.
@@ -26,10 +33,14 @@ export class MalloyErrorStrategy extends DefaultErrorStrategy {
     recognizer: Parser,
     e: InputMismatchException
   ): void {
-    const offending = this.getTokenErrorDisplay(
-      e.getOffendingToken(recognizer)
-    );
+    const offendingToken = e.getOffendingToken(recognizer);
     const expected = e.expectedTokens?.toArray() ?? [];
+    const reserved = reservedNameMessage(offendingToken, expected, recognizer);
+    if (reserved) {
+      this.notifyErrorListeners(recognizer, reserved, e);
+      return;
+    }
+    const offending = this.getTokenErrorDisplay(offendingToken);
     const clause = describeExpected(expected, recognizer.vocabulary);
     this.notifyErrorListeners(recognizer, unexpected(offending, clause), e);
   }
@@ -40,8 +51,13 @@ export class MalloyErrorStrategy extends DefaultErrorStrategy {
     }
     this.beginErrorCondition(recognizer);
     const t = recognizer.currentToken;
-    const offending = this.getTokenErrorDisplay(t);
     const expected = this.getExpectedTokens(recognizer).toArray();
+    const reserved = reservedNameMessage(t, expected, recognizer);
+    if (reserved) {
+      recognizer.notifyErrorListeners(reserved, t, undefined);
+      return;
+    }
+    const offending = this.getTokenErrorDisplay(t);
     const clause = describeExpected(expected, recognizer.vocabulary);
     recognizer.notifyErrorListeners(
       unexpected(offending, clause),
@@ -56,12 +72,34 @@ export class MalloyErrorStrategy extends DefaultErrorStrategy {
     }
     this.beginErrorCondition(recognizer);
     const t = recognizer.currentToken;
-    const offending = this.getTokenErrorDisplay(t);
     const expected = this.getExpectedTokens(recognizer).toArray();
+    const reserved = reservedNameMessage(t, expected, recognizer);
+    if (reserved) {
+      recognizer.notifyErrorListeners(reserved, t, undefined);
+      return;
+    }
+    const offending = this.getTokenErrorDisplay(t);
     const clause = describeExpected(expected, recognizer.vocabulary);
     const msg = clause
       ? `missing ${clause} before ${offending}`
       : `something is missing before ${offending}`;
     recognizer.notifyErrorListeners(msg, t, undefined);
+  }
+
+  // Dispatched from reportError (already in error condition), unlike the inline-
+  // recovery methods above — an inErrorRecoveryMode guard here would swallow the
+  // error. Short-circuit to the reserved-word hint, else defer to super.
+  protected reportNoViableAlternative(
+    recognizer: Parser,
+    e: NoViableAltException
+  ): void {
+    const t = recognizer.currentToken;
+    const expected = this.getExpectedTokens(recognizer).toArray();
+    const reserved = reservedNameMessage(t, expected, recognizer);
+    if (reserved) {
+      this.notifyErrorListeners(recognizer, reserved, e);
+      return;
+    }
+    super.reportNoViableAlternative(recognizer, e);
   }
 }

--- a/packages/malloy/src/lang/syntax-errors/token-names.ts
+++ b/packages/malloy/src/lang/syntax-errors/token-names.ts
@@ -3,8 +3,9 @@
  * SPDX-License-Identifier: MIT
  */
 
-import type {Vocabulary} from 'antlr4ts';
+import type {Parser, Vocabulary} from 'antlr4ts';
 import {Token} from 'antlr4ts';
+import {MalloyParser} from '../lib/Malloy/MalloyParser';
 import {KEYWORD_DISPLAY_NAMES} from '../lib/Malloy/keyword-display-names';
 
 // Pattern tokens have neither a literal nor a keyword spelling to show, so they
@@ -62,4 +63,28 @@ export function describeExpected(
     return undefined;
   }
   return joinOr(displays);
+}
+
+// When a bare-word reserved token appears where a name (IDENTIFIER) was legal,
+// the user meant it as a field name; return a "quote it" message. undefined
+// otherwise, so the caller keeps its normal message.
+export function reservedNameMessage(
+  offending: Token | undefined,
+  expected: number[],
+  recognizer: Parser
+): string | undefined {
+  const text = offending?.text;
+  if (!text || !/^[A-Za-z_][A-Za-z0-9_]*$/.test(text)) return undefined;
+  const symbolic = recognizer.vocabulary.getSymbolicName(offending!.type);
+  if (symbolic === undefined || KEYWORD_DISPLAY_NAMES[symbolic] === undefined) {
+    return undefined;
+  }
+  if (!expected.includes(MalloyParser.IDENTIFIER)) return undefined;
+  // A reserved word followed by '(' is a function call (count()), not a name.
+  // offending is the current token here, so LA(2) is the next on-channel token;
+  // LA fetches it lazily rather than pre-filling the stream.
+  if (recognizer.inputStream.LA(2) === MalloyParser.OPAREN) {
+    return undefined;
+  }
+  return `'${text}' is a reserved word, so to use it as a name you must quote it: \`${text}\``;
 }

--- a/packages/malloy/src/lang/test/expressions.spec.ts
+++ b/packages/malloy/src/lang/test/expressions.spec.ts
@@ -55,6 +55,20 @@ describe('expressions', () => {
       expect(new BetaExpression(`${unit}(ats to @2030)`)).toParse();
     });
 
+    describe('now', () => {
+      test('now is a value', () => expect(expr`now`).compilesTo('{now}'));
+      test('now() compiles as now', () =>
+        expect(expr`now()`).compilesTo('{now}'));
+      test('now() warns that now is not a function', () =>
+        expect(model`run: a -> { select: x is now() }`).toLogAtLeast(
+          warningMessage(
+            "'now' is a value, not a function; the parentheses are unnecessary. Write 'now'."
+          )
+        ));
+      test('now (no parens) does not warn', () =>
+        expect(model`run: a -> { select: x is now }`).toTranslate());
+    });
+
     describe('truncation of a non-time value', () => {
       test('a join/struct suggests quoting the colliding field', () =>
         expect(model`run: a -> { select: x is aninline.year }`).toLogAtLeast(

--- a/packages/malloy/src/lang/test/syntax-errors.spec.ts
+++ b/packages/malloy/src/lang/test/syntax-errors.spec.ts
@@ -213,6 +213,43 @@ describe('custom error messages', () => {
     });
   });
 
+  describe('reserved word used as a name', () => {
+    const quoteHint =
+      "'year' is a reserved word, so to use it as a name you must quote it: `year`";
+    test('group_by: a reserved word', () => {
+      expect('run: a -> { group_by: year }').toLogAtLeast(
+        errorMessage(quoteHint)
+      );
+    });
+    test('select: a reserved word', () => {
+      expect('run: a -> { select: year }').toLogAtLeast(
+        errorMessage(quoteHint)
+      );
+    });
+    test('naming a dimension with a reserved word', () => {
+      expect('source: x is a extend { dimension: year is 1 }').toLogAtLeast(
+        errorMessage(quoteHint)
+      );
+    });
+    test('reserved word in a where expression', () => {
+      expect('run: a -> { select: astr; where: timestamp = 1 }').toLogAtLeast(
+        errorMessage(
+          "'timestamp' is a reserved word, so to use it as a name you must quote it: `timestamp`"
+        )
+      );
+    });
+    test('reserved word as a bare source reference', () => {
+      // A backtick-named reserved-word source, referenced bare, suggests quoting.
+      expect(
+        'source: `import` is a extend {}\nrun: import -> { select: * }'
+      ).toLogAtLeast(
+        errorMessage(
+          "'import' is a reserved word, so to use it as a name you must quote it: `import`"
+        )
+      );
+    });
+  });
+
   describe('queryStatement', () => {
     test('misspelled group_by:', () => {
       expect('source: x is a -> { groupBy: name }').toLogAtLeast(


### PR DESCRIPTION
Two parser errors that told the writer nothing useful, both seen in the malloyyo agent field reports.

`now()` — `now` is a value, not a function, so the parentheses produced `no viable alternative at input '('`. We now accept `now()`, warn that the parentheses are unnecessary, and compile it as `now`.

A reserved word used where a name is expected — `group_by: year`, `select: source`, a bare reference to a backtick-named source — produced raw ANTLR token-set output. It now says the word is reserved and to quote it (`` `year` ``). The check runs across all of `MalloyErrorStrategy`'s report paths and reuses the keyword-spelling table from #2947; it's the lightweight cousin of #2946's grammar-level reserved-word handling for `order_by:`.
