### PR TITLE
Rename MalloyElement annotation member `note` to `ownAnnotation`

### DIFF
--- a/jest.config.simple.ts
+++ b/jest.config.simple.ts
@@ -6,7 +6,7 @@
 
 import type {Config} from 'jest';
 
-process.env.TZ = 'America/Los_Angeles';
+process.env['TZ'] = 'America/Los_Angeles';
 
 // ESM-only deps that ship plain static import/export must be transformed (not
 // ignored) so jest's CJS runtime can load them. See DEPENDENCY-MANAGEMENT.md.

--- a/packages/malloy/src/lang/ast/field-space/include-utils.ts
+++ b/packages/malloy/src/lang/ast/field-space/include-utils.ts
@@ -193,8 +193,8 @@ export function processIncludeList(
           } else {
             joinState.star = item.kind ?? 'inherit';
             joinState.starNote = {
-              notes: f.note?.notes ?? [],
-              blockNotes: item.note?.blockNotes ?? [],
+              notes: f.ownAnnotation?.notes ?? [],
+              blockNotes: item.ownAnnotation?.blockNotes ?? [],
             };
           }
         } else {
@@ -245,10 +245,10 @@ export function processIncludeList(
               joinState.modifiers.set(f.as ?? name, item.kind);
             }
             joinState.fieldsIncluded.add(name);
-            if (f.note || item.note) {
+            if (f.ownAnnotation || item.ownAnnotation) {
               joinState.notes.set(name, {
-                notes: f.note?.notes ?? [],
-                blockNotes: item.note?.blockNotes ?? [],
+                notes: f.ownAnnotation?.notes ?? [],
+                blockNotes: item.ownAnnotation?.blockNotes ?? [],
               });
             }
           }

--- a/packages/malloy/src/lang/ast/field-space/reference-field.ts
+++ b/packages/malloy/src/lang/ast/field-space/reference-field.ts
@@ -74,7 +74,7 @@ export class ReferenceField extends SpaceField {
       if (refTo instanceof SpaceField) {
         const origFd = refTo.constructorFieldDef();
         if (origFd) {
-          const notes = this.fieldRef.note;
+          const notes = this.fieldRef.ownAnnotation;
           if (origFd.annotations || notes) {
             const annotations: AnnotationsDef = {
               ...(notes ?? {}),

--- a/packages/malloy/src/lang/ast/query-elements/anonymous-query.ts
+++ b/packages/malloy/src/lang/ast/query-elements/anonymous-query.ts
@@ -8,7 +8,6 @@ import type {AnnotationsDef} from '../../../model';
 import type {DocStatement, Document} from '../types/malloy-element';
 import {MalloyElement} from '../types/malloy-element';
 import type {Noteable} from '../types/noteable';
-import {extendNoteMethod} from '../types/noteable';
 import type {SourceQueryElement} from '../source-query-elements/source-query-element';
 
 export class AnonymousQuery
@@ -23,8 +22,7 @@ export class AnonymousQuery
   }
 
   readonly isNoteableObj = true;
-  extendNote = extendNoteMethod;
-  note?: AnnotationsDef;
+  ownAnnotation?: AnnotationsDef;
 
   execute(doc: Document): void {
     const queryObj = this.queryExpr.getQuery();
@@ -36,7 +34,7 @@ export class AnonymousQuery
       return;
     }
     const modelQuery = {...queryObj.query()};
-    const annotation = this.note || {};
+    const annotation = this.ownAnnotation || {};
     if (modelQuery.annotations) {
       annotation.inherits = modelQuery.annotations;
     }

--- a/packages/malloy/src/lang/ast/query-items/field-declaration.ts
+++ b/packages/malloy/src/lang/ast/query-items/field-declaration.ts
@@ -33,7 +33,6 @@ import {
   typecheckProject,
 } from './typecheck_utils';
 import type {Noteable} from '../types/noteable';
-import {extendNoteMethod} from '../types/noteable';
 import type {DynamicSpace} from '../field-space/dynamic-space';
 import {SpaceField} from '../types/space-field';
 import {DefSpace} from '../field-space/def-space';
@@ -49,8 +48,7 @@ export abstract class AtomicFieldDeclaration
   implements Noteable, MakeEntry
 {
   readonly isNoteableObj = true;
-  extendNote = extendNoteMethod;
-  note?: AnnotationsDef;
+  ownAnnotation?: AnnotationsDef;
 
   constructor(
     readonly expr: ExpressionDef,
@@ -155,8 +153,8 @@ export abstract class AtomicFieldDeclaration
       if (this.exprSrc) {
         ret.code = this.exprSrc;
       }
-      if (this.note) {
-        ret.annotations = {...this.note};
+      if (this.ownAnnotation) {
+        ret.annotations = {...this.ownAnnotation};
       }
       return ret;
     }

--- a/packages/malloy/src/lang/ast/query-items/field-references.ts
+++ b/packages/malloy/src/lang/ast/query-items/field-references.ts
@@ -18,7 +18,6 @@ import {FieldName} from '../types/field-space';
 import type {LookupResult} from '../types/lookup-result';
 import {ListOf, MalloyElement} from '../types/malloy-element';
 import type {Noteable} from '../types/noteable';
-import {extendNoteMethod} from '../types/noteable';
 import type {MakeEntry} from '../types/space-entry';
 import {ExprIdReference} from '../expressions/expr-id-reference';
 import type {FieldDeclarationConstructor} from './field-declaration';
@@ -49,8 +48,7 @@ export abstract class FieldReference
   implements Noteable, MakeEntry
 {
   readonly isNoteableObj = true;
-  note?: AnnotationsDef;
-  extendNote = extendNoteMethod;
+  ownAnnotation?: AnnotationsDef;
 
   constructor(names: FieldName[]) {
     super(names);
@@ -128,8 +126,8 @@ export abstract class FieldReference
       this.list.map(n => new FieldName(n.refString))
     );
     const decl = new declCtor(new ExprIdReference(renamedRef), autoName);
-    if (this.note) {
-      decl.note = this.note;
+    if (this.ownAnnotation) {
+      decl.ownAnnotation = this.ownAnnotation;
     }
     // Attach under this reference so the synthetic nodes inherit its location
     // and resolve back to the translator for logging.
@@ -337,9 +335,8 @@ export class ViewOrScalarFieldReference extends FieldReference {
 
 export class WildcardFieldReference extends MalloyElement implements Noteable {
   elementType = 'wildcardFieldReference';
-  note?: AnnotationsDef;
+  ownAnnotation?: AnnotationsDef;
   readonly isNoteableObj = true;
-  extendNote = extendNoteMethod;
   except = new Set<string>();
   constructor(readonly joinPath: FieldReference | undefined) {
     super();

--- a/packages/malloy/src/lang/ast/query-properties/nest.ts
+++ b/packages/malloy/src/lang/ast/query-properties/nest.ts
@@ -69,7 +69,7 @@ export class NestFieldDeclaration
         name: this.name,
         pipeline: pipelineWithDrillPaths,
         annotations: {
-          ...this.note,
+          ...this.ownAnnotation,
           inherits: annotations,
         },
         location: this.location,

--- a/packages/malloy/src/lang/ast/source-properties/join.ts
+++ b/packages/malloy/src/lang/ast/source-properties/join.ts
@@ -21,7 +21,6 @@ import type {FieldSpace} from '../types/field-space';
 import type {ModelEntryReference} from '../types/malloy-element';
 import {MalloyElement} from '../types/malloy-element';
 import type {Noteable} from '../types/noteable';
-import {extendNoteMethod} from '../types/noteable';
 import type {MakeEntry} from '../types/space-entry';
 import type {SourceQueryElement} from '../source-query-elements/source-query-element';
 import {ErrorFactory} from '../error-factory';
@@ -38,9 +37,8 @@ export abstract class Join
   abstract getStructDef(parameterSpace: ParameterSpace): JoinFieldDef;
   abstract fixupJoinOn(outer: FieldSpace, inStruct: JoinFieldDef): void;
   readonly isNoteableObj = true;
-  extendNote = extendNoteMethod;
   abstract sourceExpr: SourceQueryElement;
-  note?: AnnotationsDef;
+  ownAnnotation?: AnnotationsDef;
 
   makeEntry(fs: DynamicSpace) {
     fs.newEntry(
@@ -96,8 +94,8 @@ export class KeyJoin extends Join {
       location: this.location,
     };
 
-    if (this.note) {
-      joinStruct.annotations = {...this.note};
+    if (this.ownAnnotation) {
+      joinStruct.annotations = {...this.ownAnnotation};
     }
     return joinStruct;
   }
@@ -210,8 +208,8 @@ export class ExpressionJoin extends Join {
       matrixOperation,
       location: this.location,
     };
-    if (this.note) {
-      joinStruct.annotations = {...this.note};
+    if (this.ownAnnotation) {
+      joinStruct.annotations = {...this.ownAnnotation};
     }
     return joinStruct;
   }

--- a/packages/malloy/src/lang/ast/source-properties/renames.ts
+++ b/packages/malloy/src/lang/ast/source-properties/renames.ts
@@ -9,14 +9,13 @@ import {RenameSpaceField} from '../field-space/rename-space-field';
 import {DefinitionList} from '../types/definition-list';
 import type {FieldName} from '../types/field-space';
 import {MalloyElement} from '../types/malloy-element';
-import {extendNoteMethod, type Noteable} from '../types/noteable';
+import {type Noteable} from '../types/noteable';
 import type {MakeEntry} from '../types/space-entry';
 import {SpaceField} from '../types/space-field';
 
 export class RenameField extends MalloyElement implements Noteable, MakeEntry {
   elementType = 'renameField';
-  note?: AnnotationsDef;
-  extendNote = extendNoteMethod;
+  ownAnnotation?: AnnotationsDef;
   readonly isNoteableObj = true;
 
   constructor(
@@ -65,7 +64,7 @@ export class RenameField extends MalloyElement implements Noteable, MakeEntry {
             oldValue.found,
             this.newName,
             this.location,
-            this.note ? {...this.note} : undefined
+            this.ownAnnotation ? {...this.ownAnnotation} : undefined
           )
         );
       } else {

--- a/packages/malloy/src/lang/ast/source-properties/user-type-shape.ts
+++ b/packages/malloy/src/lang/ast/source-properties/user-type-shape.ts
@@ -15,12 +15,10 @@ import {
 } from '../../../model/malloy_types';
 import {ListOf, MalloyElement} from '../types/malloy-element';
 import type {Noteable} from '../types/noteable';
-import {extendNoteMethod} from '../types/noteable';
 
 export abstract class UserTypeMember extends MalloyElement implements Noteable {
   readonly isNoteableObj = true;
-  extendNote = extendNoteMethod;
-  note?: AnnotationsDef;
+  ownAnnotation?: AnnotationsDef;
   constructor(readonly name: string) {
     super();
   }
@@ -40,8 +38,8 @@ export class UserTypeMemberDef extends UserTypeMember {
       name: this.name,
       typeDef: this.typeDef,
     };
-    if (this.note) {
-      field.annotations = {...this.note};
+    if (this.ownAnnotation) {
+      field.annotations = {...this.ownAnnotation};
     }
     return field;
   }
@@ -95,13 +93,13 @@ export class UserTypeMemberIndirect extends UserTypeMember {
       typeDef = mkArrayTypeDef(typeDef);
     }
     const field: UserTypeFieldDef = {name: this.name, typeDef};
-    if (this.note) {
+    if (this.ownAnnotation) {
       field.annotations = modelEntry.entry.annotations
         ? {
-            ...this.note,
+            ...this.ownAnnotation,
             inherits: modelEntry.entry.annotations,
           }
-        : {...this.note};
+        : {...this.ownAnnotation};
     } else if (modelEntry.entry.annotations) {
       field.annotations = {
         inherits: modelEntry.entry.annotations,

--- a/packages/malloy/src/lang/ast/source-properties/view-field-declaration.ts
+++ b/packages/malloy/src/lang/ast/source-properties/view-field-declaration.ts
@@ -9,7 +9,6 @@ import {MalloyElement} from '../types/malloy-element';
 import type {DynamicSpace} from '../field-space/dynamic-space';
 import type {View} from '../view-elements/view';
 import type {Noteable} from '../types/noteable';
-import {extendNoteMethod} from '../types/noteable';
 import {detectAndRemovePartialStages} from '../query-utils';
 import {ASTViewField} from '../field-space/ast-view-field';
 import type {MakeEntry} from '../types/space-entry';
@@ -20,8 +19,7 @@ export class ViewFieldDeclaration
 {
   elementType = 'view-field-declaration';
   readonly isNoteableObj = true;
-  extendNote = extendNoteMethod;
-  note?: model.AnnotationsDef;
+  ownAnnotation?: model.AnnotationsDef;
 
   constructor(
     readonly name: string,
@@ -47,7 +45,7 @@ export class ViewFieldDeclaration
       name: this.name,
       pipeline: checkedPipeline,
       annotations: {
-        ...this.note,
+        ...this.ownAnnotation,
         inherits: annotations,
       },
       location: this.location,

--- a/packages/malloy/src/lang/ast/source-query-elements/include-item.ts
+++ b/packages/malloy/src/lang/ast/source-query-elements/include-item.ts
@@ -11,7 +11,6 @@ import type {
 } from '../query-items/field-references';
 import type {AnnotationsDef} from '../../../model';
 import type {Noteable} from '../types/noteable';
-import {extendNoteMethod} from '../types/noteable';
 
 // type RenameSpec = {
 //   as: string;
@@ -26,8 +25,7 @@ export abstract class IncludeItem extends MalloyElement {
 export class IncludeAccessItem extends IncludeItem implements Noteable {
   elementType = 'include-access-item';
   readonly isNoteableObj = true;
-  extendNote = extendNoteMethod;
-  note?: AnnotationsDef;
+  ownAnnotation?: AnnotationsDef;
   constructor(
     readonly kind: 'private' | 'public' | 'internal' | undefined,
     readonly fields: IncludeListItem[]
@@ -60,8 +58,7 @@ export class IncludeExceptItem extends IncludeItem {
 export class IncludeListItem extends MalloyElement implements Noteable {
   elementType = 'include-list-item';
   readonly isNoteableObj = true;
-  extendNote = extendNoteMethod;
-  note?: AnnotationsDef;
+  ownAnnotation?: AnnotationsDef;
 
   constructor(
     readonly name: AccessModifierFieldReference | WildcardFieldReference,

--- a/packages/malloy/src/lang/ast/statements/define-given.ts
+++ b/packages/malloy/src/lang/ast/statements/define-given.ts
@@ -25,7 +25,6 @@ import type {ExprValue} from '../types/expr-value';
 import type {DocStatement, Document} from '../types/malloy-element';
 import {DocStatementList, MalloyElement} from '../types/malloy-element';
 import type {Noteable} from '../types/noteable';
-import {extendNoteMethod} from '../types/noteable';
 
 // `filter<T>` defaults can't be type-checked via TD.eq — the filter
 // expression value shape doesn't match an atomic typeDef. Catch only
@@ -76,8 +75,7 @@ export class GivenDeclaration
 {
   elementType = 'given';
   readonly isNoteableObj = true;
-  extendNote = extendNoteMethod;
-  note?: AnnotationsDef;
+  ownAnnotation?: AnnotationsDef;
   readonly default?: ConstantExpression;
 
   constructor(
@@ -237,7 +235,7 @@ export class GivenDeclaration
       defaultText,
       givenUsage,
       location: this.location,
-      annotations: this.note ? {...this.note} : undefined,
+      annotations: this.ownAnnotation ? {...this.ownAnnotation} : undefined,
       ...(this.inline ? {inline: true} : {}),
     };
     doc.documentGivens.set(id, givenIR);
@@ -261,7 +259,7 @@ export class GivenDeclaration
       },
       definition: {
         type: typeDefToString(this.typeDef),
-        annotations: this.note ? {...this.note} : undefined,
+        annotations: this.ownAnnotation ? {...this.ownAnnotation} : undefined,
         location: this.location,
         defaultText,
       },

--- a/packages/malloy/src/lang/ast/statements/define-query.ts
+++ b/packages/malloy/src/lang/ast/statements/define-query.ts
@@ -8,7 +8,6 @@ import type {AnnotationsDef, NamedQueryDef} from '../../../model/malloy_types';
 import type {DocStatement, Document} from '../types/malloy-element';
 import {MalloyElement, DocStatementList} from '../types/malloy-element';
 import type {Noteable} from '../types/noteable';
-import {extendNoteMethod} from '../types/noteable';
 import type {SourceQueryElement} from '../source-query-elements/source-query-element';
 
 export class DefineQuery
@@ -25,8 +24,7 @@ export class DefineQuery
   }
 
   readonly isNoteableObj = true;
-  extendNote = extendNoteMethod;
-  note?: AnnotationsDef;
+  ownAnnotation?: AnnotationsDef;
 
   execute(doc: Document): void {
     const existing = doc.getEntry(this.name);
@@ -51,10 +49,10 @@ export class DefineQuery
       name: this.name,
       location: this.location,
     };
-    if (this.note) {
+    if (this.ownAnnotation) {
       entry.annotations = entry.annotations
-        ? {...this.note, inherits: entry.annotations}
-        : {...this.note};
+        ? {...this.ownAnnotation, inherits: entry.annotations}
+        : {...this.ownAnnotation};
     }
     doc.setEntry(this.name, {entry, exported: true});
   }

--- a/packages/malloy/src/lang/ast/statements/define-source.ts
+++ b/packages/malloy/src/lang/ast/statements/define-source.ts
@@ -16,7 +16,6 @@ import type {HasParameter} from '../parameters/has-parameter';
 import type {DocStatement, Document} from '../types/malloy-element';
 import {MalloyElement, DocStatementList} from '../types/malloy-element';
 import type {Noteable} from '../types/noteable';
-import {extendNoteMethod} from '../types/noteable';
 import type {SourceQueryElement} from '../source-query-elements/source-query-element';
 import {getPartitionCompositeDesc} from '../../composite-source-utils';
 
@@ -40,8 +39,7 @@ export class DefineSource
     }
   }
   readonly isNoteableObj = true;
-  extendNote = extendNoteMethod;
-  note?: AnnotationsDef;
+  ownAnnotation?: AnnotationsDef;
 
   execute(doc: Document): void {
     if (doc.modelEntry(this.name)) {
@@ -66,13 +64,13 @@ export class DefineSource
       as: this.name,
       location: this.location,
     };
-    if (this.note) {
+    if (this.ownAnnotation) {
       entry.annotations = structDef.annotations
         ? {
-            ...this.note,
+            ...this.ownAnnotation,
             inherits: structDef.annotations,
           }
-        : {...this.note};
+        : {...this.ownAnnotation};
     }
     if (isSourceDef(entry)) {
       // Every source gets a stable identity for its own definition. referenceID
@@ -87,7 +85,7 @@ export class DefineSource
     }
     entry.partitionComposite =
       getPartitionCompositeDesc(
-        this.note,
+        this.ownAnnotation,
         structDef,
         this.sourceExpr ?? this
       ) ?? structDef.partitionComposite;

--- a/packages/malloy/src/lang/ast/statements/define-user-type.ts
+++ b/packages/malloy/src/lang/ast/statements/define-user-type.ts
@@ -6,7 +6,6 @@
 import type {DocStatement, Document} from '../types/malloy-element';
 import {MalloyElement, DocStatementList} from '../types/malloy-element';
 import type {Noteable} from '../types/noteable';
-import {extendNoteMethod} from '../types/noteable';
 import type {
   AnnotationsDef,
   UserTypeDef,
@@ -67,8 +66,7 @@ export class DefineUserType
     this.has({shapeDef});
   }
   readonly isNoteableObj = true;
-  extendNote = extendNoteMethod;
-  note?: AnnotationsDef;
+  ownAnnotation?: AnnotationsDef;
 
   execute(doc: Document): void {
     if (doc.modelEntry(this.name)) {
@@ -88,8 +86,8 @@ export class DefineUserType
       fields,
       location: this.location,
     };
-    if (this.note) {
-      entry.annotations = {...this.note};
+    if (this.ownAnnotation) {
+      entry.annotations = {...this.ownAnnotation};
     }
     doc.setEntry(this.name, {entry, exported: this.exported});
   }

--- a/packages/malloy/src/lang/ast/types/definition-list.ts
+++ b/packages/malloy/src/lang/ast/types/definition-list.ts
@@ -7,32 +7,25 @@ import type {AnnotationsDef} from '../../../model';
 import type {MalloyElement} from './malloy-element';
 import {ListOf} from './malloy-element';
 import type {Noteable} from '../types/noteable';
-import {extendNoteHelper, isNoteable} from '../types/noteable';
+import {extendOwnAnnotation, isNoteable} from '../types/noteable';
 
 export abstract class DefinitionList<DT extends MalloyElement>
   extends ListOf<DT>
   implements Noteable
 {
   readonly isNoteableObj = true;
-  note?: AnnotationsDef;
+  ownAnnotation?: AnnotationsDef;
 
-  extendNote(ext: Partial<AnnotationsDef>) {
-    extendNoteHelper(this, ext);
-    this.distributeAnnotation();
-  }
-
-  distributeAnnotation() {
-    if (this.note) {
+  // Noteable hook: push this list's own (block) annotation down onto its
+  // members. The block annotation is attached after construction, so it has
+  // to distribute here, at attach time, rather than from the constructor.
+  afterExtendAnnotation(): void {
+    if (this.ownAnnotation) {
       for (const el of this.elements) {
         if (isNoteable(el)) {
-          el.extendNote(this.note);
+          extendOwnAnnotation(el, this.ownAnnotation);
         }
       }
     }
-  }
-
-  protected newContents(): void {
-    super.newContents();
-    this.distributeAnnotation();
   }
 }

--- a/packages/malloy/src/lang/ast/types/malloy-element.ts
+++ b/packages/malloy/src/lang/ast/types/malloy-element.ts
@@ -38,7 +38,7 @@ import {GlobalNameSpace} from './global-name-space';
 import type {ModelEntry} from './model-entry';
 import type {NameSpace} from './name-space';
 import type {Noteable} from './noteable';
-import {isNoteable, extendNoteMethod} from './noteable';
+import {extendOwnAnnotation, isNoteable} from './noteable';
 
 export abstract class MalloyElement {
   abstract elementType: string;
@@ -442,8 +442,7 @@ export class DocStatementList
   elementType = 'topLevelStatements';
   execCursor = 0;
   readonly isNoteableObj = true;
-  extendNote = extendNoteMethod;
-  note?: AnnotationsDef;
+  ownAnnotation?: AnnotationsDef;
   noteCursor = 0;
   executeList(doc: Document): ModelDataRequest {
     while (this.execCursor < this.elements.length) {
@@ -451,8 +450,8 @@ export class DocStatementList
       if (this.noteCursor === this.execCursor) {
         // We only want to set the note on each element once,
         // but we might execute a element multiple times
-        if (this.note && isNoteable(el)) {
-          el.extendNote(this.note);
+        if (this.ownAnnotation && isNoteable(el)) {
+          extendOwnAnnotation(el, this.ownAnnotation);
         }
         this.noteCursor += 1;
       }

--- a/packages/malloy/src/lang/ast/types/noteable.ts
+++ b/packages/malloy/src/lang/ast/types/noteable.ts
@@ -10,24 +10,27 @@ import type {AnnotationsDef} from '../../../model/malloy_types';
  */
 export interface Noteable {
   isNoteableObj: true;
-  note?: AnnotationsDef;
-  extendNote(ext: Partial<AnnotationsDef>): void;
+  ownAnnotation?: AnnotationsDef;
+  // Optional hook, run after this element's own annotation is extended.
+  // Container elements (definition lists) implement it to push a block
+  // annotation down onto their members; leaf elements leave it undefined.
+  afterExtendAnnotation?(): void;
 }
 
 export function isNoteable(el: unknown): el is Noteable {
   return (el as Noteable).isNoteableObj;
 }
 
-export function extendNoteMethod(this: Noteable, ext: Partial<AnnotationsDef>) {
-  extendNoteHelper(this, ext);
-}
-
-export function extendNoteHelper(to: Noteable, ext: Partial<AnnotationsDef>) {
+export function extendOwnAnnotation(
+  to: Noteable,
+  ext: Partial<AnnotationsDef>
+) {
   if (
     (ext.notes && ext.notes.length > 0) ||
     (ext.blockNotes && ext.blockNotes.length > 0) ||
     ext.inherits !== undefined
   ) {
-    to.note = {...to.note, ...ext};
+    to.ownAnnotation = {...to.ownAnnotation, ...ext};
+    to.afterExtendAnnotation?.();
   }
 }

--- a/packages/malloy/src/lang/malloy-to-ast.ts
+++ b/packages/malloy/src/lang/malloy-to-ast.ts
@@ -55,6 +55,7 @@ import {isNotUndefined, rangeFromContext, rangeFromToken} from './utils';
 import {isFilterable} from '@malloydata/malloy-filter';
 import type * as Malloy from '@malloydata/malloy-interfaces';
 import {Timer} from '../timing';
+import {extendOwnAnnotation} from './ast/types/noteable';
 
 class ErrorNode extends ast.SourceQueryElement {
   elementType = 'parseErrorSourceQuery';
@@ -411,7 +412,7 @@ export class MalloyToAST
     const defs = defsCx.map(dcx => this.visitSourceDefinition(dcx));
     const blockNotes = this.getNotes(pcx.tags());
     const defList = new ast.DefineSourceList(defs);
-    defList.extendNote({blockNotes});
+    extendOwnAnnotation(defList, {blockNotes});
     return defList;
   }
 
@@ -424,7 +425,7 @@ export class MalloyToAST
     const blockNotes = this.getNotes(pcx.tags());
     const block = new ast.DefineGivens(givens);
     for (const g of givens) {
-      g.extendNote({blockNotes});
+      extendOwnAnnotation(g, {blockNotes});
     }
     return this.astAt(block, pcx);
   }
@@ -473,7 +474,7 @@ export class MalloyToAST
       }
     }
     const decl = new ast.GivenDeclaration(name, typeDef, defVal, inline);
-    decl.extendNote({notes: this.getNotes(pcx.tags())});
+    extendOwnAnnotation(decl, {notes: this.getNotes(pcx.tags())});
     return this.astAt(decl, pcx);
   }
 
@@ -534,7 +535,7 @@ export class MalloyToAST
     const defs = defsCx.map(dcx => this.visitUserTypeDefinition(dcx));
     const blockNotes = this.getNotes(pcx.tags());
     const defList = new ast.DefineUserTypeList(defs);
-    defList.extendNote({blockNotes});
+    extendOwnAnnotation(defList, {blockNotes});
     return defList;
   }
 
@@ -550,7 +551,7 @@ export class MalloyToAST
     const notes = this.getNotes(pcx.tags()).concat(
       this.getIsNotes(pcx.isDefine())
     );
-    def.extendNote({notes});
+    extendOwnAnnotation(def, {notes});
     return this.astAt(def, pcx);
   }
 
@@ -601,7 +602,7 @@ export class MalloyToAST
       member = new ast.UserTypeMemberDef(name, typeResult);
     }
     const notes = this.getNotes(pcx.tags());
-    member.extendNote({notes});
+    extendOwnAnnotation(member, {notes});
     return this.astAt(member, pcx);
   }
 
@@ -724,7 +725,7 @@ export class MalloyToAST
     const notes = this.getNotes(pcx.tags()).concat(
       this.getIsNotes(pcx.isDefine())
     );
-    exploreDef.extendNote({notes});
+    extendOwnAnnotation(exploreDef, {notes});
     return this.astAt(exploreDef, pcx);
   }
 
@@ -807,7 +808,7 @@ export class MalloyToAST
       }
     }
     const joinMany = new ast.JoinStatement(joins, accessLabel);
-    joinMany.extendNote({blockNotes: this.getNotes(pcx.tags())});
+    extendOwnAnnotation(joinMany, {blockNotes: this.getNotes(pcx.tags())});
     return joinMany;
   }
 
@@ -824,7 +825,7 @@ export class MalloyToAST
       }
     }
     const joinOne = new ast.JoinStatement(joins, accessLabel);
-    joinOne.extendNote({blockNotes: this.getNotes(pcx.tags())});
+    extendOwnAnnotation(joinOne, {blockNotes: this.getNotes(pcx.tags())});
     return joinOne;
   }
 
@@ -846,7 +847,7 @@ export class MalloyToAST
       }
     }
     const joinCross = new ast.JoinStatement(joins, accessLabel);
-    joinCross.extendNote({blockNotes: this.getNotes(pcx.tags())});
+    extendOwnAnnotation(joinCross, {blockNotes: this.getNotes(pcx.tags())});
     return joinCross;
   }
 
@@ -906,7 +907,7 @@ export class MalloyToAST
     if (onCx) {
       join.joinOn = this.getFieldExpr(onCx);
     }
-    join.extendNote({notes: this.getNotes(pcx.tags()).concat(notes)});
+    extendOwnAnnotation(join, {notes: this.getNotes(pcx.tags()).concat(notes)});
     return this.astAt(join, pcx);
   }
 
@@ -914,7 +915,7 @@ export class MalloyToAST
     const {joinAs, joinFrom, notes} = this.getJoinFrom(pcx.joinFrom());
     const joinOn = this.getFieldExpr(pcx.fieldExpr());
     const join = new ast.KeyJoin(joinAs, joinFrom, joinOn);
-    join.extendNote({notes: this.getNotes(pcx.tags()).concat(notes)});
+    extendOwnAnnotation(join, {notes: this.getNotes(pcx.tags()).concat(notes)});
     return this.astAt(join, pcx);
   }
 
@@ -929,7 +930,7 @@ export class MalloyToAST
     const notes = this.getNotes(pcx.tags()).concat(
       this.getIsNotes(pcx.isDefine())
     );
-    def.extendNote({notes});
+    extendOwnAnnotation(def, {notes});
     return this.astAt(def, pcx);
   }
 
@@ -940,7 +941,7 @@ export class MalloyToAST
       ast.DimensionFieldDeclaration
     );
     const stmt = new ast.Dimensions(defs, accessLabel);
-    stmt.extendNote({blockNotes: this.getNotes(pcx.tags())});
+    extendOwnAnnotation(stmt, {blockNotes: this.getNotes(pcx.tags())});
     return this.astAt(stmt, pcx);
   }
 
@@ -971,7 +972,7 @@ export class MalloyToAST
       ast.MeasureFieldDeclaration
     );
     const stmt = new ast.Measures(defs, accessLabel);
-    stmt.extendNote({blockNotes: this.getNotes(pcx.tags())});
+    extendOwnAnnotation(stmt, {blockNotes: this.getNotes(pcx.tags())});
     return this.astAt(stmt, pcx);
   }
 
@@ -1005,7 +1006,7 @@ export class MalloyToAST
     const notes = this.getNotes(pcx.tags()).concat(
       this.getIsNotes(pcx.isDefine())
     );
-    rename.extendNote({notes});
+    extendOwnAnnotation(rename, {notes});
     return this.astAt(rename, pcx);
   }
 
@@ -1015,7 +1016,7 @@ export class MalloyToAST
     const renames = rcxs.map(rcx => this.visitRenameEntry(rcx));
     const stmt = new ast.Renames(renames, accessLabel);
     const blockNotes = this.getNotes(pcx.tags());
-    stmt.extendNote({blockNotes});
+    extendOwnAnnotation(stmt, {blockNotes});
     return this.astAt(stmt, pcx);
   }
 
@@ -1052,7 +1053,7 @@ export class MalloyToAST
       .map(cx => this.visitExploreQueryDef(cx));
     const queryDefs = new ast.Views(babyTurtles, accessLabel);
     const blockNotes = this.getNotes(pcx.tags());
-    queryDefs.extendNote({blockNotes});
+    extendOwnAnnotation(queryDefs, {blockNotes});
     return queryDefs;
   }
 
@@ -1190,7 +1191,7 @@ export class MalloyToAST
         ast.AggregateFieldReference
       )
     );
-    agStmt.extendNote({blockNotes: this.getNotes(pcx.tags())});
+    extendOwnAnnotation(agStmt, {blockNotes: this.getNotes(pcx.tags())});
     return agStmt;
   }
 
@@ -1202,7 +1203,7 @@ export class MalloyToAST
         ast.GroupByFieldReference
       )
     );
-    groupBy.extendNote({blockNotes: this.getNotes(pcx.tags())});
+    extendOwnAnnotation(groupBy, {blockNotes: this.getNotes(pcx.tags())});
     return groupBy;
   }
 
