### PR TITLE
Normalize rowLimit across connection backends

### DIFF
--- a/packages/malloy-db-bigquery/src/bigquery_connection.ts
+++ b/packages/malloy-db-bigquery/src/bigquery_connection.ts
@@ -33,8 +33,10 @@ import type {
   SQLSourceRequest,
 } from '@malloydata/malloy';
 import {
+  DEFAULT_ROW_LIMIT,
   mkArrayDef,
   Malloy,
+  resolveRunSQLOptions,
   StandardSQLDialect,
   toAsyncGenerator,
   sqlKey,
@@ -139,7 +141,7 @@ export class BigQueryConnection
   public readonly name: string;
   private readonly dialect = new StandardSQLDialect();
   static DEFAULT_QUERY_OPTIONS: RunSQLOptions = {
-    rowLimit: 10,
+    rowLimit: DEFAULT_ROW_LIMIT,
   };
 
   private bigQuery: BigQuerySDK;
@@ -219,17 +221,17 @@ export class BigQueryConnection
     return setup + '\n' + sql;
   }
 
-  private readQueryOptions(): RunSQLOptions {
-    const options = BigQueryConnection.DEFAULT_QUERY_OPTIONS;
-    if (this.queryOptions) {
-      if (this.queryOptions instanceof Function) {
-        return {...options, ...this.queryOptions()};
-      } else {
-        return {...options, ...this.queryOptions};
-      }
-    } else {
-      return options;
-    }
+  private readQueryOptions(
+    runOptions: RunSQLOptions = {}
+  ): RunSQLOptions & {rowLimit: number} {
+    const connectionOptions =
+      typeof this.queryOptions === 'function'
+        ? this.queryOptions()
+        : this.queryOptions;
+    return resolveRunSQLOptions(
+      {...BigQueryConnection.DEFAULT_QUERY_OPTIONS, ...connectionOptions},
+      runOptions
+    );
   }
 
   public canPersist(): this is PersistSQLResults {
@@ -250,18 +252,19 @@ export class BigQueryConnection
 
   private async _runSQL(
     sqlCommand: string,
-    {rowLimit, abortSignal}: RunSQLOptions = {},
+    options: RunSQLOptions = {},
     rowIndex = 0
   ): Promise<{
     data: MalloyQueryData;
     schema: bigquery.ITableFieldSchema | undefined;
   }> {
-    const defaultOptions = this.readQueryOptions();
-    const pageSize = rowLimit ?? defaultOptions.rowLimit;
+    const {rowLimit: pageSize, abortSignal} = this.readQueryOptions(options);
 
     try {
       const queryResultsOptions: QueryResultsOptions = {
-        maxResults: pageSize,
+        // The paginator treats 0 as "unset", so request one row and enforce
+        // the zero-row contract on the returned array below.
+        maxResults: Math.max(pageSize, 1),
         startIndex: rowIndex.toString(),
       };
 
@@ -279,7 +282,7 @@ export class BigQueryConnection
       // TODO even though we have 10 minute timeout limit, we still should confirm that resulting metadata has "jobComplete: true"
       const queryCostBytes = jobResult[2]?.totalBytesProcessed;
       const data: MalloyQueryData = {
-        rows: jobResult[0],
+        rows: jobResult[0].slice(0, pageSize),
         totalRows,
         runStats: {
           queryCostBytes: queryCostBytes ? +queryCostBytes : undefined,
@@ -764,8 +767,9 @@ export class BigQueryConnection
 
   public runSQLStream(
     sqlCommand: string,
-    {rowLimit, abortSignal}: RunSQLOptions = {}
+    options: RunSQLOptions = {}
   ): AsyncIterableIterator<QueryRecord> {
+    const {rowLimit, abortSignal} = this.readQueryOptions(options);
     const streamBigQuery = (
       onError: (error: Error) => void,
       onData: (data: QueryRecord) => void,
@@ -776,12 +780,13 @@ export class BigQueryConnection
         this: ResourceStream<RowMetadata>,
         rowMetadata: RowMetadata
       ) {
+        if (index >= rowLimit || abortSignal?.aborted) {
+          this.end();
+          return;
+        }
         onData(rowMetadata);
         index += 1;
-        if (
-          (rowLimit !== undefined && index >= rowLimit) ||
-          abortSignal?.aborted
-        ) {
+        if (index >= rowLimit) {
           this.end();
         }
       }

--- a/packages/malloy-db-bigquery/src/index.ts
+++ b/packages/malloy-db-bigquery/src/index.ts
@@ -5,16 +5,24 @@
 
 export {BigQueryConnection} from './bigquery_connection';
 
-import {registerConnectionType} from '@malloydata/malloy';
+import {
+  queryOptionsFromConnectionConfig,
+  registerConnectionType,
+  ROW_LIMIT_CONNECTION_PROPERTY,
+} from '@malloydata/malloy';
 import type {ConnectionConfig} from '@malloydata/malloy';
 import {BigQueryConnection} from './bigquery_connection';
 
 registerConnectionType('bigquery', {
   displayName: 'BigQuery',
   factory: async (config: ConnectionConfig) => {
-    return new BigQueryConnection(config);
+    return new BigQueryConnection(
+      config,
+      queryOptionsFromConnectionConfig(config)
+    );
   },
   properties: [
+    ROW_LIMIT_CONNECTION_PROPERTY,
     {
       name: 'projectId',
       displayName: 'Project ID',

--- a/packages/malloy-db-bigquery/src/row_limit.unit.spec.ts
+++ b/packages/malloy-db-bigquery/src/row_limit.unit.spec.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright Contributors to the Malloy project
+ * SPDX-License-Identifier: MIT
+ */
+
+import type {QueryResultsOptions} from '@google-cloud/bigquery';
+import {BigQueryConnection} from './bigquery_connection';
+
+type BigQueryJobResult = [
+  Array<{value: number}>,
+  undefined,
+  {totalRows: string; schema: {fields: []}},
+];
+
+type TestableBigQueryConnection = {
+  createBigQueryJobAndGetResults(
+    sql: string,
+    jobId?: string,
+    options?: QueryResultsOptions
+  ): Promise<BigQueryJobResult>;
+};
+
+describe('BigQuery rowLimit', () => {
+  it.each([
+    ['configured value', undefined, 2],
+    ['per-run override', 3, 3],
+    ['zero', 0, 0],
+  ])('applies %s', async (_name, perRunRowLimit, expectedRows) => {
+    const connection = new BigQueryConnection('bigquery', {rowLimit: 2});
+    const getResults = jest
+      .spyOn(
+        connection as unknown as TestableBigQueryConnection,
+        'createBigQueryJobAndGetResults'
+      )
+      .mockResolvedValue([
+        Array.from({length: 5}, (_, value) => ({value})),
+        undefined,
+        {totalRows: '5', schema: {fields: []}},
+      ]);
+    const options =
+      perRunRowLimit === undefined ? {} : {rowLimit: perRunRowLimit};
+
+    const result = await connection.runSQL('SELECT value', options);
+
+    expect(result.rows).toHaveLength(expectedRows);
+    expect(getResults.mock.calls[0][2]?.maxResults).toBe(
+      Math.max(expectedRows, 1)
+    );
+  });
+});

--- a/packages/malloy-db-databricks/src/databricks_connection.ts
+++ b/packages/malloy-db-databricks/src/databricks_connection.ts
@@ -21,9 +21,10 @@ import type {
 } from '@malloydata/malloy';
 import {
   DatabricksDialect,
-  sqlKey,
   makeDigest,
   mkFieldDef,
+  resolveRunSQLOptions,
+  sqlKey,
 } from '@malloydata/malloy';
 import {TinyParser} from '@malloydata/malloy/internal';
 import {BaseConnection} from '@malloydata/malloy/connection';
@@ -214,6 +215,28 @@ export class DatabricksConnection
     return result;
   }
 
+  // Fetch exactly one chunk for user query results. `fetchAll({maxRows})`
+  // treats maxRows as a chunk size and continues until the result is exhausted.
+  // A single fetchChunk therefore avoids downloading rows beyond rowLimit.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private async executeLimited(sql: string, rowLimit: number): Promise<any[]> {
+    await this.ensureConnected();
+    const operation = await this.session.executeStatement(sql, {
+      runAsync: true,
+    });
+    try {
+      if (rowLimit === 0) {
+        // Preserve statement execution semantics without fetching a result
+        // chunk. Closing a still-running async operation may cancel it.
+        await operation.finished();
+        return [];
+      }
+      return await operation.fetchChunk({maxRows: rowLimit});
+    } finally {
+      await operation.close();
+    }
+  }
+
   async manifestTemporaryTable(sqlCommand: string): Promise<string> {
     const hash = makeDigest(sqlCommand);
     const tableName = `tt${hash.slice(0, this.dialect.maxIdentifierLength - 2)}`;
@@ -226,15 +249,20 @@ export class DatabricksConnection
     await this.runRawSQL('SELECT 1');
   }
 
-  async runSQL(sql: string, options?: RunSQLOptions): Promise<MalloyQueryData> {
-    const result = await this.runRawSQL(sql);
-    if (options?.rowLimit && result.rows.length > options.rowLimit) {
-      return {
-        rows: result.rows.slice(0, options.rowLimit),
-        totalRows: result.totalRows,
-      };
+  async runSQL(
+    sql: string,
+    options: RunSQLOptions = {}
+  ): Promise<MalloyQueryData> {
+    const {rowLimit} = resolveRunSQLOptions(this.queryOptions, options);
+    try {
+      const rows = (await this.executeLimited(sql, rowLimit)) as QueryData;
+      // The SDK exposes no exact total without draining every chunk, which
+      // would defeat rowLimit's fetch cap. Report the rows actually fetched,
+      // matching other backends that cannot obtain total-result metadata.
+      return {rows: rows.slice(0, rowLimit), totalRows: rows.length};
+    } catch (e) {
+      throw new Error(`Databricks SQL error: ${e.message}`);
     }
-    return result;
   }
 
   public getDigest(): string {

--- a/packages/malloy-db-databricks/src/index.ts
+++ b/packages/malloy-db-databricks/src/index.ts
@@ -5,7 +5,11 @@
 
 export {DatabricksConnection} from './databricks_connection';
 
-import {registerConnectionType} from '@malloydata/malloy';
+import {
+  queryOptionsFromConnectionConfig,
+  registerConnectionType,
+  ROW_LIMIT_CONNECTION_PROPERTY,
+} from '@malloydata/malloy';
 import type {ConnectionConfig} from '@malloydata/malloy';
 import {DatabricksConnection} from './databricks_connection';
 
@@ -15,31 +19,39 @@ registerConnectionType('databricks', {
     const host = typeof config['host'] === 'string' ? config['host'] : '';
     const path = typeof config['path'] === 'string' ? config['path'] : '';
 
-    return new DatabricksConnection(config.name, {
-      host,
-      path,
-      token: typeof config['token'] === 'string' ? config['token'] : undefined,
-      oauthClientId:
-        typeof config['oauthClientId'] === 'string'
-          ? config['oauthClientId']
-          : undefined,
-      oauthClientSecret:
-        typeof config['oauthClientSecret'] === 'string'
-          ? config['oauthClientSecret']
-          : undefined,
-      defaultCatalog:
-        typeof config['defaultCatalog'] === 'string'
-          ? config['defaultCatalog']
-          : undefined,
-      defaultSchema:
-        typeof config['defaultSchema'] === 'string'
-          ? config['defaultSchema']
-          : undefined,
-      setupSQL:
-        typeof config['setupSQL'] === 'string' ? config['setupSQL'] : undefined,
-    });
+    return new DatabricksConnection(
+      config.name,
+      {
+        host,
+        path,
+        token:
+          typeof config['token'] === 'string' ? config['token'] : undefined,
+        oauthClientId:
+          typeof config['oauthClientId'] === 'string'
+            ? config['oauthClientId']
+            : undefined,
+        oauthClientSecret:
+          typeof config['oauthClientSecret'] === 'string'
+            ? config['oauthClientSecret']
+            : undefined,
+        defaultCatalog:
+          typeof config['defaultCatalog'] === 'string'
+            ? config['defaultCatalog']
+            : undefined,
+        defaultSchema:
+          typeof config['defaultSchema'] === 'string'
+            ? config['defaultSchema']
+            : undefined,
+        setupSQL:
+          typeof config['setupSQL'] === 'string'
+            ? config['setupSQL']
+            : undefined,
+      },
+      queryOptionsFromConnectionConfig(config)
+    );
   },
   properties: [
+    ROW_LIMIT_CONNECTION_PROPERTY,
     {name: 'host', displayName: 'Host', type: 'string'},
     {
       name: 'path',

--- a/packages/malloy-db-databricks/src/row_limit.unit.spec.ts
+++ b/packages/malloy-db-databricks/src/row_limit.unit.spec.ts
@@ -1,0 +1,108 @@
+/*
+ * Copyright Contributors to the Malloy project
+ * SPDX-License-Identifier: MIT
+ */
+
+import {DatabricksConnection} from './databricks_connection';
+
+type TestableDatabricksConnection = {
+  executeLimited(sql: string, rowLimit: number): Promise<object[]>;
+};
+
+type DatabricksOperation = {
+  fetchAll: jest.Mock;
+  fetchChunk: jest.Mock;
+  finished: jest.Mock;
+  close: jest.Mock;
+};
+
+describe('Databricks rowLimit', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it.each([
+    ['configured value', undefined, 2],
+    ['per-run override', 3, 3],
+    ['zero', 0, 0],
+  ])('applies %s', async (_name, perRunRowLimit, expectedRows) => {
+    const connection = new DatabricksConnection(
+      'databricks',
+      {host: '', path: ''},
+      {rowLimit: 2}
+    );
+    const executeLimited = jest
+      .spyOn(
+        connection as unknown as TestableDatabricksConnection,
+        'executeLimited'
+      )
+      .mockResolvedValue(
+        Array.from({length: expectedRows}, (_, value) => ({value}))
+      );
+    const options =
+      perRunRowLimit === undefined ? {} : {rowLimit: perRunRowLimit};
+
+    const result = await connection.runSQL('SELECT value', options);
+
+    expect(result.rows).toHaveLength(expectedRows);
+    expect(result.totalRows).toBe(expectedRows);
+    expect(executeLimited).toHaveBeenCalledWith('SELECT value', expectedRows);
+  });
+
+  it('fetches one bounded chunk and closes the operation', async () => {
+    const connection = new DatabricksConnection('databricks', {
+      host: '',
+      path: '',
+    });
+    const operation: DatabricksOperation = {
+      fetchAll: jest.fn(),
+      fetchChunk: jest.fn(async () => [{value: 1}, {value: 2}]),
+      finished: jest.fn(),
+      close: jest.fn(),
+    };
+    const executeStatement = jest.fn(async () => operation);
+    (
+      connection as unknown as {
+        session: {executeStatement: typeof executeStatement};
+      }
+    ).session = {executeStatement};
+
+    const rows = await (
+      connection as unknown as TestableDatabricksConnection
+    ).executeLimited('SELECT value', 2);
+
+    expect(rows).toHaveLength(2);
+    expect(operation.fetchChunk).toHaveBeenCalledWith({maxRows: 2});
+    expect(operation.fetchAll).not.toHaveBeenCalled();
+    expect(operation.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('waits for a zero-row statement without fetching and then closes', async () => {
+    const connection = new DatabricksConnection('databricks', {
+      host: '',
+      path: '',
+    });
+    const operation: DatabricksOperation = {
+      fetchAll: jest.fn(),
+      fetchChunk: jest.fn(),
+      finished: jest.fn(),
+      close: jest.fn(),
+    };
+    const executeStatement = jest.fn(async () => operation);
+    (
+      connection as unknown as {
+        session: {executeStatement: typeof executeStatement};
+      }
+    ).session = {executeStatement};
+
+    const rows = await (
+      connection as unknown as TestableDatabricksConnection
+    ).executeLimited('SELECT value', 0);
+
+    expect(rows).toEqual([]);
+    expect(operation.finished).toHaveBeenCalledTimes(1);
+    expect(operation.fetchChunk).not.toHaveBeenCalled();
+    expect(operation.fetchAll).not.toHaveBeenCalled();
+    expect(operation.close).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/malloy-db-duckdb/src/browser.ts
+++ b/packages/malloy-db-duckdb/src/browser.ts
@@ -3,14 +3,20 @@
  * SPDX-License-Identifier: MIT
  */
 
-import {registerConnectionType} from '@malloydata/malloy';
+import {
+  queryOptionsFromConnectionConfig,
+  registerConnectionType,
+  ROW_LIMIT_CONNECTION_PROPERTY,
+} from '@malloydata/malloy';
 import type {ConnectionConfig} from '@malloydata/malloy';
 import {DuckDBWASMConnection} from './duckdb_wasm_connection_browser';
 
 registerConnectionType('duckdb_wasm', {
   displayName: 'DuckDB',
-  factory: async (config: ConnectionConfig) => new DuckDBWASMConnection(config),
+  factory: async (config: ConnectionConfig) =>
+    new DuckDBWASMConnection(config, queryOptionsFromConnectionConfig(config)),
   properties: [
+    ROW_LIMIT_CONNECTION_PROPERTY,
     {
       name: 'databasePath',
       displayName: 'Database Path',

--- a/packages/malloy-db-duckdb/src/duckdb.spec.ts
+++ b/packages/malloy-db-duckdb/src/duckdb.spec.ts
@@ -10,9 +10,10 @@ import path from 'path';
 import {DuckDBCommon} from './duckdb_common';
 import {DuckDBConnection} from './duckdb_connection';
 import type {SQLSourceRequest, StructDef} from '@malloydata/malloy';
-import {mkArrayDef} from '@malloydata/malloy';
+import {MalloyConfig, mkArrayDef} from '@malloydata/malloy';
 import {createTestRuntime, mkTestModel} from '@malloydata/malloy/test';
 import '@malloydata/malloy/test/matchers';
+import './native';
 
 /*
  * !IMPORTANT
@@ -727,6 +728,75 @@ describe('DuckDBConnection', () => {
         }
       );
     });
+  });
+});
+
+describe('DuckDB rowLimit config', () => {
+  it('applies config, per-run overrides, and zero', async () => {
+    const config = new MalloyConfig({
+      connections: {
+        limited: {
+          is: 'duckdb',
+          databasePath: ':memory:',
+          rowLimit: 3,
+        },
+      },
+    });
+    const connection = await config.connections.lookupConnection('limited');
+    try {
+      expect(
+        (await connection.runSQL('SELECT * FROM range(10)')).rows
+      ).toHaveLength(3);
+      expect(
+        (await connection.runSQL('SELECT * FROM range(10)', {rowLimit: 5})).rows
+      ).toHaveLength(5);
+      expect(
+        (await connection.runSQL('SELECT * FROM range(10)', {rowLimit: 0})).rows
+      ).toHaveLength(0);
+    } finally {
+      await connection.close();
+    }
+  });
+
+  it('applies the shared default when config omits rowLimit', async () => {
+    const config = new MalloyConfig({
+      connections: {
+        defaulted: {is: 'duckdb', databasePath: ':memory:'},
+      },
+    });
+    const connection = await config.connections.lookupConnection('defaulted');
+    try {
+      expect(
+        (await connection.runSQL('SELECT * FROM range(1005)')).rows
+      ).toHaveLength(1000);
+    } finally {
+      await connection.close();
+    }
+  });
+
+  it('does not truncate a Malloy limit above the former ten-row cap', async () => {
+    const config = new MalloyConfig({
+      connections: {
+        duckdb: {is: 'duckdb', databasePath: ':memory:'},
+      },
+    });
+    const connection = await config.connections.lookupConnection('duckdb');
+    const runtime = createTestRuntime(connection);
+    try {
+      const result = await runtime
+        .loadQuery(
+          `
+          run: duckdb.sql("SELECT range AS value FROM range(100)") -> {
+            select: *
+            limit: 25
+          }
+        `
+        )
+        .run();
+      expect(result.data.rowCount).toBe(25);
+    } finally {
+      await connection.close();
+    }
   });
 });
 

--- a/packages/malloy-db-duckdb/src/duckdb_common.ts
+++ b/packages/malloy-db-duckdb/src/duckdb_common.ts
@@ -19,14 +19,16 @@ import type {
   SQLSourceRequest,
 } from '@malloydata/malloy';
 import {
+  DEFAULT_ROW_LIMIT,
   DuckDBDialect,
   makeDigest,
   mkFieldDef,
+  resolveRunSQLOptions,
   sqlKey,
 } from '@malloydata/malloy';
 import {BaseConnection} from '@malloydata/malloy/connection';
 
-export interface DuckDBQueryOptions {
+export interface DuckDBQueryOptions extends RunSQLOptions {
   rowLimit: number;
 }
 
@@ -48,7 +50,7 @@ export abstract class DuckDBCommon
 
   private readonly dialect = new DuckDBDialect();
   static DEFAULT_QUERY_OPTIONS: DuckDBQueryOptions = {
-    rowLimit: 10,
+    rowLimit: DEFAULT_ROW_LIMIT,
   };
 
   public readonly name: string = 'duckdb_common';
@@ -57,17 +59,17 @@ export abstract class DuckDBCommon
     return this.dialect.name;
   }
 
-  protected readQueryOptions(): DuckDBQueryOptions {
-    const options = DuckDBCommon.DEFAULT_QUERY_OPTIONS;
-    if (this.queryOptions) {
-      if (this.queryOptions instanceof Function) {
-        return {...options, ...this.queryOptions()};
-      } else {
-        return {...options, ...this.queryOptions};
-      }
-    } else {
-      return options;
-    }
+  protected readQueryOptions(
+    runOptions: RunSQLOptions = {}
+  ): DuckDBQueryOptions {
+    const connectionOptions =
+      typeof this.queryOptions === 'function'
+        ? this.queryOptions()
+        : this.queryOptions;
+    return resolveRunSQLOptions(
+      {...DuckDBCommon.DEFAULT_QUERY_OPTIONS, ...connectionOptions},
+      runOptions
+    );
   }
 
   constructor(protected queryOptions?: QueryOptionsReader) {
@@ -101,8 +103,7 @@ export abstract class DuckDBCommon
     sql: string,
     options: RunSQLOptions = {}
   ): Promise<MalloyQueryData> {
-    const defaultOptions = this.readQueryOptions();
-    const rowLimit = options.rowLimit ?? defaultOptions.rowLimit;
+    const {rowLimit} = this.readQueryOptions(options);
 
     const statements = sql.split('-- hack: split on this');
 

--- a/packages/malloy-db-duckdb/src/duckdb_connection.ts
+++ b/packages/malloy-db-duckdb/src/duckdb_connection.ts
@@ -464,10 +464,9 @@ export class DuckDBConnection extends DuckDBCommon {
 
   public async *runSQLStream(
     sql: string,
-    {rowLimit, abortSignal}: RunSQLOptions = {}
+    options: RunSQLOptions = {}
   ): AsyncIterableIterator<QueryRecord> {
-    const defaultOptions = this.readQueryOptions();
-    rowLimit ??= defaultOptions.rowLimit;
+    const {rowLimit, abortSignal} = this.readQueryOptions(options);
     await this.setup();
     if (!this.connection) {
       throw new Error('Connection not open');

--- a/packages/malloy-db-duckdb/src/duckdb_wasm_connection.ts
+++ b/packages/malloy-db-duckdb/src/duckdb_wasm_connection.ts
@@ -439,13 +439,12 @@ export abstract class DuckDBWASMConnection extends DuckDBCommon {
 
   public async *runSQLStream(
     sql: string,
-    {rowLimit, abortSignal}: RunSQLOptions = {}
+    options: RunSQLOptions = {}
   ): AsyncIterableIterator<QueryRecord> {
     if (!this.connection) {
       throw new Error('duckdb-wasm not connected');
     }
-    const defaultOptions = this.readQueryOptions();
-    rowLimit ??= defaultOptions.rowLimit;
+    const {rowLimit, abortSignal} = this.readQueryOptions(options);
     await this.setup();
     const statements = sql.split('-- hack: split on this');
 
@@ -462,7 +461,9 @@ export abstract class DuckDBWASMConnection extends DuckDBCommon {
     }
 
     let index = 0;
-    for await (const chunk of await this.connection.send(statements[0])) {
+    rowChunks: for await (const chunk of await this.connection.send(
+      statements[0]
+    )) {
       if (done) {
         break;
       }
@@ -471,7 +472,7 @@ export abstract class DuckDBWASMConnection extends DuckDBCommon {
           (rowLimit !== undefined && index >= rowLimit) ||
           abortSignal?.aborted
         ) {
-          break;
+          break rowChunks;
         }
         yield unwrapRow(row, chunk.schema);
         index++;

--- a/packages/malloy-db-duckdb/src/native.ts
+++ b/packages/malloy-db-duckdb/src/native.ts
@@ -3,7 +3,11 @@
  * SPDX-License-Identifier: MIT
  */
 
-import {registerConnectionType} from '@malloydata/malloy';
+import {
+  queryOptionsFromConnectionConfig,
+  registerConnectionType,
+  ROW_LIMIT_CONNECTION_PROPERTY,
+} from '@malloydata/malloy';
 import type {ConnectionConfig} from '@malloydata/malloy';
 import {DuckDBConnection} from './duckdb_connection';
 
@@ -16,9 +20,13 @@ registerConnectionType('duckdb', {
       options['databasePath'] = options['path'];
       delete options['path'];
     }
-    return new DuckDBConnection(options);
+    return new DuckDBConnection(
+      options,
+      queryOptionsFromConnectionConfig(config)
+    );
   },
   properties: [
+    ROW_LIMIT_CONNECTION_PROPERTY,
     {
       name: 'databasePath',
       displayName: 'Database Path',

--- a/packages/malloy-db-mysql/src/index.ts
+++ b/packages/malloy-db-mysql/src/index.ts
@@ -5,26 +5,41 @@
 
 export {MySQLConnection, MySQLExecutor} from './mysql_connection';
 
-import {registerConnectionType} from '@malloydata/malloy';
+import {
+  queryOptionsFromConnectionConfig,
+  registerConnectionType,
+  ROW_LIMIT_CONNECTION_PROPERTY,
+} from '@malloydata/malloy';
 import type {ConnectionConfig} from '@malloydata/malloy';
 import {MySQLConnection} from './mysql_connection';
 
 registerConnectionType('mysql', {
   displayName: 'MySQL',
   factory: async (config: ConnectionConfig) => {
-    return new MySQLConnection(config.name, {
-      host: typeof config['host'] === 'string' ? config['host'] : undefined,
-      port: typeof config['port'] === 'number' ? config['port'] : undefined,
-      database:
-        typeof config['database'] === 'string' ? config['database'] : undefined,
-      user: typeof config['user'] === 'string' ? config['user'] : undefined,
-      password:
-        typeof config['password'] === 'string' ? config['password'] : undefined,
-      setupSQL:
-        typeof config['setupSQL'] === 'string' ? config['setupSQL'] : undefined,
-    });
+    return new MySQLConnection(
+      config.name,
+      {
+        host: typeof config['host'] === 'string' ? config['host'] : undefined,
+        port: typeof config['port'] === 'number' ? config['port'] : undefined,
+        database:
+          typeof config['database'] === 'string'
+            ? config['database']
+            : undefined,
+        user: typeof config['user'] === 'string' ? config['user'] : undefined,
+        password:
+          typeof config['password'] === 'string'
+            ? config['password']
+            : undefined,
+        setupSQL:
+          typeof config['setupSQL'] === 'string'
+            ? config['setupSQL']
+            : undefined,
+      },
+      queryOptionsFromConnectionConfig(config)
+    );
   },
   properties: [
+    ROW_LIMIT_CONNECTION_PROPERTY,
     {name: 'host', displayName: 'Host', type: 'string', optional: true},
     {
       name: 'port',

--- a/packages/malloy-db-mysql/src/mysql_connection.spec.ts
+++ b/packages/malloy-db-mysql/src/mysql_connection.spec.ts
@@ -12,6 +12,31 @@ const hasCredentials = !!config.user;
 
 const describeMySQL = hasCredentials ? describe : describe.skip;
 
+describe('MySQL rowLimit', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it.each([
+    ['configured value', undefined, 2],
+    ['per-run override', 3, 3],
+    ['zero', 0, 0],
+  ])('applies %s', async (_name, perRunRowLimit, expectedRows) => {
+    const connection = new MySQLConnection('mysql', {}, {rowLimit: 2});
+    jest.spyOn(connection, 'runRawSQL').mockResolvedValue({
+      rows: Array.from({length: 5}, (_, value) => ({value})),
+      totalRows: 5,
+    });
+
+    const options =
+      perRunRowLimit === undefined ? {} : {rowLimit: perRunRowLimit};
+    const result = await connection.runSQL('SELECT value', options);
+
+    expect(result.rows).toHaveLength(expectedRows);
+    expect(result.totalRows).toBe(5);
+  });
+});
+
 describeMySQL('db:MySQL', () => {
   const connection = new MySQLConnection('mysql', config, {});
 

--- a/packages/malloy-db-mysql/src/mysql_connection.ts
+++ b/packages/malloy-db-mysql/src/mysql_connection.ts
@@ -18,7 +18,12 @@ import type {
   TableSourceDef,
   SQLSourceRequest,
 } from '@malloydata/malloy';
-import {MySQLDialect, sqlKey, makeDigest} from '@malloydata/malloy';
+import {
+  makeDigest,
+  MySQLDialect,
+  resolveRunSQLOptions,
+  sqlKey,
+} from '@malloydata/malloy';
 import {BaseConnection} from '@malloydata/malloy/connection';
 import {randomUUID} from 'crypto';
 import * as MYSQL from 'mysql2/promise';
@@ -126,9 +131,16 @@ export class MySQLConnection
     await this.runRawSQL('SELECT 1');
   }
 
-  runSQL(sql: string, _options?: RunSQLOptions): Promise<MalloyQueryData> {
-    // TODO: what are options here?
-    return this.runRawSQL(sql);
+  async runSQL(
+    sql: string,
+    options: RunSQLOptions = {}
+  ): Promise<MalloyQueryData> {
+    const {rowLimit} = resolveRunSQLOptions(this.queryOptions, options);
+    const result = await this.runRawSQL(sql);
+    if (result.rows.length > rowLimit) {
+      result.rows = result.rows.slice(0, rowLimit);
+    }
+    return result;
   }
 
   isPool(): this is PooledConnection {

--- a/packages/malloy-db-postgres/src/index.ts
+++ b/packages/malloy-db-postgres/src/index.ts
@@ -9,16 +9,24 @@ export {
 } from './postgres_connection';
 export type {PostgresSSLConfig} from './postgres_connection';
 
-import {registerConnectionType} from '@malloydata/malloy';
+import {
+  queryOptionsFromConnectionConfig,
+  registerConnectionType,
+  ROW_LIMIT_CONNECTION_PROPERTY,
+} from '@malloydata/malloy';
 import type {ConnectionConfig} from '@malloydata/malloy';
 import {PostgresConnection} from './postgres_connection';
 
 registerConnectionType('postgres', {
   displayName: 'PostgreSQL',
   factory: async (config: ConnectionConfig) => {
-    return new PostgresConnection(config);
+    return new PostgresConnection(
+      config,
+      queryOptionsFromConnectionConfig(config)
+    );
   },
   properties: [
+    ROW_LIMIT_CONNECTION_PROPERTY,
     {name: 'host', displayName: 'Host', type: 'string', optional: true},
     {name: 'port', displayName: 'Port', type: 'number', optional: true},
     {name: 'username', displayName: 'Username', type: 'string', optional: true},

--- a/packages/malloy-db-postgres/src/postgres_connection.ts
+++ b/packages/malloy-db-postgres/src/postgres_connection.ts
@@ -29,6 +29,7 @@ import type {
 import {
   PostgresDialect,
   mkArrayDef,
+  resolveRunSQLOptions,
   sqlKey,
   makeDigest,
   decodeDottedTablePath,
@@ -116,7 +117,6 @@ type PostgresConnectionConfigurationReader =
   | PostgresConnectionConfiguration
   | (() => Promise<PostgresConnectionConfiguration>);
 
-const DEFAULT_PAGE_SIZE = 1000;
 const SCHEMA_PAGE_SIZE = 1000;
 
 // pg verifies the server certificate against the host it actually connects to,
@@ -206,7 +206,7 @@ export class PostgresConnection
     }
   }
 
-  private async readQueryConfig(): Promise<RunSQLOptions> {
+  protected async readQueryConfig(): Promise<RunSQLOptions> {
     if (this.queryOptionsReader instanceof Function) {
       return this.queryOptionsReader();
     } else {
@@ -291,7 +291,7 @@ export class PostgresConnection
 
   protected async runPostgresQuery(
     sqlCommand: string,
-    _pageSize: number,
+    rowLimit: number,
     _rowIndex: number,
     deJSON: boolean,
     values?: unknown[]
@@ -304,16 +304,15 @@ export class PostgresConnection
     if (Array.isArray(result)) {
       result = result.pop();
     }
+    const totalRows = result.rows.length;
+    const rows = result.rows.slice(0, rowLimit);
     if (deJSON) {
-      for (let i = 0; i < result.rows.length; i++) {
-        result.rows[i] = result.rows[i].row;
+      for (let i = 0; i < rows.length; i++) {
+        rows[i] = rows[i].row;
       }
     }
     await client.end();
-    return {
-      rows: result.rows as QueryData,
-      totalRows: result.rows.length,
-    };
+    return {rows: rows as QueryData, totalRows};
   }
 
   async fetchSelectSchema(
@@ -514,23 +513,21 @@ export class PostgresConnection
 
   public async runSQL(
     sql: string,
-    {rowLimit}: RunSQLOptions = {},
+    options: RunSQLOptions = {},
     rowIndex = 0
   ): Promise<MalloyQueryData> {
     const config = await this.readQueryConfig();
+    const {rowLimit} = resolveRunSQLOptions(config, options);
 
-    return this.runPostgresQuery(
-      sql,
-      rowLimit ?? config.rowLimit ?? DEFAULT_PAGE_SIZE,
-      rowIndex,
-      true
-    );
+    return this.runPostgresQuery(sql, rowLimit, rowIndex, true);
   }
 
   public async *runSQLStream(
     sqlCommand: string,
-    {rowLimit, abortSignal}: RunSQLOptions = {}
+    options: RunSQLOptions = {}
   ): AsyncIterableIterator<QueryRecord> {
+    const config = await this.readQueryConfig();
+    const {rowLimit, abortSignal} = resolveRunSQLOptions(config, options);
     const query = new QueryStream(sqlCommand);
     const client = await this.getClient();
     await this.withTlsHint(() => client.connect());
@@ -538,12 +535,13 @@ export class PostgresConnection
     const rowStream = client.query(query);
     let index = 0;
     for await (const row of rowStream) {
+      if (index >= rowLimit || abortSignal?.aborted) {
+        query.destroy();
+        break;
+      }
       yield row.row as QueryRecord;
       index += 1;
-      if (
-        (rowLimit !== undefined && index >= rowLimit) ||
-        abortSignal?.aborted
-      ) {
+      if (index >= rowLimit) {
         query.destroy();
         break;
       }
@@ -625,7 +623,7 @@ export class PooledPostgresConnection
 
   protected async runPostgresQuery(
     sqlCommand: string,
-    _pageSize: number,
+    rowLimit: number,
     _rowIndex: number,
     deJSON: boolean,
     values?: unknown[]
@@ -636,21 +634,22 @@ export class PooledPostgresConnection
     if (Array.isArray(result)) {
       result = result.pop();
     }
+    const totalRows = result.rows.length;
+    const rows = result.rows.slice(0, rowLimit);
     if (deJSON) {
-      for (let i = 0; i < result.rows.length; i++) {
-        result.rows[i] = result.rows[i].row;
+      for (let i = 0; i < rows.length; i++) {
+        rows[i] = rows[i].row;
       }
     }
-    return {
-      rows: result.rows as QueryData,
-      totalRows: result.rows.length,
-    };
+    return {rows: rows as QueryData, totalRows};
   }
 
   public async *runSQLStream(
     sqlCommand: string,
-    {rowLimit, abortSignal}: RunSQLOptions = {}
+    options: RunSQLOptions = {}
   ): AsyncIterableIterator<QueryRecord> {
+    const config = await this.readQueryConfig();
+    const {rowLimit, abortSignal} = resolveRunSQLOptions(config, options);
     const query = new QueryStream(sqlCommand);
     let index = 0;
     // This is a strange hack... `this.pool.query(query)` seems to return the wrong
@@ -661,12 +660,13 @@ export class PooledPostgresConnection
     const client = await this.withTlsHint(() => pool.connect());
     const resultStream: QueryStream = client.query(query);
     for await (const row of resultStream) {
+      if (index >= rowLimit || abortSignal?.aborted) {
+        query.destroy();
+        break;
+      }
       yield row.row as QueryRecord;
       index += 1;
-      if (
-        (rowLimit !== undefined && index >= rowLimit) ||
-        abortSignal?.aborted
-      ) {
+      if (index >= rowLimit) {
         query.destroy();
         break;
       }

--- a/packages/malloy-db-postgres/src/row_limit.unit.spec.ts
+++ b/packages/malloy-db-postgres/src/row_limit.unit.spec.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright Contributors to the Malloy project
+ * SPDX-License-Identifier: MIT
+ */
+
+import type {MalloyQueryData} from '@malloydata/malloy';
+import {DEFAULT_ROW_LIMIT} from '@malloydata/malloy';
+import {PostgresConnection} from './postgres_connection';
+
+class CapturingPostgresConnection extends PostgresConnection {
+  rowLimits: number[] = [];
+
+  protected async runPostgresQuery(
+    _sqlCommand: string,
+    rowLimit: number
+  ): Promise<MalloyQueryData> {
+    this.rowLimits.push(rowLimit);
+    return {rows: [], totalRows: 0};
+  }
+}
+
+describe('Postgres rowLimit', () => {
+  it.each([
+    ['shared default', undefined, undefined, DEFAULT_ROW_LIMIT],
+    ['configured value', 25, undefined, 25],
+    ['per-run override', 25, 5, 5],
+    ['zero', 25, 0, 0],
+  ])(
+    'applies %s',
+    async (_name, configuredRowLimit, perRunRowLimit, expected) => {
+      const queryOptions =
+        configuredRowLimit === undefined
+          ? undefined
+          : {rowLimit: configuredRowLimit};
+      const connection = new CapturingPostgresConnection(
+        'postgres',
+        queryOptions
+      );
+      const runOptions =
+        perRunRowLimit === undefined ? {} : {rowLimit: perRunRowLimit};
+
+      await connection.runSQL('SELECT 1', runOptions);
+
+      expect(connection.rowLimits).toEqual([expected]);
+    }
+  );
+
+  it('slices rows in the real query path while preserving totalRows', async () => {
+    const connection = new PostgresConnection('postgres');
+    const client = {
+      connect: jest.fn(),
+      query: jest
+        .fn()
+        .mockResolvedValueOnce({rows: []})
+        .mockResolvedValueOnce({
+          rows: [{row: {value: 1}}, {row: {value: 2}}, {row: {value: 3}}],
+        }),
+      end: jest.fn(),
+    };
+    const testable = connection as unknown as {
+      getClient(): Promise<typeof client>;
+      runPostgresQuery(
+        sql: string,
+        rowLimit: number,
+        rowIndex: number,
+        deJSON: boolean
+      ): Promise<MalloyQueryData>;
+    };
+    jest.spyOn(testable, 'getClient').mockResolvedValue(client);
+
+    const result = await testable.runPostgresQuery('SELECT value', 2, 0, true);
+
+    expect(result).toEqual({
+      rows: [{value: 1}, {value: 2}],
+      totalRows: 3,
+    });
+    expect(client.end).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/malloy-db-publisher/src/index.ts
+++ b/packages/malloy-db-publisher/src/index.ts
@@ -5,9 +5,19 @@
 
 export {PublisherConnection} from './publisher_connection';
 
-import {registerConnectionType} from '@malloydata/malloy';
+import {
+  queryOptionsFromConnectionConfig,
+  registerConnectionType,
+  ROW_LIMIT_CONNECTION_PROPERTY,
+} from '@malloydata/malloy';
 import type {ConnectionConfig} from '@malloydata/malloy';
 import {PublisherConnection} from './publisher_connection';
+
+// Publisher forwards to a remotely configured connection. Accept a local
+// override, but do not inject the local default over the remote connection's
+// own configured rowLimit.
+const {default: _defaultRowLimit, ...publisherRowLimitProperty} =
+  ROW_LIMIT_CONNECTION_PROPERTY;
 
 registerConnectionType('publisher', {
   displayName: 'Malloy Publisher',
@@ -24,9 +34,14 @@ registerConnectionType('publisher', {
         typeof config['accessToken'] === 'string'
           ? config['accessToken']
           : undefined,
+      queryOptions:
+        config['rowLimit'] === undefined
+          ? undefined
+          : queryOptionsFromConnectionConfig(config),
     });
   },
   properties: [
+    publisherRowLimitProperty,
     {
       name: 'connectionUri',
       displayName: 'Connection URI',

--- a/packages/malloy-db-publisher/src/publisher_connection.ts
+++ b/packages/malloy-db-publisher/src/publisher_connection.ts
@@ -14,9 +14,10 @@ import type {
   SQLSourceRequest,
   TableSourceDef,
   RunSQLOptions,
+  QueryOptionsReader,
   TestableConnection,
 } from '@malloydata/malloy';
-import {makeDigest} from '@malloydata/malloy';
+import {makeDigest, resolveRunSQLOptions} from '@malloydata/malloy';
 import {BaseConnection} from '@malloydata/malloy/connection';
 import type {
   Connection,
@@ -31,6 +32,7 @@ import {AxiosError} from 'axios';
 interface PublisherConnectionOptions {
   connectionUri: string;
   accessToken?: string;
+  queryOptions?: QueryOptionsReader;
 }
 
 export class PublisherConnection
@@ -95,7 +97,8 @@ export class PublisherConnection
       connectionsTestApi,
       connectionAttributes,
       connectionData,
-      options.accessToken
+      options.accessToken,
+      options.queryOptions
     );
     await connection.test();
     return connection;
@@ -116,7 +119,8 @@ export class PublisherConnection
     connectionsTestApi: ConnectionsTestApi,
     connectionAttributes: ConnectionAttributes,
     connectionData: Connection,
-    accessToken: string | undefined
+    accessToken: string | undefined,
+    private readonly queryOptions?: QueryOptionsReader
   ) {
     super();
     this.name = name;
@@ -212,10 +216,11 @@ export class PublisherConnection
     let result = {} as MalloyQueryData;
     try {
       // TODO: Add support for abortSignal.
-      options.abortSignal = undefined;
+      const effectiveOptions = this.resolveRemoteOptions(options);
+      const {abortSignal: _abortSignal, ...remoteOptions} = effectiveOptions;
       const request: PostQuerydataRequest = {
         sqlStatement: sql,
-        options: JSON.stringify(options),
+        options: JSON.stringify(remoteOptions),
       };
       const response = await this.connectionsApi.postQuerydata(
         this.projectName,
@@ -226,6 +231,13 @@ export class PublisherConnection
         }
       );
       result = JSON.parse(response.data.data as string) as MalloyQueryData;
+      result = {
+        ...result,
+        rows:
+          effectiveOptions.rowLimit === undefined
+            ? result.rows
+            : result.rows.slice(0, effectiveOptions.rowLimit),
+      };
     } catch (error: AxiosError | unknown) {
       this.extractAndThrowError(error, 'Failed to execute SQL query');
     }
@@ -238,11 +250,12 @@ export class PublisherConnection
   ): AsyncIterableIterator<QueryRecord> {
     try {
       // TODO: Add support for abortSignal.
-      options.abortSignal = undefined;
+      const effectiveOptions = this.resolveRemoteOptions(options);
+      const {abortSignal: _abortSignal, ...remoteOptions} = effectiveOptions;
       // TODO: Add real streaming support to publisher API.
       const request: PostQuerydataRequest = {
         sqlStatement: sqlCommand,
-        options: JSON.stringify(options),
+        options: JSON.stringify(remoteOptions),
       };
       const response = await this.connectionsApi.postQuerydata(
         this.projectName,
@@ -255,7 +268,11 @@ export class PublisherConnection
       const queryData = JSON.parse(
         response.data.data as string
       ) as MalloyQueryData;
-      for (const row of queryData.rows) {
+      const rows =
+        effectiveOptions.rowLimit === undefined
+          ? queryData.rows
+          : queryData.rows.slice(0, effectiveOptions.rowLimit);
+      for (const row of rows) {
         yield row;
       }
     } catch (error: AxiosError | unknown) {
@@ -278,6 +295,25 @@ export class PublisherConnection
         'Failed to test connection configuration'
       );
     }
+  }
+
+  private resolveRemoteOptions(options: RunSQLOptions): RunSQLOptions {
+    const connectionOptions =
+      typeof this.queryOptions === 'function'
+        ? this.queryOptions()
+        : this.queryOptions;
+    const effectiveOptions = {...connectionOptions, ...options};
+
+    if (
+      connectionOptions?.rowLimit !== undefined ||
+      options.rowLimit !== undefined
+    ) {
+      return {
+        ...effectiveOptions,
+        ...resolveRunSQLOptions(connectionOptions, options),
+      };
+    }
+    return effectiveOptions;
   }
 
   public async manifestTemporaryTable(sqlCommand: string): Promise<string> {

--- a/packages/malloy-db-publisher/src/publisher_connection.unit.spec.ts
+++ b/packages/malloy-db-publisher/src/publisher_connection.unit.spec.ts
@@ -547,7 +547,7 @@ describe('db:Publisher', () => {
         jest.clearAllMocks();
       });
 
-      it('should run SQL query successfully', async () => {
+      it('should run SQL query with the configured row limit', async () => {
         const mockQueryData: MalloyQueryData = {
           rows: [
             {id: 1, name: 'test1'},
@@ -592,17 +592,21 @@ describe('db:Publisher', () => {
           connectionUri:
             'http://test.com/api/v0/projects/test-project/connections/test-connection',
           accessToken: 'test-token',
+          queryOptions: {rowLimit: 1},
         });
 
         const result = await connection.runSQL('SELECT * FROM test_table');
 
-        expect(result).toEqual(mockQueryData);
+        expect(result).toEqual({
+          ...mockQueryData,
+          rows: [mockQueryData.rows[0]],
+        });
         expect(mockConnectionsApi.postQuerydata).toHaveBeenCalledWith(
           'test-project',
           'test-connection',
           {
             sqlStatement: 'SELECT * FROM test_table',
-            options: JSON.stringify({}),
+            options: JSON.stringify({rowLimit: 1}),
           },
           {
             headers: {
@@ -657,10 +661,11 @@ describe('db:Publisher', () => {
           connectionUri:
             'http://test.com/api/v0/projects/test-project/connections/test-connection',
           accessToken: 'test-token',
+          queryOptions: {rowLimit: 1},
         });
 
         const options = {
-          rowLimit: 100,
+          rowLimit: 0,
           timeoutMs: 5000,
         };
 
@@ -669,7 +674,7 @@ describe('db:Publisher', () => {
           options
         );
 
-        expect(result).toEqual(mockQueryData);
+        expect(result).toEqual({...mockQueryData, rows: []});
         expect(mockConnectionsApi.postQuerydata).toHaveBeenCalledWith(
           'test-project',
           'test-connection',
@@ -777,7 +782,10 @@ describe('db:Publisher', () => {
         expect(mockConnectionsApi.postQuerydata).toHaveBeenCalledWith(
           'test-project',
           'test-connection',
-          {sqlStatement: 'SELECT * FROM test_table', options: '{}'},
+          {
+            sqlStatement: 'SELECT * FROM test_table',
+            options: '{}',
+          },
           {
             headers: {
               Authorization: 'Bearer test-token',

--- a/packages/malloy-db-snowflake/src/index.ts
+++ b/packages/malloy-db-snowflake/src/index.ts
@@ -6,7 +6,11 @@
 export {SnowflakeConnection} from './snowflake_connection';
 export {buildPoolOptions} from './snowflake_pool_options';
 
-import {registerConnectionType} from '@malloydata/malloy';
+import {
+  queryOptionsFromConnectionConfig,
+  registerConnectionType,
+  ROW_LIMIT_CONNECTION_PROPERTY,
+} from '@malloydata/malloy';
 import type {ConnectionConfig} from '@malloydata/malloy';
 import type {ConnectionOptions} from 'snowflake-sdk';
 import {SnowflakeConnection} from './snowflake_connection';
@@ -23,6 +27,7 @@ registerConnectionType('snowflake', {
       schemaSampleTimeoutMs,
       schemaSampleRowLimit,
       schemaSampleFullScanMaxBytes,
+      rowLimit: _rowLimit,
       poolMin,
       poolMax,
       poolTestOnBorrow,
@@ -36,6 +41,7 @@ registerConnectionType('snowflake', {
     const connOptions = props as unknown as ConnectionOptions;
     return new SnowflakeConnection(name, {
       connOptions,
+      queryOptions: queryOptionsFromConnectionConfig(config),
       setupSQL: typeof setupSQL === 'string' ? setupSQL : undefined,
       timeoutMs:
         typeof timeoutMs === 'number'
@@ -65,6 +71,7 @@ registerConnectionType('snowflake', {
     });
   },
   properties: [
+    ROW_LIMIT_CONNECTION_PROPERTY,
     {name: 'account', displayName: 'Account', type: 'string'},
     {name: 'username', displayName: 'Username', type: 'string', optional: true},
     {

--- a/packages/malloy-db-snowflake/src/row_limit.unit.spec.ts
+++ b/packages/malloy-db-snowflake/src/row_limit.unit.spec.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright Contributors to the Malloy project
+ * SPDX-License-Identifier: MIT
+ */
+
+import {SnowflakeConnection} from './snowflake_connection';
+
+const mockBatch = jest.fn();
+
+jest.mock('./snowflake_executor', () => ({
+  SnowflakeExecutor: jest.fn().mockImplementation(() => ({
+    batch: mockBatch,
+  })),
+}));
+
+describe('Snowflake rowLimit', () => {
+  afterEach(() => {
+    mockBatch.mockReset();
+  });
+
+  it.each([
+    ['configured value', undefined, 2],
+    ['per-run override', 3, 3],
+    ['zero', 0, 0],
+  ])('applies %s', async (_name, perRunRowLimit, expectedRows) => {
+    const connection = new SnowflakeConnection('snowflake', {
+      connOptions: {
+        account: 'test',
+        username: 'test',
+        password: 'test',
+      },
+      queryOptions: {rowLimit: 2},
+    });
+    mockBatch.mockResolvedValue(
+      Array.from({length: 5}, (_, value) => ({value}))
+    );
+    const options =
+      perRunRowLimit === undefined ? {} : {rowLimit: perRunRowLimit};
+
+    const result = await connection.runSQL('SELECT value', options);
+
+    expect(result.rows).toHaveLength(expectedRows);
+    expect(mockBatch.mock.calls[0][1].rowLimit).toBe(expectedRows);
+  });
+});

--- a/packages/malloy-db-snowflake/src/snowflake_connection.ts
+++ b/packages/malloy-db-snowflake/src/snowflake_connection.ts
@@ -18,7 +18,12 @@ import type {
   TestableConnection,
   SQLSourceRequest,
 } from '@malloydata/malloy';
-import {SnowflakeDialect, sqlKey, makeDigest} from '@malloydata/malloy';
+import {
+  makeDigest,
+  resolveRunSQLOptions,
+  SnowflakeDialect,
+  sqlKey,
+} from '@malloydata/malloy';
 import {BaseConnection} from '@malloydata/malloy/connection';
 
 import {SnowflakeExecutor} from './snowflake_executor';
@@ -266,10 +271,7 @@ export class SnowflakeConnection
     sql: string,
     options: RunSQLOptions = {}
   ): Promise<MalloyQueryData> {
-    const effectiveOptions: RunSQLOptions = {
-      ...this.queryOptions,
-      ...options,
-    };
+    const effectiveOptions = resolveRunSQLOptions(this.queryOptions, options);
     const rowLimit = effectiveOptions.rowLimit;
     let rows = await this.executor.batch(sql, effectiveOptions, this.timeoutMs);
     if (rowLimit !== undefined && rows.length > rowLimit) {
@@ -282,10 +284,7 @@ export class SnowflakeConnection
     sqlCommand: string,
     options: RunSQLOptions = {}
   ): AsyncIterableIterator<QueryRecord> {
-    const streamQueryOptions = {
-      ...this.queryOptions,
-      ...options,
-    };
+    const streamQueryOptions = resolveRunSQLOptions(this.queryOptions, options);
 
     for await (const row of await this.executor.stream(
       sqlCommand,

--- a/packages/malloy-db-snowflake/src/snowflake_executor.row_limit.spec.ts
+++ b/packages/malloy-db-snowflake/src/snowflake_executor.row_limit.spec.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright Contributors to the Malloy project
+ * SPDX-License-Identifier: MIT
+ */
+
+import {Readable} from 'stream';
+
+const mockCreatePool = jest.fn();
+
+jest.mock('snowflake-sdk', () => ({
+  __esModule: true,
+  default: {
+    configure: jest.fn(),
+    createPool: (...args: unknown[]) => mockCreatePool(...args),
+  },
+}));
+
+import {SnowflakeExecutor} from './snowflake_executor';
+
+describe('SnowflakeExecutor streaming rowLimit', () => {
+  it('returns no rows and cancels the stream when rowLimit is zero', async () => {
+    type StatementDouble = {
+      cancel: jest.Mock;
+      streamRows: jest.Mock;
+    };
+    const cancel = jest.fn();
+    const streamRows = jest.fn(() =>
+      Readable.from([{value: 1}, {value: 2}], {objectMode: true})
+    );
+    const statement: StatementDouble = {cancel, streamRows};
+    const connection = {
+      execute: jest.fn(
+        (options: {
+          complete: (error: undefined, statement: StatementDouble) => void;
+        }) => {
+          queueMicrotask(() => options.complete(undefined, statement));
+          return statement;
+        }
+      ),
+    };
+    const pool = {
+      acquire: jest.fn(async () => connection),
+      release: jest.fn(async () => undefined),
+    };
+    mockCreatePool.mockReturnValue(pool);
+
+    const executor = new SnowflakeExecutor({account: 'test'});
+    (
+      executor as unknown as {
+        sessionInitialized: WeakMap<object, Promise<void>>;
+      }
+    ).sessionInitialized.set(connection, Promise.resolve());
+
+    const rows: unknown[] = [];
+    for await (const row of await executor.stream('SELECT value', {
+      rowLimit: 0,
+    })) {
+      rows.push(row);
+    }
+
+    expect(rows).toEqual([]);
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(pool.release).toHaveBeenCalledWith(connection);
+  });
+});

--- a/packages/malloy-db-snowflake/src/snowflake_executor.ts
+++ b/packages/malloy-db-snowflake/src/snowflake_executor.ts
@@ -424,6 +424,14 @@ export class SnowflakeExecutor {
 
               function handleData(this: Readable, row: QueryRecord) {
                 if (streamEnded) return;
+                if (
+                  options?.rowLimit !== undefined &&
+                  index >= options.rowLimit
+                ) {
+                  _stmt.cancel();
+                  handleEnd();
+                  return;
+                }
                 onData(row);
                 if (
                   options?.rowLimit !== undefined &&

--- a/packages/malloy-db-trino/src/index.ts
+++ b/packages/malloy-db-trino/src/index.ts
@@ -11,7 +11,11 @@ export {
 } from './trino_connection';
 export {TrinoExecutor} from './trino_executor';
 
-import {registerConnectionType} from '@malloydata/malloy';
+import {
+  queryOptionsFromConnectionConfig,
+  registerConnectionType,
+  ROW_LIMIT_CONNECTION_PROPERTY,
+} from '@malloydata/malloy';
 import type {
   ConnectionConfig,
   ConnectionPropertyDefinition,
@@ -64,6 +68,7 @@ function configToTrinoConfig(
 }
 
 const trinoProperties: ConnectionPropertyDefinition[] = [
+  ROW_LIMIT_CONNECTION_PROPERTY,
   {name: 'server', displayName: 'Server', type: 'string', optional: true},
   {name: 'port', displayName: 'Port', type: 'number', optional: true},
   {name: 'catalog', displayName: 'Catalog', type: 'string', optional: true},
@@ -121,6 +126,7 @@ const trinoProperties: ConnectionPropertyDefinition[] = [
 ];
 
 const prestoProperties: ConnectionPropertyDefinition[] = [
+  ROW_LIMIT_CONNECTION_PROPERTY,
   {name: 'server', displayName: 'Server', type: 'string', optional: true},
   {name: 'port', displayName: 'Port', type: 'number', optional: true},
   {name: 'catalog', displayName: 'Catalog', type: 'string', optional: true},
@@ -142,7 +148,7 @@ registerConnectionType('trino', {
   factory: async (config: ConnectionConfig) => {
     return new TrinoConnection(
       config.name,
-      undefined,
+      queryOptionsFromConnectionConfig(config),
       configToTrinoConfig(config)
     );
   },
@@ -154,7 +160,7 @@ registerConnectionType('presto', {
   factory: async (config: ConnectionConfig) => {
     return new PrestoConnection(
       config.name,
-      undefined,
+      queryOptionsFromConnectionConfig(config),
       configToBaseConfig(config)
     );
   },

--- a/packages/malloy-db-trino/src/trino_connection.spec.ts
+++ b/packages/malloy-db-trino/src/trino_connection.spec.ts
@@ -3,8 +3,15 @@
  * SPDX-License-Identifier: MIT
  */
 
-import type {AtomicTypeDef, FieldDef} from '@malloydata/malloy';
-import {TrinoConnection, TrinoExecutor} from '.';
+import type {
+  AtomicTypeDef,
+  FieldDef,
+  RunSQLOptions,
+  StructDef,
+} from '@malloydata/malloy';
+import type {BaseRunner} from '.';
+import {TrinoConnection, TrinoExecutor, TrinoPrestoConnection} from '.';
+import {PrestoConnection, PrestoRunner, TrinoRunner} from './trino_connection';
 
 // array(varchar) is array
 const ARRAY_SCHEMA = 'array(integer)';
@@ -27,6 +34,132 @@ const recordSchema: FieldDef[] = [
   {name: 'b', ...intType},
   {name: 'c', ...stringType},
 ];
+
+class TestTrinoConnection extends TrinoPrestoConnection {
+  protected async fillStructDefForSqlBlockSchema(
+    _sql: string,
+    _structDef: StructDef
+  ): Promise<void> {}
+}
+
+describe('Trino rowLimit', () => {
+  it.each([
+    ['configured value', undefined, 25],
+    ['per-run override', 5, 5],
+    ['zero', 0, 0],
+  ])('passes %s to the runner', async (_name, perRunRowLimit, expected) => {
+    let receivedOptions: RunSQLOptions | undefined;
+    const runner: BaseRunner = {
+      runSQL: jest.fn(async (_sql, options) => {
+        receivedOptions = options;
+        return {rows: [], columns: []};
+      }),
+    };
+    const connection = new TestTrinoConnection('trino', runner, {rowLimit: 25});
+    const options =
+      perRunRowLimit === undefined ? {} : {rowLimit: perRunRowLimit};
+
+    await connection.runSQL('SELECT 1', options);
+
+    expect(receivedOptions?.rowLimit).toBe(expected);
+  });
+
+  it('cancels the Trino query when the limit stops pagination', async () => {
+    const runner = new TrinoRunner({});
+    const cancel = jest.fn(async () => ({}));
+    const query = jest.fn(async () => ({
+      next: jest.fn(async () => ({
+        done: false,
+        value: {
+          id: 'query-id',
+          nextUri: 'https://trino.test/next',
+          columns: [{name: 'value', type: 'integer'}],
+          data: [[1], [2]],
+        },
+      })),
+    }));
+    (
+      runner as unknown as {
+        client: {query: typeof query; cancel: typeof cancel};
+      }
+    ).client = {query, cancel};
+
+    const result = await runner.runSQL('SELECT value', {rowLimit: 1});
+
+    expect(result.rows).toEqual([[1]]);
+    expect(cancel).toHaveBeenCalledWith('query-id');
+  });
+
+  it('does not cancel a completed Trino result page', async () => {
+    const runner = new TrinoRunner({});
+    const cancel = jest.fn(async () => ({}));
+    const query = jest.fn(async () => ({
+      next: jest.fn(async () => ({
+        done: false,
+        value: {
+          id: 'query-id',
+          columns: [{name: 'value', type: 'integer'}],
+          data: [[1], [2]],
+        },
+      })),
+    }));
+    (
+      runner as unknown as {
+        client: {query: typeof query; cancel: typeof cancel};
+      }
+    ).client = {query, cancel};
+
+    const result = await runner.runSQL('SELECT value', {rowLimit: 1});
+
+    expect(result.rows).toEqual([[1]]);
+    expect(cancel).not.toHaveBeenCalled();
+  });
+
+  it('slices Presto results without wrapping the SQL', async () => {
+    const runner = new PrestoRunner({});
+    const query = jest.fn(async () => ({
+      columns: [{name: 'value', type: 'integer'}],
+      data: [[1], [2]],
+    }));
+    (runner as unknown as {client: {query: typeof query}}).client = {query};
+
+    const result = await runner.runSQL('EXPLAIN SELECT 1', {rowLimit: 0});
+
+    expect(query).toHaveBeenCalledWith('EXPLAIN SELECT 1');
+    expect(result.rows).toEqual([]);
+  });
+
+  it('lets Presto schema discovery bypass a configured zero limit', async () => {
+    class SchemaTestPrestoConnection extends PrestoConnection {
+      receivedOptions: RunSQLOptions | undefined;
+
+      override async runSQL(_sql: string, options: RunSQLOptions = {}) {
+        this.receivedOptions = options;
+        return {rows: [{'Query Plan': 'unused'}], totalRows: 1};
+      }
+
+      fill(sql: string, structDef: StructDef) {
+        return this.fillStructDefForSqlBlockSchema(sql, structDef);
+      }
+    }
+
+    const connection = new SchemaTestPrestoConnection(
+      'presto',
+      {rowLimit: 0},
+      {}
+    );
+    const schemaFromExplain = jest
+      .spyOn(PrestoConnection, 'schemaFromExplain')
+      .mockImplementation(() => undefined);
+
+    try {
+      await connection.fill('SELECT 1', {} as StructDef);
+      expect(connection.receivedOptions).toEqual({rowLimit: 1});
+    } finally {
+      schemaFromExplain.mockRestore();
+    }
+  });
+});
 
 describe('Trino connection', () => {
   let connection: TrinoConnection;

--- a/packages/malloy-db-trino/src/trino_connection.ts
+++ b/packages/malloy-db-trino/src/trino_connection.ts
@@ -21,7 +21,14 @@ import type {
   TestableConnection,
   SQLSourceRequest,
 } from '@malloydata/malloy';
-import {TrinoDialect, mkFieldDef, sqlKey, makeDigest} from '@malloydata/malloy';
+import {
+  DEFAULT_ROW_LIMIT,
+  TrinoDialect,
+  makeDigest,
+  mkFieldDef,
+  resolveRunSQLOptions,
+  sqlKey,
+} from '@malloydata/malloy';
 import {TinyParser} from '@malloydata/malloy/internal';
 
 import {BaseConnection} from '@malloydata/malloy/connection';
@@ -74,7 +81,7 @@ export interface BaseRunner {
   }>;
 }
 
-class PrestoRunner implements BaseRunner {
+export class PrestoRunner implements BaseRunner {
   client: PrestoClient;
   constructor(config: TrinoConnectionConfiguration) {
     const prestoClientConfig: PrestoClientConfig = {
@@ -96,19 +103,19 @@ class PrestoRunner implements BaseRunner {
   }
   async runSQL(sql: string, options: RunSQLOptions = {}) {
     let ret: PrestoQuery | undefined = undefined;
-    const q = options.rowLimit
-      ? `SELECT * FROM(${sql}) LIMIT ${options.rowLimit}`
-      : sql;
     let error: string | undefined = undefined;
     try {
-      ret = (await this.client.query(q)) || [];
+      ret = (await this.client.query(sql)) || [];
       // console.log(ret);
     } catch (errorObj) {
       // console.log(error);
       error = errorObj.toString();
     }
     return {
-      rows: ret && ret.data ? ret.data : [],
+      rows:
+        ret && ret.data
+          ? ret.data.slice(0, options.rowLimit ?? ret.data.length)
+          : [],
       columns:
         ret && ret.columns
           ? (ret.columns as {name: string; type: string}[])
@@ -118,7 +125,7 @@ class PrestoRunner implements BaseRunner {
   }
 }
 
-class TrinoRunner implements BaseRunner {
+export class TrinoRunner implements BaseRunner {
   client: Trino;
   constructor(config: TrinoConnectionConfiguration) {
     let server = config.server;
@@ -154,15 +161,19 @@ class TrinoRunner implements BaseRunner {
       };
     }
     const columns = queryResult.value.columns;
+    const queryId = queryResult.value.id;
 
     const outputRows: unknown[][] = [];
     while (
       queryResult !== null &&
-      (!options.rowLimit || outputRows.length < options.rowLimit)
+      (options.rowLimit === undefined || outputRows.length < options.rowLimit)
     ) {
       const rows = queryResult.value.data ?? [];
       for (const row of rows) {
-        if (!options.rowLimit || outputRows.length < options.rowLimit) {
+        if (
+          options.rowLimit === undefined ||
+          outputRows.length < options.rowLimit
+        ) {
           outputRows.push(row as unknown[]);
         }
       }
@@ -171,6 +182,14 @@ class TrinoRunner implements BaseRunner {
       } else {
         break;
       }
+    }
+    if (
+      options.rowLimit !== undefined &&
+      outputRows.length >= options.rowLimit &&
+      queryResult.value.nextUri !== undefined
+    ) {
+      // A cancellation failure must not discard rows already fetched.
+      await this.client.cancel(queryId).catch(() => undefined);
     }
     // console.log(outputRows);
     // console.log(columns);
@@ -184,7 +203,7 @@ export abstract class TrinoPrestoConnection
 {
   protected readonly dialect = new TrinoDialect();
   static DEFAULT_QUERY_OPTIONS: RunSQLOptions = {
-    rowLimit: 10,
+    rowLimit: DEFAULT_ROW_LIMIT,
   };
 
   protected setupSQL: string | undefined;
@@ -230,17 +249,20 @@ export abstract class TrinoPrestoConnection
     return this.name;
   }
 
-  private readQueryOptions(): RunSQLOptions {
-    const options = TrinoConnection.DEFAULT_QUERY_OPTIONS;
-    if (this.queryOptions) {
-      if (this.queryOptions instanceof Function) {
-        return {...options, ...this.queryOptions()};
-      } else {
-        return {...options, ...this.queryOptions};
-      }
-    } else {
-      return options;
-    }
+  private readQueryOptions(
+    runOptions: RunSQLOptions = {}
+  ): RunSQLOptions & {rowLimit: number} {
+    const connectionOptions =
+      typeof this.queryOptions === 'function'
+        ? this.queryOptions()
+        : this.queryOptions;
+    return resolveRunSQLOptions(
+      {
+        ...TrinoPrestoConnection.DEFAULT_QUERY_OPTIONS,
+        ...connectionOptions,
+      },
+      runOptions
+    );
   }
 
   public canPersist(): this is PersistSQLResults {
@@ -279,7 +301,10 @@ export abstract class TrinoPrestoConnection
     _rowIndex = 0
   ): Promise<MalloyQueryData> {
     await this.ensureSetup();
-    const r = await this.client.runSQL(sqlCommand, options);
+    const r = await this.client.runSQL(
+      sqlCommand,
+      this.readQueryOptions(options)
+    );
 
     if (r.error) {
       throw new Error(r.error);
@@ -494,7 +519,9 @@ export class PrestoConnection extends TrinoPrestoConnection {
     sql: string,
     structDef: StructDef
   ): Promise<void> {
-    const explainResult = await this.runSQL(`EXPLAIN ${sql}`, {});
+    // Schema discovery needs one EXPLAIN row even when the connection is
+    // configured with rowLimit: 0.
+    const explainResult = await this.runSQL(`EXPLAIN ${sql}`, {rowLimit: 1});
     PrestoConnection.schemaFromExplain(explainResult, structDef, this.dialect);
   }
 

--- a/packages/malloy/src/api/foundation/config.spec.ts
+++ b/packages/malloy/src/api/foundation/config.spec.ts
@@ -9,11 +9,17 @@ import {
   createConnectionsFromConfig,
   registerConnectionType,
 } from '../../connection/registry';
+import {
+  DEFAULT_ROW_LIMIT,
+  queryOptionsFromConnectionConfig,
+  ROW_LIMIT_CONNECTION_PROPERTY,
+} from '../../connection/query_options';
 import type {ConnectionConfig, Connection} from '../../connection/types';
 import type {URLReader} from '../../runtime_types';
 
 let capturedStrictMode: unknown;
 let strictFactoryCalls = 0;
+let capturedRowLimit: unknown;
 
 function mockConnection(name: string, dialectName = 'mock'): Connection {
   return {
@@ -55,11 +61,15 @@ function mockReader(files: Record<string, unknown>): URLReader {
 beforeEach(() => {
   capturedStrictMode = undefined;
   strictFactoryCalls = 0;
+  capturedRowLimit = undefined;
   registerConnectionType('mockdb', {
     displayName: 'MockDB',
-    factory: async (config: ConnectionConfig) =>
-      mockConnection(config.name, 'mockdb-dialect'),
+    factory: async (config: ConnectionConfig) => {
+      capturedRowLimit = queryOptionsFromConnectionConfig(config).rowLimit;
+      return mockConnection(config.name, 'mockdb-dialect');
+    },
     properties: [
+      ROW_LIMIT_CONNECTION_PROPERTY,
       {name: 'host', displayName: 'Host', type: 'string', optional: true},
       {name: 'port', displayName: 'Port', type: 'number', optional: true},
       {
@@ -105,6 +115,20 @@ describe('MalloyConfig.log validation warnings', () => {
 
   it('accepts a valid config', () => {
     expect(configLog({connections: {mydb: {is: 'mockdb'}}})).toEqual([]);
+  });
+
+  it('accepts rowLimit as a registered connection property', () => {
+    expect(
+      configLog({connections: {mydb: {is: 'mockdb', rowLimit: 25}}})
+    ).toEqual([]);
+  });
+
+  it('warns when rowLimit is not a number', () => {
+    const log = configLog({
+      connections: {mydb: {is: 'mockdb', rowLimit: '25'}},
+    });
+    expect(log).toHaveLength(1);
+    expect(log[0].message).toContain('should be a number');
   });
 
   it('reports JSON parse errors (string form)', () => {
@@ -822,6 +846,37 @@ describe('MalloyConfig property defaults and includeDefaultConnections', () => {
     await config.connections.lookupConnection('myref');
     expect(capturedFlavor).toBe('vanilla');
   });
+
+  it('passes the shared rowLimit default to a connection factory', async () => {
+    const config = new MalloyConfig({
+      connections: {mydb: {is: 'mockdb'}},
+    });
+    await config.connections.lookupConnection('mydb');
+    expect(capturedRowLimit).toBe(DEFAULT_ROW_LIMIT);
+  });
+
+  it.each([0, 25])(
+    'passes an explicit rowLimit of %s to a connection factory',
+    async rowLimit => {
+      const config = new MalloyConfig({
+        connections: {mydb: {is: 'mockdb', rowLimit}},
+      });
+      await config.connections.lookupConnection('mydb');
+      expect(capturedRowLimit).toBe(rowLimit);
+    }
+  );
+
+  it.each([-1, 1.5])(
+    'rejects an invalid rowLimit of %s at the factory boundary',
+    async rowLimit => {
+      const config = new MalloyConfig({
+        connections: {mydb: {is: 'mockdb', rowLimit}},
+      });
+      await expect(config.connections.lookupConnection('mydb')).rejects.toThrow(
+        RangeError
+      );
+    }
+  );
 
   it('silently drops unresolved reference-shaped defaults', async () => {
     // No `rootDirectory` in the config overlay (default overlay returns

--- a/packages/malloy/src/connection/CONTEXT.md
+++ b/packages/malloy/src/connection/CONTEXT.md
@@ -8,6 +8,7 @@ The connection subsystem provides database backend abstractions, a centralized r
 - `base_connection.ts` — Abstract base class with schema caching; all backends extend this
 - `registry.ts` — Module-level `Map<string, ConnectionTypeDef>` with register/lookup functions
 - `registry.spec.ts` — Registry tests
+- `query_options.ts` — Shared `rowLimit` property, default, validation, and per-run option resolution
 - `validate_table_path.ts` — Helpers that re-validate a `tablePath` against the destination dialect (or any registered dialect) before it crosses an API boundary into SQL. See [Canonical tablePath invariant](#canonical-tablepath-invariant) below.
 
 ## Canonical tablePath invariant
@@ -35,9 +36,9 @@ import {registerConnectionType} from '@malloydata/malloy';
 registerConnectionType('duckdb', { displayName: 'DuckDB', factory: async ..., properties: [...] });
 ```
 
-Registered backends: `duckdb`, `bigquery`, `postgres`, `snowflake`, `trino`, `presto`, `mysql`, `publisher`
+Registered backends: `duckdb`, `duckdb_wasm`, `bigquery`, `postgres`, `snowflake`, `trino`, `presto`, `mysql`, `databricks`, `publisher`
 
-The convenience package `@malloydata/malloy-connections` (`packages/malloy-connections/`) imports all 6 database db-\* packages for side-effect registration (not publisher).
+The convenience package `@malloydata/malloy-connections` (`packages/malloy-connections/`) imports all seven local database packages for side-effect registration (not publisher).
 
 ### ConnectionTypeDef
 
@@ -141,35 +142,40 @@ so the docs site stays in sync. Add to the PR checklist:
 
 ## Per-Backend Properties
 
+All local database types expose `rowLimit` as an advanced number property with a default of 1000. Query execution resolves it in this order: per-run `RunSQLOptions.rowLimit`, connection `rowLimit`, then the shared default. Values must be non-negative integers; zero requests no returned rows. Publisher accepts `rowLimit` as an optional local override but deliberately has no local default: omitting it lets the remote connection's configuration remain authoritative.
+
 **DuckDB** (`displayName: "DuckDB"`):
-`databasePath` (file), `workingDirectory` (string), `motherDuckToken` (secret), `additionalExtensions` (string — comma-separated, factory parses to array), `readOnly` (boolean), `shareable` (boolean), `setupSQL` (text, advanced). The remaining properties — `securityPolicy`, `allowedDirectories`, `enableExternalAccess`, `lockConfiguration`, `autoloadKnownExtensions`, `autoinstallKnownExtensions`, `allowCommunityExtensions`, `allowUnsignedExtensions`, `tempFileEncryption`, `threads`, `memoryLimit`, `tempDirectory`, `extensionDirectory` — are all `advanced: true` (security policy, extension policy, and resource tuning).
+`rowLimit` (number, advanced), `databasePath` (file), `workingDirectory` (string), `motherDuckToken` (secret), `additionalExtensions` (string — comma-separated, factory parses to array), `readOnly` (boolean), `shareable` (boolean), `setupSQL` (text, advanced). The remaining properties — `securityPolicy`, `allowedDirectories`, `enableExternalAccess`, `lockConfiguration`, `autoloadKnownExtensions`, `autoinstallKnownExtensions`, `allowCommunityExtensions`, `allowUnsignedExtensions`, `tempFileEncryption`, `threads`, `memoryLimit`, `tempDirectory`, `extensionDirectory` — are all `advanced: true` (security policy, extension policy, and resource tuning).
 
 When `shareable: true` (and `databasePath` is a local file), the DuckDB connection binds its primary database to `:memory:` and brackets file access with `ATTACH 'path' AS malloy_db; USE malloy_db.main;` in `setupOnce()` and `DETACH malloy_db` in `idle()`. This releases the OS file lock between operations so other tools (`malloy-cli`, the `duckdb` CLI, another malloy host) can open the same file. The `:memory:` primary stays alive across `idle()`, so the `BaseConnection.schemaCache` and any `CREATE TEMPORARY TABLE` state survive a cycle. Shareable connections do not participate in `DuckDBConnection.activeDBs` sharing — each owns its own in-memory instance. `readOnly: true` is honored via `(READ_ONLY)` on the ATTACH so it scopes the real file, not the writable in-memory primary.
 
 **BigQuery** (`displayName: "BigQuery"`):
-`projectId` (string), `serviceAccountKeyPath` (file), `location` (string), `maximumBytesBilled` (string, advanced), `timeoutMs` (string, advanced), `billingProjectId` (string, advanced), `setupSQL` (text, advanced)
+`rowLimit` (number, advanced), `projectId` (string), `serviceAccountKeyPath` (file), `location` (string), `maximumBytesBilled` (string, advanced), `timeoutMs` (string, advanced), `billingProjectId` (string, advanced), `setupSQL` (text, advanced)
 
 **PostgreSQL** (`displayName: "PostgreSQL"`):
-`host` (string), `port` (number), `username` (string), `password` (password), `databaseName` (string), `connectionString` (string, advanced), `setupSQL` (text, advanced), `ssl` (json, advanced)
+`rowLimit` (number, advanced), `host` (string), `port` (number), `username` (string), `password` (password), `databaseName` (string), `connectionString` (string, advanced), `setupSQL` (text, advanced), `ssl` (json, advanced)
 
 **Snowflake** (`displayName: "Snowflake"`):
-`account` (string, required), `username` (string), `password` (password), `role` (string), `warehouse` (string), `database` (string), `schema` (string), `privateKeyPath` (file), `privateKeyPass` (password), `timeoutMs` (number, advanced), `schemaSampleTimeoutMs` (number, advanced), `schemaSampleRowLimit` (number, advanced), `schemaSampleFullScanMaxBytes` (number, advanced), `setupSQL` (text, advanced), `poolMin` (number, advanced), `poolMax` (number, advanced), `poolTestOnBorrow` (boolean, advanced)
+`rowLimit` (number, advanced), `account` (string, required), `username` (string), `password` (password), `role` (string), `warehouse` (string), `database` (string), `schema` (string), `privateKeyPath` (file), `privateKeyPass` (password), `timeoutMs` (number, advanced), `schemaSampleTimeoutMs` (number, advanced), `schemaSampleRowLimit` (number, advanced), `schemaSampleFullScanMaxBytes` (number, advanced), `setupSQL` (text, advanced), `poolMin` (number, advanced), `poolMax` (number, advanced), `poolTestOnBorrow` (boolean, advanced)
 Factory extracts `name`, `setupSQL`, `timeoutMs`, and the three pool fields; passes remaining properties as snowflake-sdk `ConnectionOptions`. The pool fields are assembled into a `generic-pool` options object via `buildPoolOptions()` and shallow-merged with `SnowflakeExecutor.defaultPoolOptions_` (`{min: 1, max: 1, testOnBorrow: true, testOnReturn: true}`); omitting all three preserves the defaults.
 
 **Trino** (`displayName: "Trino"`):
-`server` (string), `port` (number), `catalog` (string), `schema` (string), `user` (string), `password` (password), `setupSQL` (text, advanced), `source` (string, advanced), `ssl` (json, advanced), `session` (json, advanced), `extraCredential` (json, advanced), `extraHeaders` (json, advanced)
+`rowLimit` (number, advanced), `server` (string), `port` (number), `catalog` (string), `schema` (string), `user` (string), `password` (password), `setupSQL` (text, advanced), `source` (string, advanced), `ssl` (json, advanced), `session` (json, advanced), `extraCredential` (json, advanced), `extraHeaders` (json, advanced)
 The json-typed properties pass through to `trino-client`'s `ConnectionOptions` via `extraConfig`.
 
 **Presto** (`displayName: "Presto"`):
-`server` (string), `port` (number), `catalog` (string), `schema` (string), `user` (string), `password` (password), `setupSQL` (text, advanced)
+`rowLimit` (number, advanced), `server` (string), `port` (number), `catalog` (string), `schema` (string), `user` (string), `password` (password), `setupSQL` (text, advanced)
 
 **MySQL** (`displayName: "MySQL"`):
-`host` (string), `port` (number), `database` (string), `user` (string), `password` (password), `setupSQL` (text, advanced)
+`rowLimit` (number, advanced), `host` (string), `port` (number), `database` (string), `user` (string), `password` (password), `setupSQL` (text, advanced)
+
+**Databricks** (`displayName: "Databricks"`):
+`rowLimit` (number, advanced), `host` (string, required), `path` (string, required), `token` (secret), `oauthClientId` (string, advanced), `oauthClientSecret` (secret, advanced), `defaultCatalog` (string), `defaultSchema` (string), `setupSQL` (text, advanced)
 
 **Publisher** (`displayName: "Malloy Publisher"`):
-`connectionUri` (string, required), `accessToken` (secret)
+`rowLimit` (number, advanced), `connectionUri` (string, required), `accessToken` (secret)
 
-All backends support `setupSQL` (text) — SQL statements run when the connection is first established.
+All local database backends support `setupSQL` (text) — SQL statements run when the connection is first established.
 
 ## Key Types
 

--- a/packages/malloy/src/connection/index.ts
+++ b/packages/malloy/src/connection/index.ts
@@ -1,3 +1,4 @@
 export * from './types';
 export * from './base_connection';
 export * from './registry';
+export * from './query_options';

--- a/packages/malloy/src/connection/query_options.spec.ts
+++ b/packages/malloy/src/connection/query_options.spec.ts
@@ -1,0 +1,108 @@
+/*
+ * Copyright Contributors to the Malloy project
+ * SPDX-License-Identifier: MIT
+ */
+
+import {
+  DEFAULT_ROW_LIMIT,
+  queryOptionsFromConnectionConfig,
+  resolveRunSQLOptions,
+  ROW_LIMIT_CONNECTION_PROPERTY,
+} from './query_options';
+
+describe('connection query options', () => {
+  it('declares the shared rowLimit config property', () => {
+    expect(ROW_LIMIT_CONNECTION_PROPERTY).toEqual({
+      name: 'rowLimit',
+      displayName: 'Default Row Limit',
+      type: 'number',
+      optional: true,
+      advanced: true,
+      default: DEFAULT_ROW_LIMIT,
+      description:
+        'Maximum number of rows returned by this connection unless overridden for an individual query run.',
+    });
+  });
+
+  it('uses the shared default when connection config omits rowLimit', () => {
+    expect(queryOptionsFromConnectionConfig({name: 'test'})).toEqual({
+      rowLimit: DEFAULT_ROW_LIMIT,
+    });
+  });
+
+  it.each([0, 25])('reads connection rowLimit %s', rowLimit => {
+    expect(queryOptionsFromConnectionConfig({name: 'test', rowLimit})).toEqual({
+      rowLimit,
+    });
+  });
+
+  it.each(['5', null])(
+    'rejects a non-number connection rowLimit %s',
+    rowLimit => {
+      expect(() =>
+        queryOptionsFromConnectionConfig({name: 'test', rowLimit})
+      ).toThrow(TypeError);
+    }
+  );
+
+  it.each([-1, 1.5, Number.NaN, Number.POSITIVE_INFINITY])(
+    'rejects invalid connection rowLimit %s',
+    rowLimit => {
+      expect(() =>
+        queryOptionsFromConnectionConfig({name: 'test', rowLimit})
+      ).toThrow(RangeError);
+    }
+  );
+
+  it('uses per-run options over configured options', () => {
+    expect(resolveRunSQLOptions({rowLimit: 25}, {rowLimit: 5})).toMatchObject({
+      rowLimit: 5,
+    });
+  });
+
+  it('preserves a zero per-run limit', () => {
+    expect(resolveRunSQLOptions({rowLimit: 25}, {rowLimit: 0})).toMatchObject({
+      rowLimit: 0,
+    });
+  });
+
+  it('reads a dynamic connection option once per resolution', () => {
+    const reader = jest.fn(() => ({rowLimit: 25}));
+    expect(resolveRunSQLOptions(reader).rowLimit).toBe(25);
+    expect(reader).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses the per-run abort signal over the configured signal', () => {
+    const configured = new AbortController();
+    const perRun = new AbortController();
+    expect(
+      resolveRunSQLOptions(
+        {rowLimit: 25, abortSignal: configured.signal},
+        {abortSignal: perRun.signal}
+      ).abortSignal
+    ).toBe(perRun.signal);
+  });
+
+  it.each([
+    ['configured', () => resolveRunSQLOptions({rowLimit: '5' as never})],
+    [
+      'per-run',
+      () => resolveRunSQLOptions({rowLimit: 25}, {rowLimit: '5' as never}),
+    ],
+  ])('rejects a non-number %s rowLimit', (_source, resolve) => {
+    expect(resolve).toThrow(TypeError);
+  });
+
+  it.each([-1, 1.5, Number.NaN, Number.POSITIVE_INFINITY])(
+    'rejects invalid configured rowLimit %s',
+    rowLimit => {
+      expect(() => resolveRunSQLOptions({rowLimit})).toThrow(RangeError);
+    }
+  );
+
+  it('does not hide an invalid configured value behind a per-run override', () => {
+    expect(() => resolveRunSQLOptions({rowLimit: -1}, {rowLimit: 5})).toThrow(
+      RangeError
+    );
+  });
+});

--- a/packages/malloy/src/connection/query_options.ts
+++ b/packages/malloy/src/connection/query_options.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright Contributors to the Malloy project
+ * SPDX-License-Identifier: MIT
+ */
+
+import type {QueryOptionsReader, RunSQLOptions} from '../run_sql_options';
+import type {ConnectionPropertyDefinition} from './registry';
+import type {ConnectionConfig} from './types';
+
+export const DEFAULT_ROW_LIMIT = 1000;
+
+export interface ResolvedRunSQLOptions extends RunSQLOptions {
+  rowLimit: number;
+}
+
+/** Shared `malloy-config.json` property for database connection row limits. */
+export const ROW_LIMIT_CONNECTION_PROPERTY: ConnectionPropertyDefinition = {
+  name: 'rowLimit',
+  displayName: 'Default Row Limit',
+  type: 'number',
+  optional: true,
+  advanced: true,
+  default: DEFAULT_ROW_LIMIT,
+  description:
+    'Maximum number of rows returned by this connection unless overridden for an individual query run.',
+};
+
+function assertRowLimit(
+  value: unknown,
+  label: string
+): asserts value is number {
+  if (typeof value !== 'number') {
+    throw new TypeError(`${label} must be a number`);
+  }
+  if (!Number.isInteger(value) || value < 0) {
+    throw new RangeError(`${label} must be a non-negative integer`);
+  }
+}
+
+/**
+ * Read and validate the connection-level row limit at the factory boundary.
+ *
+ * `MalloyConfig` applies registered property defaults before calling a factory,
+ * but the legacy `createConnectionsFromConfig` path calls factories directly.
+ * Keeping the fallback here makes both paths behave the same.
+ */
+export function queryOptionsFromConnectionConfig(
+  config: ConnectionConfig
+): RunSQLOptions {
+  const configuredRowLimit = config['rowLimit'];
+  const rowLimit =
+    configuredRowLimit === undefined ? DEFAULT_ROW_LIMIT : configuredRowLimit;
+  assertRowLimit(rowLimit, `Connection "${config.name}" rowLimit`);
+  return {rowLimit};
+}
+
+/** Resolve per-run options over connection options and the shared default. */
+export function resolveRunSQLOptions(
+  queryOptions?: QueryOptionsReader,
+  runOptions: RunSQLOptions = {}
+): ResolvedRunSQLOptions {
+  const connectionOptions =
+    typeof queryOptions === 'function' ? queryOptions() : queryOptions;
+
+  if (connectionOptions?.rowLimit !== undefined) {
+    assertRowLimit(connectionOptions.rowLimit, 'Configured rowLimit');
+  }
+  if (runOptions.rowLimit !== undefined) {
+    assertRowLimit(runOptions.rowLimit, 'Per-run rowLimit');
+  }
+
+  const rowLimit =
+    runOptions.rowLimit ?? connectionOptions?.rowLimit ?? DEFAULT_ROW_LIMIT;
+  const abortSignal = runOptions.abortSignal ?? connectionOptions?.abortSignal;
+
+  return abortSignal === undefined ? {rowLimit} : {rowLimit, abortSignal};
+}

--- a/packages/malloy/src/connection/types.ts
+++ b/packages/malloy/src/connection/types.ts
@@ -94,7 +94,7 @@ export interface Connection extends InfoConnection {
    * Run some SQL and yield results.
    *
    * @param sql The SQL to run.
-   * @param options.pageSize Maximum number of results to return at once.
+   * @param options.rowLimit Maximum number of results to return at once.
    * @return The rows of data resulting from running the given SQL query
    * and the total number of rows available.
    */

--- a/packages/malloy/src/doc/configuration.md
+++ b/packages/malloy/src/doc/configuration.md
@@ -98,6 +98,24 @@ Two mechanisms fill in missing values, from two different directions:
 
 DuckDB's `workingDirectory` default, for example, is `{config: "rootDirectory"}`. Any duckdb entry that doesn't explicitly set `workingDirectory` picks up the project root from the `config` overlay. The user never has to know that `workingDirectory` exists.
 
+Every local database connection also exposes an advanced `rowLimit` number property. It caps the rows returned by a query unless that individual run supplies its own `rowLimit`; the shared default is 1000. For example:
+
+```json
+{
+  "connections": {
+    "local": {
+      "is": "duckdb",
+      "databasePath": "analytics.duckdb",
+      "rowLimit": 250
+    }
+  }
+}
+```
+
+`rowLimit` must be a non-negative integer, and zero is valid. It is an execution safety boundary, distinct from Malloy's `limit:` query property, which is compiled into SQL.
+
+Publisher connections accept the same property as an optional local override. When omitted, Publisher sends no `rowLimit`, so the remote connection's own configured value or default remains authoritative.
+
 **`includeDefaultConnections`** — a boolean flag at the top of the config. When `true`, the resolver fabricates one connection entry per registered backend type not already named in `connections`. The fabricated entry has no explicit properties; property defaults then fill it in as usual.
 
 A soloist can get working connections with nothing but:

--- a/packages/malloy/src/index.ts
+++ b/packages/malloy/src/index.ts
@@ -215,6 +215,13 @@ export type {
 export type {Overlay, ConfigOverlays} from './api/foundation';
 export type {FilesystemContext, MalloyConfigOptions} from './api/foundation';
 export type {RuntimeContext} from './api/foundation';
+export {
+  DEFAULT_ROW_LIMIT,
+  ROW_LIMIT_CONNECTION_PROPERTY,
+  queryOptionsFromConnectionConfig,
+  resolveRunSQLOptions,
+} from './connection/query_options';
+export type {ResolvedRunSQLOptions} from './connection/query_options';
 export type {QueryOptionsReader, RunSQLOptions} from './run_sql_options';
 export type {
   EventStream,

--- a/test/src/core/streaming.spec.ts
+++ b/test/src/core/streaming.spec.ts
@@ -53,6 +53,20 @@ describe('Streaming tests', () => {
       expect(rows[0].cell('code').string.value).toBe('00A');
     });
 
+    it(`zero row stream - ${databaseName}`, async () => {
+      const stream = runtime
+        .loadModel(
+          `source: airports is ${databaseName}.table('malloytest.airports')`
+        )
+        .loadQuery('run: airports -> { select: code; order_by: code }')
+        .runStream({rowLimit: 0});
+      const rows: DataRecord[] = [];
+      for await (const row of stream) {
+        rows.push(row);
+      }
+      expect(rows).toEqual([]);
+    });
+
     it(`stream to JSON - ${databaseName}`, async () => {
       const stream = runtime
         .loadModel(


### PR DESCRIPTION
## Summary

- add shared `rowLimit` configuration metadata and validation with a default of 1000
- thread `malloy.config` row limits through every registered database connection factory
- apply consistent `per-run > connection config > default` precedence in batch and streaming paths
- add regression coverage for zero-row limits, per-run overrides, streaming, and the former 10-row cap

Fixes #2786

## Root cause

`rowLimit` existed as a run option, but connection factories did not consistently register or forward the same setting from `malloy.config`. Individual backends then supplied independent defaults, including several hard-coded limits of 10. As a result, configuration could validate incompletely, be dropped during connection construction, or behave differently between batch and streaming execution.

## Resulting behavior

- precedence is `per-run rowLimit > connection rowLimit > 1000`
- `rowLimit: 0` is valid and returns no rows
- invalid values (negative, fractional, non-numeric, `NaN`, or infinite) are rejected
- Publisher forwards an explicit local override, but when no local value is supplied it leaves the remote server's configured default intact

## Areas that need focused review

1. **Shared policy and public surface**
   - `packages/malloy/src/connection/query_options.ts`
   - whether 1000 is the desired common default and whether zero should remain valid
2. **Factory configuration wiring**
   - BigQuery, Databricks, DuckDB native, DuckDB WASM, MySQL, Postgres, Snowflake, Trino/Presto, and Publisher registrations in their respective `src/index.ts`, `native.ts`, or `browser.ts` files
   - each factory must register `rowLimit` and pass the resolved connection value without replacing a valid zero
3. **Backend-specific execution behavior**
   - Publisher: omitted local configuration must not override the remote default
   - Databricks: bounded single-chunk fetches and `totalRows` reporting fetched rows rather than draining the operation
   - Trino: cancellation after reaching the bound; Presto: schema `EXPLAIN` uses a one-row internal override without wrapping user SQL
   - BigQuery, DuckDB, Postgres, and Snowflake: streaming stops exactly at the bound, including zero
4. **Configuration/API compatibility**
   - generated `malloy-config.json` schema exposure and validation behavior
   - callers that previously depended on backend-specific defaults of 10

## Validation

- relevant TypeScript package build passed for Malloy plus BigQuery, Databricks, DuckDB, MySQL, Postgres, Publisher, Snowflake, and Trino
- ESLint passed for all changed TypeScript files
- 10 focused suites passed: 162 tests passed, 10 skipped
- focused DuckDB configuration tests passed, including the issue reproduction with `limit: 25`
- DuckDB zero-row streaming regression passed
- `git diff --check` passed

The full DuckDB suite also reaches two unrelated Windows idle file-lock failures; the focused row-limit and zero-streaming tests pass. A companion documentation update in `malloydata/malloydata.github.io` is still needed.
