### PR TITLE
Add headless dispatch/tag-config tests and document the renderer testing layers

### DIFF
--- a/packages/malloy-render/CONTEXT.md
+++ b/packages/malloy-render/CONTEXT.md
@@ -2,7 +2,7 @@
 
 The `malloy-render` package handles visualization and rendering of Malloy query results. It transforms query results into rich, interactive visualizations and tables.
 
-**Related docs:** [README.md](./README.md) for public-facing installation and usage, [DEVELOPING.md](./DEVELOPING.md) for the local development workflow, [docs/validation.md](./docs/validation.md) for the renderer validation contract, [docs/plugin-system.md](./docs/plugin-system.md) / [docs/plugin-api-reference.md](./docs/plugin-api-reference.md) / [docs/plugin-quick-start.md](./docs/plugin-quick-start.md) for plugin authoring, [docs/renderer_tags_overview.md](./docs/renderer_tags_overview.md) and [docs/renderer_tag_cheatsheet.md](./docs/renderer_tag_cheatsheet.md) for the user-facing tag vocabulary.
+**Related docs:** [README.md](./README.md) for public-facing installation and usage, [DEVELOPING.md](./DEVELOPING.md) for the local development workflow, [docs/validation.md](./docs/validation.md) for the renderer validation contract, [docs/testing.md](./docs/testing.md) for the testing layers and harnesses, [docs/plugin-system.md](./docs/plugin-system.md) / [docs/plugin-api-reference.md](./docs/plugin-api-reference.md) / [docs/plugin-quick-start.md](./docs/plugin-quick-start.md) for plugin authoring, [docs/renderer_tags_overview.md](./docs/renderer_tags_overview.md) and [docs/renderer_tag_cheatsheet.md](./docs/renderer_tag_cheatsheet.md) for the user-facing tag vocabulary.
 
 Built on **Solid.js** (reactive UI) and **Vega** (declarative charts).
 
@@ -93,8 +93,11 @@ The table uses CSS Grid with subgrid. Layout is calculated in `table-layout.ts`:
 - Column ranges are tracked for each field to support nested tables
 
 ### Testing
-Use Storybook (`npm run storybook`) to test visual changes. Stories are in `src/stories/*.stories.malloy`.
-For non-visual logic (settings serialization, tag parsing, drill query behavior, utility formatting), add targeted Jest tests under `src/**/*.spec.ts` where possible.
+Test at the cheapest layer that can observe the behavior — the layers and their harnesses are in **[docs/testing.md](docs/testing.md)**. The short version:
+- **Dispatch & tag config** (`renderAs()`, `tag-configs.ts` resolvers, chart settings) is a function of the result *schema* — test it compile-only with the `RenderFieldMetadata` harness in `src/render-field-metadata.spec.ts`. No query run, no DOM.
+- **Vega spec generation** — `runChartQuery` in `src/plugins/spec-test-support/harness.ts` (runs a query, no DOM).
+- **Validation contract** — `test/src/render/render-validator.spec.ts`, which needs the built UMD bundle (full `npm run build`).
+- **Pixels** — Storybook (`npm run storybook`), stories in `src/stories/*.stories.malloy`.
 
 ## Plugin System
 

--- a/packages/malloy-render/CONTEXT.md
+++ b/packages/malloy-render/CONTEXT.md
@@ -8,14 +8,12 @@ Built on **Solid.js** (reactive UI) and **Vega** (declarative charts).
 
 ## Distribution & Public Surface
 
