### PR TITLE
fix(snowflake): load test timestamps as TIMESTAMP_NTZ (dialect dropped TIMESTAMP_LTZ in #2578)

### DIFF
--- a/test/snowflake/load_test_data.sql
+++ b/test/snowflake/load_test_data.sql
@@ -7,6 +7,11 @@ create database malloytest;
 use malloytest;
 create schema malloytest;
 
+-- Pin UTC so the TIMESTAMP_LTZ -> TIMESTAMP_NTZ conversion at the end of this
+-- script is a lossless wall-clock identity (the parquet data is stored as UTC
+-- instants).
+ALTER SESSION SET TIMEZONE = 'UTC';
+
 CREATE OR REPLACE FILE FORMAT PARQUET_SCHEMA_DETECTION
   TYPE = PARQUET
   BINARY_AS_TEXT = FALSE
@@ -155,3 +160,29 @@ FROM '@~/staged/state_facts.parquet'
 FILE_FORMAT = 'PARQUET_SCHEMA_DETECTION'
 MATCH_BY_COLUMN_NAME = CASE_INSENSITIVE
 ON_ERROR = CONTINUE;
+
+-- INFER_SCHEMA maps timezone-aware parquet timestamps to TIMESTAMP_LTZ, which
+-- the Malloy Snowflake dialect does not support (it degrades to `sql native`,
+-- breaking time truncation and year()/quarter()). Rewrite every TIMESTAMP_LTZ
+-- column in the schema to TIMESTAMP_NTZ. Snowflake has no in-place retype
+-- between timestamp variants, so each column is rebuilt via add / copy / drop /
+-- rename; the UTC session pin above makes the copy preserve the stored instant
+-- exactly. The columns are discovered dynamically so this stays correct if the
+-- test corpus gains or loses a timestamp column. Wrapped in EXECUTE IMMEDIATE
+-- $$...$$ so it is a single statement (snowsql splits input on ';').
+EXECUTE IMMEDIATE $$
+DECLARE
+  ltz_cols CURSOR FOR
+    SELECT TABLE_NAME, COLUMN_NAME
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = CURRENT_SCHEMA() AND DATA_TYPE = 'TIMESTAMP_LTZ';
+BEGIN
+  FOR col IN ltz_cols DO
+    EXECUTE IMMEDIATE 'ALTER TABLE malloytest.' || col.TABLE_NAME || ' ADD COLUMN "' || col.COLUMN_NAME || '__ntz" TIMESTAMP_NTZ';
+    EXECUTE IMMEDIATE 'UPDATE malloytest.' || col.TABLE_NAME || ' SET "' || col.COLUMN_NAME || '__ntz" = "' || col.COLUMN_NAME || '"::TIMESTAMP_NTZ';
+    EXECUTE IMMEDIATE 'ALTER TABLE malloytest.' || col.TABLE_NAME || ' DROP COLUMN "' || col.COLUMN_NAME || '"';
+    EXECUTE IMMEDIATE 'ALTER TABLE malloytest.' || col.TABLE_NAME || ' RENAME COLUMN "' || col.COLUMN_NAME || '__ntz" TO "' || col.COLUMN_NAME || '"';
+  END FOR;
+  RETURN 'normalized timestamp_ltz columns to timestamp_ntz';
+END;
+$$;


### PR DESCRIPTION
## What

Normalize `TIMESTAMP_LTZ` columns to `TIMESTAMP_NTZ` in the Snowflake test-data
loader (`test/snowflake/load_test_data.sql`), so a fresh load produces data the
Malloy Snowflake dialect can query.

## Why

The shared test parquet files store their timestamp columns as timezone-aware
UTC (`timestamp[us, tz=UTC]`, i.e. the parquet `isAdjustedToUTC` flag is set).
The loader's file format uses `USE_LOGICAL_TYPE = TRUE`, so Snowflake's
`INFER_SCHEMA` correctly maps those columns to `TIMESTAMP_LTZ`.

The Malloy Snowflake dialect does not support `TIMESTAMP_LTZ`: it degrades to
`sql native`, which cannot be truncated or passed to `year()`/`quarter()`.
`TIMESTAMP_LTZ` support was intentionally removed from the dialect in #2578
("remove accidental support of timestamp_ltz"). That change updated the dialect
but did not update the loader, so the two have been out of step since: the
loader still produces `TIMESTAMP_LTZ`, which the dialect now rejects.

This went unnoticed because the maintained Snowflake CI instance was loaded
before #2578 and has not been reloaded since, so its tables retain the types
they had. A clean `drop database; load` (e.g. standing up a new Snowflake CI
account) is the first time the mismatch surfaces. Running the suite against a
freshly loaded instance fails two tests:

- `test/src/databases/all/functions.spec.ts` -- `partition_by` uses
  `year(dep_time)` / `quarter(dep_time)` on `flights` and fails to compile:
  `Unsupported SQL native type 'timestamp_ltz' not allowed in expression`.
- `test/src/databases/all/time.spec.ts` -- nested-timezone rendering fails with
  `Cannot do time truncation on type 'sql native'`.

Both are timestamp columns loaded as `TIMESTAMP_LTZ`
(`flights.dep_time`, `flights.arr_time`, `alltypes.t_timestamp`).

## What this changes

`test/snowflake/load_test_data.sql`:

1. Pins the session timezone to UTC before loading, so the conversion below is a
   lossless wall-clock identity (the source data is UTC instants).
2. After the loads, rewrites every `TIMESTAMP_LTZ` column in the schema to
   `TIMESTAMP_NTZ`. Snowflake has no in-place retype between timestamp variants,
   so each column is rebuilt via add / copy / drop / rename. Columns are
   discovered dynamically from `INFORMATION_SCHEMA`, so the fix stays correct if
   the test corpus gains or loses a timestamp column. The block is wrapped in a
   single `EXECUTE IMMEDIATE $$...$$` statement because `snowsql -f` splits input
   on `;`.

## Note on scope

This fixes the loader to match the dialect's current expectation
(`TIMESTAMP_NTZ`). The dialect change (#2578) deliberately dropped
`TIMESTAMP_LTZ` support; this PR leaves the loader as the layer that reconciles
the tz-aware parquet source with that decision, rather than reintroducing LTZ
handling in the dialect or regenerating the parquet fixtures as tz-naive.
Either of those would be a larger, separate change; this is the minimal fix that
makes a fresh Snowflake load pass the suite.

## Testing

Verified against a freshly provisioned Snowflake account: after a clean load
with this change, all `TIMESTAMP_LTZ` columns are converted to `TIMESTAMP_NTZ`
(none remain), row counts are unchanged, and `npm run ci-snowflake` passes
(25 suites; 825 passed, 40 skipped, 1 todo, 0 failed). The two tests noted above
move from failing to passing; nothing else changes.
