### PR TITLE
fix(persist): compile PersistSource.getSQL with finalize=false (bare source SELECT)

### DIFF
--- a/packages/malloy/src/api/foundation/core.ts
+++ b/packages/malloy/src/api/foundation/core.ts
@@ -1757,17 +1757,11 @@ export class PersistSource implements Taggable {
     const sd = this.persistableDef;
     const queryModel = this.model.queryModel;
 
-    // Compile with finalize=false: a persist source's SQL defines the data the
-    // materialized table should physically contain (a bare projection), not a
-    // runnable result set. Finalizing appends the dialect's result-serialization
-    // stage (Dialect.sqlFinalStage) whenever Dialect.hasFinalStage is true —
-    // e.g. Postgres wraps the last stage in `row_to_json(...) as row`. If that
-    // wrapper were included, CREATE TABLE AS would store a single JSON column
-    // instead of real columns, and the BuildID (mkBuildID over this SQL) would
-    // not match the serve-time lookup, which resolves persist sources from the
-    // bare (unfinalized) source SELECT. Both effects break query routing to the
-    // materialized table on dialects with a final stage. No-op where
-    // hasFinalStage is false (e.g. BigQuery/duckdb).
+    // Compile with finalize=false so this SQL is the bare source SELECT.
+    // The build-time key (makeBuildId over this SQL) must equal the serve-time
+    // manifest lookup key, which query_query.ts recomputes from the same
+    // unfinalized SELECT; finalizing would diverge the two on dialects with a
+    // final stage (Postgres) and mis-materialize the table.
     if (sd.type === 'sql_select') {
       return getCompiledSQL(
         sd,

--- a/packages/malloy/src/api/foundation/core.ts
+++ b/packages/malloy/src/api/foundation/core.ts
@@ -1757,14 +1757,25 @@ export class PersistSource implements Taggable {
     const sd = this.persistableDef;
     const queryModel = this.model.queryModel;
 
+    // Compile with finalize=false: a persist source's SQL defines the data the
+    // materialized table should physically contain (a bare projection), not a
+    // runnable result set. Finalizing appends the dialect's result-serialization
+    // stage (Dialect.sqlFinalStage) whenever Dialect.hasFinalStage is true —
+    // e.g. Postgres wraps the last stage in `row_to_json(...) as row`. If that
+    // wrapper were included, CREATE TABLE AS would store a single JSON column
+    // instead of real columns, and the BuildID (mkBuildID over this SQL) would
+    // not match the serve-time lookup, which resolves persist sources from the
+    // bare (unfinalized) source SELECT. Both effects break query routing to the
+    // materialized table on dialects with a final stage. No-op where
+    // hasFinalStage is false (e.g. BigQuery/duckdb).
     if (sd.type === 'sql_select') {
       return getCompiledSQL(
         sd,
         options ?? {},
-        (query, opts) => queryModel.compileQuery(query, opts).sql
+        (query, opts) => queryModel.compileQuery(query, opts, false).sql
       );
     } else {
-      const compiled = queryModel.compileQuery(sd.query, options);
+      const compiled = queryModel.compileQuery(sd.query, options, false);
       return compiled.sql;
     }
   }

--- a/packages/malloy/src/api/foundation/persist-source-sql.spec.ts
+++ b/packages/malloy/src/api/foundation/persist-source-sql.spec.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright Contributors to the Malloy project
+ * SPDX-License-Identifier: MIT
+ */
+
+import {Model} from './core';
+import type {PersistSource} from './core';
+import {TestTranslator} from '../../lang/test/test-translator';
+
+// Build a Model directly from translated IR (no live connection) so
+// PersistSource.getSQL() can be exercised the way the build/serve paths use it.
+function modelOf(src: string): Model {
+  const tt = new TestTranslator(src);
+  const compiled = tt.translate();
+  if (!compiled.modelDef) {
+    throw new Error(`source did not translate:\n${src}`);
+  }
+  return new Model(compiled.modelDef, [], []);
+}
+
+function persistSourceNamed(model: Model, name: string): PersistSource {
+  const source = Object.values(model.getBuildPlan().sources).find(
+    s => s.name === name
+  );
+  if (!source) {
+    throw new Error(`no persist source named ${name} in the build plan`);
+  }
+  return source;
+}
+
+describe('PersistSource.getSQL — bare source SELECT (finalize=false)', () => {
+  // Postgres is the only dialect with `hasFinalStage = true`; its final stage
+  // wraps the result in `SELECT row_to_json(finalStage) as row ...`. getSQL()
+  // must NOT include that wrapper — the persist SQL defines the physical table
+  // (real columns), and its BuildID must match the serve-time lookup, which
+  // resolves the source from the bare (unfinalized) SELECT. Including the
+  // wrapper would materialize a single JSON column and mis-key the manifest.
+  test('a postgres persist source does not emit the row_to_json final stage', () => {
+    const model = modelOf(`
+      ##! experimental.persistence
+      #@ persist
+      source: pg_rollup is _pg_.table('aTable') -> {
+        group_by: astr
+        aggregate: n is count()
+      }
+    `);
+
+    const sql = persistSourceNamed(model, 'pg_rollup').getSQL();
+
+    expect(sql).not.toMatch(/row_to_json/i);
+    expect(sql).not.toMatch(/finalStage/);
+    // It is still the real query — the grouped projection is present.
+    expect(sql).toMatch(/group by/i);
+    expect(sql).toMatch(/count\(/i);
+  });
+
+  // duckdb has `hasFinalStage = false`, so finalize never added a stage there;
+  // this guards that the shared getSQL() change is a no-op for such dialects.
+  test('a duckdb persist source is unaffected (no final stage either way)', () => {
+    const model = modelOf(`
+      ##! experimental.persistence
+      #@ persist
+      source: db_rollup is _db_.table('aTable') -> {
+        group_by: astr
+        aggregate: n is count()
+      }
+    `);
+
+    const sql = persistSourceNamed(model, 'db_rollup').getSQL();
+
+    expect(sql).not.toMatch(/row_to_json/i);
+    expect(sql).toMatch(/group by/i);
+    expect(sql).toMatch(/count\(/i);
+  });
+});

--- a/packages/malloy/src/api/foundation/persist-source-sql.spec.ts
+++ b/packages/malloy/src/api/foundation/persist-source-sql.spec.ts
@@ -5,10 +5,12 @@
 
 import {Model} from './core';
 import type {PersistSource} from './core';
+import type {BuildManifest} from '../../model';
 import {TestTranslator} from '../../lang/test/test-translator';
 
-// Build a Model directly from translated IR (no live connection) so
-// PersistSource.getSQL() can be exercised the way the build/serve paths use it.
+// Build a Model directly from translated IR (no live connection) so the
+// build path (PersistSource.getSQL()) and the serve path (query compilation
+// with a manifest) can be exercised the way persistence uses them.
 function modelOf(src: string): Model {
   const tt = new TestTranslator(src);
   const compiled = tt.translate();
@@ -28,14 +30,41 @@ function persistSourceNamed(model: Model, name: string): PersistSource {
   return source;
 }
 
-describe('PersistSource.getSQL — bare source SELECT (finalize=false)', () => {
-  // Postgres is the only dialect with `hasFinalStage = true`; its final stage
-  // wraps the result in `SELECT row_to_json(finalStage) as row ...`. getSQL()
-  // must NOT include that wrapper — the persist SQL defines the physical table
-  // (real columns), and its BuildID must match the serve-time lookup, which
-  // resolves the source from the bare (unfinalized) SELECT. Including the
-  // wrapper would materialize a single JSON column and mis-key the manifest.
-  test('a postgres persist source does not emit the row_to_json final stage', () => {
+describe('PersistSource build key matches serve-time manifest lookup', () => {
+  const CONN_DIGEST = 'test-conn-digest';
+  const MATERIALIZED = 'MATERIALIZED_TBL';
+
+  // Assert the invariant that matters — build-key == serve-key — through its
+  // only observable consequence: a query routes to the materialized table.
+  // Build a manifest whose single entry is keyed by the source's build-time
+  // BuildID (makeBuildId over getSQL()), then compile a query that references
+  // the source with that manifest. The serve path recomputes its own lookup
+  // key from the bare source SELECT (query_query.ts). When the keys agree the
+  // FROM becomes the materialized table; when they diverge the lookup misses
+  // and the source is inlined instead.
+  function routedSQL(
+    model: Model,
+    sourceName: string,
+    connectionName: string
+  ): string {
+    const source = persistSourceNamed(model, sourceName);
+    const buildId = source.makeBuildId(CONN_DIGEST, source.getSQL());
+    const manifest: BuildManifest = {
+      entries: {[buildId]: {tableName: MATERIALIZED}},
+    };
+    return model.getPreparedQuery().getPreparedResult({
+      buildManifest: manifest,
+      connectionDigests: {[connectionName]: CONN_DIGEST},
+    }).sql;
+  }
+
+  // Postgres is the only dialect with `hasFinalStage = true`. If getSQL()
+  // finalized the query, its BuildID would be hashed over the `row_to_json`
+  // wrapper while the serve path keys off the bare SELECT — the keys would
+  // diverge, the lookup would miss, and the query would inline the source
+  // instead of routing. This trips on any future divergence between the two
+  // paths without ever naming the Postgres codegen.
+  test('a postgres persist source routes to the materialized table', () => {
     const model = modelOf(`
       ##! experimental.persistence
       #@ persist
@@ -43,20 +72,16 @@ describe('PersistSource.getSQL — bare source SELECT (finalize=false)', () => {
         group_by: astr
         aggregate: n is count()
       }
+      run: pg_rollup -> { select: * }
     `);
 
-    const sql = persistSourceNamed(model, 'pg_rollup').getSQL();
-
-    expect(sql).not.toMatch(/row_to_json/i);
-    expect(sql).not.toMatch(/finalStage/);
-    // It is still the real query — the grouped projection is present.
-    expect(sql).toMatch(/group by/i);
-    expect(sql).toMatch(/count\(/i);
+    expect(routedSQL(model, 'pg_rollup', '_pg_')).toContain(MATERIALIZED);
   });
 
-  // duckdb has `hasFinalStage = false`, so finalize never added a stage there;
-  // this guards that the shared getSQL() change is a no-op for such dialects.
-  test('a duckdb persist source is unaffected (no final stage either way)', () => {
+  // duckdb has `hasFinalStage = false`, so build and serve keys agree
+  // trivially; this guards that the shared getSQL() change stays a no-op for
+  // dialects without a final stage.
+  test('a duckdb persist source routes to the materialized table', () => {
     const model = modelOf(`
       ##! experimental.persistence
       #@ persist
@@ -64,12 +89,9 @@ describe('PersistSource.getSQL — bare source SELECT (finalize=false)', () => {
         group_by: astr
         aggregate: n is count()
       }
+      run: db_rollup -> { select: * }
     `);
 
-    const sql = persistSourceNamed(model, 'db_rollup').getSQL();
-
-    expect(sql).not.toMatch(/row_to_json/i);
-    expect(sql).toMatch(/group by/i);
-    expect(sql).toMatch(/count\(/i);
+    expect(routedSQL(model, 'db_rollup', '_db_')).toContain(MATERIALIZED);
   });
 });

--- a/packages/malloy/src/lang/test/test-translator.ts
+++ b/packages/malloy/src/lang/test/test-translator.ts
@@ -198,6 +198,18 @@ export const bqTableDef: SourceDef = {
   fields: baseFields,
 };
 
+// Postgres table definition — Postgres is the only dialect with
+// `hasFinalStage = true`, so it is the one that exercises the persist-source
+// finalize=false path (see PersistSource.getSQL).
+export const pgTableDef: SourceDef = {
+  type: 'table',
+  name: 'aTable',
+  dialect: 'postgres',
+  tablePath: 'aTable',
+  connection: '_pg_',
+  fields: baseFields,
+};
+
 /**
  * A TestTranlator never actually talks to connection, instead uses
  * some mocked schema definitions.
@@ -206,6 +218,7 @@ export const bqTableDef: SourceDef = {
 export const mockSchema: TableSourceDef[] = [
   aTableDef,
   bqTableDef,
+  pgTableDef,
   {
     type: 'table',
     name: 'carriers',
@@ -402,9 +415,11 @@ export class TestTranslator extends MalloyTranslator {
     contents: {
       _db_: {type: 'connection', name: '_db_'},
       _bq_: {type: 'connection', name: '_bq_'},
+      _pg_: {type: 'connection', name: '_pg_'},
       a: {...aTableDef, primaryKey: 'astr', name: 'a'},
       b: {...aTableDef, primaryKey: 'astr', name: 'b'},
       bq_a: {...bqTableDef, primaryKey: 'astr', name: 'bq_a'},
+      pg_a: {...pgTableDef, primaryKey: 'astr', name: 'pg_a'},
       ab: {
         ...aTableDef,
         primaryKey: 'astr',
@@ -472,6 +487,7 @@ export class TestTranslator extends MalloyTranslator {
     }
     this.connectionDialectZone.define('_db_', TEST_DIALECT);
     this.connectionDialectZone.define('_bq_', 'standardsql');
+    this.connectionDialectZone.define('_pg_', 'postgres');
     for (const flag of options.compilerFlags ?? []) {
       this.compilerFlagSrc.push(`##! ${flag}\n`);
     }

--- a/packages/malloy/src/lang/test/test-translator.ts
+++ b/packages/malloy/src/lang/test/test-translator.ts
@@ -419,7 +419,6 @@ export class TestTranslator extends MalloyTranslator {
       a: {...aTableDef, primaryKey: 'astr', name: 'a'},
       b: {...aTableDef, primaryKey: 'astr', name: 'b'},
       bq_a: {...bqTableDef, primaryKey: 'astr', name: 'bq_a'},
-      pg_a: {...pgTableDef, primaryKey: 'astr', name: 'pg_a'},
       ab: {
         ...aTableDef,
         primaryKey: 'astr',


### PR DESCRIPTION
## Summary

`PersistSource.getSQL()` compiled the source's inner query with `finalize=true`, which appends the dialect's result-serialization stage (`Dialect.sqlFinalStage`) whenever `Dialect.hasFinalStage` is true. **Postgres is the only dialect with `hasFinalStage = true`**, and it wraps the last stage in `SELECT row_to_json(finalStage) as row FROM ...`.

For a `#@ persist` source, `getSQL()` feeds two things: the `CREATE TABLE AS (...)` used to build the materialized table, and the `BuildID` (`mkBuildID` over this SQL) used as the manifest key. The serve path resolves a persist source from the **bare (unfinalized) source SELECT**. So on Postgres the `row_to_json` wrapper caused two failures:

1. **Wrong physical table** — `CREATE TABLE AS (getSQL())` materialized a single JSON `row` column instead of real columns. (BigQuery, `hasFinalStage=false`, got real columns and worked.)
2. **Manifest key mismatch** — the build-time BuildID (hashed over the `row_to_json` SQL) didn't equal the serve-time lookup key (hashed over the bare SELECT), so queries fell through to a base-table scan instead of routing to the materialized table.

Compiling with `finalize=false` returns the bare source SELECT, which fixes both: the materialized table has real columns, and the BuildID matches the serve-time key. It is a **no-op for dialects without a final stage** (BigQuery, duckdb, etc.), since `finalize` only adds a stage when `hasFinalStage` is true.

## Changes

- `packages/malloy/src/api/foundation/core.ts` — `PersistSource.getSQL()` now passes `finalize=false` to `compileQuery` (both the `sql_select` and `query_source` branches).
- `packages/malloy/src/lang/test/test-translator.ts` — add a Postgres table (`pgTableDef` / `pg_a`) and `_pg_` connection to the mock harness (Postgres is the only dialect that exercises the final-stage path).
- `packages/malloy/src/api/foundation/persist-source-sql.spec.ts` — new spec asserting `getSQL()` on a Postgres persist source omits the `row_to_json` final stage (and is unaffected for duckdb).

## Test plan

- [ ] `jest --selectProjects malloy-core --testPathPattern persist-source-sql`
- [ ] Confirm no other persist / build-plan snapshots regress
- [ ] End-to-end: a `#@ persist` source on Postgres builds a table with real columns and a query routes to it (verified on a downstream deployment)

> Note: I could not run the full suite in my local checkout due to a pre-existing, unrelated dependency/build state (a parser-generator migration left the `malloy-filter` `dist` requiring `moo`/`nearley`, and the global `test/jest.setup.ts` imports `@malloydata/db-duckdb`). The new spec compiles cleanly and mirrors existing `test-translator`-based specs; CI should exercise it.

Made with [Cursor](https://cursor.com)