### PR TITLE
Snowflake CI: key-pair auth over env vars, not a TOML written to $HOME

### DIFF
--- a/.github/workflows/db-snowflake.yaml
+++ b/.github/workflows/db-snowflake.yaml
@@ -4,7 +4,9 @@ permissions: {}
 on:
   workflow_call:
     secrets:
-      SNOWFLAKE_CONNECTION:
+      SNOW_CI_ACCOUNT:
+        required: true
+      SNOW_CI_KEY:
         required: true
 
 jobs:
@@ -22,9 +24,14 @@ jobs:
         with:
           node-version-file: '.node-version'
       - name: Test
-        run: |
-          ./scripts/gen-snowflake-auth.sh
-          npm run ci-snowflake
+        run: npm run ci-snowflake
         env:
           CI: true
-          SNOWFLAKE_CONNECTION: ${{ secrets.SNOWFLAKE_CONNECTION }}
+          SNOWFLAKE_ACCOUNT: ${{ secrets.SNOW_CI_ACCOUNT }}
+          SNOWFLAKE_PRIVATE_KEY_RAW: ${{ secrets.SNOW_CI_KEY }}
+          SNOWFLAKE_AUTHENTICATOR: SNOWFLAKE_JWT
+          SNOWFLAKE_USER: MALLOY_CI
+          SNOWFLAKE_ROLE: MALLOY_CI_ROLE
+          SNOWFLAKE_WAREHOUSE: MALLOY_CI_WH
+          SNOWFLAKE_DATABASE: MALLOYTEST
+          SNOWFLAKE_SCHEMA: malloytest

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -91,7 +91,8 @@ jobs:
     needs: [check-permission, pull_and_build]
     uses: './.github/workflows/db-snowflake.yaml'
     secrets:
-      SNOWFLAKE_CONNECTION: ${{ secrets.SNOWFLAKE_CONNECTION }}
+      SNOW_CI_ACCOUNT: ${{ secrets.SNOW_CI_ACCOUNT }}
+      SNOW_CI_KEY: ${{ secrets.SNOW_CI_KEY }}
   db-mysql:
     needs: pull_and_build
     uses: './.github/workflows/db-mysql.yaml'

--- a/packages/malloy-db-snowflake/CONTEXT.md
+++ b/packages/malloy-db-snowflake/CONTEXT.md
@@ -21,3 +21,30 @@ only when every owner moves.
 run the live Snowflake suite, confirm the native chain still builds on every
 platform. The cross-cutting pin ledger is [`DEPENDENCY-MANAGEMENT.md`](../../DEPENDENCY-MANAGEMENT.md);
 the Dependabot flow is in [`.github/CONTEXT.md`](../../.github/CONTEXT.md).
+
+## `~/.snowflake/connections.toml` is read with the *driver's* schema, not Snowflake's
+
+`getConnectionOptionsFromToml` spreads that file straight into `snowflake-sdk`, so
+its effective schema is the driver's camelCase `ConnectionOptions`, not the
+snake_case format Snowflake documents. A `connections.toml` written the way
+Snowflake's docs describe — `private_key_file` for key-pair auth — **silently
+fails**: the driver discards the unrecognized key, without even a log line
+(its unknown-parameter warning is behind `validateDefaultParameters`, off by
+default), and authenticates with no key.
+Write `privateKeyPath` (absolute; `~` is not expanded) or `privateKey` (PEM text).
+Both spellings can coexist in one file if you also need `snow` — each tool warns
+and ignores the other's key.
+
+`snowflake-sdk` 2.3.5 fixed this upstream (`normalizeConnectionOptions()`), but our
+parser bypasses the driver's loader, so the bump alone won't pick it up.
+
+## Test-harness env vars are named after the Snowflake CLI's
+
+`getConnectionOptionsFromEnv` is not user-facing config — only this package's spec
+and `test/src/runtimes.ts` call it. `SNOWFLAKE_ACCOUNT` gates it; unset, callers
+fall back to the TOML.
+
+The names match `snow`'s, so a name never means two things:
+`SNOWFLAKE_PRIVATE_KEY_RAW` → `privateKey` (PEM text), `..._FILE` → `privateKeyPath`,
+`..._PASSPHRASE` → `privateKeyPass`. Do **not** add a bare `SNOWFLAKE_PRIVATE_KEY`;
+Snowflake has no such variable, and it sits one underscore from `_FILE`, a path.

