### PR TITLE
Pin uuid + @noble/hashes below their ESM-only majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -66,6 +66,17 @@ updates:
       - dependency-name: "@google-cloud/bigquery"
       - dependency-name: "@google-cloud/common"
       - dependency-name: "@google-cloud/paginator"
+      # uuid + @noble/hashes held below their ESM-only majors. uuid 12+ and
+      # @noble/hashes 2+ dropped CommonJS (pure ESM), which breaks every downstream
+      # consumer's esbuild bundle and ts-jest runtime — an ESM-only runtime dep leaks
+      # downstream exactly like a native binary, so the core stays CJS. Held on the
+      # last CJS majors (uuid ^11, @noble/hashes ^1) via caret ranges in
+      # packages/malloy/package.json; ignore the MAJOR only so CJS-line minors/patches
+      # still flow. See DEPENDENCY-MANAGEMENT.md.
+      - dependency-name: "uuid"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@noble/hashes"
+        update-types: ["version-update:semver-major"]
     groups:
       # Not for fragmentation (the per-platform node-bindings are transitive here,
       # so they never fan out). It's a deliberate callout: a duckdb bump has

--- a/DEPENDENCY-MANAGEMENT.md
+++ b/DEPENDENCY-MANAGEMENT.md
@@ -31,41 +31,55 @@ We may decide to respond to a Dependabot report in one of three ways
 It is important to know that, even for security dependencies, we might have to pin instead of move, and usually this is not really an issue. The security report on the package is a part of the package which we do not actually touch, so it isn't an actual securiry problem for people down stream of the Malloy package.
 
 **A pin has two surfaces, and both are mandatory.** To actually hold a version you
-must (1) **exact-pin** it in the owning package's `package.json` — the existing
-`^range` would otherwise let a fresh `npm install` resolve the bad version — *and*
-(2) **`ignore`** it in `dependabot.yml`, or the next group PR re-bumps it straight
-back. **One without the other is not a pin.** Databricks is the cautionary tale:
-#2888 pinned `package.json` to `1.15.0` but skipped the `ignore`, so connectors-group
-PR #2934 reverted it a week later and shipped the break in `@malloydata/malloy`
-0.0.418. Every entry below names both surfaces. (The *transitive* advisories a pin
-holds open are alert-only — no PR — and are listed under each entry as the cost.)
+must (1) **constrain the range** in the owning package's `package.json` so a fresh
+`npm install` can't reach the bad version — *and* (2) **`ignore`** it in
+`dependabot.yml`, or the next group PR re-bumps it straight back. **One without the
+other is not a pin.** Databricks is the cautionary tale: #2888 pinned `package.json`
+to `1.15.0` but skipped the `ignore`, so connectors-group PR #2934 reverted it a week
+later and shipped the break in `@malloydata/malloy` 0.0.418. Every entry below names
+both surfaces. (The *transitive* advisories a pin holds open are alert-only — no PR —
+and are listed under each entry as the cost.)
 
-### ESM-only majors — triage before holding
+**Caret by default; exact only when the caret can't hold.** Prefer a **caret major-cap**
+(`^11.1.1`) plus a **major-only** `ignore` — it bars the bad *major* while still
+letting CJS-line minors/patches and their security fixes flow (uuid, @noble/hashes,
+vega-lite, `@types/*` all work this way). Drop to a hard **exact pin** (no caret) only
+when you hit a wall: the breaker is *in-range*, so a caret would still resolve it on a
+fresh install (databricks `1.15.0`, pg `8.7.3`, vscode-textmate `9.0.0`). Exact is the
+escalation, not the default.
+
+### ESM-only majors — and the downstream-leak trap
 
 The npm ecosystem is migrating to ESM-only packages. Our code ships CommonJS and our
-tests run under jest's CJS runtime, so an ESM-only dep can fail to load. But **not
-every ESM-only major is a hold** — split them before deciding:
+tests run under jest's CJS runtime, so an ESM-only dep can fail to load. Before holding
+one, two splits matter: *who pays*, and *what kind of break*.
 
