### PR TITLE
Fix stale npm script name in ci-test-sanity-check comment

### DIFF
--- a/scripts/ci-test-sanity-check.sh
+++ b/scripts/ci-test-sanity-check.sh
@@ -4,7 +4,7 @@
 # tests in the source tree.
 #
 # test/consumer-canary is excluded: its spec deliberately runs under its own plain
-# ts-jest config (the `consumer-canary` CI job, `npm run canary`), not the main
+# ts-jest config (the `consumer-canary` CI job, `npm run consumer-canary`), not the main
 # jest projects, so it never appears in `jest --listTests`. See
 # test/consumer-canary/CONTEXT.md.
 


### PR DESCRIPTION
Follow-up to #2955. The canary npm scripts were renamed `canary` → `consumer-canary`, but a comment in `scripts/ci-test-sanity-check.sh` still referenced `npm run canary`. Comment-only, no behavior change.

Swept the repo for other stale references from the rename — this was the only one; the workflow, `run-tests.yaml`, `package.json`, eslint config, and the canary files are all consistent.