@@ -1214,7 +1215,7 @@ export class MalloyToAST
         ast.CalculateFieldReference
       )
     );
-    stmt.extendNote({blockNotes: this.getNotes(pcx.tags())});
+    extendOwnAnnotation(stmt, {blockNotes: this.getNotes(pcx.tags())});
     return stmt;
   }
 
@@ -1254,11 +1255,11 @@ export class MalloyToAST
         }
       }
       const def = new makeFieldDef(expr, ref.outputName);
-      def.extendNote({notes: this.getNotes(pcx.tags())});
+      extendOwnAnnotation(def, {notes: this.getNotes(pcx.tags())});
       return def;
     }
     const ref = this.getFieldPath(pcx.fieldPath(), makeFieldRef);
-    ref.extendNote({notes: this.getNotes(pcx.tags())});
+    extendOwnAnnotation(ref, {notes: this.getNotes(pcx.tags())});
     return ref;
   }
 
@@ -1305,7 +1306,7 @@ export class MalloyToAST
     pcx: parse.ProjectStatementContext
   ): ast.ProjectStatement {
     const stmt = this.visitFieldCollection(pcx.fieldCollection());
-    stmt.extendNote({blockNotes: this.getNotes(pcx.tags())});
+    extendOwnAnnotation(stmt, {blockNotes: this.getNotes(pcx.tags())});
     return stmt;
   }
 
