### PR TITLE
Fix blank bar chart when stack is set without a series

### DIFF
--- a/packages/malloy-render/src/plugins/bar-chart/generate-bar_chart-vega-spec.spec.ts
+++ b/packages/malloy-render/src/plugins/bar-chart/generate-bar_chart-vega-spec.spec.ts
@@ -27,6 +27,7 @@ import {
   SOURCE4,
 } from '@/plugins/spec-test-support/harness';
 import type {VegaChartProps} from '@/component/types';
+import type {GroupMark} from 'vega';
 import {getBarChartSettings} from '@/plugins/bar-chart/get-bar_chart-settings';
 import {
   generateBarChartVegaSpecV2,
@@ -147,6 +148,51 @@ describe('bar_chart honors # label tags in default tooltips', () => {
       'Reach (HH)',
       'Avg Reach',
     ]);
+  }, 60000);
+});
+
+describe('bar_chart stack without a series', () => {
+  function barEncode(spec: VegaChartProps['spec']) {
+    const group = spec.marks?.find((m): m is GroupMark => m.type === 'group');
+    const bars = group?.marks?.find(m => m.name === 'bars');
+    return bars?.encode?.enter;
+  }
+  function yScaleDomain(spec: VegaChartProps['spec']) {
+    return spec.scales?.find(s => s.name === 'yscale')?.domain;
+  }
+
+  test('uses the unstacked encoding', async () => {
+    const {spec} = await buildBarProps(
+      SOURCE,
+      `
+      # bar_chart.stack
+      run: data -> {
+        group_by: audience_name
+        aggregate: total_reach is reach.sum()
+      }
+      `
+    );
+    const enter = barEncode(spec);
+    expect(enter?.y).toMatchObject({scale: 'yscale', field: 'y'});
+    expect(enter?.y2).toMatchObject({scale: 'yscale', value: 0});
+    expect(yScaleDomain(spec)).toEqual([0, 100]);
+  }, 60000);
+
+  test('still stacks y0/y1 when a series is present', async () => {
+    const {spec} = await buildBarProps(
+      SOURCE,
+      `
+      # bar_chart.stack
+      run: data -> {
+        group_by: audience_name, period
+        aggregate: total_reach is reach.sum()
+      }
+      `
+    );
+    const enter = barEncode(spec);
+    expect(enter?.y).toMatchObject({scale: 'yscale', field: 'y0'});
+    expect(enter?.y2).toMatchObject({scale: 'yscale', field: 'y1'});
+    expect(yScaleDomain(spec)).toMatchObject({data: 'values', field: 'y1'});
   }, 60000);
 });
 

