### PR TITLE
ci: write npm publish summary to GitHub Actions run page

### DIFF
--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -26,10 +26,19 @@ jobs:
           CLEAN_BRANCH_NAME=$(echo $BRANCH_NAME | sed -e 's/\//-/')
           VERSION=$(jq -r .version ./lerna.json)-$CLEAN_BRANCH_NAME-$PRERELEASE
           npx lerna version $VERSION --exact --allow-branch=$BRANCH_NAME --yes --no-push --no-git-tag-version
+          # Accumulate a per-package table for the GitHub Actions run summary.
+          echo "## 📦 npm Pre-release Summary" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Version**: \`$VERSION\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Tag**: \`dev\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Package | Result |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| --- | --- |" >> "$GITHUB_STEP_SUMMARY"
           for package in $PACKAGES; do
             PKG_NAME=$(jq -r .name ./$package/package.json)
             if npm view "$PKG_NAME@$VERSION" version &>/dev/null; then
               echo "SKIPPED $PKG_NAME@$VERSION (already published)"
+              echo "| \`$PKG_NAME\` | ⏭️ skipped (already published) |" >> "$GITHUB_STEP_SUMMARY"
             else
               echo Publishing $PKG_NAME $VERSION
               # MIT requires the license text to travel with the package. The
@@ -38,6 +47,7 @@ jobs:
               # see .gitignore for packages/*/LICENSE.
               cp LICENSE "$package/LICENSE"
               npm publish -w $package --access=public --tag dev
+              echo "| [\`$PKG_NAME\`](https://www.npmjs.com/package/$PKG_NAME/v/$VERSION) | ✅ published |" >> "$GITHUB_STEP_SUMMARY"
             fi
           done
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -72,10 +72,19 @@ jobs:
           PACKAGES=$(jq -r '.workspaces.packages[]' ./package.json | xargs echo)
           echo Publishing $PACKAGES
           VERSION=$(jq -r .version ./lerna.json)
+          # Accumulate a per-package table for the GitHub Actions run summary.
+          echo "## 📦 npm Release Summary" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Version**: \`$VERSION\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Tag**: \`latest\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Package | Result |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| --- | --- |" >> "$GITHUB_STEP_SUMMARY"
           for package in $PACKAGES; do
             PKG_NAME=$(jq -r .name ./$package/package.json)
             if npm view "$PKG_NAME@$VERSION" version &>/dev/null; then
               echo "SKIPPED $PKG_NAME@$VERSION (already published)"
+              echo "| \`$PKG_NAME\` | ⏭️ skipped (already published) |" >> "$GITHUB_STEP_SUMMARY"
             else
               echo Publishing $PKG_NAME $VERSION
               # MIT requires the license text to travel with the package. The
@@ -84,13 +93,17 @@ jobs:
               # see .gitignore for packages/*/LICENSE.
               cp LICENSE "$package/LICENSE"
               npm publish -w $package --access=public
+              echo "| [\`$PKG_NAME\`](https://www.npmjs.com/package/$PKG_NAME/v/$VERSION) | ✅ published |" >> "$GITHUB_STEP_SUMMARY"
             fi
           done
+          echo "" >> "$GITHUB_STEP_SUMMARY"
           # Create GitHub Release with auto-generated notes from PRs
           if gh release view v$VERSION &>/dev/null; then
             echo "SKIPPED release v$VERSION (already exists)"
+            echo "- **GitHub Release**: v$VERSION (already existed)" >> "$GITHUB_STEP_SUMMARY"
           else
             gh release create v$VERSION --generate-notes --title "v$VERSION"
+            echo "- **GitHub Release**: [v$VERSION](https://github.com/malloydata/malloy/releases/tag/v$VERSION)" >> "$GITHUB_STEP_SUMMARY"
           fi
           # Bump version
           npx lerna version patch --exact --yes --no-push --no-git-tag-version


### PR DESCRIPTION
The malloy-cli publish workflow prints a tidy summary to the GitHub Actions run page when it finishes publishing to npm. The main malloy publish workflows didn't — you had to read the raw log to see what shipped. This brings that summary here.

Because these workflows publish a *loop* of workspace packages (and skip any already published at the target version), the summary is a per-package table rather than the CLI's single-package blurb: it shows the version, the dist-tag, and ✅ published / ⏭️ skipped for each package, with npm links. `release.yaml` also links the GitHub Release.

The table is built inline as the publish loop runs rather than in a separate trailing step. That's what makes the per-package detail possible, and it has a nice side effect: a mid-loop failure still leaves a summary recording exactly which packages made it out before things broke.

- `release.yaml` → `latest`
- `prerelease.yaml` → `dev`

Visible only on real runs (`\$GITHUB_STEP_SUMMARY` is set by the runner), so the next dispatch of each workflow is where it shows up.