@@ -1438,7 +1439,7 @@ export class MalloyToAST
       .map(cx => this.visitTopLevelQueryDef(cx));
     const blockNotes = this.getNotes(pcx.tags());
     const queryDefs = new ast.DefineQueryList(stmts);
-    queryDefs.extendNote({blockNotes});
+    extendOwnAnnotation(queryDefs, {blockNotes});
     return queryDefs;
   }
 
@@ -1450,7 +1451,7 @@ export class MalloyToAST
     );
     if (queryExpr instanceof ast.SourceQueryElement) {
       const queryDef = new ast.DefineQuery(queryName, queryExpr);
-      queryDef.extendNote({notes});
+      extendOwnAnnotation(queryDef, {notes});
       return this.astAt(queryDef, pcx);
     }
     throw this.internalError(
@@ -1465,13 +1466,13 @@ export class MalloyToAST
     const theQuery = this.astAt(new ast.AnonymousQuery(query), defCx);
     const notes = this.getNotes(pcx.topLevelAnonQueryDef().tags());
     const blockNotes = this.getNotes(pcx.tags());
-    theQuery.extendNote({notes, blockNotes});
+    extendOwnAnnotation(theQuery, {notes, blockNotes});
     return this.astAt(theQuery, pcx);
   }
 
   visitNestStatement(pcx: parse.NestStatementContext): ast.Nests {
     const nests = this.visitNestedQueryList(pcx.nestedQueryList());
-    nests.extendNote({blockNotes: this.getNotes(pcx.tags())});
+    extendOwnAnnotation(nests, {blockNotes: this.getNotes(pcx.tags())});
     return nests;
   }
 
