### PR TITLE
feat(malloy): experimental givens access-predicate inspect + SQL emit

### DIFF
--- a/packages/malloy/src/api/foundation/core.ts
+++ b/packages/malloy/src/api/foundation/core.ts
@@ -18,6 +18,7 @@ import type {
   Given as InternalGiven,
   GivenID,
   GivenTypeDef,
+  GivenValue,
   Query as InternalQuery,
   Pipeline,
   ModelDef,
@@ -57,6 +58,7 @@ import {
   getCompiledSQL,
   getModelAnnotations,
   safeRecordGet,
+  predicateExprToSQL,
 } from '../../model';
 import {mkModelDef} from '../../model/utils';
 import type {Dialect} from '../../dialect';
@@ -562,6 +564,105 @@ export class Explore extends Entity implements Taggable {
       return this.structDef.resultMetadata?.filterList || [];
     }
     return [];
+  }
+
+  private requireGivensExperiment(method: string): void {
+    // Read the resolved model annotations (the import/extend fold) so the flag
+    // carries across `extend`, matching getBuildPlan's gate.
+    const modelTag = this.modelAnnotations.parseAsTag('!').tag;
+    if (!modelTag.has('experimental', 'givens')) {
+      throw new Error(
+        `Model must have ##! experimental.givens to use ${method}`
+      );
+    }
+  }
+
+  /**
+   * THIS IS A HIGHLY EXPERIMENTAL API AND MAY VANISH OR CHANGE WITHOUT NOTICE
+   *
+   * The source-level access filters — the `where:` predicates that isolate this
+   * source's data (RLAC). Unlike `.filters` (drill/result filters), these are the
+   * filters marked `isSourceFilter`. Each `FilterCondition` exposes the source
+   * text (`.code`), the walkable expression tree (`.e`), and pre-computed field
+   * and given references (`.refSummary`) — enough to reconstruct a compound
+   * predicate (`or`, cross-column), not just a per-field map.
+   *
+   * Requires the model to declare `##! experimental.givens`.
+   */
+  public get accessFilters(): FilterCondition[] {
+    this.requireGivensExperiment('accessFilters');
+    return (this.sourceStructDef?.filterList ?? []).filter(
+      f => f.isSourceFilter
+    );
+  }
+
+  /**
+   * THIS IS A HIGHLY EXPERIMENTAL API AND MAY VANISH OR CHANGE WITHOUT NOTICE
+   *
+   * Compile this source's access predicate (see `accessFilters`) to a single
+   * dialect-appropriate SQL boolean expression for a concrete set of given
+   * values — a bare WHERE fragment (no `WHERE` keyword), in the source's own
+   * dialect. A host splices this into its own SQL to re-apply the source's row
+   * isolation when indexing rows.
+   *
+   * Columns are qualified with `options.tableAlias` (default `base`, which must
+   * be a bare SQL identifier `[A-Za-z_][A-Za-z0-9_]*`); the caller must expose
+   * the source's table under that alias. Predicates that reference a
+   * joined field — directly (`orders.amount`) or via a local dimension that
+   * aliases one — are rejected, since the emitted alias has no entry in the
+   * caller's `FROM`; base-relative columns (including nested record columns) are
+   * fine. An unsatisfied given (no supplied value and no declaration default)
+   * throws, so the predicate fails closed. A source with no access filters
+   * returns `'true'` (no restriction); a caller whose policy requires a predicate
+   * should check `accessFilters` is non-empty first.
+   *
+   * Requires the model to declare `##! experimental.givens` (a bare
+   * `##! experimental` is not sufficient).
+   */
+  public accessFilterSQL(options?: {
+    givens?: Record<string, GivenValue>;
+    tableAlias?: string;
+  }): string {
+    const filters = this.accessFilters; // also enforces the experiment gate
+    const source = this.sourceStructDef;
+    if (!source) {
+      throw new Error(
+        `Cannot get access filter SQL from a struct of type ${this.structDef.type}`
+      );
+    }
+    // The access predicate can only be bound if this model declares every given
+    // it references. A detached Explore (created via `fromJSON`/serialization)
+    // carries the source and annotations but not the model's given declarations,
+    // so binding would otherwise fail deep in the compiler with a confusing
+    // "unknown given". Detect that here and fail with an actionable message.
+    const modelGivens = this._ownerModelDef.givens ?? {};
+    for (const filter of filters) {
+      for (const usage of filter.refSummary?.givenUsage ?? []) {
+        if (!modelGivens[usage.id]) {
+          throw new Error(
+            'accessFilterSQL: the access predicate references givens this ' +
+              "Explore's model does not declare. This usually means the Explore " +
+              'was created via fromJSON/serialization, which does not carry given ' +
+              'declarations — obtain the Explore from a compiled Model instead.'
+          );
+        }
+      }
+    }
+    const resolved = options?.givens
+      ? resolveSuppliedGivens(options.givens, this._ownerModelDef)
+      : new Map<GivenID, Expr>();
+    evaluateInlineGivens(resolved, this._ownerModelDef);
+    const result = predicateExprToSQL(
+      source,
+      filters,
+      modelGivens,
+      resolved.size > 0 ? resolved : undefined,
+      options?.tableAlias ?? 'base'
+    );
+    if (result.error !== undefined) {
+      throw new Error(result.error);
+    }
+    return result.sql;
   }
 
   get limit(): number | undefined {

--- a/packages/malloy/src/index.ts
+++ b/packages/malloy/src/index.ts
@@ -63,6 +63,15 @@ export type {
   Expr,
   // Needed for drills in render
   FilterCondition,
+  // Walking access predicates (experimental givens): the reference summary on a
+  // FilterCondition and the Expr leaf nodes a consumer narrows on.
+  RefSummary,
+  FieldUsage,
+  FieldUsageEntry,
+  GivenUsage,
+  GivenUsageEntry,
+  FieldnameNode,
+  GivenRefNode,
   // Used in Composer
   Argument,
   Parameter,

--- a/packages/malloy/src/model/CONTEXT.md
+++ b/packages/malloy/src/model/CONTEXT.md
@@ -190,7 +190,9 @@ Most `##!` flags are consumed **at translation time** (the `inExperiment` gates
 in `lang/`). The Foundation API also reads `##! experimental.persistence` at
 **runtime** — off the resolved model annotations (`Model.modelAnnotations`, the
 fold, so it carries across extend) — to gate `getBuildPlan()` / manifest
-substitution. There is deliberately no **SQL-gen-time** `##!` mechanism: the
+substitution. `##! experimental.givens` is gated the same way to guard
+`Explore.accessFilters` / `accessFilterSQL` (the access-predicate inspect + SQL
+emit API). There is deliberately no **SQL-gen-time** `##!` mechanism: the
 former per-object `modelAnnotations` carrier and `modelCompilerFlags()` were
 removed once their only consumer (`unsafe_complex_select_query`, a temporary BQ
 escape hatch) proved unnecessary; the guard it bypassed is now a plain compiler

--- a/packages/malloy/src/model/index.ts
+++ b/packages/malloy/src/model/index.ts
@@ -48,6 +48,8 @@ export {
 } from './utils';
 export {getModelAnnotations} from './annotation_utils';
 export {constantExprToSQL} from './constant_expression_compiler';
+export {predicateExprToSQL} from './predicate_expression_compiler';
+export type {PredicateExpressionResult} from './predicate_expression_compiler';
 export {getCompiledSQL} from './sql_compiled';
 export {MalloyCompileError} from './malloy_compile_error';
 export {

--- a/packages/malloy/src/model/predicate_expression_compiler.ts
+++ b/packages/malloy/src/model/predicate_expression_compiler.ts
@@ -1,0 +1,207 @@
+/*
+ * Copyright Contributors to the Malloy project
+ * SPDX-License-Identifier: MIT
+ */
+
+import type {
+  Expr,
+  FilterCondition,
+  Given,
+  GivenID,
+  QuerySegment,
+  SourceDef,
+  TurtleDef,
+} from './malloy_types';
+import {expressionIsScalar, isBaseTable} from './malloy_types';
+import type {QueryInfo} from '../dialect';
+import {exprToSQL} from './expression_compiler';
+import {AndChain} from './utils';
+import {QueryStruct, type ModelRootInterface} from './query_node';
+import type {EventStream} from '../runtime_types';
+import {FieldInstanceResultRoot} from './field_instance';
+import type {JoinInstance} from './join_instance';
+
+/**
+ * Minimal FieldInstanceResultRoot for compiling a source's access predicate.
+ * A predicate over the source's own columns never touches output fields or
+ * the group-set machinery, so almost everything here is the empty/identity
+ * value. `getQueryInfo` carries the source's query timezone so temporal
+ * literals in the predicate render correctly.
+ *
+ * Mirrors `ConstantFieldInstanceResultRoot` in constant_expression_compiler.ts.
+ */
+class PredicateFieldInstanceResultRoot extends FieldInstanceResultRoot {
+  override joins = new Map<string, JoinInstance>();
+  override havings = new AndChain();
+  override isComplexQuery = false;
+  override queryUsesPartitioning = false;
+  override computeOnlyGroups: number[] = [];
+  override elimatedComputeGroups = false;
+
+  constructor(private readonly queryTimezone: string) {
+    const minimalTurtleDef: TurtleDef = {
+      type: 'turtle',
+      name: '__predicate__',
+      pipeline: [],
+    };
+    super(minimalTurtleDef);
+
+    const minimalOutputStruct: SourceDef = {
+      type: 'table',
+      name: '__predicate_output__',
+      fields: [],
+      tablePath: '__predicate__',
+      connection: '__predicate__',
+      dialect: 'standardsql',
+    };
+    const minimalSegment: QuerySegment = {
+      type: 'project',
+      filterList: [],
+      queryFields: [],
+      outputStruct: minimalOutputStruct,
+      isRepeated: false,
+    };
+    this.firstSegment = minimalSegment;
+  }
+
+  override root(): FieldInstanceResultRoot {
+    return this;
+  }
+
+  override getQueryInfo(): QueryInfo {
+    return {queryTimezone: this.queryTimezone};
+  }
+}
+
+/**
+ * QueryStruct rooted at a real source, used to compile that source's access
+ * predicate in isolation. Unlike `ConstantQueryStruct` it keeps the inherited
+ * `getFieldByName` so the predicate's column references resolve against the
+ * source's own fields. The only override is `getIdentifier`: the host splices
+ * the returned fragment into its own SQL, so top-level columns are qualified
+ * with a caller-supplied alias (default `base`) rather than Malloy's hardcoded
+ * `base`.
+ */
+class PredicateQueryStruct extends QueryStruct {
+  constructor(
+    source: SourceDef,
+    modelGivens: Record<GivenID, Given>,
+    resolvedGivens: Map<GivenID, Expr> | undefined,
+    private readonly tableAlias: string,
+    eventStream?: EventStream
+  ) {
+    const model: ModelRootInterface = {
+      structs: new Map(),
+      givens: modelGivens,
+    };
+    super(source, undefined, {model}, {eventStream, resolvedGivens});
+  }
+
+  override getIdentifier(): string {
+    if (isBaseTable(this.structDef)) {
+      return this.tableAlias;
+    }
+    return super.getIdentifier();
+  }
+}
+
+export type PredicateExpressionResult =
+  | {sql: string; error?: undefined}
+  | {sql?: undefined; error: string};
+
+/**
+ * Compile a source's access filters to a single dialect-appropriate SQL boolean
+ * expression (a bare WHERE fragment, no `WHERE` keyword). Multiple filters are
+ * AND-ed together. Field references are resolved against `source` and qualified
+ * with `tableAlias`; given references are resolved from `resolvedGivens` (with
+ * declaration defaults via `modelGivens`).
+ *
+ * `tableAlias` must be a bare SQL identifier (`[A-Za-z_][A-Za-z0-9_]*`); it is
+ * interpolated directly into the emitted SQL, so anything else returns `{error}`
+ * rather than risk injection.
+ *
+ * A source with no access filters yields `'true'` (no restriction = match-all,
+ * consistent with `f''`), never an empty string — so the caller can always
+ * splice the result into `... WHERE <fragment>`. A caller whose policy requires
+ * a predicate should check that there are filters before calling.
+ *
+ * Returns `{error}` when the predicate references a joined field (directly, like
+ * `orders.amount`, or transitively via a local dimension that aliases one) —
+ * such a reference renders with Malloy's internal join alias, which the caller's
+ * `FROM <table> AS <tableAlias>` query has no entry for, so this API is scoped to
+ * the source's own columns. Genuine compile failures (an unbound given, a missing
+ * field) throw `MalloyCompileError`, which the caller surfaces as a fail-closed
+ * error.
+ */
+export function predicateExprToSQL(
+  source: SourceDef,
+  filters: FilterCondition[],
+  modelGivens: Record<GivenID, Given>,
+  resolvedGivens: Map<GivenID, Expr> | undefined,
+  tableAlias: string,
+  eventStream?: EventStream
+): PredicateExpressionResult {
+  // The alias is interpolated straight into SQL. For an access-control API the
+  // safe contract is a bare SQL identifier; reject anything else so a caller
+  // that ever routes untrusted input here can't inject. (`base` and any plain
+  // identifier pass.)
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(tableAlias)) {
+    return {
+      error:
+        `Invalid tableAlias '${tableAlias}': must be a bare SQL identifier ` +
+        '([A-Za-z_][A-Za-z0-9_]*).',
+    };
+  }
+
+  const context = new PredicateQueryStruct(
+    source,
+    modelGivens,
+    resolvedGivens,
+    tableAlias,
+    eventStream
+  );
+  const resultSet = new PredicateFieldInstanceResultRoot(
+    source.queryTimezone ?? 'UTC'
+  );
+  const chain = new AndChain();
+  for (const filter of filters) {
+    // Source `where:` filters are always scalar — the translator rejects
+    // aggregates in a source filter at compile time (refined-source.ts), so a
+    // non-scalar here means an upstream invariant broke. Fail loud rather than
+    // silently dropping a filter, which for an access-control predicate would
+    // fail open.
+    if (!expressionIsScalar(filter.expressionType)) {
+      throw new Error(
+        'predicateExprToSQL: source access filter has non-scalar ' +
+          `expressionType '${filter.expressionType}'; expected a scalar ` +
+          'predicate. This is an internal invariant violation.'
+      );
+    }
+    chain.add(exprToSQL(resultSet, context, filter.e));
+  }
+
+  // Reject any predicate that reached a joined field. A reference that leaves the
+  // source's base row is the only thing that allocates a join alias, and
+  // `getAliasIdentifier` (the sole writer of pathAliasMap) is the only place that
+  // happens. So a non-empty pathAliasMap after compilation means the emitted SQL
+  // names an alias the caller cannot satisfy. This is the authoritative check: it
+  // catches both direct joined refs and local dimensions that alias a joined
+  // field, where a syntactic path-length check on the filter would miss the
+  // latter. Base-relative columns (including nested record columns) never
+  // allocate an alias, so they pass.
+  if (context.pathAliasMap.size > 0) {
+    const joined = Array.from(context.pathAliasMap.keys())
+      .map(p => p.replace(/\.$/, ''))
+      .filter(p => p.length > 0)
+      .join(', ');
+    return {
+      error:
+        `Access predicate references joined field(s) [${joined}]. ` +
+        "accessFilterSQL supports only the source's own columns.",
+    };
+  }
+
+  // No access filters → no restriction. Emit `true` rather than an empty string
+  // so the caller can always splice into `... WHERE <fragment>`.
+  return {sql: chain.empty() ? 'true' : chain.sql()};
+}

--- a/packages/malloy/src/model/test/predicate_expression_compiler.spec.ts
+++ b/packages/malloy/src/model/test/predicate_expression_compiler.spec.ts
@@ -1,0 +1,110 @@
+/*
+ * Copyright Contributors to the Malloy project
+ * SPDX-License-Identifier: MIT
+ */
+
+import type {Expr, FilterCondition, SourceDef} from '../malloy_types';
+import {predicateExprToSQL} from '../predicate_expression_compiler';
+
+// A two-column source. `dialect` is flipped per-test to exercise dialect
+// routing without needing a live connection.
+function mkSource(dialect: string): SourceDef {
+  return {
+    type: 'table',
+    name: 'rows',
+    tablePath: 'rows',
+    connection: 'test',
+    dialect,
+    fields: [
+      {type: 'number', name: 'tenant_id'},
+      {type: 'boolean', name: 'is_public'},
+    ],
+  };
+}
+
+// tenant_id = 1 or is_public
+const COMPOUND: Expr = {
+  node: 'or',
+  kids: {
+    left: {
+      node: '=',
+      kids: {
+        left: {node: 'field', path: ['tenant_id']},
+        right: {node: 'numberLiteral', literal: '1'},
+      },
+    },
+    right: {node: 'field', path: ['is_public']},
+  },
+};
+
+function mkFilter(e: Expr, fieldPaths: string[][]): FilterCondition {
+  return {
+    node: 'filterCondition',
+    code: 'tenant_id = 1 or is_public',
+    expressionType: 'scalar',
+    isSourceFilter: true,
+    e,
+    refSummary: {fieldUsage: fieldPaths.map(path => ({path}))},
+  };
+}
+
+describe('predicateExprToSQL', () => {
+  const filter = mkFilter(COMPOUND, [['tenant_id'], ['is_public']]);
+
+  test('compiles a compound predicate for DuckDB', () => {
+    const r = predicateExprToSQL(
+      mkSource('duckdb'),
+      [filter],
+      {},
+      undefined,
+      'base'
+    );
+    expect(r.error).toBeUndefined();
+    expect(r.sql).toContain('base."tenant_id"');
+    expect(r.sql).toContain('base."is_public"');
+    expect(r.sql?.toLowerCase()).toContain('or');
+  });
+
+  test('compiles the same predicate for Postgres (dialect-routed)', () => {
+    const r = predicateExprToSQL(
+      mkSource('postgres'),
+      [filter],
+      {},
+      undefined,
+      'base'
+    );
+    expect(r.error).toBeUndefined();
+    expect(r.sql).toContain('base."tenant_id"');
+    expect(r.sql).toContain('base."is_public"');
+  });
+
+  test('qualifies columns with a caller-supplied alias', () => {
+    const r = predicateExprToSQL(
+      mkSource('duckdb'),
+      [filter],
+      {},
+      undefined,
+      'idx'
+    );
+    expect(r.sql).toContain('idx."tenant_id"');
+    expect(r.sql).not.toContain('base.');
+  });
+
+  test('emits `true` (not empty) when there are no filters', () => {
+    const r = predicateExprToSQL(mkSource('duckdb'), [], {}, undefined, 'base');
+    expect(r.error).toBeUndefined();
+    expect(r.sql).toBe('true');
+  });
+
+  test('rejects a tableAlias that is not a bare SQL identifier', () => {
+    const r = predicateExprToSQL(
+      mkSource('duckdb'),
+      [filter],
+      {},
+      undefined,
+      'base; DROP TABLE x'
+    );
+    expect(r.sql).toBeUndefined();
+    expect(r.error).toMatch(/Invalid tableAlias/);
+  });
+});

--- a/test/src/core/access-filters.spec.ts
+++ b/test/src/core/access-filters.spec.ts
@@ -1,0 +1,294 @@
+/*
+ * Copyright Contributors to the Malloy project
+ * SPDX-License-Identifier: MIT
+ */
+
+import {runtimeFor} from '../runtimes';
+import {Explore} from '@malloydata/malloy';
+import type {Expr} from '@malloydata/malloy';
+
+const runtime = runtimeFor('duckdb');
+
+const envDatabases = (
+  process.env['MALLOY_DATABASES'] ||
+  process.env['MALLOY_DATABASE'] ||
+  'duckdb'
+).split(',');
+
+let describe = globalThis.describe;
+if (!envDatabases.includes('duckdb')) {
+  describe = describe.skip;
+  describe.skip = describe;
+}
+
+afterAll(async () => {
+  await runtime.connection.close();
+});
+
+// A four-row table: tenants 1,2,3 with one public row (tenant 3).
+const ROWS_SQL =
+  "SELECT * FROM (VALUES (1, false, 'a'), (1, false, 'b'), " +
+  "(2, false, 'c'), (3, true, 'd')) AS t(tenant_id, is_public, label)";
+
+// Compound access predicate: a tenant sees its own rows OR any public row.
+const COMPOUND_MODEL = `
+  ##! experimental.givens
+  given: TENANT :: number
+  source: rows is duckdb.sql("""${ROWS_SQL}""") extend {
+    where: tenant_id = $TENANT or is_public
+  }
+`;
+
+/** Collect every field path and given refName referenced anywhere in an Expr. */
+function walkRefs(e: Expr): {fields: string[]; givens: string[]} {
+  const fields: string[] = [];
+  const givens: string[] = [];
+  const visit = (node: unknown): void => {
+    if (!node || typeof node !== 'object') return;
+    const n = node as {node?: string; path?: string[]; refName?: string};
+    if (n.node === 'field' && n.path) fields.push(n.path.join('.'));
+    if (n.node === 'given' && n.refName) givens.push(n.refName);
+    for (const v of Object.values(node)) {
+      if (Array.isArray(v)) v.forEach(visit);
+      else if (v && typeof v === 'object') visit(v);
+    }
+  };
+  visit(e);
+  return {fields, givens};
+}
+
+describe('access predicate inspect + SQL emit (experimental.givens)', () => {
+  test('accessFilters exposes the compound predicate as a walkable tree', async () => {
+    const explore = await runtime
+      .loadModel(COMPOUND_MODEL)
+      .getExploreByName('rows');
+    const filters = explore.accessFilters;
+    expect(filters).toHaveLength(1);
+
+    const filter = filters[0];
+    // The source text round-trips.
+    expect(filter.code).toContain('tenant_id');
+    expect(filter.code).toContain('is_public');
+    // The top-level combinator is the `or` — a per-field map could not carry this.
+    expect(filter.e.node).toBe('or');
+    expect(filter.isSourceFilter).toBe(true);
+
+    // Field + given references are reconstructable, both by walking `.e` and
+    // from the pre-computed refSummary.
+    const refs = walkRefs(filter.e);
+    expect(refs.fields.sort()).toEqual(['is_public', 'tenant_id']);
+    expect(refs.givens).toEqual(['TENANT']);
+
+    const summaryFields =
+      filter.refSummary?.fieldUsage.map(u => u.path.join('.')).sort() ?? [];
+    expect(summaryFields).toEqual(['is_public', 'tenant_id']);
+    expect(filter.refSummary?.givenUsage ?? []).toHaveLength(1);
+  });
+
+  test('accessFilterSQL emits a WHERE fragment and isolates rows end-to-end', async () => {
+    const explore = await runtime
+      .loadModel(COMPOUND_MODEL)
+      .getExploreByName('rows');
+    const where = explore.accessFilterSQL({givens: {TENANT: 1}});
+
+    // Default alias is `base`; columns are qualified and quoted.
+    expect(where).toContain('base."tenant_id"');
+    expect(where).toContain('base."is_public"');
+    expect(where.toLowerCase()).toContain('or');
+    expect(where).not.toMatch(/where/i); // bare fragment, no keyword
+
+    // Run the fragment against the same data exposed AS base. Tenant 1 should
+    // see its own rows (a, b) plus the public row (d), but not tenant 2's (c).
+    const {rows} = await runtime.connection.runSQL(
+      `SELECT label FROM (${ROWS_SQL}) AS base WHERE ${where} ORDER BY label`
+    );
+    expect(rows.map(r => r['label'])).toEqual(['a', 'b', 'd']);
+  });
+
+  test('accessFilterSQL honors a caller-supplied table alias', async () => {
+    const explore = await runtime
+      .loadModel(COMPOUND_MODEL)
+      .getExploreByName('rows');
+    const where = explore.accessFilterSQL({
+      givens: {TENANT: 2},
+      tableAlias: 'idx',
+    });
+    expect(where).toContain('idx."tenant_id"');
+    expect(where).not.toContain('base.');
+
+    const {rows} = await runtime.connection.runSQL(
+      `SELECT label FROM (${ROWS_SQL}) AS idx WHERE ${where} ORDER BY label`
+    );
+    // Tenant 2's own row (c) plus the public row (d).
+    expect(rows.map(r => r['label'])).toEqual(['c', 'd']);
+  });
+
+  test('an unsatisfied given fails closed (throws)', async () => {
+    const explore = await runtime
+      .loadModel(COMPOUND_MODEL)
+      .getExploreByName('rows');
+    // No value supplied and no declaration default for TENANT.
+    expect(() => explore.accessFilterSQL()).toThrow(/TENANT/);
+  });
+
+  test('a source with no access filters emits `true`, not empty string', async () => {
+    const explore = await runtime
+      .loadModel(
+        `
+        ##! experimental.givens
+        source: rows is duckdb.sql("""${ROWS_SQL}""")
+      `
+      )
+      .getExploreByName('rows');
+    expect(explore.accessFilters).toHaveLength(0);
+    expect(explore.accessFilterSQL()).toBe('true');
+  });
+
+  test('both APIs require the experimental.givens flag', async () => {
+    // Same shape, but no `##! experimental.givens` and a constant predicate so
+    // the model compiles without the flag.
+    const explore = await runtime
+      .loadModel(
+        `
+        source: rows is duckdb.sql("""${ROWS_SQL}""") extend {
+          where: tenant_id > 0
+        }
+      `
+      )
+      .getExploreByName('rows');
+    expect(() => explore.accessFilters).toThrow(/experimental\.givens/);
+    expect(() => explore.accessFilterSQL()).toThrow(/experimental\.givens/);
+  });
+
+  // A join in the source: a tenant's events are isolated by the joined user's
+  // tenant_id. The emitted predicate would reference the `users` join alias,
+  // which the caller's `FROM events AS base` query cannot satisfy.
+  const USERS_SQL =
+    'SELECT * FROM (VALUES (1, 100), (2, 200)) AS t(user_id, tenant_id)';
+  const EVENTS_SQL =
+    "SELECT * FROM (VALUES (10, 1, 'a'), (11, 2, 'b')) AS t(event_id, user_id, label)";
+
+  test('rejects a direct joined-field reference in the access predicate', async () => {
+    const explore = await runtime
+      .loadModel(
+        `
+        ##! experimental.givens
+        given: TENANT :: number
+        source: users is duckdb.sql("""${USERS_SQL}""")
+        source: events is duckdb.sql("""${EVENTS_SQL}""") extend {
+          join_one: users on user_id = users.user_id
+          where: users.tenant_id = $TENANT
+        }
+      `
+      )
+      .getExploreByName('events');
+    // Given supplied so binding succeeds and we reach the join-alias check.
+    expect(() => explore.accessFilterSQL({givens: {TENANT: 100}})).toThrow(
+      /joined field/
+    );
+  });
+
+  test('rejects a local dimension that aliases a joined field', async () => {
+    const explore = await runtime
+      .loadModel(
+        `
+        ##! experimental.givens
+        given: TENANT :: number
+        source: users is duckdb.sql("""${USERS_SQL}""")
+        source: events is duckdb.sql("""${EVENTS_SQL}""") extend {
+          join_one: users on user_id = users.user_id
+          dimension: my_tenant is users.tenant_id
+          where: my_tenant = $TENANT
+        }
+      `
+      )
+      .getExploreByName('events');
+    // The filter references `my_tenant` (a one-part path), but it expands to the
+    // joined `users.tenant_id` — a syntactic path check would miss this.
+    expect(() => explore.accessFilterSQL({givens: {TENANT: 100}})).toThrow(
+      /joined field/
+    );
+  });
+
+  test('detached (deserialized) Explore: inspect works, given-bound emit throws clearly', async () => {
+    const live = await runtime
+      .loadModel(COMPOUND_MODEL)
+      .getExploreByName('rows');
+    const detached = Explore.fromJSON(live.toJSON());
+    // Inspection survives serialization (structure lives on the structDef).
+    expect(detached.accessFilters).toHaveLength(1);
+    // Binding does not: fromJSON drops the model's given declarations, so this
+    // fails with an actionable message rather than a confusing "unknown given".
+    expect(() => detached.accessFilterSQL({givens: {TENANT: 1}})).toThrow(
+      /does not declare/
+    );
+  });
+
+  test('uses a given declaration default when no value is supplied', async () => {
+    const explore = await runtime
+      .loadModel(
+        `
+        ##! experimental.givens
+        given: TENANT :: number is 1
+        source: rows is duckdb.sql("""${ROWS_SQL}""") extend {
+          where: tenant_id = $TENANT or is_public
+        }
+      `
+      )
+      .getExploreByName('rows');
+    // No givens supplied → the declaration default (1) binds, same as query
+    // execution. Tenant 1's rows (a, b) plus the public row (d).
+    const where = explore.accessFilterSQL();
+    const {rows} = await runtime.connection.runSQL(
+      `SELECT label FROM (${ROWS_SQL}) AS base WHERE ${where} ORDER BY label`
+    );
+    expect(rows.map(r => r['label'])).toEqual(['a', 'b', 'd']);
+  });
+
+  test('ANDs multiple source where: clauses into one fragment', async () => {
+    const explore = await runtime
+      .loadModel(
+        `
+        ##! experimental.givens
+        given: TENANT :: number
+        source: rows is duckdb.sql("""${ROWS_SQL}""") extend {
+          where: tenant_id = $TENANT
+          where: is_public = false
+        }
+      `
+      )
+      .getExploreByName('rows');
+    expect(explore.accessFilters).toHaveLength(2);
+    const where = explore.accessFilterSQL({givens: {TENANT: 1}});
+    expect(where.toUpperCase()).toContain('AND');
+    const {rows} = await runtime.connection.runSQL(
+      `SELECT label FROM (${ROWS_SQL}) AS base WHERE ${where} ORDER BY label`
+    );
+    // tenant 1 AND not public → a, b (d is public, c is tenant 2).
+    expect(rows.map(r => r['label'])).toEqual(['a', 'b']);
+  });
+
+  test('allows base-relative nested record columns (not treated as a join)', async () => {
+    // A struct/record column on the base row. Referencing a nested field stays
+    // base-relative (`base."acl"...`), so it is emitted, not rejected as a join.
+    const RECORD_SQL =
+      "SELECT {'tid': 1, 'pub': false} AS acl, 'a' AS label " +
+      "UNION ALL SELECT {'tid': 2, 'pub': false}, 'c' " +
+      "UNION ALL SELECT {'tid': 3, 'pub': true}, 'd'";
+    const explore = await runtime
+      .loadModel(
+        `
+        ##! experimental.givens
+        given: TENANT :: number
+        source: rows is duckdb.sql("""${RECORD_SQL}""") extend {
+          where: acl.tid = $TENANT or acl.pub
+        }
+      `
+      )
+      .getExploreByName('rows');
+    // Not rejected as a joined field; emits a base-qualified fragment.
+    const where = explore.accessFilterSQL({givens: {TENANT: 1}});
+    expect(where).toContain('base');
+    expect(where).not.toMatch(/joined field/);
+  });
+});


### PR DESCRIPTION
## Givens-native access-predicate inspect + SQL emit

Adds two additive, **experimental** (`##! experimental.givens`) public APIs on
`Explore`, for a host platform that indexes a source's dimension values and must
re-apply the source's row-level access predicate as SQL. The design and the
open decisions are captured in this description (see "Decisions" below).

### Why

A host builds a search index of a source's values and must (a) read a source's
access predicate to learn which row fields isolate the data and how they combine,
and (b) re-apply that predicate to index rows as SQL. Neither was cleanly
possible today: `Explore.filters` returns the drill/result filters (not the
source access filters), and there is no public way to compile a predicate that
references source fields (`constantExprToSQL` deliberately rejects field refs).

### What

- **`Explore.accessFilters: FilterCondition[]`** — the source-level `where:`
  filters (those marked `isSourceFilter`), as walkable `FilterCondition`s. `.e`
  exposes the full expression tree, so compound predicates (`or`, cross-column)
  are reconstructable, not just a per-field map; `.refSummary` carries
  pre-computed field/given footprints.
- **`Explore.accessFilterSQL({givens, tableAlias})`** — compiles that predicate
  to a bare SQL `WHERE` fragment (no `WHERE` keyword) in the source's dialect for
  a concrete set of given values. Columns are qualified with `tableAlias`
  (default `base`), e.g. `(base."tenant_id"=1) or base."is_public"`.

Implementation reuses the expression compiler: a new
`model/predicate_expression_compiler.ts` mirrors `constant_expression_compiler.ts`
but resolves field refs against the real source and binds givens via the same
`resolveSuppliedGivens`/`evaluateInlineGivens` pipeline query execution uses.
Also re-exports `RefSummary`/`FieldUsage`/`FieldUsageEntry`/`GivenUsage`/
`GivenUsageEntry`/`FieldnameNode`/`GivenRefNode` from the top-level package.

### Decisions (requesting review)

The load-bearing API-shape calls — all implemented as described, flagged because
they are the parts most expensive to change once the surface ships:

1. **Scope: source-own columns only.** A predicate that references a joined field
   — directly (`orders.amount`) or via a local dimension that aliases one
   (`dimension: t is users.tenant_id; where: t = $T`) — is rejected, because the
   emitted SQL would name an internal join alias the caller's `FROM ... AS base`
   has no entry for. Detection is by whether compilation allocated any foreign
   table alias (authoritative, vs. a syntactic path check that misses the
   dimension-aliased case); base-relative columns, including nested record
   columns, are allowed. *Is this the right boundary?*
2. **Caller-supplied `tableAlias`, default `base`.** The host controls the alias
   it splices into; `base` matches Malloy's own output. Validated as a bare SQL
   identifier (`[A-Za-z_][A-Za-z0-9_]*`) since it is interpolated into SQL.
   Hardest to change later.
3. **Both members on `Explore`** (an access predicate is a property of a source);
   no `Model`-level convenience added. *Want a `Model` shortcut?*
4. **`refSummary` promoted to the public type surface**, so consumers read
   footprints without walking `.e`. This commits to those IR shapes as public
   API. *Acceptable vs. walk-`.e`-only?*
5. **Methods throw without `##! experimental.givens` (fail-closed)**, not
   silent-empty (which would masquerade as "no access control"). Matches the
   `getBuildPlan`/`experimental.persistence` convention; note this is stricter
   than the language gate, which accepts a bare `##! experimental`.
6. **An empty predicate emits `'true'`, never `''`** — a gated source with no
   `where:` filters has no restriction, and `'true'` keeps `... WHERE <fragment>`
   valid SQL. Callers whose policy requires a predicate check `accessFilters`.
7. **Detached (deserialized) Explore: inspect works, given-bound emit throws
   clearly.** `fromJSON` carries the source + annotations but not the model's
   given declarations. `accessFilters` still works; `accessFilterSQL({givens})`
   detects the missing declarations and throws an actionable error rather than a
   confusing deep-compiler "unknown given".

### Tests

- `model/test/predicate_expression_compiler.spec.ts` (no DB): compound predicate
  compiles for DuckDB **and** Postgres (dialect routing), alias override, the
  empty-predicate `'true'` case, and rejection of a non-identifier `tableAlias`.
- `test/src/core/access-filters.spec.ts` (DuckDB, end-to-end): `accessFilters`
  returns the `or` tree with the `{tenant_id, is_public}` + `TENANT` footprint;
  the emitted fragment, run against the table `AS base`/`AS idx`, returns the
  tenant's rows **plus** the public rows; a given declaration default binds when
  no value is supplied; multiple `where:` clauses AND into one fragment;
  base-relative nested record columns are allowed; unsatisfied given throws;
  empty predicate emits `true`; the experimental gate throws without the flag; a
  direct joined ref and a dimension-aliased joined ref are both rejected; a
  detached Explore inspects but throws on given-bound emit.

### Backward compatibility

Purely additive. `Explore.filters` is untouched and distinct from `accessFilters`.
No existing behavior changes.

### Follow-up (separate PR)

`f'never'` — a filter literal matching nothing (fail-closed value for
filter-typed givens), to live in `@malloydata/malloy-filter` symmetric with `f''`
(match-all). Tracked separately to keep this change set focused.