--- a/packages/malloy-db-snowflake/src/snowflake_executor.spec.ts
+++ b/packages/malloy-db-snowflake/src/snowflake_executor.spec.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright Contributors to the Malloy project
+ * SPDX-License-Identifier: MIT
+ */
+
+import {SnowflakeExecutor} from './snowflake_executor';
+
+const SNOWFLAKE_VARS = [
+  'SNOWFLAKE_ACCOUNT',
+  'SNOWFLAKE_USER',
+  'SNOWFLAKE_PASSWORD',
+  'SNOWFLAKE_ROLE',
+  'SNOWFLAKE_WAREHOUSE',
+  'SNOWFLAKE_DATABASE',
+  'SNOWFLAKE_SCHEMA',
+  'SNOWFLAKE_AUTHENTICATOR',
+  'SNOWFLAKE_PRIVATE_KEY_RAW',
+  'SNOWFLAKE_PRIVATE_KEY_FILE',
+  'SNOWFLAKE_PRIVATE_KEY_PASSPHRASE',
+];
+
+describe('getConnectionOptionsFromEnv', () => {
+  const saved = new Map<string, string | undefined>();
+
+  beforeEach(() => {
+    for (const name of SNOWFLAKE_VARS) {
+      saved.set(name, process.env[name]);
+      delete process.env[name];
+    }
+  });
+
+  afterEach(() => {
+    for (const [name, value] of saved) {
+      if (value === undefined) {
+        delete process.env[name];
+      } else {
+        process.env[name] = value;
+      }
+    }
+    saved.clear();
+  });
+
+  it('returns undefined when SNOWFLAKE_ACCOUNT is unset', () => {
+    process.env['SNOWFLAKE_USER'] = 'someone';
+    expect(SnowflakeExecutor.getConnectionOptionsFromEnv()).toBeUndefined();
+  });
+
+  it('returns undefined when SNOWFLAKE_ACCOUNT is empty', () => {
+    // A GitHub Actions secret that does not exist interpolates to '', not unset.
+    process.env['SNOWFLAKE_ACCOUNT'] = '';
+    expect(SnowflakeExecutor.getConnectionOptionsFromEnv()).toBeUndefined();
+  });
+
+  it('maps the key-pair variables onto the driver option names', () => {
+    process.env['SNOWFLAKE_ACCOUNT'] = 'acct';
+    process.env['SNOWFLAKE_AUTHENTICATOR'] = 'SNOWFLAKE_JWT';
+    process.env['SNOWFLAKE_PRIVATE_KEY_RAW'] = '-----BEGIN PRIVATE KEY-----';
+    process.env['SNOWFLAKE_PRIVATE_KEY_FILE'] = '/keys/malloy.p8';
+    process.env['SNOWFLAKE_PRIVATE_KEY_PASSPHRASE'] = 'hunter2';
+
+    expect(SnowflakeExecutor.getConnectionOptionsFromEnv()).toMatchObject({
+      authenticator: 'SNOWFLAKE_JWT',
+      privateKey: '-----BEGIN PRIVATE KEY-----',
+      privateKeyPath: '/keys/malloy.p8',
+      privateKeyPass: 'hunter2',
+    });
+  });
+
+  it('maps the identity and namespace variables', () => {
+    process.env['SNOWFLAKE_ACCOUNT'] = 'acct';
+    process.env['SNOWFLAKE_USER'] = 'user';
+    process.env['SNOWFLAKE_PASSWORD'] = 'pw';
+    process.env['SNOWFLAKE_ROLE'] = 'role';
+    process.env['SNOWFLAKE_WAREHOUSE'] = 'wh';
+    process.env['SNOWFLAKE_DATABASE'] = 'db';
+    process.env['SNOWFLAKE_SCHEMA'] = 'sch';
+
+    expect(SnowflakeExecutor.getConnectionOptionsFromEnv()).toMatchObject({
+      account: 'acct',
+      username: 'user',
+      password: 'pw',
+      role: 'role',
+      warehouse: 'wh',
+      database: 'db',
+      schema: 'sch',
+    });
+  });
+
+  it('applies the shared connection defaults', () => {
+    // jsTreatIntegerAsBigInt is load-bearing: without it, integer columns lose
+    // precision. The env path must not diverge from the toml path here.
+    process.env['SNOWFLAKE_ACCOUNT'] = 'acct';
+    expect(SnowflakeExecutor.getConnectionOptionsFromEnv()).toMatchObject({
+      jsTreatIntegerAsBigInt: true,
+      clientSessionKeepAlive: true,
+    });
+  });
+});