@@ -1504,7 +1505,7 @@ export class MalloyToAST
     }
     const nestDef = new ast.NestFieldDeclaration(name, vExpr);
     const isDefineCx = pcx.isDefine();
-    nestDef.extendNote({
+    extendOwnAnnotation(nestDef, {
       notes: this.getNotes(pcx.tags()).concat(
         isDefineCx ? this.getIsNotes(isDefineCx) : []
       ),
@@ -1523,7 +1524,7 @@ export class MalloyToAST
     const notes = this.getNotes(pcx.tags()).concat(
       this.getIsNotes(pcx.isDefine())
     );
-    queryDef.extendNote({notes});
+    extendOwnAnnotation(queryDef, {notes});
     return this.astAt(queryDef, pcx);
   }
 
@@ -2375,7 +2376,7 @@ export class MalloyToAST
       const kind = this.getAccessLabelProp(pcx.accessLabelProp());
       const fieldList = this.getIncludeList(listCx);
       const item = this.astAt(new ast.IncludeAccessItem(kind, fieldList), pcx);
-      item.extendNote({blockNotes});
+      extendOwnAnnotation(item, {blockNotes});
       return item;
     }
   }
@@ -2440,7 +2441,7 @@ export class MalloyToAST
       new ast.IncludeListItem(reference, as?.refString),
       pcx
     );
