### PR TITLE
ci: read Node version from .node-version instead of floating 24.x

### DIFF
--- a/.github/dependabot-pins.md
+++ b/.github/dependabot-pins.md
@@ -141,6 +141,29 @@ without the experimental flag (jest → vitest, or jest gains stable ESM), or ga
 drops the ESM-only `import()`. Then bump the trio together, confirm `db-bigquery`
 **and** the ci-core bigquery `streaming.spec` pass **without** the flag, and unpin.
 
+### Node runtime — pinned at `24.16.0` via `.node-version`
+Not a dependency, but a deliberate hold that belongs here. Node **24.17.0** carries
+a `http.Agent` keep-alive socket-reuse regression that makes `node-fetch` (under
+`google-auth-library`/`gaxios`) throw a false `ERR_STREAM_PREMATURE_CLOSE` —
+surfaced as `Invalid response body while trying to fetch
+https://www.googleapis.com/oauth2/v4/token: Premature close` — whenever Google's
+OAuth endpoint closes a pooled idle connection. It hits the ci-core bigquery
+`streaming.spec` (which authenticates to BigQuery and runs live queries), and
+because socket reuse is timing-dependent it presents as an **intermittent** failure,
+not every run.
+
+`.node-version` pins `24.16.0`; the CI workflows read it via
+`actions/setup-node` `node-version-file: '.node-version'` (they previously floated
+`node-version: 24.x` and so silently picked up 24.17.0 while ignoring the committed
+pin). `scripts/ci-env-sanity-check.sh` already asserts `.node-version` exists, so the
+pin has one authoritative source.
+
+Cost: held one Node patch behind until the regression is fixed upstream.
+
+Revisit when: Node ships the keep-alive fix (or `google-auth-library`/`gaxios` stops
+reusing the socket), then bump `.node-version` and confirm the bigquery
+`streaming.spec` is stable across repeated runs.
+
 ## Not pins — context, so this list stays short
 
 - **Connector SDKs other than Snowflake** (`trino-client`, `@databricks/sql`,

--- a/.github/workflows/db-bigquery.yaml
+++ b/.github/workflows/db-bigquery.yaml
@@ -17,10 +17,10 @@ jobs:
           name: workspace
       - name: Extract workspace
         run: tar --use-compress-program='zstd -d -T0' -xf workspace.tzst && rm workspace.tzst
-      - name: Use Node.js 24.x
+      - name: Use Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: 24.x
+          node-version-file: '.node-version'
       - name: GCloud auth
         uses: 'google-github-actions/auth@v3'
         with:

--- a/.github/workflows/db-databricks.yaml
+++ b/.github/workflows/db-databricks.yaml
@@ -21,10 +21,10 @@ jobs:
           name: workspace
       - name: Extract workspace
         run: tar --use-compress-program='zstd -d -T0' -xf workspace.tzst && rm workspace.tzst
-      - name: Use Node.js 24.x
+      - name: Use Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: 24.x
+          node-version-file: '.node-version'
       - name: Test
         run: npm run ci-databricks
         env:

--- a/.github/workflows/db-duckdb-wasm.yaml
+++ b/.github/workflows/db-duckdb-wasm.yaml
@@ -13,10 +13,10 @@ jobs:
           name: workspace
       - name: Extract workspace
         run: tar --use-compress-program='zstd -d -T0' -xf workspace.tzst && rm workspace.tzst
-      - name: Use Node.js 24.x
+      - name: Use Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: 24.x
+          node-version-file: '.node-version'
       - name: Test
         run: npm run ci-duckdb-wasm
         env:

--- a/.github/workflows/db-duckdb.yaml
+++ b/.github/workflows/db-duckdb.yaml
@@ -13,10 +13,10 @@ jobs:
           name: workspace
       - name: Extract workspace
         run: tar --use-compress-program='zstd -d -T0' -xf workspace.tzst && rm workspace.tzst
-      - name: Use Node.js 24.x
+      - name: Use Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: 24.x
+          node-version-file: '.node-version'
       - name: Test
         run: npm run ci-duckdb
         env:

--- a/.github/workflows/db-motherduck.yaml
+++ b/.github/workflows/db-motherduck.yaml
@@ -17,10 +17,10 @@ jobs:
           name: workspace
       - name: Extract workspace
         run: tar --use-compress-program='zstd -d -T0' -xf workspace.tzst && rm workspace.tzst
-      - name: Use Node.js 24.x
+      - name: Use Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: 24.x
+          node-version-file: '.node-version'
       - name: Test
         run: npm run ci-motherduck
         env:

--- a/.github/workflows/db-mysql.yaml
+++ b/.github/workflows/db-mysql.yaml
@@ -13,10 +13,10 @@ jobs:
           name: workspace
       - name: Extract workspace
         run: tar --use-compress-program='zstd -d -T0' -xf workspace.tzst && rm workspace.tzst
-      - name: Use Node.js 24.x
+      - name: Use Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: 24.x
+          node-version-file: '.node-version'
       - name: Test
         run: |
           ./test/mysql/mysql_start.sh

--- a/.github/workflows/db-postgres.yaml
+++ b/.github/workflows/db-postgres.yaml
@@ -27,10 +27,10 @@ jobs:
           name: workspace
       - name: Extract workspace
         run: tar --use-compress-program='zstd -d -T0' -xf workspace.tzst && rm workspace.tzst
-      - name: Use Node.js 24.x
+      - name: Use Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: 24.x
+          node-version-file: '.node-version'
       - name: Test
         run: |
           echo CREATE EXTENSION tsm_system_rows\; | psql

--- a/.github/workflows/db-presto.yaml
+++ b/.github/workflows/db-presto.yaml
@@ -17,10 +17,10 @@ jobs:
           name: workspace
       - name: Extract workspace
         run: tar --use-compress-program='zstd -d -T0' -xf workspace.tzst && rm workspace.tzst
-      - name: Use Node.js 24.x
+      - name: Use Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: 24.x
+          node-version-file: '.node-version'
       - name: Test
         run: |
           ./test/presto/presto_start.sh --slim

--- a/.github/workflows/db-publisher.yaml
+++ b/.github/workflows/db-publisher.yaml
@@ -20,10 +20,10 @@ jobs:
           name: workspace
       - name: Extract workspace
         run: tar --use-compress-program='zstd -d -T0' -xf workspace.tzst && rm workspace.tzst
-      - name: Use Node.js 24.x
+      - name: Use Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: 24.x
+          node-version-file: '.node-version'
       - name: Test
         run: npm run ci-publisher
         env:

--- a/.github/workflows/db-snowflake.yaml
+++ b/.github/workflows/db-snowflake.yaml
@@ -17,10 +17,10 @@ jobs:
           name: workspace
       - name: Extract workspace
         run: tar --use-compress-program='zstd -d -T0' -xf workspace.tzst && rm workspace.tzst
-      - name: Use Node.js 24.x
+      - name: Use Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: 24.x
+          node-version-file: '.node-version'
       - name: Test
         run: |
           ./scripts/gen-snowflake-auth.sh

--- a/.github/workflows/db-trino.yaml
+++ b/.github/workflows/db-trino.yaml
@@ -17,10 +17,10 @@ jobs:
           name: workspace
       - name: Extract workspace
         run: tar --use-compress-program='zstd -d -T0' -xf workspace.tzst && rm workspace.tzst
-      - name: Use Node.js 24.x
+      - name: Use Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: 24.x
+          node-version-file: '.node-version'
       - name: Test
         run: |
           ./test/trino/trino_start.sh

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -35,10 +35,10 @@ jobs:
           name: workspace
       - name: Extract workspace
         run: tar --use-compress-program='zstd -d -T0' -xf workspace.tzst && rm workspace.tzst
-      - name: Use Node.js 24.x
+      - name: Use Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: 24.x
+          node-version-file: '.node-version'
       - name: GCloud auth
         uses: 'google-github-actions/auth@v3'
         with:

--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: 24.x
+          node-version-file: '.node-version'
       - name: npm install, build, and publish
         run: |
           echo BRANCH_NAME=$BRANCH_NAME

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: 24.x
+          node-version-file: '.node-version'
       - name: Install and build
         run: |
           npm --no-audit --no-fund ci --loglevel error
@@ -38,7 +38,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: 24.x
+          node-version-file: '.node-version'
       - name: Precheck (dialect-agnostic tests + duckdb)
         run: npm run precheck
 
@@ -60,7 +60,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: 24.x
+          node-version-file: '.node-version'
       - name: Upgrade npm for trusted publishing (OIDC)
         run: npm install -g npm@latest
       - name: Publish and bump version

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -32,10 +32,10 @@ jobs:
       - uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
-      - name: Use Node.js 24.x
+      - name: Use Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: 24.x
+          node-version-file: '.node-version'
       - name: Install and build
         run: |
           npm ci --loglevel error


### PR DESCRIPTION
## Why

CI was intermittently failing the ci-core bigquery `streaming.spec` with:

```
Invalid response body while trying to fetch
https://www.googleapis.com/oauth2/v4/token: Premature close
```

Root cause: the workflows hardcoded `node-version: 24.x`, which floats to
the latest 24.x release. CI picked up **Node 24.17.0**, whose `http.Agent`
keep-alive socket-reuse regression makes `node-fetch` (under
`google-auth-library`/`gaxios`) throw a false `ERR_STREAM_PREMATURE_CLOSE`
when Google's OAuth endpoint closes a pooled idle connection. Because
socket reuse is timing-dependent, it presented as a flake rather than a
hard failure.

Meanwhile the repo already commits `.node-version` = `24.16.0` (and
`scripts/ci-env-sanity-check.sh` asserts it exists) — but nothing fed it
to `setup-node`, so the pin was declared and sanity-checked yet never
enforced. Local dev honors `.node-version` and so was unaffected.

## What

Point `actions/setup-node` at `node-version-file: '.node-version'` across
all workflows, so CI runs the committed pin from one authoritative source
instead of floating. Step labels renamed `Use Node.js 24.x` → `Use Node.js`
(the version now lives in `.node-version`). Rationale recorded in
`.github/dependabot-pins.md`.

## Revisit

Bump `.node-version` once Node ships the keep-alive fix (or google-auth /
gaxios stops reusing the socket), and confirm the bigquery `streaming.spec`
is stable across repeated runs.