--- a/packages/malloy-render/src/plugins/bar-chart/generate-bar_chart-vega-spec.ts
+++ b/packages/malloy-render/src/plugins/bar-chart/generate-bar_chart-vega-spec.ts
@@ -199,6 +199,7 @@ export function generateBarChartVegaSpecV2(
    *************************************/
 
   const isGrouping = hasSeries && !settings.isStack;
+  // Docs: "stack bars when a series is present", so y0/y1 exist only when both hold.
   const isStacking = hasSeries && settings.isStack;
 
   // Calculate min/max across all y columns
@@ -386,9 +387,9 @@ export function generateBarChartVegaSpecV2(
         width: xWidth,
         y: {
           scale: 'yscale',
-          field: settings.isStack ? 'y0' : 'y',
+          field: isStacking ? 'y0' : 'y',
         },
-        y2: settings.isStack
+        y2: isStacking
           ? {'scale': 'yscale', 'field': 'y1'}
           : {'scale': 'yscale', 'value': 0},
       },
@@ -703,7 +704,7 @@ export function generateBarChartVegaSpecV2(
         name: 'yscale',
         nice: true,
         range: 'height',
-        domain: settings.isStack
+        domain: isStacking
           ? {data: 'values', field: 'y1'}
           : (chartSettings.yScale.domain ?? {data: 'values', field: 'y'}),
       },


### PR DESCRIPTION
## What

`# bar_chart.stack` on a query with **no series** renders a blank chart: an axis label, no y-axis ticks, no bars.

The spec generator gates the stack **transform** on `isStacking` (`hasSeries && isStack`) at `generate-bar_chart-vega-spec.ts:480`, but three **consumers** read raw `settings.isStack`: the bar mark's `y` (`:389`) and `y2` (`:391`) encodings, and the yscale `domain` (`:706`). When `isStack` is true but `hasSeries` is false, the transform never runs, so those three reference `y0`/`y1` fields that were never produced. Bar heights resolve to `NaN`, the y domain resolves to `[null, null]`, and nothing paints. The axis label still renders because it reads `settings.yChannel.fields` rather than the data, which is what makes the failure look like a working chart that lost its bars.

Stacking a single series should be a no-op.

## Repro

```malloy
# bar_chart.stack
run: data -> {
  group_by: audience_name
  aggregate: total_reach is reach.sum()
}
```

<img width="1200" height="700" alt="1-before" src="https://github.com/user-attachments/assets/f2a66c5c-9a59-4043-8e5f-85495117bb28" />
<img width="1200" height="700" alt="2-after" src="https://github.com/user-attachments/assets/c9fa8e76-9477-4fe3-99aa-7fc062299d95" />
<img width="1200" height="700" alt="3-after-control-still-stacks" src="https://github.com/user-attachments/assets/4dd7f7e2-79a2-4a3c-abf3-168b93db50b4" />


Blank before, a normal (unstacked) bar chart after. The same tag with two dimensions autofills the series channel and stacks correctly, before and after.

## Fix

Route the three consumers through the `isStacking` the producer already uses. Only one cell of the truth table moves:

| hasSeries | isStack | isStacking | y0/y1 exist? | before | after |
|---|---|---|---|---|---|
| T | T | T | yes | y0 / y1 / domain y1 | unchanged |
| T | F | F | no | y / value:0 / else | unchanged |
| **F** | **T** | **F** | **no — transform skipped** | **y0 / y1 / domain y1 — reads fields nothing produced** | **y / value:0 / else** |
| F | F | F | no | y / value:0 / else | unchanged |

No case where `hasSeries` is true changes at all, so grouped and stacked-with-series charts are untouched. `:624`/`:627` already read `isStacking`, which is what made these three the outliers; after this there are no raw `settings.isStack` reads left in the generator.

## Why not normalize `isStack` in the settings layer instead

Forcing `isStack = false` when there's no series would also fix the blank chart, but it would break tag round-tripping. `get-bar_chart-settings.ts:109` is `const isStack = vizTag.has('stack')` — the field means "the user wrote `# bar_chart.stack`", independent of series. `settings-to-tag.ts:53` regenerates the tag with `if (settings.isStack !== defaultBarChartSettings.isStack)` (default `false`), so normalizing it to `false` would silently **drop the user's `stack` tag** on round-trip. It would also leave the producer/consumer asymmetry live for the next caller.

## Why `stack` stays a no-op without a series

This means `# bar_chart.stack` on a query with no series renders plain bars, i.e. the tag has no effect. That is deliberate: it's the documented contract, not a shortcut.

- `bar_charts.malloynb:10` — "`.stack` | Stack bars when series is present"
- `renderer_tags_overview.md:24` — "`.stack`: Stacks bars when a series is present."
- `bar-chart-settings.ts` — "Whether to stack bars when multiple series are present"

`hasSeries && settings.isStack` *is* "when a series is present", so `isStacking` already encodes the documented rule and the three consumers now agree with it. I've noted this at the declaration so the `hasSeries &&` doesn't get optimised back out later.

The alternative — making the transform run on `settings.isStack` alone (a one-line change, since the consumers already read `isStacking`) — would additionally sum repeated x values when there's no series. It's tempting, and it fixes this bug equally well, but it silently redefines `stack` against all three docs, so it doesn't belong in a bug-fix PR. Happy to raise it separately if you think the tag should mean "sum values sharing an x" regardless of series.

## Note on the legacy twin

`src/component/bar-chart/generate-bar_chart-vega-spec.ts` carries the identical bug (`isStacking` defined at `:172`, unused at `:369`/`:371`/`:704`). It's left alone deliberately: its only export `generateBarChartVegaSpec` has zero call sites, and the live path is `src/plugins/bar-chart/` via `bar-chart-plugin.tsx:20`. Happy to fix or delete it in a separate PR if you'd prefer. (Worth flagging that `packages/malloy-render/CONTEXT.md` describes `src/component/` as "the new renderer, the default", which reads as though that copy is live.)

## Tests

Two tests in the existing `generate-bar_chart-vega-spec.spec.ts`: one pinning the unstacked encoding and the resolved domain for the no-series case, one control confirming a real series still stacks `y0`/`y1`. Verified the first fails on the unfixed tree and the control passes both ways, so it isn't vacuous. Full `malloy-render` project: 155/155 green. Also verified visually in Storybook.