-    item.extendNote({notes});
+    extendOwnAnnotation(item, {notes});
     return item;
   }
 

--- a/packages/malloy/src/lang/test/givens.spec.ts
+++ b/packages/malloy/src/lang/test/givens.spec.ts
@@ -187,7 +187,7 @@ describe('given: declarations', () => {
         # label="Tenant"
         TENANT :: string
     `);
-    expect(givens[0].note?.notes?.map(n => n.text)).toEqual([
+    expect(givens[0].ownAnnotation?.notes?.map(n => n.text)).toEqual([
       '# label="Tenant"\n',
     ]);
   });
@@ -202,7 +202,7 @@ describe('given: declarations', () => {
     // Block notes from the `given:` statement are pushed onto each child
     // declaration's note via extendNote, the same way DefineSourceList works.
     for (const g of givens) {
-      const blockNotes = g.note?.blockNotes?.map(n => n.text) ?? [];
+      const blockNotes = g.ownAnnotation?.blockNotes?.map(n => n.text) ?? [];
       expect(blockNotes).toContain('# block_tag\n');
     }
   });


### PR DESCRIPTION
The annotation member on `MalloyElement` was named `note` — a poor choice made early, before annotations grew block notes and inheritance. It holds a full `AnnotationsDef`, not a note, so the name has aged badly, and it recently tripped up an AI working in here into treating a whole annotation struct as a single note.

Cleaning up the name also cleaned up how the `Noteable` interface works — block-annotation distribution no longer rides on a setter side-effect.

Details are in the diff if you care.

(Also carries a one-line `jest.config.simple.ts` fix: a `process.env.TZ` property access that TypeScript 6.0 started rejecting.)