-- **Class 1 — static ESM** (plain `import`/`export`, e.g. `@noble/hashes` v2,
-  `uuid` v14 — whose `node` export condition is itself ESM).
-  jest's default `transformIgnorePatterns` skips `node_modules`, so it sees the raw
-  `import` and throws *"Cannot use import statement outside a module."* The fix is
-  to **transform** it: add the package to `transformIgnoreModules` in
-  **both** `jest.config.ts` (in `defaultConfig`, which every `projects` entry
-  spreads — the top-level `transform` does **not** cascade into `projects`) and
-  `jest.config.simple.ts`. babel-jest then rewrites its ESM to CJS and it loads.
-  **Takeable**, one line. (`@motherduck/wasm-client` is listed there too, but it's
-  held at CJS 0.6, so it doesn't actually exercise this.)
-- **Class 2 — runtime dynamic `import()` of an ESM-only target** (e.g. gaxios 7
-  under `@google-cloud/bigquery` 8). The break isn't syntax jest can transform —
-  it's a `require`-an-ESM call at runtime needing `--experimental-vm-modules`,
-  which we reject (see the BigQuery hold). **A genuine hold**, untouchable by
-  `transformIgnoreModules`.
+**Who pays — devDependency vs published runtime dependency.** This is the one we
+learned the hard way.
+- A **devDependency** (never shipped) only has to satisfy *our* jest. An ESM-only one
+  is **takeable**: add it to `transformIgnoreModules` in **both** `jest.config.ts`
+  (in `defaultConfig`, which every `projects` entry spreads — the top-level `transform`
+  does **not** cascade into `projects`) and `jest.config.simple.ts`; babel-jest then
+  rewrites its ESM to CJS and it loads. One line.
+- A **published runtime dependency** of a core package (e.g. `@malloydata/malloy`) is
+  the opposite. The transform fixes *our* tests but **does nothing for consumers** — a
+  downstream app that bundles with esbuild or tests with ts-jest inherits the raw ESM
+  and breaks, and can't even see why. **An ESM-only runtime dep leaks downstream
+  exactly like a native `.node` binary.** So it is *not* takeable; it's a hold — pin to
+  the last CJS-consumable major. This bit us in 0.0.419: `uuid` v14 and `@noble/hashes`
+  v2 were taken as "takeable", green in malloy's own CI, and broke the vscode extension
+  and malloy-cli the moment they consumed it (see the hold below).
 
-Note both *compile* under TypeScript; the divide is purely how jest loads them at
-runtime. A Class-1 dep also typically forces small source edits for the package's
-own API changes (noble v2: `/sha256`→`/sha2.js`, `.js` extensions mandatory,
-`Uint8Array`-only inputs via `utf8ToBytes`).
+**What kind of break — static ESM vs runtime dynamic `import()`.**
+- **Static ESM** (plain `import`/`export`): babel-jest can transform it (devDep case),
+  or you pin (runtime-dep case).
+- **Runtime dynamic `import()` of an ESM-only target** (e.g. gaxios 7 under
+  `@google-cloud/bigquery` 8): not syntax jest can transform — a `require`-an-ESM call
+  at runtime needing `--experimental-vm-modules`, which we reject. A genuine hold
+  regardless (see the BigQuery hold).
+
+(`@motherduck/wasm-client` stays in `transformIgnoreModules` defensively, but it's held
+at CJS 0.6, so it doesn't actually exercise the transform.)
 
 ## Held because the upgrade breaks this repo
 
@@ -220,6 +234,29 @@ per-platform `@databricks/databricks-sql-kernel-*` `.node` binaries, `approve-na
 them in each — then take 1.16.0+ and verify against the live Databricks CI env. Until
 then it's supported-or-rots: the connector is welded to the embedding apps' bundlers,
 so it can't float.
+
+### uuid + @noble/hashes — held below their ESM-only majors
+Owned by `packages/malloy` (core, published as `@malloydata/malloy`). **uuid 12+ and
+@noble/hashes 2+ dropped CommonJS** — pure ESM (`"type": "module"`, no `require`
+build). malloy is CJS and is consumed by apps that bundle with esbuild and test with
+ts-jest, so a pure-ESM runtime dep breaks every consumer's bundle and test runner —
+while malloy's own CI stays green (babel-jest transforms it locally). Same leak as a
+native binary, different mechanism. It shipped in 0.0.419 and broke the vscode
+extension and malloy-cli on the spot; 0.0.420 pins both back to their last CJS majors.
+
+Held: `uuid ^11.1.1` and `@noble/hashes ^1.8.0` in `packages/malloy/package.json`
+(plus the root devDep `uuid`) — caret ranges that cap below the ESM major, with a
+**major-only** `ignore` in `dependabot.yml` so CJS-line minors/patches still flow.
+@noble/hashes also needed two import-path reverts in `model/utils.ts`
+(`/sha2.js`→`/sha256`, drop the `.js`); the digest is byte-identical. Both are out of
+`transformIgnoreModules` now — they're CJS again, so no transform is needed.
+
+Cost: held on uuid 11 / @noble 1; no security advisory rides on either today.
+
+Revisit when: consumers can take ESM — the embedding apps' bundler **and** test runner
+handle ESM-only deps, or `@malloydata/malloy` ships a **bundled** artifact that inlines
+its runtime deps (making consumer module-format moot, and retiring this whole class of
+leak). Until then, the core stays CJS-consumable.
 
 ### Node runtime — pinned at `24.16.0` via `.node-version`
 Not a dependency, but a deliberate hold that belongs here. Node **24.17.0** carries

--- a/jest.config.simple.ts
+++ b/jest.config.simple.ts
@@ -10,11 +10,9 @@ process.env.TZ = 'America/Los_Angeles';
 
 // ESM-only deps that ship plain static import/export must be transformed (not
 // ignored) so jest's CJS runtime can load them. See DEPENDENCY-MANAGEMENT.md.
-const transformIgnoreModules = [
-  '@motherduck/wasm-client',
-  '@noble/hashes',
-  'uuid',
-].join('|');
+// (uuid and @noble/hashes were pinned to CJS-consumable majors, so they no longer
+// need transforming — an ESM-only runtime dep leaks downstream like a native one.)
+const transformIgnoreModules = ['@motherduck/wasm-client'].join('|');
 
 const config: Config = {
   preset: 'ts-jest',

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -4,12 +4,10 @@ process.env['TZ'] = 'America/Los_Angeles';
 
 // ESM-only deps that ship plain static import/export: jest's CJS runtime can't
 // load them as-is, so they must be transformed (not ignored). See the Class-1
-// ESM note in DEPENDENCY-MANAGEMENT.md.
-const transformIgnoreModules = [
-  '@motherduck/wasm-client',
-  '@noble/hashes',
-  'uuid',
-].join('|');
+// ESM note in DEPENDENCY-MANAGEMENT.md. (uuid and @noble/hashes were here until
+// they were pinned to CJS-consumable majors — an ESM-only runtime dep leaks
+// downstream like a native binary, so the core stays CJS.)
+const transformIgnoreModules = ['@motherduck/wasm-client'].join('|');
 
 const defaultConfig: Config = {
   preset: 'ts-jest',

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "ts-node": "^10.9.1",
         "typescript": "^6.0.3",
         "unified": "^11.0.5",
-        "uuid": "^14.0.0",
+        "uuid": "^11.1.1",
         "yargs": "^18.0.0"
       },
       "engines": {
@@ -7329,18 +7329,6 @@
         "@emnapi/core": "^1.1.0",
         "@emnapi/runtime": "^1.1.0",
         "@tybys/wasm-util": "^0.9.0"
-      }
-    },
-    "node_modules/@noble/hashes": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
-      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -28923,16 +28911,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
-      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist-node/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {
@@ -30331,13 +30319,13 @@
         "@malloydata/malloy-filter": "0.0.420",
         "@malloydata/malloy-interfaces": "0.0.420",
         "@malloydata/malloy-tag": "0.0.420",
-        "@noble/hashes": "^2.2.0",
+        "@noble/hashes": "^1.8.0",
         "antlr4ts": "^0.5.0-alpha.4",
         "assert": "^2.0.0",
         "jaro-winkler": "^0.2.8",
         "lodash": "^4.18.1",
         "luxon": "^3.7.2",
-        "uuid": "^14.0.0"
+        "uuid": "^11.1.1"
       },
       "devDependencies": {
         "@types/jaro-winkler": "^0.2.3",
@@ -32279,6 +32267,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/malloy/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "packages/malloy/node_modules/lodash": {

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "ts-node": "^10.9.1",
     "typescript": "^6.0.3",
     "unified": "^11.0.5",
-    "uuid": "^14.0.0",
+    "uuid": "^11.1.1",
     "yargs": "^18.0.0"
   },
   "dependencies": {},

--- a/packages/malloy/package.json
+++ b/packages/malloy/package.json
@@ -54,13 +54,13 @@
     "@malloydata/malloy-filter": "0.0.420",
     "@malloydata/malloy-interfaces": "0.0.420",
     "@malloydata/malloy-tag": "0.0.420",
-    "@noble/hashes": "^2.2.0",
+    "@noble/hashes": "^1.8.0",
     "antlr4ts": "^0.5.0-alpha.4",
     "assert": "^2.0.0",
     "jaro-winkler": "^0.2.8",
     "lodash": "^4.18.1",
     "luxon": "^3.7.2",
-    "uuid": "^14.0.0"
+    "uuid": "^11.1.1"
   },
   "devDependencies": {
     "@types/jaro-winkler": "^0.2.3",

--- a/packages/malloy/src/model/utils.ts
+++ b/packages/malloy/src/model/utils.ts
@@ -4,8 +4,8 @@
  */
 
 import {v4 as uuidv4, v5 as uuidv5} from 'uuid';
-import {sha256} from '@noble/hashes/sha2.js';
-import {bytesToHex, utf8ToBytes} from '@noble/hashes/utils.js';
+import {sha256} from '@noble/hashes/sha256';
+import {bytesToHex, utf8ToBytes} from '@noble/hashes/utils';
 import type {
   AtomicTypeDef,
   Expr,
@@ -170,8 +170,9 @@ export function makeDigest(...parts: (string | undefined)[]): string {
   const combined = parts
     .map(p => (p === undefined ? '{undefined}' : `${p.length}:${p}`))
     .join('/');
-  // @noble/hashes v2 dropped implicit string hashing; v1 accepted a string and
-  // UTF-8 encoded it internally, so utf8ToBytes here yields the identical digest.
+  // @noble/hashes is pinned to v1 (v2 is ESM-only — see DEPENDENCY-MANAGEMENT.md).
+  // v1's sha256 also accepts a string directly, but we utf8-encode explicitly so the
+  // digest is stable and unambiguous (and identical to the v2 form we briefly used).
   return bytesToHex(sha256(utf8ToBytes(combined)));
 }
 


### PR DESCRIPTION
## Why

`uuid` 12+ and `@noble/hashes` 2+ **dropped CommonJS** — they're pure ESM (`"type": "module"`, no `require` build). malloy is CommonJS and is consumed by apps that **bundle with esbuild** and **test with ts-jest**, so a pure-ESM runtime dep breaks every consumer's bundle and test runner — while malloy's own CI stays green because babel-jest transforms it locally. It shipped in **0.0.419** and broke the vscode extension and malloy-cli the moment they consumed `@malloydata/malloy`.

**An ESM-only runtime dep leaks downstream exactly like a native `.node` binary** — same class as the databricks/snowflake pins, different mechanism. The core package must stay CJS-consumable.

## What

- Pin **uuid → `^11.1.1`** and **@noble/hashes → `^1.8.0`** (last CJS majors) in `packages/malloy/package.json` (+ root devDep `uuid`). Caret major-caps + **major-only** dependabot ignores, so CJS-line minors/patches and their security fixes still flow.
- Revert two `@noble/hashes` import paths in `model/utils.ts` (`/sha2.js`→`/sha256`, drop `.js`). The sha256 digest is **byte-identical** — verified against Node's `crypto` — so no cache-key / temp-view-name drift across the connectors that use `makeDigest`.
- Drop both from jest `transformIgnoreModules` (CJS again, no transform needed).
- `DEPENDENCY-MANAGEMENT.md`: the **devDependency-vs-published-runtime-dep** lesson (an ESM-only *runtime* dep leaks; a *devDep* is takeable), the **caret-default / exact-only-when-walled** pin policy, and a full uuid+@noble hold entry.

Green locally: `npm run build` + `npm run precheck`.