### PR TITLE
feat(db-postgres): forward TLS ssl options to pg Client/Pool

### DIFF
--- a/packages/malloy-db-postgres/README.md
+++ b/packages/malloy-db-postgres/README.md
@@ -5,3 +5,32 @@ Malloy is a modern open source language for describing data relationships and tr
 ## This package
 
 This package facilitates using the `malloydata/malloy` library with Postgres - see [here](https://github.com/malloydata/malloy/blob/main/packages/malloy/README.md) for additional information.
+
+## Verified TLS through a tunnel
+
+`PostgresConnectionConfiguration.ssl` is forwarded verbatim to `pg`'s TLS options. To get servername-based certificate verification through a local tunnel (e.g. an SSH bastion forwarding to a remote Postgres), connect via the loopback IP rather than `localhost` — `pg` overwrites `servername` with `host` whenever `host` is a DNS name. If the certificate doesn't match the host `pg` connects to, `pg` throws a certificate error and the connector annotates it with this servername/host guidance.
+
+```ts
+import {PostgresConnection} from '@malloydata/db-postgres';
+
+const connection = new PostgresConnection({
+  name: 'tunneled_postgres',
+  host: '127.0.0.1', // must be an IP, not 'localhost', for servername to take effect
+  port: 5432,
+  ssl: {
+    servername: 'db.example.com',
+    ca: '<PEM-encoded CA certificate>',
+  },
+});
+```
+
+### Semantics (pg/Node `tls`, not libpq)
+
+- `ssl: true` — full verification against the system trust store, hostname included (verify-full). A self-signed or custom-CA server fails unless you supply `ca` (and/or set `servername` for a tunnel).
+- `ssl: { rejectUnauthorized: false }` — encrypt but do **not** verify (libpq's `sslmode=require`/`no-verify`). Use only when verification is impossible; it does not stop MITM.
+- `ssl: { ca }` — trust a specific CA (a PEM string, or an array of PEMs for rotation). This is the path for AWS RDS (or use `NODE_EXTRA_CA_CERTS`) and Cloud SQL.
+- **verify-ca** against a cert whose SAN/CN doesn't match any reachable name (e.g. Cloud SQL *legacy* per-instance certs) needs a `checkServerIdentity` override. That is a function, so it is **not** expressible in a saved `json` config — construct the connection programmatically and pass the full `pg` `ssl` (`tls.ConnectionOptions`) directly.
+
+Do **not** put TLS parameters in both `ssl` and the `connectionString`: `pg` merges URL ssl params (`sslmode`, `sslrootcert`, …) *over* the `ssl` object, silently dropping it. Set TLS in one place.
+
+`ssl` is passed through literally — `json` config is never reference-resolved (a malloy security invariant), so `key`/`passphrase` cannot be pulled from an `{env:...}`/overlay reference. Inject secret material programmatically at construction time; never persist it in a shared connection config.

--- a/packages/malloy-db-postgres/src/index.ts
+++ b/packages/malloy-db-postgres/src/index.ts
@@ -7,6 +7,7 @@ export {
   PostgresConnection,
   PooledPostgresConnection,
 } from './postgres_connection';
+export type {PostgresSSLConfig} from './postgres_connection';
 
 import {registerConnectionType} from '@malloydata/malloy';
 import type {ConnectionConfig} from '@malloydata/malloy';
@@ -47,6 +48,15 @@ registerConnectionType('postgres', {
       optional: true,
       advanced: true,
       description: 'SQL statements to run when the connection is established',
+    },
+    {
+      name: 'ssl',
+      displayName: 'SSL',
+      type: 'json',
+      optional: true,
+      advanced: true,
+      description:
+        'TLS/SSL options forwarded to pg, e.g. {"servername":"db.example.com","ca":"<PEM>"}. Passed through literally (json config is never reference-resolved), so do not place secret key/passphrase material in shared config.',
     },
   ],
 });

