### PR TITLE
feat(db-snowflake): map TIMESTAMP_LTZ to timestamp, and write LTZ

### DIFF
--- a/packages/malloy-db-snowflake/src/snowflake_connection.spec.ts
+++ b/packages/malloy-db-snowflake/src/snowflake_connection.spec.ts
@@ -111,7 +111,7 @@ describe('db:Snowflake', () => {
     const y = await conn.fetchSelectSchema(x);
     expect(y.fields).toEqual([
       {name: 'TS_NTZ', type: 'timestamp'},
-      {name: 'TS_LTZ', type: 'sql native', rawType: 'timestamp_ltz'},
+      {name: 'TS_LTZ', type: 'timestamp'},
       {name: 'TS_TZ', type: 'timestamptz'},
     ]);
   });
@@ -410,6 +410,18 @@ describe('numeric value reading', () => {
         ).toMatchResult(testModel, {F: 10.5});
       }
     );
+  });
+
+  describe('timestamp types', () => {
+    // TIMESTAMP_LTZ maps to `timestamp`, so its values reach the JS date parser
+    // through the full result pipeline. This exercises the pinned
+    // TIMESTAMP_LTZ_OUTPUT_FORMAT; under the UTC session pin the naive literal
+    // is read as UTC.
+    it('reads TIMESTAMP_LTZ as a timestamp instant', async () => {
+      await expect(
+        'run: snowflake.sql("SELECT TO_TIMESTAMP_LTZ(\'2024-01-01 12:34:56\') as ts")'
+      ).toMatchResult(testModel, {TS: new Date('2024-01-01T12:34:56.000Z')});
+    });
   });
 });
 

--- a/packages/malloy-db-snowflake/src/snowflake_executor.ts
+++ b/packages/malloy-db-snowflake/src/snowflake_executor.ts
@@ -230,9 +230,17 @@ export class SnowflakeExecutor {
       options,
       timeoutMs
     );
-    // so javascript can parse the dates
+    // so javascript can parse the dates. LTZ is pinned to the same ISO format
+    // as NTZ because Malloy maps TIMESTAMP_LTZ to `timestamp` (and writes its
+    // own timestamp columns as LTZ), so LTZ values reach the same JS parse path.
     await this._execute(
       "ALTER SESSION SET TIMESTAMP_NTZ_OUTPUT_FORMAT='YYYY-MM-DDTHH24:MI:SS.FF3TZH:TZM';",
+      conn,
+      options,
+      timeoutMs
+    );
+    await this._execute(
+      "ALTER SESSION SET TIMESTAMP_LTZ_OUTPUT_FORMAT='YYYY-MM-DDTHH24:MI:SS.FF3TZH:TZM';",
       conn,
       options,
       timeoutMs

--- a/packages/malloy/src/dialect/snowflake/snowflake.ts
+++ b/packages/malloy/src/dialect/snowflake/snowflake.ts
@@ -89,7 +89,12 @@ const snowflakeToMalloyTypes: {[key: string]: BasicAtomicTypeDef} = {
   'timestamptz': {type: 'timestamptz'},
   'timestamp_tz': {type: 'timestamptz'},
   'timestamp with time zone': {type: 'timestamptz'},
-  /* timestamp_ltz is not supported in malloy snowflake dialect */
+  // TIMESTAMP_LTZ is a genuine instant (persisted UTC); under Malloy's UTC
+  // session pin it is indistinguishable from NTZ, so it maps to `timestamp`
+  // like NTZ. malloyTypeToSQLType writes instants here too.
+  'timestampltz': {type: 'timestamp'},
+  'timestamp_ltz': {type: 'timestamp'},
+  'timestamp with local time zone': {type: 'timestamp'},
 };
 
 export class SnowflakeDialect extends Dialect {
@@ -594,6 +599,13 @@ ${indent(sql)}
       return `ARRAY(${this.malloyTypeToSQLType(malloyType.elementTypeDef)})`;
     } else if (malloyType.type === 'timestamptz') {
       return 'TIMESTAMP_TZ';
+    } else if (malloyType.type === 'timestamp') {
+      // A Malloy `timestamp` is an instant, and TIMESTAMP_LTZ is Snowflake's
+      // instant type. Emit it explicitly rather than the bare word TIMESTAMP,
+      // whose type is decided per account (TIMESTAMP_TYPE_MAPPING: NTZ or LTZ).
+      // NTZ only reads as an instant under the UTC session pin; LTZ is correct
+      // without it, and leaves NTZ for the future `datetime` type.
+      return 'TIMESTAMP_LTZ';
     }
     return malloyType.type;
   }

--- a/test/snowflake/load_test_data.sh
+++ b/test/snowflake/load_test_data.sh
@@ -2,7 +2,7 @@
 #
 # Load the malloytest tables into Snowflake.
 #
-# Requires the snowsql CLI and a configured Snowflake connection
+# Requires the Snowflake CLI (`snow`) and a configured Snowflake connection
 # (~/.snowflake/connections.toml, or the SNOWFLAKE_* env vars).
 #
 set -e
@@ -12,4 +12,4 @@ SCRIPTDIR=$(cd $(dirname $0); pwd)
 # load_test_data.sql stages files with file://../data/... paths, so it must
 # run with this directory as the working directory.
 cd "$SCRIPTDIR"
-snowsql -f load_test_data.sql
+snow sql -f load_test_data.sql

--- a/test/src/databases/all/expr.spec.ts
+++ b/test/src/databases/all/expr.spec.ts
@@ -338,8 +338,7 @@ describe.each(runtimes.runtimeList)('%s', (databaseName, runtime) => {
   });
 
   // TODO not sure why this test needs to be skipped on postgres, feels like an oversight
-  // NOTE: unless underlying type is stored as a timestamp snowflake does not support extraction
-  test.when(!['postgres', 'snowflake', 'mysql'].includes(databaseName))(
+  test.when(!['postgres', 'mysql'].includes(databaseName))(
     'model: dates named',
     async () => {
       await expect(`


### PR DESCRIPTION
Malloy mapped Snowflake's `TIMESTAMP_LTZ` to `sql native`, so it couldn't read an LTZ column as a timestamp — and on an account where a bare `TIMESTAMP` resolves to LTZ, it couldn't read back its own writes either. `TIMESTAMP_LTZ` is a genuine instant, indistinguishable from `TIMESTAMP_NTZ` under Malloy's UTC session pin, so it should just be a `timestamp`. This maps it (reverting #2578, now with a measured reason) and closes the write side by emitting `TIMESTAMP_LTZ` explicitly instead of a bare `TIMESTAMP` whose type an account setting decides.

Supersedes #2972, which fixed the same report by converting the data in the loader; mapping the type makes that conversion unnecessary and also covers the write-side account bug it didn't touch. The reporter's actual trigger — a deprecated `snowsql` — is fixed by moving the loader to `snow sql`.

## Impact

- Malloy now writes its own timestamp columns as `TIMESTAMP_LTZ`. Under the UTC pin this is value-identical to the `NTZ` they used to become on a default account.
- A consequence worth naming: the `timestamptz -> timestamp` cast with no query timezone now preserves the instant rather than dropping the offset (the old bare-`TIMESTAMP` fallback took the local wall clock). This is more correct — both are instants in Malloy's model — but it is a silent change on the cast path that has no dedicated test today.