-Ships as a **single UMD bundle** (`dist/module/index.umd.js`). `package.json` `exports` declares one entry; there are no subpath imports, no public ESM, no headless entry. All integration goes through `MalloyRenderer` (or the legacy `HTMLView`, still exported for the VS Code notebook schema view).
+`package.json` `exports` declares a single `.` entry with conditions: `import` → `dist/module/index.mjs` (ESM, added in #2945 so ESM consumers like malloy-explorer resolve the ES build), `require`/`default` → the **UMD bundle** (`dist/module/index.umd.js`). There are no subpath imports and no headless entry. All integration goes through `MalloyRenderer` (or the legacy `HTMLView`, still exported for the VS Code notebook schema view).
 
 Two non-obvious consequences:
 
 - **`@malloydata/malloy-tag` is a runtime dependency for type resolution only.** The UMD inlines malloy-tag (vite `external: []`); nothing escapes to `require()` at runtime. But the published `.d.ts` files (`api/plugin-types.d.ts`, `data_tree/fields/base.d.ts`, `util.d.ts`, etc.) re-export `Tag`, so consumer TypeScript needs the package installed.
-- **The UMD cannot be loaded in Node without a DOM stub.** Solid.js calls `delegateEvents()` at module-eval time and reads `window.document`. The headless validator (`@malloydata/render-validator`) installs and removes global `window`/`document`/`navigator` stubs around its `require()` of this package; any other Node consumer must do the same.
-
-`dist/module/index.mjs` exists but is not an exports entry — treat as internal.
+- **The bundle cannot be loaded in Node without a DOM stub** (either condition). Solid.js calls `delegateEvents()` at module-eval time and reads `window.document`. The headless validator (`@malloydata/render-validator`) installs and removes global `window`/`document`/`navigator` stubs around its `require()` of this package; any other Node consumer must do the same.
 
 ## Vega is pinned at v5 — a deliberate hold
 

--- a/packages/malloy-render/docs/testing.md
+++ b/packages/malloy-render/docs/testing.md
@@ -1,0 +1,67 @@
+# Testing the renderer
+
+The renderer's behavior splits into layers with very different testing costs.
+Test at the cheapest layer that can observe the behavior; escalate only when a
+lower layer can't see it.
+
+| Layer | What it answers | Harness | Needs |
+|---|---|---|---|
+| Dispatch & tag config | "Does this markup select the right renderer, with the right resolved settings?" | `src/render-field-metadata.spec.ts` (compile-only, see below) | schema only — no query run, no data, no DOM |
+| Chart spec generation | "Does the generated Vega spec encode the data and tags correctly?" | `src/plugins/spec-test-support/harness.ts` (`runChartQuery`) | runs a real DuckDB query, no DOM |
+| Tag validation contract | "Do bad tags produce the right diagnostics?" | `test/src/render/render-validator.spec.ts` | the **built UMD bundle** — run a full `npm run build` first, `npm run dev` is not enough |
+| Pixels | "Does it look right?" | Storybook (`npm run storybook`), stories in `src/stories/*.stories.malloy` | a browser and your eyes |
+
+## The compile-only harness (dispatch & tag config)
+
+Everything the renderer decides at setup time — which renderer a field gets
+(`renderAs()`), what the tag resolvers in `tag-configs.ts` produce, what chart
+settings resolve to — is a function of the result **schema**, not the data.
+That means these tests never need to execute a query: compile the model with
+`getPreparedResult()` and construct `RenderFieldMetadata` directly on the
+stable result. DuckDB is used only to describe an inline `duckdb.sql(...)`
+table at compile time.
+
+```typescript
+async function metadataFor(malloySource: string): Promise<RenderFieldMetadata> {
+  const pr = await runtime
+    .loadModel(malloySource)
+    .loadQueryByName('q')
+    .getPreparedResult();
+  return new RenderFieldMetadata(pr.toStableResult());
+}
+```
+
+From the metadata you can assert on `field.renderAs()` (dispatch),
+`field.getTagConfig<T>()` (setup-time resolvers), and per-plugin settings
+functions like `getBarChartSettings(field)`. These tests run in plain Node in
+under a second — no Solid, no Vega runtime, no DOM stubs.
+
+Prefer this harness for any new tag, any change to dispatch precedence, and
+any resolver in `tag-configs.ts`. If a behavior can be pinned here, a
+Storybook story for it is documentation, not the test.
+
+## The chart-query harness (spec generation)
+
+When the behavior lives in a Vega spec generator (axis titles, legend scales,
+tooltip shapes), use `runChartQuery` from `src/plugins/spec-test-support/`.
+It runs a real query, builds the full render metadata, and hands back what the
+spec generators consume. Costs a query execution per test but still no DOM.
+
+## Pinning known bugs
+
+Some tests deliberately pin behavior that is known to be wrong (they are
+labeled `KNOWN BUG` / `PINNED` in the test name, with a comment explaining
+the actual behavior). Their job is to make a behavior change *loud*: if a
+change flips one, update it knowingly — don't "fix" the test to keep it
+green without understanding what changed.
+
+## Running
+
+Renderer unit tests live in the `malloy-render` jest project:
+
+```
+npx jest --selectProjects malloy-render
+```
+
+Do not run the repo's full test suite unrestricted; use targeted projects or
+paths.

--- a/packages/malloy-render/src/render-field-metadata.spec.ts
+++ b/packages/malloy-render/src/render-field-metadata.spec.ts
@@ -1,0 +1,184 @@
+/*
+ * Copyright Contributors to the Malloy project
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+ * Headless dispatch/config tests against the current renderer.
+ *
+ * Markup is compiled to a result schema with getPreparedResult() — no query
+ * execution, no data files; DuckDB is used only to describe inline SQL at
+ * compile time. RenderFieldMetadata is constructed directly on the stable
+ * result, so these tests exercise dispatch (shouldRenderAs) and the
+ * setup-time tag resolvers without a DOM, Solid, or Vega.
+ */
+
+import {DuckDBConnection} from '@malloydata/db-duckdb';
+import {SingleConnectionRuntime} from '@malloydata/malloy';
+import {RenderFieldMetadata} from './render-field-metadata';
+import {getBarChartSettings} from './plugins/bar-chart/get-bar_chart-settings';
+import type {Field, NestField} from './data_tree';
+
+let connection: DuckDBConnection;
+let runtime: SingleConnectionRuntime;
+
+beforeAll(async () => {
+  connection = new DuckDBConnection('duckdb');
+  await connection.connecting;
+  runtime = new SingleConnectionRuntime({connection});
+});
+
+afterAll(async () => {
+  await connection.close();
+});
+
+async function metadataFor(malloySource: string): Promise<RenderFieldMetadata> {
+  const pr = await runtime
+    .loadModel(malloySource)
+    .loadQueryByName('q')
+    .getPreparedResult();
+  return new RenderFieldMetadata(pr.toStableResult());
+}
+
+function childField(metadata: RenderFieldMetadata, name: string): Field {
+  const root = metadata.rootField as NestField;
+  const field = root.fields.find(f => f.name === name);
+  if (!field) {
+    throw new Error(`No field named ${name} in result root`);
+  }
+  return field;
+}
+
+const SQL_SOURCE =
+  "duckdb.sql(\"SELECT 1 as val, 'a' as str, DATE '2026-01-01' as d\")";
+
+describe('dispatch (shouldRenderAs) on the compiled schema', () => {
+  test('untagged query renders as table; atomic children as cell', async () => {
+    const metadata = await metadataFor(`
+      query: q is ${SQL_SOURCE} -> { select: val, str }
+    `);
+    expect(metadata.rootField.renderAs()).toBe('table');
+    expect(childField(metadata, 'val').renderAs()).toBe('cell');
+  });
+
+  test('# bar_chart on a nest renders as chart', async () => {
+    const metadata = await metadataFor(`
+      query: q is ${SQL_SOURCE} -> {
+        group_by: str
+        # bar_chart
+        nest: by_val is { group_by: val; aggregate: c is count() }
+      }
+    `);
+    expect(childField(metadata, 'by_val').renderAs()).toBe('chart');
+  });
+
+  test('# viz=table on a tagged chart nest wins over legacy flag', async () => {
+    const metadata = await metadataFor(`
+      query: q is ${SQL_SOURCE} -> {
+        group_by: str
+        # bar_chart viz=table
+        nest: by_val is { group_by: val; aggregate: c is count() }
+      }
+    `);
+    expect(childField(metadata, 'by_val').renderAs()).toBe('table');
+  });
+
+  test('KNOWN BUG: # table declared after # bar_chart still renders as chart', async () => {
+    // Pins today's behavior deliberately: cross-type selection ignores
+    // declaration order (viz short-circuit + fixed RENDER_TAG_LIST priority),
+    // so the later # table cannot displace the earlier # bar_chart. If this
+    // ever changes, it should change knowingly, not by surprise.
+    const metadata = await metadataFor(`
+      query: q is ${SQL_SOURCE} -> {
+        group_by: str
+        # bar_chart
+        # table
+        nest: by_val is { group_by: val; aggregate: c is count() }
+      }
+    `);
+    expect(childField(metadata, 'by_val').renderAs()).toBe('chart');
+  });
+
+  test('# link on a string field renders as link', async () => {
+    const metadata = await metadataFor(`
+      query: q is ${SQL_SOURCE} -> {
+        select:
+          # link
+          str
+      }
+    `);
+    expect(childField(metadata, 'str').renderAs()).toBe('link');
+  });
+});
+
+describe('setup-time tag resolvers (tag-configs)', () => {
+  test('# transpose.limit lands in the table nest config', async () => {
+    const metadata = await metadataFor(`
+      query: q is ${SQL_SOURCE} -> {
+        group_by: str
+        # transpose.limit=5
+        nest: by_val is { group_by: val; aggregate: c is count() }
+      }
+    `);
+    const field = childField(metadata, 'by_val');
+    expect(field.renderAs()).toBe('table');
+    const config = field.getTagConfig<{transposeLimit?: number}>();
+    expect(config?.transposeLimit).toBe(5);
+  });
+
+  test('explicit viz.x and viz.stack land in chart settings', async () => {
+    const metadata = await metadataFor(`
+      query: q is ${SQL_SOURCE} -> {
+        group_by: d
+        # viz=bar { x=str stack }
+        nest: by_str is {
+          group_by: str, val
+          aggregate: c is count()
+        }
+      }
+    `);
+    const chart = childField(metadata, 'by_str') as NestField;
+    const settings = getBarChartSettings(chart);
+    // Channel fields are key-encoded paths (JSON.stringify of the path
+    // relative to the chart), not bare field names.
+    expect(settings.xChannel.fields).toEqual([JSON.stringify(['str'])]);
+    expect(settings.isStack).toBe(true);
+  });
+
+  test('PINNED: embedded # x alongside explicit viz.x accumulates (throws), not suppressed', async () => {
+    // The channel sources are not a pick order: an embedded # x is added to
+    // the x channel even when viz.x already named a different field, and the
+    // resolver then rejects the 2-dimension x axis.
+    const metadata = await metadataFor(`
+      query: q is ${SQL_SOURCE} -> {
+        group_by: d
+        # viz=bar { x=str }
+        nest: by_str is {
+          group_by:
+            str
+            # x
+            val
+          aggregate: c is count()
+        }
+      }
+    `);
+    const chart = childField(metadata, 'by_str') as NestField;
+    expect(() => getBarChartSettings(chart)).toThrow(
+      'at most 1 dimension for the x axis'
+    );
+  });
+
+  test('# currency resolves to a currency cell-format config', async () => {
+    const metadata = await metadataFor(`
+      query: q is ${SQL_SOURCE} -> {
+        select:
+          # currency
+          val
+      }
+    `);
+    const field = childField(metadata, 'val');
+    expect(field.renderAs()).toBe('cell');
+    const config = field.getTagConfig<{mode: string}>();
+    expect(config?.mode).toBe('currency');
+  });
+});


### PR DESCRIPTION
## What

Adds `render-field-metadata.spec.ts`: a compile-only test suite for renderer **dispatch** (`shouldRenderAs`) and the **setup-time tag resolvers**. Markup is compiled to a result schema with `getPreparedResult()` — no query execution, no data files, no DOM; DuckDB only describes an inline `duckdb.sql(...)` at compile time. The suite runs in plain Node in about a second.

Also adds `docs/testing.md`, which lays out the renderer's four testing layers (dispatch/config → Vega spec generation → validation contract → Storybook) and which harness serves each, and points `CONTEXT.md`'s Testing section at it. The recent `spec-test-support/harness.ts` covers the Vega-spec layer; this PR fills in the layer below it, which nothing covered.

## Why some tests pin bugs

Two tests are labeled `KNOWN BUG` / `PINNED` and assert today's *wrong* behavior on purpose:

- `# table` declared after `# bar_chart` still renders as chart (cross-type selection ignores declaration order).
- An embedded `# x` alongside an explicit `viz.x` accumulates into the channel and throws, rather than one source winning.

Their job is to make any change to these behaviors loud and deliberate instead of silent.

## Testing

`npx jest --selectProjects malloy-render` — 10 suites, 153 tests, all passing.