--- a/packages/malloy-db-postgres/src/postgres_connection.ts
+++ b/packages/malloy-db-postgres/src/postgres_connection.ts
@@ -36,8 +36,50 @@ import {
 import {BaseConnection} from '@malloydata/malloy/connection';
 
 import {Client, Pool} from 'pg';
-import type {FieldDef} from 'pg';
+import type {ClientConfig, FieldDef} from 'pg';
 import QueryStream from 'pg-query-stream';
+
+/**
+ * Serializable TLS options for a Postgres connection, forwarded verbatim into
+ * pg's native `Object.assign(clientOptions, ssl)`. This is the subset that can
+ * live in a saved/registry connection config (all PEM strings + booleans).
+ *
+ * Semantics (these mirror pg / Node `tls`, NOT libpq):
+ * - `ssl: true` (or `rejectUnauthorized: true`, the default) → full
+ *   verification against the trust store, including hostname (verify-full).
+ * - `rejectUnauthorized: false` → encrypt but do NOT verify (libpq's
+ *   `sslmode=require` / `no-verify`); use only when you can't verify.
+ * - `ca` pins a trusted CA (PEM, or an array of PEMs).
+ *
+ * `servername` only takes effect when the connection `host` is an IP literal
+ * (e.g. `127.0.0.1`) — pg overwrites `servername` with `host` whenever `host`
+ * is a DNS name like `localhost`, so servername-based verification through a
+ * tunnel requires connecting via IP. When the certificate doesn't match the
+ * host pg connected to, pg throws; the connector annotates that error with
+ * this servername/host guidance.
+ *
+ * verify-ca against a cert with no matching SAN/CN (e.g. Cloud SQL legacy
+ * per-instance certs) needs `checkServerIdentity`, a function — not
+ * expressible here or in `type: 'json'` config. Pass the full pg `ssl`
+ * (`tls.ConnectionOptions`) via the config-reader constructor form
+ * (`new PostgresConnection(name, queryOptions, () => ({..., ssl}))`) for that
+ * case; the serializable options object is limited to this subset.
+ *
+ * `ssl` is passed through literally — `type: 'json'` config is never
+ * reference-resolved (a malloy security invariant), so secret `key`/
+ * `passphrase` material cannot be pulled from an `{env:...}`/overlay
+ * reference. Inject secrets programmatically at construction; never persist
+ * them in a shared connection config. Secrets are never logged.
+ */
+export type PostgresSSLConfig = {
+  ca?: string | string[];
+  cert?: string;
+  key?: string;
+  passphrase?: string;
+  crl?: string | string[];
+  servername?: string;
+  rejectUnauthorized?: boolean;
+};
 
 interface PostgresConnectionConfiguration {
   host?: string;
@@ -47,6 +89,10 @@ interface PostgresConnectionConfiguration {
   databaseName?: string;
   connectionString?: string;
   setupSQL?: string;
+  // Programmatic callers get pg's full ssl surface (incl. `checkServerIdentity`
+  // for verify-ca). Saved/registry config is limited to the serializable
+  // PostgresSSLConfig subset — see PostgresConnectionOptions.
+  ssl?: ClientConfig['ssl'];
 }
 
 interface InfoSchemaColumn {
@@ -73,6 +119,25 @@ type PostgresConnectionConfigurationReader =
 const DEFAULT_PAGE_SIZE = 1000;
 const SCHEMA_PAGE_SIZE = 1000;
 
+// pg verifies the server certificate against the host it actually connects to,
+// not `ssl.servername` (which pg drops when the host is a DNS name). When that
+// check fails, pg throws a terse altname error; augment it with how to fix a
+// tunneled connection rather than trying to predict pg's host resolution up
+// front. Mutates and returns the original error so its type and stack survive.
+function addTlsHint(err: unknown): unknown {
+  if (!(err instanceof Error)) return err;
+  const code = (err as {code?: unknown}).code;
+  const isCertHostMismatch =
+    code === 'ERR_TLS_CERT_ALTNAME_INVALID' ||
+    (/certificate/i.test(err.message) &&
+      /altname|does not match/i.test(err.message));
+  if (isCertHostMismatch) {
+    err.message +=
+      "\n[malloy-db-postgres] The server certificate does not match the host pg connected to. pg verifies against the connection host, not ssl.servername, unless the host is an IP. For a tunnel, connect via the DB's IP (e.g. host '127.0.0.1') and set ssl.servername to the real hostname; or omit ssl.servername to verify against the host directly.";
+  }
+  return err;
+}
+
 /**
  * Decode a canonical Postgres dotted-table path into its underlying
  * identifier strings as they appear in `information_schema`. The schema
@@ -92,7 +157,12 @@ function decodeDottedSegments(input: string): string[] | undefined {
 }
 
 export interface PostgresConnectionOptions
-  extends ConnectionConfig, PostgresConnectionConfiguration {}
+  extends ConnectionConfig, Omit<PostgresConnectionConfiguration, 'ssl'> {
+  // Serializable subset only. Full pg TLS options (functions/Buffers) are not
+  // representable in `type: 'json'` config; pass them programmatically via the
+  // `PostgresConnectionConfiguration` (name/configReader) constructor form.
+  ssl?: boolean | PostgresSSLConfig;
+}
 
 export class PostgresConnection
   extends BaseConnection
@@ -191,23 +261,32 @@ export class PostgresConnection
     return true;
   }
 
+  protected buildClientConfig(
+    cfg: PostgresConnectionConfiguration
+  ): ClientConfig {
+    return {
+      user: cfg.username,
+      password: cfg.password,
+      database: cfg.databaseName,
+      port: cfg.port,
+      host: cfg.host,
+      connectionString: cfg.connectionString,
+      ssl: cfg.ssl,
+    };
+  }
+
+  // Runs a connect/query op, annotating pg's terse certificate-mismatch error
+  // with actionable TLS guidance (see addTlsHint).
+  protected async withTlsHint<T>(op: () => Promise<T>): Promise<T> {
+    try {
+      return await op();
+    } catch (e) {
+      throw addTlsHint(e);
+    }
+  }
+
   protected async getClient(): Promise<Client> {
-    const {
-      username: user,
-      password,
-      databaseName: database,
-      port,
-      host,
-      connectionString,
-    } = await this.readConfig();
-    return new Client({
-      user,
-      password,
-      database,
-      port,
-      host,
-      connectionString,
-    });
+    return new Client(this.buildClientConfig(await this.readConfig()));
   }
 
   protected async runPostgresQuery(
@@ -218,7 +297,7 @@ export class PostgresConnection
     values?: unknown[]
   ): Promise<MalloyQueryData> {
     const client = await this.getClient();
-    await client.connect();
+    await this.withTlsHint(() => client.connect());
     await this.connectionSetup(client);
 
     let result = await client.query(sqlCommand, values);
@@ -248,7 +327,7 @@ export class PostgresConnection
       name: sqlKey(sqlRef.connection, sqlRef.selectStr),
     };
     const client = await this.getClient();
-    await client.connect();
+    await this.withTlsHint(() => client.connect());
     await this.connectionSetup(client);
     // 1) Get row-descriptor without fetching data
     const res = await client.query({
@@ -454,7 +533,7 @@ export class PostgresConnection
   ): AsyncIterableIterator<QueryRecord> {
     const query = new QueryStream(sqlCommand);
     const client = await this.getClient();
-    await client.connect();
+    await this.withTlsHint(() => client.connect());
     await this.connectionSetup(client);
     const rowStream = client.query(query);
     let index = 0;
@@ -528,22 +607,7 @@ export class PooledPostgresConnection
 
   async getPool(): Promise<Pool> {
     if (!this._pool) {
-      const {
-        username: user,
-        password,
-        databaseName: database,
-        port,
-        host,
-        connectionString,
-      } = await this.readConfig();
-      this._pool = new Pool({
-        user,
-        password,
-        database,
-        port,
-        host,
-        connectionString,
-      });
+      this._pool = new Pool(this.buildClientConfig(await this.readConfig()));
       this._pool.on('acquire', client => {
         client.query("SET TIME ZONE 'UTC'");
         if (this.setupSQL) {
@@ -567,7 +631,7 @@ export class PooledPostgresConnection
     values?: unknown[]
   ): Promise<MalloyQueryData> {
     const pool = await this.getPool();
-    let result = await pool.query(sqlCommand, values);
+    let result = await this.withTlsHint(() => pool.query(sqlCommand, values));
 
     if (Array.isArray(result)) {
       result = result.pop();
@@ -594,7 +658,7 @@ export class PooledPostgresConnection
     // `QueryStream` as well, but it's not. So instead, we get a client and call
     // `client.query(query)`, which does what it's supposed to.
     const pool = await this.getPool();
-    const client = await pool.connect();
+    const client = await this.withTlsHint(() => pool.connect());
     const resultStream: QueryStream = client.query(query);
     for await (const row of resultStream) {
       yield row.row as QueryRecord;

--- a/packages/malloy-db-postgres/src/postgres_ssl.spec.ts
+++ b/packages/malloy-db-postgres/src/postgres_ssl.spec.ts
@@ -1,0 +1,199 @@
+/*
+ * Copyright Contributors to the Malloy project
+ * SPDX-License-Identifier: MIT
+ */
+
+const mockClient = jest.fn();
+const mockPool = jest.fn();
+const mockClientConnect = jest.fn();
+const mockPoolQuery = jest.fn();
+
+jest.mock('pg', () => ({
+  Client: jest.fn().mockImplementation(config => {
+    mockClient(config);
+    return {
+      connect: mockClientConnect,
+      query: jest.fn().mockResolvedValue({rows: [], fields: []}),
+      end: jest.fn().mockResolvedValue(undefined),
+      on: jest.fn(),
+    };
+  }),
+  Pool: jest.fn().mockImplementation(config => {
+    mockPool(config);
+    return {
+      query: mockPoolQuery,
+      connect: jest.fn(),
+      on: jest.fn(),
+    };
+  }),
+}));
+
+import {
+  PostgresConnection,
+  PooledPostgresConnection,
+} from './postgres_connection';
+import type {PostgresConnectionOptions} from './postgres_connection';
+
+// getClient/getPool are protected — reach them through a thin subclass.
+class TestablePostgresConnection extends PostgresConnection {
+  public async testGetClient() {
+    return this.getClient();
+  }
+}
+
+class TestablePooledPostgresConnection extends PooledPostgresConnection {
+  public async testGetPool() {
+    return this.getPool();
+  }
+}
+
+function makeOptions(
+  overrides: Partial<PostgresConnectionOptions>
+): PostgresConnectionOptions {
+  return {
+    name: 'ssl_test',
+    ...overrides,
+  };
+}
+
+function altnameError(): Error {
+  const e = new Error(
+    "Hostname/IP does not match certificate's altnames: Host: localhost. is not in the cert's altnames: DNS:db.example.com"
+  );
+  (e as {code?: string}).code = 'ERR_TLS_CERT_ALTNAME_INVALID';
+  return e;
+}
+
+describe('postgres ssl passthrough', () => {
+  beforeEach(() => {
+    mockClientConnect.mockResolvedValue(undefined);
+    mockPoolQuery.mockResolvedValue({rows: [], fields: []});
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('forwarding', () => {
+    it('forwards an ssl object to the Client config', async () => {
+      const ssl = {servername: '127.0.0.1', ca: 'PEM'};
+      const connection = new TestablePostgresConnection(
+        makeOptions({host: '127.0.0.1', ssl})
+      );
+      await connection.testGetClient();
+      expect(mockClient).toHaveBeenCalledTimes(1);
+      expect(mockClient.mock.calls[0][0].ssl).toEqual(ssl);
+    });
+
+    it('forwards an ssl object to the Pool config', async () => {
+      const ssl = {servername: '127.0.0.1', ca: 'PEM'};
+      const connection = new TestablePooledPostgresConnection(
+        makeOptions({host: '127.0.0.1', ssl})
+      );
+      await connection.testGetPool();
+      expect(mockPool).toHaveBeenCalledTimes(1);
+      expect(mockPool.mock.calls[0][0].ssl).toEqual(ssl);
+    });
+
+    it('forwards ssl: true to the Client config', async () => {
+      const connection = new TestablePostgresConnection(
+        makeOptions({host: '127.0.0.1', ssl: true})
+      );
+      await connection.testGetClient();
+      expect(mockClient.mock.calls[0][0].ssl).toBe(true);
+    });
+
+    it('forwards ssl: true to the Pool config', async () => {
+      const connection = new TestablePooledPostgresConnection(
+        makeOptions({host: '127.0.0.1', ssl: true})
+      );
+      await connection.testGetPool();
+      expect(mockPool.mock.calls[0][0].ssl).toBe(true);
+    });
+
+    it('leaves ssl undefined when unset (Client) — regression guard', async () => {
+      const connection = new TestablePostgresConnection(
+        makeOptions({host: '127.0.0.1'})
+      );
+      await connection.testGetClient();
+      expect(mockClient.mock.calls[0][0].ssl).toBeUndefined();
+    });
+
+    it('leaves ssl undefined when unset (Pool) — regression guard', async () => {
+      const connection = new TestablePooledPostgresConnection(
+        makeOptions({host: '127.0.0.1'})
+      );
+      await connection.testGetPool();
+      expect(mockPool.mock.calls[0][0].ssl).toBeUndefined();
+    });
+
+    // Guards the field remapping in buildClientConfig (username→user,
+    // databaseName→database) so the ssl refactor can't silently drop them.
+    it('preserves the non-ssl field mapping', async () => {
+      const connection = new TestablePostgresConnection(
+        makeOptions({
+          host: 'db.example.com',
+          port: 5433,
+          username: 'me',
+          password: 'pw',
+          databaseName: 'analytics',
+          connectionString: 'postgres://db.example.com/analytics',
+        })
+      );
+      await connection.testGetClient();
+      expect(mockClient.mock.calls[0][0]).toMatchObject({
+        user: 'me',
+        password: 'pw',
+        database: 'analytics',
+        port: 5433,
+        host: 'db.example.com',
+        connectionString: 'postgres://db.example.com/analytics',
+      });
+    });
+  });
+
+  // pg verifies the cert against the host it connects to, not ssl.servername,
+  // and throws a terse altname error on mismatch. The connector reacts to that
+  // real error rather than predicting pg's host resolution up front.
+  describe('certificate-mismatch error annotation', () => {
+    it('annotates pg cert-mismatch on the non-pooled path', async () => {
+      mockClientConnect.mockRejectedValueOnce(altnameError());
+      const connection = new PostgresConnection(
+        makeOptions({host: 'localhost', ssl: {servername: 'db.example.com'}})
+      );
+      await expect(connection.runSQL('SELECT 1')).rejects.toThrow(
+        /does not match the host pg connected to/
+      );
+    });
+
+    it('annotates pg cert-mismatch on the pooled path', async () => {
+      mockPoolQuery.mockRejectedValueOnce(altnameError());
+      const connection = new PooledPostgresConnection(
+        makeOptions({host: 'localhost', ssl: {servername: 'db.example.com'}})
+      );
+      await expect(connection.runSQL('SELECT 1')).rejects.toThrow(
+        /does not match the host pg connected to/
+      );
+    });
+
+    it('preserves the original error message when annotating', async () => {
+      mockClientConnect.mockRejectedValueOnce(altnameError());
+      const connection = new PostgresConnection(
+        makeOptions({host: 'localhost', ssl: {servername: 'db.example.com'}})
+      );
+      await expect(connection.runSQL('SELECT 1')).rejects.toThrow(
+        /does not match certificate's altnames/
+      );
+    });
+
+    it('leaves unrelated connection errors unchanged', async () => {
+      mockClientConnect.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+      const connection = new PostgresConnection(
+        makeOptions({host: 'localhost'})
+      );
+      await expect(connection.runSQL('SELECT 1')).rejects.toThrow(
+        /^ECONNREFUSED$/
+      );
+    });
+  });
+});

--- a/packages/malloy/src/connection/CONTEXT.md
+++ b/packages/malloy/src/connection/CONTEXT.md
@@ -150,7 +150,7 @@ When `shareable: true` (and `databasePath` is a local file), the DuckDB connecti
 `projectId` (string), `serviceAccountKeyPath` (file), `location` (string), `maximumBytesBilled` (string, advanced), `timeoutMs` (string, advanced), `billingProjectId` (string, advanced), `setupSQL` (text, advanced)
 
 **PostgreSQL** (`displayName: "PostgreSQL"`):
-`host` (string), `port` (number), `username` (string), `password` (password), `databaseName` (string), `connectionString` (string, advanced), `setupSQL` (text, advanced)
+`host` (string), `port` (number), `username` (string), `password` (password), `databaseName` (string), `connectionString` (string, advanced), `setupSQL` (text, advanced), `ssl` (json, advanced)
 
 **Snowflake** (`displayName: "Snowflake"`):
 `account` (string, required), `username` (string), `password` (password), `role` (string), `warehouse` (string), `database` (string), `schema` (string), `privateKeyPath` (file), `privateKeyPass` (password), `timeoutMs` (number, advanced), `schemaSampleTimeoutMs` (number, advanced), `schemaSampleRowLimit` (number, advanced), `schemaSampleFullScanMaxBytes` (number, advanced), `setupSQL` (text, advanced), `poolMin` (number, advanced), `poolMax` (number, advanced), `poolTestOnBorrow` (boolean, advanced)


### PR DESCRIPTION
## What

`@malloydata/db-postgres` exposed no way to pass TLS options to the underlying `pg` `Client`/`Pool` — `getClient()`/`getPool()` built the config with no `ssl` field, so `pg` derived TLS only from host/env. That made **verified TLS through a tunnel impossible**: when you port-forward Postgres and connect to `127.0.0.1`, the server cert is for the real DB host, so verification fails on hostname mismatch and the only option left is `sslmode=no-verify`.

This adds an `ssl` passthrough, mirroring how `@malloydata/db-trino` already exposes `ssl`. **Backwards compatible: when `ssl` is unset, behavior is byte-for-byte identical to today.**

Closes #2960.

## Design

- **Two-tier typing.** `PostgresConnectionConfiguration.ssl` accepts pg's full `ssl` (`boolean | tls.ConnectionOptions`) for programmatic callers — so `checkServerIdentity`-based verify-ca against a cert with no matching SAN/CN (e.g. Cloud SQL legacy per-instance certs) is possible via the config-reader constructor form. `PostgresConnectionOptions` (saved/registry `json` config) is narrowed to a serializable `PostgresSSLConfig` subset (PEM strings + booleans; `ca`/`crl` accept `string | string[]`), registered as a `type: 'json'` manifest property like Trino's.
- **Shared config builder.** Both `getClient()` and `getPool()` go through `buildClientConfig()`.
- **Reacts to pg's error instead of predicting its host resolution.** pg verifies the cert against the host it connects to, not `ssl.servername` (which it drops for DNS-name hosts). Rather than reproduce pg's host-resolution logic up front, the connector catches pg's terse `ERR_TLS_CERT_ALTNAME_INVALID` at connect time and annotates it with actionable guidance (connect via the DB's IP and set `servername`, or omit `servername`). [Per review feedback — earlier revisions guessed the host ahead of pg, which is fragile.]

## Semantics (pg / Node `tls`, not libpq — documented in the package README)

- `ssl: true` → full verification against the trust store, including hostname (verify-full).
- `ssl: { rejectUnauthorized: false }` → encrypt but do not verify.
- `ssl: { ca }` → trust a specific CA (PEM, or an array for rotation).

## Tests

11 unit tests (pg mocked, no live DB): `ssl` forwarding for `Client` and `Pool`, `ssl: true`, the unset regression guard, the non-`ssl` field mapping, and the certificate-mismatch annotation on both the pooled and non-pooled paths (including that unrelated errors pass through untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)