### PR TITLE
Bump prettier to 3.9.5 and reformat

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "jest-silent-reporter": "^0.6.0",
         "jest-util": "^29.0.0",
         "lerna": "^9.0.7",
-        "prettier": "^3.0.3",
+        "prettier": "^3.9.5",
         "ts-jest": "^29.4.9",
         "ts-node": "^10.9.1",
         "typescript": "^6.0.3",
@@ -25380,9 +25380,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
-      "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.5.tgz",
+      "integrity": "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "jest-silent-reporter": "^0.6.0",
     "jest-util": "^29.0.0",
     "lerna": "^9.0.7",
-    "prettier": "^3.0.3",
+    "prettier": "^3.9.5",
     "ts-jest": "^29.4.9",
     "ts-node": "^10.9.1",
     "typescript": "^6.0.3",

--- a/packages/malloy-db-snowflake/src/snowflake_connection.ts
+++ b/packages/malloy-db-snowflake/src/snowflake_connection.ts
@@ -68,9 +68,7 @@ export interface TableSizeProbe {
  *     is the acknowledged "can't help you" case from the design doc.
  */
 export type SampleStrategy =
-  | 'full-scan-then-sample'
-  | 'tablesample-only'
-  | 'tablesample-then-limit';
+  'full-scan-then-sample' | 'tablesample-only' | 'tablesample-then-limit';
 
 export function pickSampleStrategy(
   probe: TableSizeProbe | undefined,

--- a/packages/malloy-db-trino/src/trino_connection.ts
+++ b/packages/malloy-db-trino/src/trino_connection.ts
@@ -43,10 +43,7 @@ export interface TrinoManagerOptions {
 }
 
 export type TrinoExtraConfigKey =
-  | 'ssl'
-  | 'session'
-  | 'extraCredential'
-  | 'extraHeaders';
+  'ssl' | 'session' | 'extraCredential' | 'extraHeaders';
 
 export interface TrinoConnectionConfiguration {
   server?: string;

--- a/packages/malloy-filter/src/filter_interface.ts
+++ b/packages/malloy-filter/src/filter_interface.ts
@@ -150,14 +150,7 @@ export function isNumberFilter(sc: unknown): sc is NumberFilter {
 }
 
 export type TemporalUnit =
-  | 'second'
-  | 'minute'
-  | 'hour'
-  | 'day'
-  | 'week'
-  | 'month'
-  | 'quarter'
-  | 'year';
+  'second' | 'minute' | 'hour' | 'day' | 'week' | 'month' | 'quarter' | 'year';
 
 export interface TemporalLiteral {
   moment: 'literal';
@@ -281,10 +274,7 @@ export function isTemporalFilter(sc: unknown): sc is TemporalFilter {
 }
 
 export type FilterExpression =
-  | BooleanFilter
-  | NumberFilter
-  | StringFilter
-  | TemporalFilter;
+  BooleanFilter | NumberFilter | StringFilter | TemporalFilter;
 
 export function isFilterExpression(obj: unknown): obj is FilterExpression {
   return typeof obj === 'object' && obj !== null && 'operator' in obj;
@@ -305,12 +295,7 @@ export interface FilterParserResponse<T extends FilterExpression> {
 }
 
 export type FilterableType =
-  | 'string'
-  | 'number'
-  | 'boolean'
-  | 'timestamp'
-  | 'timestamptz'
-  | 'date';
+  'string' | 'number' | 'boolean' | 'timestamp' | 'timestamptz' | 'date';
 export function isFilterable(s: string): s is FilterableType {
   return [
     'string',

--- a/packages/malloy-interfaces/src/to_malloy.ts
+++ b/packages/malloy-interfaces/src/to_malloy.ts
@@ -463,9 +463,7 @@ function fieldItemToFragments(
 
 function fieldOperationToFragments(
   operation:
-    | Malloy.GroupBy[]
-    | Malloy.Aggregate[]
-    | Malloy.CalculateOperation[],
+    Malloy.GroupBy[] | Malloy.Aggregate[] | Malloy.CalculateOperation[],
   label: string
 ): Fragment[] {
   const fragments: Fragment[] = [];

--- a/packages/malloy-interfaces/src/types.ts
+++ b/packages/malloy-interfaces/src/types.ts
@@ -2092,11 +2092,7 @@ export type Field = {
 };
 
 export type FieldInfoType =
-  | 'dimension'
-  | 'measure'
-  | 'join'
-  | 'view'
-  | 'calculate';
+  'dimension' | 'measure' | 'join' | 'view' | 'calculate';
 
 export type FieldInfo =
   | FieldInfoWithDimension
@@ -2285,8 +2281,7 @@ export type MeasureInfo = {
 export type ModelEntryValueType = 'source' | 'query';
 
 export type ModelEntryValue =
-  | ModelEntryValueWithSource
-  | ModelEntryValueWithQuery;
+  ModelEntryValueWithSource | ModelEntryValueWithQuery;
 
 export type ModelEntryValueWithSource = {kind: 'source'} & SourceInfo;
 
@@ -2423,8 +2418,7 @@ export type QueryArrow = {
 export type QueryArrowSourceType = 'refinement' | 'source_reference';
 
 export type QueryArrowSource =
-  | QueryArrowSourceWithRefinement
-  | QueryArrowSourceWithSourceReference;
+  QueryArrowSourceWithRefinement | QueryArrowSourceWithSourceReference;
 
 export type QueryArrowSourceWithRefinement = {
   kind: 'refinement';
@@ -2584,14 +2578,7 @@ export type TimestampLiteral = {
 };
 
 export type TimestampTimeframe =
-  | 'year'
-  | 'quarter'
-  | 'month'
-  | 'week'
-  | 'day'
-  | 'hour'
-  | 'minute'
-  | 'second';
+  'year' | 'quarter' | 'month' | 'week' | 'day' | 'hour' | 'minute' | 'second';
 
 export type TimestampType = {
   timeframe?: TimestampTimeframe;
@@ -2623,10 +2610,7 @@ export type ViewArrow = {
 };
 
 export type ViewDefinitionType =
-  | 'arrow'
-  | 'view_reference'
-  | 'refinement'
-  | 'segment';
+  'arrow' | 'view_reference' | 'refinement' | 'segment';
 
 export type ViewDefinition =
   | ViewDefinitionWithArrow

--- a/packages/malloy-malloy-sql/src/types.ts
+++ b/packages/malloy-malloy-sql/src/types.ts
@@ -46,8 +46,7 @@ export interface ParsedMalloySQLOtherStatementPart {
 }
 
 export type ParsedMalloySQLStatementPart =
-  | ParsedMalloySQLMalloyStatementPart
-  | ParsedMalloySQLOtherStatementPart;
+  ParsedMalloySQLMalloyStatementPart | ParsedMalloySQLOtherStatementPart;
 
 export interface MalloySQLParseResults {
   initialComments: string;
@@ -106,6 +105,4 @@ export interface MalloySQLMarkdownStatement extends MalloySQLStatementBase {
 }
 
 export type MalloySQLStatement =
-  | MalloySQLSQLStatement
-  | MalloySQLMalloyStatement
-  | MalloySQLMarkdownStatement;
+  MalloySQLSQLStatement | MalloySQLMalloyStatement | MalloySQLMarkdownStatement;

--- a/packages/malloy-query-builder/src/query-ast.ts
+++ b/packages/malloy-query-builder/src/query-ast.ts
@@ -1475,8 +1475,7 @@ export interface IASTQueryDefinition extends IASTQueryOrViewDefinition {
 }
 
 export type ASTQueryArrowSource =
-  | ASTReferenceQueryArrowSource
-  | ASTRefinementQueryDefinition;
+  ASTReferenceQueryArrowSource | ASTRefinementQueryDefinition;
 export const ASTQueryArrowSource = {
   from(definition: Malloy.QueryArrowSource) {
     switch (definition.kind) {
@@ -3999,8 +3998,7 @@ export class ASTField
    */
   get segment() {
     const groupByOrAggregate = this.parent as
-      | ASTGroupByViewOperation
-      | ASTAggregateViewOperation;
+      ASTGroupByViewOperation | ASTAggregateViewOperation;
     const operationList = groupByOrAggregate.list;
     return operationList.segment;
   }
@@ -4757,8 +4755,7 @@ export class ASTCalculateViewOperation extends ASTObjectNode<
 }
 
 export type ASTFilter =
-  | ASTFilterWithFilterString
-  | ASTFilterWithLiteralEquality;
+  ASTFilterWithFilterString | ASTFilterWithLiteralEquality;
 export const ASTFilter = {
   from(filter: Malloy.Filter) {
     switch (filter.kind) {

--- a/packages/malloy-render/src/api/plugin-types.ts
+++ b/packages/malloy-render/src/api/plugin-types.ts
@@ -54,8 +54,7 @@ export interface DOMRenderPluginInstance<
 }
 
 export type RenderPluginInstance<TMetadata = unknown> =
-  | SolidJSRenderPluginInstance<TMetadata>
-  | DOMRenderPluginInstance<TMetadata>;
+  SolidJSRenderPluginInstance<TMetadata> | DOMRenderPluginInstance<TMetadata>;
 
 export interface CoreVizPluginMethods {
   getSchema(): JSONSchemaObject;

--- a/packages/malloy-render/src/component/result-store/result-store.ts
+++ b/packages/malloy-render/src/component/result-store/result-store.ts
@@ -30,9 +30,7 @@ interface BrushDataMeasureRange extends BrushDataBase {
 }
 
 export type BrushData =
-  | BrushDataDimension
-  | BrushDataMeasure
-  | BrushDataMeasureRange;
+  BrushDataDimension | BrushDataMeasure | BrushDataMeasureRange;
 
 export type VegaBrushOutput = {
   sourceId: string;

--- a/packages/malloy-render/src/data_tree/cells/index.ts
+++ b/packages/malloy-render/src/data_tree/cells/index.ts
@@ -53,13 +53,7 @@ export type Cell =
   | SQLNativeCell;
 
 export type CellValue =
-  | string
-  | number
-  | boolean
-  | Date
-  | Cell[]
-  | Record<string, Cell>
-  | null;
+  string | number | boolean | Date | Cell[] | Record<string, Cell> | null;
 
 export const Cell = {
   from(cell: Malloy.Cell, field: Field, parent: NestCell): Cell {

--- a/packages/malloy-render/src/plugins/big-value/big-value-plugin.tsx
+++ b/packages/malloy-render/src/plugins/big-value/big-value-plugin.tsx
@@ -279,8 +279,7 @@ export const BigValuePluginFactory: RenderPluginFactory<BigValuePluginInstance> 
           // customProps, keyed by this plugin's name, the same way the table
           // renderer reads customProps.table.
           const bigValueProps = props.customProps?.['big_value'] as
-            | {embedded?: boolean}
-            | undefined;
+            {embedded?: boolean} | undefined;
 
           return (
             <BigValueComponent

--- a/packages/malloy-render/src/plugins/line-chart/line-chart-plugin.tsx
+++ b/packages/malloy-render/src/plugins/line-chart/line-chart-plugin.tsx
@@ -98,8 +98,7 @@ export const LineChartPluginFactory: RenderPluginFactory<LineChartPluginInstance
       }
 
       const lineChartOptions = pluginOptions as
-        | LineChartPluginOptions
-        | undefined;
+        LineChartPluginOptions | undefined;
       let settings: LineChartSettings;
       const seriesStats = new Map<string, SeriesStats>();
       let runtime: Runtime | undefined;

--- a/packages/malloy-render/src/util.ts
+++ b/packages/malloy-render/src/util.ts
@@ -352,13 +352,7 @@ export type ScaleKey = 'k' | 'm' | 'b' | 't' | 'q';
 
 // Suffix format key type
 export type SuffixFormatKey =
-  | 'letter'
-  | 'lower'
-  | 'word'
-  | 'short'
-  | 'finance'
-  | 'scientific'
-  | 'none';
+  'letter' | 'lower' | 'word' | 'short' | 'finance' | 'scientific' | 'none';
 
 // Scale configuration
 const SCALE_CONFIG: Record<ScaleKey, {divisor: number; threshold: number}> = {

--- a/packages/malloy-syntax-highlight/scripts/generateMonarchGrammar.ts
+++ b/packages/malloy-syntax-highlight/scripts/generateMonarchGrammar.ts
@@ -16,11 +16,9 @@ export type MonarchTokenizer = {
   [name: ReferenceString]: Monarch.IMonarchLanguageRule[];
 };
 export type MonarchPrimitiveAction =
-  | Monarch.IShortMonarchLanguageAction
-  | Monarch.IShortMonarchLanguageAction[];
+  Monarch.IShortMonarchLanguageAction | Monarch.IShortMonarchLanguageAction[];
 export type MonarchActions = (
-  | Monarch.IShortMonarchLanguageAction
-  | Monarch.IExpandedMonarchLanguageAction
+  Monarch.IShortMonarchLanguageAction | Monarch.IExpandedMonarchLanguageAction
 )[];
 
 export type TextMateRepositoryKey = string;

--- a/packages/malloy-tag/src/tags.ts
+++ b/packages/malloy-tag/src/tags.ts
@@ -54,14 +54,7 @@ export type PathSegment = string | number;
 export type Path = PathSegment[];
 
 export type TagSetValue =
-  | string
-  | number
-  | boolean
-  | Date
-  | string[]
-  | number[]
-  | Tag
-  | null;
+  string | number | boolean | Date | string[] | number[] | Tag | null;
 
 /**
  * Class for interacting with the parsed output of an annotation

--- a/packages/malloy/src/api/foundation/core.ts
+++ b/packages/malloy/src/api/foundation/core.ts
@@ -1171,12 +1171,7 @@ export interface RuntimeContext {
 }
 
 export type ReferenceKind =
-  | 'field'
-  | 'join'
-  | 'explore'
-  | 'query'
-  | 'sqlBlock'
-  | 'given';
+  'field' | 'join' | 'explore' | 'query' | 'sqlBlock' | 'given';
 
 const REFERENCE_KIND_BY_IR_TYPE: Record<
   DocumentReference['type'],

--- a/packages/malloy/src/api/foundation/runtime.ts
+++ b/packages/malloy/src/api/foundation/runtime.ts
@@ -119,11 +119,9 @@ export class Runtime {
   private _config: MalloyConfig | undefined;
   private _buildManifest: BuildManifest | undefined;
   private _resolvedBuildManifestPromise:
-    | Promise<BuildManifest | undefined>
-    | undefined;
+    Promise<BuildManifest | undefined> | undefined;
   private _resolvedGivensPromise:
-    | Promise<Record<string, GivenValue> | undefined>
-    | undefined;
+    Promise<Record<string, GivenValue> | undefined> | undefined;
   private _constructorGivensMap: ReadonlyMap<string, GivenValue>;
   private _finalizedGivensSet: ReadonlySet<string>;
   private _virtualMap: VirtualMap | undefined;

--- a/packages/malloy/src/dialect/dialect.ts
+++ b/packages/malloy/src/dialect/dialect.ts
@@ -103,11 +103,7 @@ export interface QueryInfo {
 }
 
 export type FieldReferenceType =
-  | 'table'
-  | 'nest source'
-  | 'array[scalar]'
-  | 'array[record]'
-  | 'record';
+  'table' | 'nest source' | 'array[scalar]' | 'array[record]' | 'record';
 
 const allUnits = [
   'microsecond',

--- a/packages/malloy/src/dialect/functions/util.ts
+++ b/packages/malloy/src/dialect/functions/util.ts
@@ -206,8 +206,7 @@ export interface ArrayBlueprint {
   array: TypeDescElementBlueprintOrNamedGeneric;
 }
 export type TypeDescElementBlueprintOrNamedGeneric =
-  | TypeDescElementBlueprint
-  | NamedGeneric;
+  TypeDescElementBlueprint | NamedGeneric;
 export interface RecordBlueprint {
   record: Record<string, TypeDescElementBlueprintOrNamedGeneric>;
 }
@@ -218,10 +217,7 @@ export interface SQLNativeTypeBlueprint {
 
 export type LeafPlusType = BasicExpressionType | 'any';
 export type TypeDescElementBlueprint =
-  | LeafPlusType
-  | ArrayBlueprint
-  | RecordBlueprint
-  | SQLNativeTypeBlueprint;
+  LeafPlusType | ArrayBlueprint | RecordBlueprint | SQLNativeTypeBlueprint;
 export type NamedGeneric = {generic: string};
 
 export type TypeDescBlueprint =
@@ -587,8 +583,7 @@ function expandImplBlueprint(blueprint: DefinitionBlueprint): {
 
 function expandGenericDefinitions(
   blueprint:
-    | {[name: string]: TypeDescElementBlueprintOrNamedGeneric[]}
-    | undefined
+    {[name: string]: TypeDescElementBlueprintOrNamedGeneric[]} | undefined
 ): {name: string; acceptibleTypes: FunctionGenericTypeDef[]}[] | undefined {
   if (blueprint === undefined) return undefined;
   return Object.entries(blueprint).map(([name, acceptibleTypes]) => ({

--- a/packages/malloy/src/dialect/table-path.ts
+++ b/packages/malloy/src/dialect/table-path.ts
@@ -14,8 +14,7 @@
 // take a canonical tablePath apart to talk to a metadata API.
 
 export type ValidateTablePathResult =
-  | {ok: true; canonical: string}
-  | {ok: false; error: string};
+  {ok: true; canonical: string} | {ok: false; error: string};
 
 export interface TablePathSegment {
   /** Decoded segment value: delimiters stripped, escapes unescaped. */
@@ -25,8 +24,7 @@ export interface TablePathSegment {
 }
 
 export type DecodeDottedTablePathResult =
-  | {ok: true; segments: TablePathSegment[]}
-  | {ok: false; error: string};
+  {ok: true; segments: TablePathSegment[]} | {ok: false; error: string};
 
 export type TablePathEscapeStyle = 'doubled' | 'backslash';
 

--- a/packages/malloy/src/lang/ast/expressions/expr-func.ts
+++ b/packages/malloy/src/lang/ast/expressions/expr-func.ts
@@ -114,8 +114,7 @@ export class ExprFunc extends ExpressionDef {
   private findFunctionDef(
     dialect: string | undefined
   ):
-    | {found: FunctionDef; error: undefined}
-    | {found: undefined; error: string} {
+    {found: FunctionDef; error: undefined} | {found: undefined; error: string} {
     // TODO this makes functions case-insensitive. This is weird that this is the only place
     // where case insensitivity is thing.
     const normalizedName = this.name.toLowerCase();
@@ -643,8 +642,7 @@ function findOverload(
 }
 
 type InterpolationPart =
-  | {type: 'string'; value: string}
-  | {type: 'interpolation'; path: string[]};
+  {type: 'string'; value: string} | {type: 'interpolation'; path: string[]};
 
 function parseSQLInterpolation(template: string): InterpolationPart[] {
   const parts: InterpolationPart[] = [];

--- a/packages/malloy/src/lang/ast/expressions/expr-record-literal.ts
+++ b/packages/malloy/src/lang/ast/expressions/expr-record-literal.ts
@@ -14,8 +14,7 @@ import * as TDU from '../typedesc-utils';
 import type {ExprIdReference} from './expr-id-reference';
 
 export type ElementDetails =
-  | {path: ExprIdReference}
-  | {key?: string; value: ExpressionDef};
+  {path: ExprIdReference} | {key?: string; value: ExpressionDef};
 export class RecordElement extends MalloyElement {
   elementType = 'record element';
   value: ExpressionDef;

--- a/packages/malloy/src/lang/ast/query-items/field-references.ts
+++ b/packages/malloy/src/lang/ast/query-items/field-references.ts
@@ -59,8 +59,7 @@ export abstract class FieldReference
   // does not produce an output column named for its last path element (e.g.
   // index references, view references). Overridden by the references that do.
   protected autoRenameDeclarationCtor():
-    | FieldDeclarationConstructor
-    | undefined {
+    FieldDeclarationConstructor | undefined {
     return undefined;
   }
 

--- a/packages/malloy/src/lang/ast/source-elements/composite-source.ts
+++ b/packages/malloy/src/lang/ast/source-elements/composite-source.ts
@@ -149,16 +149,14 @@ function composeSources(
           if (field.accessModifier === 'internal') {
             existing.accessModifier = 'internal';
           }
-          if (
-            !(
-              TD.eq(field, existing) ||
-              // Handle the case where both fields don't have a raw type...
-              // TODO ask MToy about this
-              (field.type === 'sql native' &&
-                existing.type === 'sql native' &&
-                field.rawType === existing.rawType)
-            )
-          ) {
+          if (!(
+            TD.eq(field, existing) ||
+            // Handle the case where both fields don't have a raw type...
+            // TODO ask MToy about this
+            (field.type === 'sql native' &&
+              existing.type === 'sql native' &&
+              field.rawType === existing.rawType)
+          )) {
             source.logTo.logError(
               'composite-field-type-mismatch',
               `field \`${

--- a/packages/malloy/src/lang/ast/types/binary_operators.ts
+++ b/packages/malloy/src/lang/ast/types/binary_operators.ts
@@ -9,15 +9,9 @@ export type LogicalMalloyOperator = 'and' | 'or';
 export type ArithmeticMalloyOperator = '+' | '-' | '*' | '/' | '%';
 export type EqualityMalloyOperator = '~' | '!~' | '=' | '!=';
 export type CompareMalloyOperator =
-  | '<'
-  | '<='
-  | '>'
-  | '>='
-  | EqualityMalloyOperator;
+  '<' | '<=' | '>' | '>=' | EqualityMalloyOperator;
 export type BinaryMalloyOperator =
-  | ArithmeticMalloyOperator
-  | CompareMalloyOperator
-  | LogicalMalloyOperator;
+  ArithmeticMalloyOperator | CompareMalloyOperator | LogicalMalloyOperator;
 
 export function getExprNode(mo: BinaryMalloyOperator): BinaryOperator {
   switch (mo) {

--- a/packages/malloy/src/lang/ast/types/field-collection-member.ts
+++ b/packages/malloy/src/lang/ast/types/field-collection-member.ts
@@ -12,8 +12,7 @@ import {
 import type {MalloyElement} from './malloy-element';
 
 export type FieldCollectionMember =
-  | FieldReferenceElement
-  | AtomicFieldDeclaration;
+  FieldReferenceElement | AtomicFieldDeclaration;
 export function isFieldCollectionMember(
   el: MalloyElement
 ): el is FieldCollectionMember {

--- a/packages/malloy/src/lang/ast/types/field-prop-statement.ts
+++ b/packages/malloy/src/lang/ast/types/field-prop-statement.ts
@@ -11,11 +11,7 @@ import {PartitionBy} from '../expressions/partition_by';
 import type {MalloyElement} from './malloy-element';
 
 export type FieldPropStatement =
-  | Filter
-  | Limit
-  | PartitionBy
-  | FunctionOrdering
-  | GroupedBy;
+  Filter | Limit | PartitionBy | FunctionOrdering | GroupedBy;
 
 export function isFieldPropStatement(
   el: MalloyElement

--- a/packages/malloy/src/lang/ast/types/query-item.ts
+++ b/packages/malloy/src/lang/ast/types/query-item.ts
@@ -9,6 +9,4 @@ import type {FieldReference} from '../query-items/field-references';
 import type {NestFieldDeclaration} from '../query-properties/nest';
 
 export type QueryItem =
-  | AtomicFieldDeclaration
-  | FieldReference
-  | NestFieldDeclaration;
+  AtomicFieldDeclaration | FieldReference | NestFieldDeclaration;

--- a/packages/malloy/src/lang/parse-log.ts
+++ b/packages/malloy/src/lang/parse-log.ts
@@ -542,8 +542,7 @@ type MessageCodeAndParameters<T extends MessageCode> = {
 export type AnyMessageCodeAndParameters = MessageCodeAndParameters<MessageCode>;
 
 type MessageFormatter<T extends MessageCode> =
-  | MessageInfo
-  | ((parameters: MessageParameterType<T>) => MessageInfo);
+  MessageInfo | ((parameters: MessageParameterType<T>) => MessageInfo);
 
 type ErrorCodeMessageMap = {
   [key in keyof MessageParameterTypes]: MessageFormatter<key>;

--- a/packages/malloy/src/model/constant_expression_compiler.ts
+++ b/packages/malloy/src/model/constant_expression_compiler.ts
@@ -175,8 +175,7 @@ class ConstantQueryStruct extends QueryStruct {
 }
 
 type ConstantExpressionResult =
-  | {sql: string; error?: undefined}
-  | {sql?: undefined; error: string};
+  {sql: string; error?: undefined} | {sql?: undefined; error: string};
 
 /**
  * Compiles an IR expression containing only constants and parameters to SQL.

--- a/packages/malloy/src/model/expression_compiler.ts
+++ b/packages/malloy/src/model/expression_compiler.ts
@@ -457,7 +457,7 @@ function expandFunctionCall(
 ) {
   function withCommas(es: Expr[]): SQLExprElement[] {
     const ret: SQLExprElement[] = [];
-    for (let i = 0; i < es.length; ) {
+    for (let i = 0; i < es.length;) {
       ret.push(es[i]);
       i += 1;
       if (i < es.length) {

--- a/packages/malloy/src/model/malloy_types.ts
+++ b/packages/malloy/src/model/malloy_types.ts
@@ -173,12 +173,7 @@ export interface FilteredExpr extends ExprWithKids {
 }
 
 export type AggregateFunctionType =
-  | 'sum'
-  | 'avg'
-  | 'count'
-  | 'distinct'
-  | 'max'
-  | 'min';
+  'sum' | 'avg' | 'count' | 'distinct' | 'max' | 'min';
 
 export interface AggregateExpr extends ExprE {
   node: 'aggregate';
@@ -339,12 +334,7 @@ export interface RegexMatchExpr extends ExprWithKids {
 }
 
 export type FilterExprType =
-  | 'string'
-  | 'number'
-  | 'boolean'
-  | 'date'
-  | 'timestamp'
-  | 'timestamptz';
+  'string' | 'number' | 'boolean' | 'date' | 'timestamp' | 'timestamptz';
 export function isFilterExprType(s: string): s is FilterExprType {
   return [
     'string',
@@ -389,9 +379,7 @@ export interface TimestamptzLiteralNode extends ExprLeaf {
 }
 
 export type TimeLiteralExpr =
-  | DateLiteralNode
-  | TimestampLiteralNode
-  | TimestamptzLiteralNode;
+  DateLiteralNode | TimestampLiteralNode | TimestamptzLiteralNode;
 
 export function isTimeLiteral(e: Expr): e is TimeLiteralExpr {
   return (
@@ -1090,10 +1078,7 @@ export type ErrorFieldDef = ErrorTypeDef & AtomicFieldDef;
 
 export type JoinType = 'one' | 'many' | 'cross';
 export type JoinRelationship =
-  | 'one_to_one'
-  | 'one_to_many'
-  | 'many_to_one'
-  | 'many_to_many';
+  'one_to_one' | 'one_to_many' | 'many_to_one' | 'many_to_many';
 
 export type MatrixOperation = 'left' | 'right' | 'full' | 'inner';
 
@@ -1211,8 +1196,7 @@ export interface FunctionOrderByDefaultExpression extends ExprLeaf {
 }
 
 export type FunctionOrderBy =
-  | FunctionOrderByExpression
-  | FunctionOrderByDefaultExpression;
+  FunctionOrderByExpression | FunctionOrderByDefaultExpression;
 
 /** reference to a data source */
 // TODO this should be renamed to `SourceRef`
@@ -1623,8 +1607,7 @@ export interface SourceRegistryReference {
  * - PersistableSourceDef: source is not in namespace (hidden dependency), stored directly
  */
 export type SourceRegistryEntry =
-  | SourceRegistryReference
-  | PersistableSourceDef;
+  SourceRegistryReference | PersistableSourceDef;
 
 /**
  * Value in the sourceRegistry, wrapping the entry with persistence info.
@@ -1773,9 +1756,7 @@ export interface NonAtomicTypeDef {
 
 export type ExpressionValueType = AtomicFieldType | NonAtomicType | TurtleType;
 export type ExpressionValueTypeDef =
-  | AtomicTypeDef
-  | NonAtomicTypeDef
-  | TurtleTypeDef;
+  AtomicTypeDef | NonAtomicTypeDef | TurtleTypeDef;
 export type BasicExpressionType = Exclude<
   ExpressionValueType,
   JoinElementType | 'turtle'
@@ -1961,9 +1942,7 @@ export interface ConnectionDef extends NamedObject {
 }
 
 export type TemporalTypeDef =
-  | DateTypeDef
-  | TimestampTypeDef
-  | TimestamptzTypeDef;
+  DateTypeDef | TimestampTypeDef | TimestamptzTypeDef;
 export type BasicAtomicTypeDef =
   | StringTypeDef
   | TemporalTypeDef
@@ -1980,10 +1959,7 @@ export type AtomicTypeDef =
   | RecordTypeDef
   | RepeatedRecordTypeDef;
 export type AtomicFieldDef =
-  | BasicAtomicDef
-  | BasicArrayDef
-  | RecordDef
-  | RepeatedRecordDef;
+  BasicAtomicDef | BasicArrayDef | RecordDef | RepeatedRecordDef;
 
 export function isBasicAtomic(
   fd: FieldDef | QueryFieldDef | AtomicTypeDef
@@ -2015,11 +1991,7 @@ export type QueryFieldDef = AtomicFieldDef | TurtleDef | RefToField;
 
 // All these share the same "type" space
 export type TypedDef =
-  | AtomicTypeDef
-  | JoinFieldDef
-  | TurtleDef
-  | RefToField
-  | StructDef;
+  AtomicTypeDef | JoinFieldDef | TurtleDef | RefToField | StructDef;
 
 export interface UserTypeFieldDef extends HasAnnotations {
   name: string;
@@ -2122,13 +2094,7 @@ export interface ModelAnnotationEntry {
 }
 
 export type QueryScalar =
-  | string
-  | boolean
-  | number
-  | bigint
-  | Date
-  | Buffer
-  | null;
+  string | boolean | number | bigint | Date | Buffer | null;
 
 /** One value in one column of returned data. */
 export type QueryValue = QueryScalar | QueryData | QueryRecord | QueryValue[];

--- a/packages/malloy/src/model/query_node.ts
+++ b/packages/malloy/src/model/query_node.ts
@@ -311,8 +311,7 @@ export class QueryStruct {
 
   // Injeected factory to break circularity with QueryQuery
   private static turtleFieldMaker:
-    | ((field: TurtleDef, parent: QueryStruct) => QueryField)
-    | undefined;
+    ((field: TurtleDef, parent: QueryStruct) => QueryField) | undefined;
 
   static registerTurtleFieldMaker(
     maker: (field: TurtleDef, parent: QueryStruct) => QueryField

--- a/packages/malloy/src/test/test-models.ts
+++ b/packages/malloy/src/test/test-models.ts
@@ -29,10 +29,7 @@ type PrimitiveValue = string | number | boolean | null | bigint;
 
 // Test data value types - can be primitives, arrays, records, or explicit TypedValues
 type TestValue =
-  | PrimitiveValue
-  | TestValue[]
-  | {[key: string]: TestValue}
-  | TypedValue;
+  PrimitiveValue | TestValue[] | {[key: string]: TestValue} | TypedValue;
 
 interface TestDataRow {
   [columnName: string]: TestValue;

--- a/test/src/test-select.ts
+++ b/test/src/test-select.ts
@@ -27,10 +27,7 @@ type PrimitiveValue = string | number | boolean | null;
 
 // Test data value types
 type TestValue =
-  | PrimitiveValue
-  | TestValue[]
-  | {[key: string]: TestValue}
-  | TypedValue;
+  PrimitiveValue | TestValue[] | {[key: string]: TestValue} | TypedValue;
 
 const nullExpr: Expr = {node: 'null'};
 


### PR DESCRIPTION
Prettier 3.9 changed how it prints short union types — it now keeps a union that fits on one line on one line and drops the leading `|`:

```ts
// before (3.8)
export type FieldInfoType =
  | 'dimension'
  | 'measure'
  | 'join'
  | 'view'
  | 'calculate';

// after (3.9)
export type FieldInfoType =
  'dimension' | 'measure' | 'join' | 'view' | 'calculate';
```

Because the tree was formatted by 3.8, the Dependabot minor-and-patch bump to prettier 3.9.5 turned the whole `prettier/prettier` lint rule red across most packages. This is that bump on its own, taken deliberately: prettier `^3.9.5` plus a repo-wide `lint-fix`. The floor is `^3.9.5` (not `^3.0.3`) so the 3.9 formatter is required — otherwise a checkout on 3.8 would fight the formatting back.

Purely mechanical — the same union collapse repeated across 37 files, no semantic change.