### PR TITLE
Fix date calendar-unit interval measurement

### DIFF
--- a/packages/malloy/src/dialect/databricks/databricks.ts
+++ b/packages/malloy/src/dialect/databricks/databricks.ts
@@ -528,8 +528,17 @@ export class DatabricksDialect extends Dialect {
   }
 
   sqlMeasureTimeExpr(df: MeasureTimeExpr): string {
-    let lVal = df.kids.left.sql;
-    let rVal = df.kids.right.sql;
+    const from = df.kids.left;
+    const to = df.kids.right;
+    let lVal = from.sql;
+    let rVal = to.sql;
+    if (
+      TD.isDate(from.typeDef) &&
+      TD.isDate(to.typeDef) &&
+      ['week', 'month', 'quarter', 'year'].includes(df.units)
+    ) {
+      return `TIMESTAMPDIFF(${df.units.toUpperCase()}, ${lVal}, ${rVal})`;
+    }
     if (inSeconds[df.units]) {
       lVal = `UNIX_MICROS(CAST(${lVal} AS TIMESTAMP))`;
       rVal = `UNIX_MICROS(CAST(${rVal} AS TIMESTAMP))`;

--- a/packages/malloy/src/dialect/mysql/mysql.ts
+++ b/packages/malloy/src/dialect/mysql/mysql.ts
@@ -553,8 +553,17 @@ export class MySQLDialect extends Dialect {
   }
 
   sqlMeasureTimeExpr(df: MeasureTimeExpr): string {
-    let lVal = df.kids.left.sql;
-    let rVal = df.kids.right.sql;
+    const from = df.kids.left;
+    const to = df.kids.right;
+    let lVal = from.sql;
+    let rVal = to.sql;
+    if (
+      TD.isDate(from.typeDef) &&
+      TD.isDate(to.typeDef) &&
+      ['week', 'month', 'quarter', 'year'].includes(df.units)
+    ) {
+      return `TIMESTAMPDIFF(${df.units.toUpperCase()}, ${lVal}, ${rVal})`;
+    }
     if (inSeconds[df.units]) {
       lVal = `UNIX_TIMESTAMP(${lVal})`;
       rVal = `UNIX_TIMESTAMP(${rVal})`;

--- a/packages/malloy/src/dialect/postgres/postgres.ts
+++ b/packages/malloy/src/dialect/postgres/postgres.ts
@@ -311,6 +311,31 @@ export class PostgresDialect extends PostgresBase {
     const to = df.kids.right;
     let lVal = from.sql;
     let rVal = to.sql;
+    if (
+      TD.isDate(from.typeDef) &&
+      TD.isDate(to.typeDef) &&
+      ['week', 'month', 'quarter', 'year'].includes(df.units)
+    ) {
+      const earlier = `LEAST(${lVal}, ${rVal})`;
+      const later = `GREATEST(${lVal}, ${rVal})`;
+      const age = `AGE(${later}, ${earlier})`;
+      const months = `(EXTRACT(YEAR FROM ${age}) * 12 + EXTRACT(MONTH FROM ${age}))`;
+      let measured: string;
+      if (df.units === 'week') {
+        measured = `TRUNC((${later} - ${earlier}) / 7.0)`;
+      } else if (df.units === 'month') {
+        measured = months;
+      } else if (df.units === 'quarter') {
+        measured = `TRUNC(${months} / 3.0)`;
+      } else {
+        measured = `EXTRACT(YEAR FROM ${age})`;
+      }
+      return `CASE
+        WHEN ${lVal} IS NULL OR ${rVal} IS NULL THEN NULL
+        WHEN ${rVal} >= ${lVal} THEN ${measured}
+        ELSE -(${measured})
+      END`;
+    }
     if (inSeconds[df.units]) {
       lVal = `EXTRACT(EPOCH FROM ${lVal})`;
       rVal = `EXTRACT(EPOCH FROM ${rVal})`;

--- a/packages/malloy/src/dialect/snowflake/snowflake.ts
+++ b/packages/malloy/src/dialect/snowflake/snowflake.ts
@@ -515,6 +515,24 @@ ${indent(sql)}
   sqlMeasureTimeExpr(df: MeasureTimeExpr): string {
     const from = df.kids.left;
     const to = df.kids.right;
+    if (
+      TD.isDate(from.typeDef) &&
+      TD.isDate(to.typeDef) &&
+      ['week', 'month', 'quarter', 'year'].includes(df.units)
+    ) {
+      const lVal = from.sql;
+      const rVal = to.sql;
+      const earlier = `LEAST(${lVal}, ${rVal})`;
+      const later = `GREATEST(${lVal}, ${rVal})`;
+      const candidate = `DATEDIFF(${df.units}, ${earlier}, ${later})`;
+      const anniversary = `DATEADD(${df.units}, ${candidate}, ${earlier})`;
+      const measured = `(${candidate} - CASE WHEN ${anniversary} > ${later} THEN 1 ELSE 0 END)`;
+      return `CASE
+        WHEN ${lVal} IS NULL OR ${rVal} IS NULL THEN NULL
+        WHEN ${rVal} >= ${lVal} THEN ${measured}
+        ELSE -(${measured})
+      END`;
+    }
     let extractUnits = 'nanoseconds';
     if (TD.isDate(from.typeDef) || TD.isDate(to.typeDef)) {
       extractUnits = 'seconds';

--- a/packages/malloy/src/dialect/standardsql/standardsql.ts
+++ b/packages/malloy/src/dialect/standardsql/standardsql.ts
@@ -493,6 +493,23 @@ ${indent(sql)}
     const to = measure.kids.right;
     let lVal = from.sql;
     let rVal = to.sql;
+    if (
+      TD.isDate(from.typeDef) &&
+      TD.isDate(to.typeDef) &&
+      ['week', 'month', 'quarter', 'year'].includes(measure.units)
+    ) {
+      const earlier = `LEAST(${lVal},${rVal})`;
+      const later = `GREATEST(${lVal},${rVal})`;
+      const unit = measure.units.toUpperCase();
+      const candidate = `DATE_DIFF(${later},${earlier},${unit})`;
+      const anniversary = `DATE_ADD(${earlier}, INTERVAL ${candidate} ${unit})`;
+      const measured = `(${candidate} - CASE WHEN ${anniversary} > ${later} THEN 1 ELSE 0 END)`;
+      return `CASE
+        WHEN ${lVal} IS NULL OR ${rVal} IS NULL THEN NULL
+        WHEN ${rVal} >= ${lVal} THEN ${measured}
+        ELSE -(${measured})
+      END`;
+    }
     if (measureMap[measure.units]) {
       const {use: measureIn, ratio} = measureMap[measure.units];
       if (!timestampMeasureable(measureIn)) {

--- a/packages/malloy/src/dialect/trino/trino.ts
+++ b/packages/malloy/src/dialect/trino/trino.ts
@@ -565,6 +565,13 @@ ${indent(sql)}
     const to = mf.kids.right;
     let lVal = from.sql;
     let rVal = to.sql;
+    if (
+      TD.isDate(from.typeDef) &&
+      TD.isDate(to.typeDef) &&
+      ['week', 'month', 'quarter', 'year'].includes(mf.units)
+    ) {
+      return `DATE_DIFF('${mf.units}',${lVal},${rVal})`;
+    }
     if (measureMap[mf.units]) {
       const {use: measureIn, ratio} = measureMap[mf.units];
       if (!timestampMeasureable(measureIn)) {

--- a/packages/malloy/src/lang/ast/expressions/expr-time-extract.ts
+++ b/packages/malloy/src/lang/ast/expressions/expr-time-extract.ts
@@ -104,10 +104,13 @@ export class ExprTimeExtract extends ExpressionDef {
             );
           }
         }
-        if (['week', 'month', 'quarter', 'year'].includes(extractTo)) {
+        if (
+          ['week', 'month', 'quarter', 'year'].includes(extractTo) &&
+          (first.type !== 'date' || last.type !== 'date')
+        ) {
           return this.loggedErrorExpr(
             'invalid-timeframe-for-time-measurement',
-            `Cannot measure interval using '${extractTo}'`
+            `Cannot measure interval using '${extractTo}' for '${first.type}' values; calendar interval measurement requires dates`
           );
         }
         if (!isTimestampUnit(extractTo)) {


### PR DESCRIPTION
### Summary

Fixes #2973.

This enables `week`, `month`, `quarter`, and `year` interval measurement for date-to-date ranges across the supported dialects.

Calendar-unit measurement for timestamps remains unsupported, but the error message is now more explicit.

### Testing

- Targeted runtime tests passed on DuckDB, MySQL, PostgreSQL, and Trino.
- SQL generation was checked for all affected dialects.
- Prettier, ESLint, and `git diff --check` passed.

I was not able to run live tests against BigQuery, Databricks, or Snowflake locally because I do not have credentials for those services.