--- a/packages/malloy-db-snowflake/src/snowflake_executor.ts
+++ b/packages/malloy-db-snowflake/src/snowflake_executor.ts
@@ -73,24 +73,25 @@ export class SnowflakeExecutor {
 
   public static getConnectionOptionsFromEnv(): ConnectionOptions | undefined {
     const account = process.env['SNOWFLAKE_ACCOUNT'];
-    if (account) {
-      const username = process.env['SNOWFLAKE_USER'];
-      const password = process.env['SNOWFLAKE_PASSWORD'];
-      const warehouse = process.env['SNOWFLAKE_WAREHOUSE'];
-      const database = process.env['SNOWFLAKE_DATABASE'];
-      const schema = process.env['SNOWFLAKE_SCHEMA'];
-      return {
-        account,
-        username,
-        password,
-        warehouse,
-        database,
-        schema,
-        // Return integers as native JS BigInt to preserve precision
-        jsTreatIntegerAsBigInt: true,
-      };
+    if (!account) {
+      return undefined;
     }
-    return undefined;
+    return {
+      ...SnowflakeExecutor.defaultConnectionOptions,
+      account,
+      username: process.env['SNOWFLAKE_USER'],
+      password: process.env['SNOWFLAKE_PASSWORD'],
+      role: process.env['SNOWFLAKE_ROLE'],
+      warehouse: process.env['SNOWFLAKE_WAREHOUSE'],
+      database: process.env['SNOWFLAKE_DATABASE'],
+      schema: process.env['SNOWFLAKE_SCHEMA'],
+      // Key-pair auth requires SNOWFLAKE_AUTHENTICATOR=SNOWFLAKE_JWT.
+      // Names match the Snowflake CLI's; _RAW is PEM text, _FILE a path.
+      authenticator: process.env['SNOWFLAKE_AUTHENTICATOR'],
+      privateKey: process.env['SNOWFLAKE_PRIVATE_KEY_RAW'],
+      privateKeyPath: process.env['SNOWFLAKE_PRIVATE_KEY_FILE'],
+      privateKeyPass: process.env['SNOWFLAKE_PRIVATE_KEY_PASSPHRASE'],
+    };
   }
 
   public static getConnectionOptionsFromToml(

--- a/scripts/gen-snowflake-auth.sh
+++ b/scripts/gen-snowflake-auth.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-mkdir $HOME/.snowflake
-echo "$SNOWFLAKE_CONNECTION" > $HOME/.snowflake/connections.toml
-chmod 0600 $HOME/.snowflake/connections.toml


### PR DESCRIPTION
## Confession

Some uncomfortable and pragmatic decisions were made during the bringup of the Snowflake dialect that are probably a bad idea. There are many reasons why fixing them right now is complicated which I will not go into. This PR is the minimal change needed to get Snowflake CI running with a "non password auth"

## The Change

Snowflake CI authenticated by writing a whole `connections.toml` to `$HOME` from
a single opaque secret. That existed because `getConnectionOptionsFromEnv()`
couldn't do key-pair auth — no private key of any kind — so the file was the only
way to get one in. The cost was that CI exercised ambient home-directory state
instead of the path users actually configure, and `runtimes.ts` silently
discarded the options object it built.

The env path now supports key-pair auth, so the script and the blob are gone.
Variable names are the Snowflake CLI's own — `SNOWFLAKE_PRIVATE_KEY_RAW` is PEM
text, `_FILE` is a path — deliberately, so a name never means two different
things. There is no bare `SNOWFLAKE_PRIVATE_KEY` in Snowflake, and it would sit
one underscore from `_FILE`.

- [x] Delete the now-unused `SNOWFLAKE_CONNECTION` repo secret.
