### PR TITLE
Fix query-class conflict diagnostics

### DIFF
--- a/packages/malloy/src/lang/ast/query-builders/project-builder.ts
+++ b/packages/malloy/src/lang/ast/query-builders/project-builder.ts
@@ -12,7 +12,6 @@ import {isPartialSegment, isProjectSegment} from '../../../model/malloy_types';
 
 import {ErrorFactory} from '../error-factory';
 import type {SourceFieldSpace} from '../types/field-space';
-import {GroupBy} from '../query-properties/group-by';
 import {ProjectFieldSpace} from '../field-space/project-field-space';
 import type {QueryProperty} from '../types/query-property';
 import {QuerySegmentBuilder} from './reduce-builder';
@@ -41,7 +40,7 @@ export class ProjectBuilder
   }
 
   execute(qp: QueryProperty): void {
-    if (qp.elementType === 'having' || qp instanceof GroupBy) {
+    if (qp.elementType === 'having') {
       qp.logError(
         'illegal-operation-in-select-segment',
         'Illegal statement in a select query operation'

--- a/packages/malloy/src/lang/ast/query-properties/aggregate.ts
+++ b/packages/malloy/src/lang/ast/query-properties/aggregate.ts
@@ -18,4 +18,5 @@ export class Aggregate
   elementType = 'aggregateList';
   readonly queryRefinementStage = LegalRefinementStage.Single;
   readonly forceQueryClass = QueryClass.Grouping;
+  readonly statement = 'aggregate:';
 }

--- a/packages/malloy/src/lang/ast/query-properties/group-by.ts
+++ b/packages/malloy/src/lang/ast/query-properties/group-by.ts
@@ -18,4 +18,5 @@ export class GroupBy
   elementType = 'groupBy';
   queryRefinementStage = LegalRefinementStage.Single;
   forceQueryClass = QueryClass.Grouping;
+  statement = 'group_by:';
 }

--- a/packages/malloy/src/lang/ast/query-properties/indexing.ts
+++ b/packages/malloy/src/lang/ast/query-properties/indexing.ts
@@ -13,6 +13,7 @@ export class Index extends MalloyElement implements QueryPropertyInterface {
   elementType = 'index';
   weightBy?: FieldName;
   forceQueryClass = QueryClass.Index;
+  statement = 'index:';
   queryRefinementStage = undefined;
 
   constructor(readonly fields: FieldReferences) {

--- a/packages/malloy/src/lang/ast/query-properties/nest.ts
+++ b/packages/malloy/src/lang/ast/query-properties/nest.ts
@@ -23,6 +23,7 @@ export class NestFieldDeclaration
   elementType = 'nest-field-declaration';
   queryRefinementStage = LegalRefinementStage.Single;
   forceQueryClass = QueryClass.Grouping;
+  statement = 'nest:';
   turtleDef: model.TurtleDef | undefined = undefined;
 
   queryExecute(executeFor: QueryBuilder) {

--- a/packages/malloy/src/lang/ast/query-properties/nests.ts
+++ b/packages/malloy/src/lang/ast/query-properties/nests.ts
@@ -18,6 +18,7 @@ export class Nests
   elementType = 'nestedQueries';
   queryRefinementStage = LegalRefinementStage.Single;
   forceQueryClass = QueryClass.Grouping;
+  statement = 'nest:';
   constructor(nests: NestFieldDeclaration[]) {
     super(nests);
   }

--- a/packages/malloy/src/lang/ast/query-properties/project-statement.ts
+++ b/packages/malloy/src/lang/ast/query-properties/project-statement.ts
@@ -18,6 +18,7 @@ export class ProjectStatement
 {
   elementType = 'projectStatement';
   forceQueryClass = QueryClass.Project;
+  statement = 'select:';
   queryRefinementStage = LegalRefinementStage.Single;
 
   queryExecute(executeFor: QueryBuilder) {

--- a/packages/malloy/src/lang/ast/query-properties/qop-desc.ts
+++ b/packages/malloy/src/lang/ast/query-properties/qop-desc.ts
@@ -18,24 +18,6 @@ import {PartialBuilder} from '../query-builders/partial-builder';
 import type {QueryOperationSpace} from '../field-space/query-spaces';
 import {modernizeTermsForUserText} from '../../utils';
 
-function queryOperationName(el: QueryProperty): string | undefined {
-  switch (el.elementType) {
-    case 'aggregateList':
-      return 'aggregate:';
-    case 'groupBy':
-      return 'group_by:';
-    case 'index':
-      return 'index:';
-    case 'nestedQueries':
-    case 'nest-field-declaration':
-      return 'nest:';
-    case 'projectStatement':
-      return 'select:';
-    case 'sampleProperty':
-      return 'sample:';
-  }
-}
-
 function queryContextName(queryClass: QueryClass): string {
   const className = modernizeTermsForUserText(queryClass);
   const article = className === 'index' ? 'an' : 'a';
@@ -63,9 +45,7 @@ export class QOpDesc extends ListOf<QueryProperty> {
       if (el.forceQueryClass) {
         if (guessType) {
           if (guessType !== el.forceQueryClass) {
-            const operationName =
-              queryOperationName(el) ??
-              modernizeTermsForUserText(el.forceQueryClass);
+            const operationName = el.statement;
             el.logError(
               `illegal-${guessType}-operation`,
               `Use of ${operationName} is not allowed in ${queryContextName(

--- a/packages/malloy/src/lang/ast/query-properties/qop-desc.ts
+++ b/packages/malloy/src/lang/ast/query-properties/qop-desc.ts
@@ -18,6 +18,30 @@ import {PartialBuilder} from '../query-builders/partial-builder';
 import type {QueryOperationSpace} from '../field-space/query-spaces';
 import {modernizeTermsForUserText} from '../../utils';
 
+function queryOperationName(el: QueryProperty): string | undefined {
+  switch (el.elementType) {
+    case 'aggregateList':
+      return 'aggregate:';
+    case 'groupBy':
+      return 'group_by:';
+    case 'index':
+      return 'index:';
+    case 'nestedQueries':
+    case 'nest-field-declaration':
+      return 'nest:';
+    case 'projectStatement':
+      return 'select:';
+    case 'sampleProperty':
+      return 'sample:';
+  }
+}
+
+function queryContextName(queryClass: QueryClass): string {
+  const className = modernizeTermsForUserText(queryClass);
+  const article = className === 'index' ? 'an' : 'a';
+  return `${article} ${className} query`;
+}
+
 export class QOpDesc extends ListOf<QueryProperty> {
   elementType = 'queryOperation';
   opClass: QueryClass | undefined;
@@ -39,13 +63,14 @@ export class QOpDesc extends ListOf<QueryProperty> {
       if (el.forceQueryClass) {
         if (guessType) {
           if (guessType !== el.forceQueryClass) {
+            const operationName =
+              queryOperationName(el) ??
+              modernizeTermsForUserText(el.forceQueryClass);
             el.logError(
               `illegal-${guessType}-operation`,
-              `Use of ${modernizeTermsForUserText(
-                el.forceQueryClass
-              )} is not allowed in a ${modernizeTermsForUserText(
+              `Use of ${operationName} is not allowed in ${queryContextName(
                 guessType
-              )} query`
+              )}`
             );
           }
         } else {
@@ -89,6 +114,13 @@ export class QOpDesc extends ListOf<QueryProperty> {
   ): OpDesc {
     const build = this.getBuilder(inputFS, isNestIn, this);
     for (const qp of this.list) {
+      if (
+        this.opClass &&
+        qp.forceQueryClass &&
+        qp.forceQueryClass !== this.opClass
+      ) {
+        continue;
+      }
       build.execute(qp);
     }
     const segment = build.finalize(this.refineThis);

--- a/packages/malloy/src/lang/ast/query-properties/sampling.ts
+++ b/packages/malloy/src/lang/ast/query-properties/sampling.ts
@@ -19,6 +19,7 @@ export class SampleProperty
   elementType = 'sampleProperty';
   queryRefinementStage = LegalRefinementStage.Tail;
   forceQueryClass = QueryClass.Index;
+  statement = 'sample:';
 
   constructor(readonly sample: Sampling) {
     super();

--- a/packages/malloy/src/lang/ast/types/query-property-interface.ts
+++ b/packages/malloy/src/lang/ast/types/query-property-interface.ts
@@ -27,6 +27,7 @@ export enum LegalRefinementStage {
 export interface QueryPropertyInterface {
   queryRefinementStage: LegalRefinementStage | undefined;
   forceQueryClass: QueryClass | undefined;
+  statement?: string;
   // Edge case for `calculate:`, which needs a grouping or
   // project to decide what kind of query it is
   needsExplicitQueryClass?: boolean;

--- a/packages/malloy/src/lang/test/locations.spec.ts
+++ b/packages/malloy/src/lang/test/locations.spec.ts
@@ -241,7 +241,7 @@ describe('source locations', () => {
   });
   test('bad query', () => {
     expect(model`run: a -> { group_by: astr; ${'select: *'} }`).toLog(
-      errorMessage(/Use of select is not allowed in a grouping query/)
+      errorMessage(/Use of select: is not allowed in a grouping query/)
     );
   });
 

--- a/packages/malloy/src/lang/test/parse.spec.ts
+++ b/packages/malloy/src/lang/test/parse.spec.ts
@@ -163,7 +163,7 @@ describe('error handling', () => {
   });
   test('refine cannot change query type', () => {
     expect('run: ab -> aturtle + { select: astr }').toLog(
-      errorMessage(/Use of select is not allowed in a grouping query/)
+      errorMessage(/Use of select: is not allowed in a grouping query/)
     );
   });
   test('undefined field ref in query', () => {

--- a/packages/malloy/src/lang/test/query.spec.ts
+++ b/packages/malloy/src/lang/test/query.spec.ts
@@ -844,7 +844,44 @@ describe('query:', () => {
       // segment; in a select it forces a grouping/select collision.
       expect(
         markSource`run: a->{ select: astr; ${'nest: b is { group_by: ai }'} }`
-      ).toLog(errorMessage('Use of grouping is not allowed in a select query'));
+      ).toLog(errorMessage('Use of nest: is not allowed in a select query'));
+    });
+    test('group_by illegal in a select segment', () => {
+      expect(markSource`run: a->{ select: astr; ${'group_by: ai'} }`).toLog(
+        errorMessage('Use of group_by: is not allowed in a select query')
+      );
+    });
+    test('aggregate illegal in a select segment', () => {
+      expect(
+        markSource`run: a->{ select: astr; ${'aggregate: c is count()'} }`
+      ).toLog(
+        errorMessage('Use of aggregate: is not allowed in a select query')
+      );
+    });
+    test('index illegal in a select segment', () => {
+      expect(markSource`run: a->{ select: astr; ${'index: *'} }`).toLog(
+        errorMessage('Use of index: is not allowed in a select query')
+      );
+    });
+    test('sample illegal in a select segment', () => {
+      expect(markSource`run: a->{ select: astr; ${'sample: true'} }`).toLog(
+        errorMessage('Use of sample: is not allowed in a select query')
+      );
+    });
+    test('select illegal in a grouping segment', () => {
+      expect(markSource`run: a->{ group_by: astr; ${'select: ai'} }`).toLog(
+        errorMessage('Use of select: is not allowed in a grouping query')
+      );
+    });
+    test('index illegal in a grouping segment', () => {
+      expect(markSource`run: a->{ group_by: astr; ${'index: *'} }`).toLog(
+        errorMessage('Use of index: is not allowed in a grouping query')
+      );
+    });
+    test('select illegal in an index segment', () => {
+      expect(markSource`run: a->{ index: *; ${'select: astr'} }`).toLog(
+        errorMessage('Use of select: is not allowed in an index query')
+      );
     });
     test('aggregate reference', () => {
       const doc = model`run: a->{ aggregate: ai.sum() }`;

--- a/packages/malloy/src/lang/test/syntax-errors.spec.ts
+++ b/packages/malloy/src/lang/test/syntax-errors.spec.ts
@@ -335,7 +335,7 @@ describe('custom error messages', () => {
             select: ai
           }
         `).toLogAtLeast(
-        errorMessage('Use of select is not allowed in a grouping query')
+        errorMessage('Use of select: is not allowed in a grouping query')
       );
     });
 
@@ -346,7 +346,7 @@ describe('custom error messages', () => {
             group_by: astr
           }
         `).toLogAtLeast(
-        errorMessage('Use of grouping is not allowed in a select query')
+        errorMessage('Use of group_by: is not allowed in a select query')
       );
     });
 


### PR DESCRIPTION
Fixes #2901

This PR updates query-class conflict diagnostics so illegal operations in the wrong query segment produce a single operation-specific error.

The change keeps the ProjectBuilder defensive check intact and handles duplicate diagnostic suppression in QOpDesc. I also checked the related forced query-class operations index: and sample:.

This is my first contribution to this repo, so feedback is very welcome.

Tests run:

npx jest --config jest.config.ts --selectProjects malloy-core --runTestsByPath packages/malloy/src/lang/test/query.spec.ts --setupFilesAfterEnv jest-expect-message --runInBand

npx jest --config jest.config.ts --selectProjects malloy-core --runTestsByPath packages/malloy/src/lang/test/parse.spec.ts packages/malloy/src/lang/test/locations.spec.ts  packages/malloy/src/lang/test/syntax-errors.spec.ts --setupFilesAfterEnv jest-expect-message --runInBand

npx eslint packages/malloy/src/lang/ast/query-builders/project-builder.ts packages/malloy/src/lang/ast/query-properties/qop-desc.ts packages/malloy/src/lang/test/locations.spec.ts packages/malloy/src/lang/test/parse.spec.ts packages/malloy/src/lang/test/query.spec.ts packages/malloy/src/lang/test/syntax-errors.spec.ts

npx tsc --build packages/malloy/tsconfig.json --pretty false

git diff --check

