### PR TITLE
Retire Dependabot security auto-updates; move pin ledger into a docs tree

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,19 +20,19 @@ updates:
       # "minor" reshaped the type exports / SpecialDuckDBValue — a 0.x minor that
       # breaks — so it broke the #2911 group build; latest is 1.5.3-r.2, so moving
       # it is a deliberate connector migration. No update-types = hold all
-      # versions (matches the @dependabot ignore comment). See DEPENDENCY-MANAGEMENT.md.
+      # versions (matches the @dependabot ignore comment). See docs/dependency-management/CONTEXT.md.
       - dependency-name: "@motherduck/wasm-client"
       # vscode-textmate held at 9.0.0: our generateMonarchGrammar.ts deep-imports
       # internal paths (vscode-textmate/release/theme, /rawGrammar) and rule types
       # that 9.3.2 — an in-range MINOR — stopped exporting, breaking the
       # syntax-highlight codegen in #2911. Also exact-pinned in
       # malloy-syntax-highlight/package.json (^9.0.0 would resolve the breaker on a
-      # fresh install). The real fix is issue #2918; see DEPENDENCY-MANAGEMENT.md.
+      # fresh install). The real fix is issue #2918; see docs/dependency-management/CONTEXT.md.
       - dependency-name: "vscode-textmate"
       # snowflake-sdk is exact-pinned (2.3.1) in malloy-db-snowflake; ignore here
       # so Dependabot stops proposing bumps that would otherwise ride the
       # connectors group. Deliberate bumps happen by hand against live Snowflake
-      # CI. See DEPENDENCY-MANAGEMENT.md.
+      # CI. See docs/dependency-management/CONTEXT.md.
       - dependency-name: "snowflake-sdk"
       # @databricks/sql exact-pinned (1.15.0) in malloy-db-databricks: 1.16.0 ships a
       # native Rust kernel (eight @databricks/databricks-sql-kernel-* .node binaries)
@@ -40,11 +40,11 @@ updates:
       # own CI passes (plain Node loads .node), so it only breaks downstream at release;
       # #2888 pinned package.json but not here, so connectors-group #2934 re-bumped it
       # and it shipped in 0.0.418. Silent pin: only a security alert resurfaces it. See
-      # DEPENDENCY-MANAGEMENT.md.
+      # docs/dependency-management/CONTEXT.md.
       - dependency-name: "@databricks/*"
       # vega-lite held at v5 (the renderer's Vega 5->6 upgrade is deferred). It's a
       # direct dep, so its major opens a recurring monthly PR; ignore the major so
-      # it stops squatting the limit. v5 minors still flow. See DEPENDENCY-MANAGEMENT.md.
+      # it stops squatting the limit. v5 minors still flow. See docs/dependency-management/CONTEXT.md.
       - dependency-name: "vega-lite"
         update-types: ["version-update:semver-major"]
       # pg + pg-query-stream held: pg-query-stream pulls pg-cursor, which
@@ -72,7 +72,7 @@ updates:
       # downstream exactly like a native binary, so the core stays CJS. Held on the
       # last CJS majors (uuid ^11, @noble/hashes ^1) via caret ranges in
       # packages/malloy/package.json; ignore the MAJOR only so CJS-line minors/patches
-      # still flow. See DEPENDENCY-MANAGEMENT.md.
+      # still flow. See docs/dependency-management/CONTEXT.md.
       - dependency-name: "uuid"
         update-types: ["version-update:semver-major"]
       - dependency-name: "@noble/hashes"
@@ -121,9 +121,3 @@ updates:
         update-types:
           - "minor"
           - "patch"
-      # Security PRs fire on advisory publication, NOT the monthly schedule.
-      # This only collapses advisories that land in the same run into one PR.
-      security:
-        applies-to: security-updates
-        patterns:
-          - "*"

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
-/docs
-
 # Workspace related exclusions
 packages/**/build
 packages/**/dist

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -122,7 +122,7 @@ Each database has its own package with connection handling and dialect-specific 
 
 #### Native-dependency pins (do not loosen casually)
 
-`snowflake-sdk` (`2.3.1`) and `@databricks/sql` (`1.15.0`) are pinned to exact, pre-native versions, not `^` ranges. Why isn't visible here: downstream clients (the VS Code extension, `malloy-cli`) bundle with esbuild, which can't bundle native `.node` binaries. Newer driver releases ship them, so an unpinned range floats one in and breaks those builds — caught only in their CI. Bumping past these requires externalize-and-ship work in each client first (their `check-native` guard trips otherwise). Full pin ledger, methodology, and revisit triggers: [`DEPENDENCY-MANAGEMENT.md`](DEPENDENCY-MANAGEMENT.md).
+`snowflake-sdk` (`2.3.1`) and `@databricks/sql` (`1.15.0`) are pinned to exact, pre-native versions, not `^` ranges. Why isn't visible here: downstream clients (the VS Code extension, `malloy-cli`) bundle with esbuild, which can't bundle native `.node` binaries. Newer driver releases ship them, so an unpinned range floats one in and breaks those builds — caught only in their CI. Bumping past these requires externalize-and-ship work in each client first (their `check-native` guard trips otherwise). Full pin ledger, methodology, and revisit triggers: [`docs/dependency-management/CONTEXT.md`](docs/dependency-management/CONTEXT.md).
 
 ### Supporting Libraries
 - `malloy-interfaces/` - TypeScript interfaces and Thrift-generated types
@@ -334,7 +334,7 @@ For deeper context on specific subsystems, see:
 - [packages/malloy-render/CONTEXT.md](packages/malloy-render/CONTEXT.md) - Data visualization and rendering
 - [test/CONTEXT.md](test/CONTEXT.md) - Test organization and infrastructure
 - [.github/workflows/CONTEXT.md](.github/workflows/CONTEXT.md) - CI and release: what CI runs, the external-PR security model, and npm publishing (OIDC trusted publishing)
-- [DEPENDENCY-MANAGEMENT.md](DEPENDENCY-MANAGEMENT.md) - How we use Dependabot, and every version we deliberately pin/hold — why, what it costs, and when to revisit
+- [docs/dependency-management/](docs/dependency-management/CONTEXT.md) - Dependency management: the pin ledger (`CONTEXT.md` — how we use Dependabot, every version we deliberately pin/hold, why, what it costs, when to revisit) plus agent-agnostic runbooks for the monthly and security passes
 
 ## Maintaining the CONTEXT Tree
 

--- a/docs/dependency-management/CONTEXT.md
+++ b/docs/dependency-management/CONTEXT.md
@@ -6,7 +6,7 @@ agent-agnostic runbooks (plain markdown any human or coding agent can follow —
 imposed on contributors):
 
 - [`dependabot-monthly.md`](dependabot-monthly.md) — the monthly version-update pass.
-- `dependabot-security.md` — the security/alert pass (to be written).
+- [`dependabot-security.md`](dependabot-security.md) — the security-advisory sweep + pin release-walk.
 
 ## Methodology
 

--- a/docs/dependency-management/CONTEXT.md
+++ b/docs/dependency-management/CONTEXT.md
@@ -1,5 +1,13 @@
 # Dependency management in the Malloy mono-repo
 
+This directory is the dependency-management context node. This file is the **pin ledger** —
+what we hold, why, what it costs, and when to revisit. The **procedures** live beside it as
+agent-agnostic runbooks (plain markdown any human or coding agent can follow — no tool is
+imposed on contributors):
+
+- [`dependabot-monthly.md`](dependabot-monthly.md) — the monthly version-update pass.
+- `dependabot-security.md` — the security/alert pass (to be written).
+
 ## Methodology
 
 We used a tiered strategy, using GitHub's Dependabot as input.  We group these, roughly into these catgories.
@@ -19,8 +27,16 @@ instead of a scatter of one-offs:
 - **`minor-and-patch`** — everything else's in-range minors/patches, folded into one
   PR (duckdb excluded — it gets its own group for the same deliberate-PR reason).
 
-The security check fires on advisory *publication*, not the monthly cadence, and only
-collapses advisories that land in the same run into one PR.
+Dependabot's **automated security updates are turned off** (the repo's
+`automated-security-fixes` setting), and the `security:` group is removed with them. For
+malloy's tree the auto-fix PRs cost more than they give: nearly every advisory is a
+*transitive* dep buried under a package we hold, which Dependabot can't fix by editing a
+manifest line — so it opens nothing, or worse bumps an already-safe *direct* copy to a
+breaking major. uuid #2959 is the cautionary case: it proposed our already-patched
+`11.1.1` → `14.0.0` (the ESM-only major we deliberately hold), fixing none of the
+vulnerable transitive copies. Security is instead monitored deliberately with
+`npm audit --omit=dev`, reconciled against the holds below; the Dependabot alert tab is
+used only to dismiss advisories with a reason.
 
 We may decide to respond to a Dependabot report in one of three ways
 

--- a/docs/dependency-management/dependabot-monthly.md
+++ b/docs/dependency-management/dependabot-monthly.md
@@ -1,0 +1,88 @@
+# Dependabot — monthly version-update pass
+
+An agent-agnostic runbook. It's plain procedure — a human, or any coding agent, can follow
+it. Bind it to whatever tool you use however you like; the knowledge lives here, in the
+tree, so no contributor is forced into a particular AI. This is a living document — if a
+step is unclear or wrong when you run it, fix it here.
+
+The once-a-month walk over Dependabot's **version-update PRs** (`.github/dependabot.yml`
+groups). Not the security alert tab, and not the pin ledger's release review — those are the
+security runbook (`dependabot-security.md`, still to be written), run on advisory
+publication rather than this cadence.
+
+The spine of this runbook is **stop if there are anomalies; don't doggedly make it happen.**
+Exactly one thing merges unattended — the minor-and-patch group, and only on green.
+Everything else is staged and handed back. Every task below names what halts it.
+
+Do these in roughly this order.
+
+0) **Orient (read-only).** Read the repo-root `CONTEXT.md`, this directory's `CONTEXT.md`
+   (the pin ledger — source of truth for what's held and why), and `.github/dependabot.yml`
+   (whose `ignore:` list is the machine-readable set of held package names). You reconcile
+   against these — you don't carry the pin list in your head.
+
+1) **Gather.** `gh pr list --author 'app/dependabot' --state open --json number,title,createdAt`.
+   Classify each PR by its title's group: `minor-and-patch`, `connectors`, `toolchain`, or
+   `duckdb`. Standalone (ungrouped) PRs are majors that fell out of a group — treat them as
+   majors in step 3. (If the taxonomy of Dependabot groups changes, this list must change
+   with it.)
+
+## 2. The minor-and-patch group — the only thing that auto-merges
+
+If there's no open minor-and-patch PR this month, say so and move on.
+
+**Anomaly gates first — read the PR body's bump list and check all three. Any trip → halt,
+name it, do not merge:**
+
+- **A member is a held package.** Cross-check every bumped package against the
+  `dependabot.yml` `ignore:` names. A held package appearing in this group means an ignore
+  is leaking (the Databricks trap — #2934 reverting #2888). Stop.
+- **A member is a `0.x` published/runtime dep.** A `0.x` minor is allowed to break (the
+  "0.x trap"). A `0.x` *dev-tool* bump with a green canary is fine; a `0.x` bump of a dep
+  that ships in an `@malloydata` package gets eyes-on. Stop and flag.
+- **A member is actually a major.** Can't happen by group definition — but verify the
+  from→to on each. If one is a major, the group is misconfigured. Stop.
+
+**Gates clean → take it to green, then merge:**
+
+1. Vouch CI yourself — this runbook grants the "Re-run all jobs" authorization. It's safe
+   here specifically: this is Dependabot bumping our *own* declared deps (first-party), not
+   an outside contributor's code, so granting CI the repo secrets carries none of the
+   external-PR risk. Re-run via the run's URL from `gh pr checks <n>`, or `gh run rerun
+   <run-id>` (you may have to run-all, as the pull-and-build artifact may have aged out).
+2. Wait for checks to finish (`gh pr checks <n>` — poll, don't re-run the command in a
+   tight loop). Require **all green**. `consumer-canary` is the load-bearing one: it
+   esbuild-bundles and ts-jest-loads the packages the way the vscode extension and
+   malloy-cli do, so a producer-green build that would break a consumer is caught here.
+   Not fully green → halt, report which check is red.
+3. All green → `gh pr merge <n> --squash`. Report merged.
+
+## 3. What's left — the majors and other groups
+
+`connectors`, `toolchain`, and standalone majors. None of these act — you present each for
+the user's call. Three buckets:
+
+- **Take it** — with the local code changes the bump needs; scope that work.
+- **Pin + ignore + document** — a deliberate hold; stage both surfaces and the ledger entry.
+- **File an issue and defer** — the default for a major with no reason-to-move yet.
+
+**The `duckdb` group is a glance, not a decision.** It's carved out of the auto-merge and
+gets its own PR precisely so a duckdb bump is taken on purpose — but month to month the
+answer is usually skip. The signal for when to actually take it is the **publish-age of the
+version we're pinned to**, read live: `npm view <pkg> time --json` for each `@duckdb/*`
+dep, look up our pinned version's publish date, and report "ours is N months old (latest is
+M)". Nudge to take it only when our pinned version crosses **~6 months**; below that, "fine,
+skip". Don't count releases-behind for `@duckdb/duckdb-wasm` — it ships daily `-dev` builds
+(400+ versions), so publish-age is the only sane measure. Taking it early for a feature
+needs no bookkeeping: the age is read from npm each run, so the clock resets itself.
+
+Note the recurring case: a major that reappears every month is a major with **no ignore** —
+either take it or silence it, or it nags forever. That's the whole point of "everything
+ignored is written down."
+
+## Report
+
+- Minor-and-patch: merged, or halted at <gate/check>.
+- Majors / other groups: the list needing your decision, one line each.
+
+Then stop.

--- a/docs/dependency-management/dependabot-security.md
+++ b/docs/dependency-management/dependabot-security.md
@@ -1,0 +1,159 @@
+# Dependabot — security sweep
+
+An agent-agnostic runbook — plain procedure a human or any coding agent can follow. Bind it
+to whatever tool you use; the knowledge lives here in the tree so no contributor is forced
+into a particular AI. This is a living document — if a step is unclear or wrong when you run
+it, fix it here.
+
+The security pass. Not the monthly version-update rhythm — that's [`dependabot-monthly.md`](dependabot-monthly.md).
+This runs whenever, and its job is to make an unbounded alert surface **painless**: whoever
+runs it should read a few lines, approve one PR, and answer at most a couple of questions.
+
+**The input is `npm audit --omit=dev`, not the Dependabot alert tab.** Same advisory data,
+but audit dedupes it and splits dev from shipped in one command; the alert tab (dozens of
+per-path duplicate rows) is only touched at the end, to dismiss-with-reason the ones we
+accept, so it stays a signal.
+
+**The spine: reconciliation buys silence.** Anything that maps to a known ledger entry prints
+*nothing*. The 150-line report only exists if you print the knowns — so don't. The bulk is
+already absorbed by the ledger; only genuinely-new or trigger-firing findings cost a line.
+
+**One principle behind the version traps below.** A version number is a *proxy* for safety,
+and a lossy one — it can't see a native binary, a module format, or a `0.x` break. Whenever
+version math (same-major, newer-exists) disagrees with a hold's **documented reason**, the
+reason wins. The `0.x`, mid-major native/ESM-boundary, and "same-major isn't safe" cautions in
+§3 and §7 are all instances of this single rule.
+
+## 0. Orient (read-only)
+
+Read the repo-root `CONTEXT.md`, **this directory's `CONTEXT.md`** (the pin ledger — the record
+of every decision already made), and `.github/dependabot.yml`'s `ignore:` list. You reconcile
+against the ledger; you do not re-decide.
+
+## 1. Sweep
+
+`npm audit --omit=dev --json`. That's *approximately* the shipped-dependency universe — but in
+a monorepo `--omit=dev` is **leaky**: a workspace package can declare a dev tool as a plain
+`dependency` (e.g. `test/` declaring `@jest/globals`), and it then rides through as if shipped.
+So before treating any tool-shaped finding (jest, js-yaml, karma, storybook…) as real shipped
+exposure, check whether a workspace **mis-declared** it as a runtime dep. If so, it's dev
+tooling in disguise — out of scope, and the actual fix is the mis-declaration, not the advisory.
+
+## 2. Reconcile each finding against the ledger — most go silent
+
+For each finding, trace it to the **direct dep** that pulls it, and look that up in the ledger:
+
+- **A documented hold, its exit-trigger not fired** → known cost. **Silent** — just count it.
+- **A not-yet-upgraded connector** (the ledger's "Not pins — context" list) → known
+  maintenance debt. **Silent** — count it.
+- **A hold whose own exit-trigger just fired** — e.g. a hold that says "revisit when a
+  security advisory forces our hand" (snowflake, databricks) and a fresh critical landed **on
+  the SDK itself**. A fired trigger is **not** automatically "go act." Before surfacing it,
+  check whether a version **you'd actually take** *clears* the advisory:
+    - a takeable version clears it → **surface as actionable** (the decision's terms are met).
+    - no takeable version clears it — the fix is a no-op at the next release and only lands in a
+      version gated behind the hold's *own* blocker (thrift: `1.16` is a no-op, the fix is in
+      `2.0`, which the Databricks native-kernel hold already blocks) → **not actionable.** The
+      hold stands; what changed is the **cost**. Route it to the "cost changed" zone (§5) and
+      update the ledger's cost line — don't raise it as work.
+- **Maps to nothing in the ledger** → **new exposure. Surface it.**
+
+## 3. Classify what surfaced — safely-fixable vs needs-a-decision
+
+- **Safely fixable → the batch:**
+  - a **direct** dep with an in-range patch → bump it.
+  - a **transitive** dep fixable by a **same-major `overrides`** entry — same major is *usually*
+    API-compatible, and the parent's own CI (§4) proves it. But "same major" is the proxy, not
+    the guarantee (see the principle up top). Two ways it lies:
+    - **`0.x`:** below `1.0.0` the *minor* is the breaking axis, so `0.16 → 0.23` is a breaking
+      jump — treat any `0.x`-minor bump as a major and send it to needs-a-decision (thrift).
+    - **mid-major native/ESM boundary:** if a hold's reason is a binary/module-format boundary
+      *inside* the major line (see §7's trap), a same-major `overrides` past it breaks downstream
+      exactly as the hold warns. Defer to the ledger's boundary.
+- **Needs a decision → the short list:**
+  - a **transitive** fix that needs a **parent (connector) bump**, or an **override across a
+    major** (or across one of the boundaries above) → accept-as-cost / force-the-bump / wait.
+  - a **new direct dep whose only fix breaks us** → the birth of a new hold.
+  - any **major**.
+
+## 4. Stage the safe batch as one PR — locally where you can, PR-verified for the rest
+
+Branch off `main`. Apply the fixes **by hand** — edit the version, add the `overrides` entry
+directly. Do **not** lean on `npm audit fix`: with holds in the tree it dies on `ERESOLVE`
+(the Vega v5 hold alone makes the tree unsatisfiable to the auto-fixer). Then mind what you can
+and can't verify locally:
+
+- Run `npm run precheck` and require it green — that's the loop you *can* close on a dev machine.
+- `consumer-canary` — the check that actually proves an `overrides` didn't break a parent's
+  runtime expectations — is **CI-only**; you cannot produce it locally. So local precheck green
+  is necessary but **not sufficient**: stage green locally, push, and let the PR's
+  `consumer-canary` be the real verdict.
+
+**Do not merge — stage it and hand it back.** If the PR's CI goes red, the override wasn't safe
+→ demote that finding to needs-a-decision and re-stage the rest.
+
+## 5. The report — this is the whole output, keep it this short
+
+```
+Security sweep — N prod findings
+✓ M reconcile to documented holds / known maintenance — no action
+→ K safely fixable — staged in <branch>, CI green:  open the PR?
+~ L a hold's cost changed — ledger update, no action forced:
+    <pkg> — <hold>: <fix got cheaper: X now takeable> | <cost now includes new advisory Y>
+? J need you:
+    <pkg>  <sev>  — <the one choice in a clause>  → <your lean>
+```
+
+- Zone ✓ is a **count, never a list**.
+- Zone → is **one PR to approve**.
+- Zone ~ is holds that **didn't move but whose cost description shifted**: a fix that got
+  *cheap* (a newly-takeable version with the trigger unfired — the release-walk's opportunity)
+  or a cost that got *heavier* (a fired trigger no takeable version clears — §2). These are
+  ledger edits, not decisions — list them so the ledger stays honest, and they reconcile as
+  "known" next sweep.
+- Zone ? is **one line per decision**, with a recommendation. If J = 0, say "nothing needs
+  you" and stop.
+
+## 6. Accept-as-cost writes to the ledger (and dismisses the alert)
+
+When you decide a finding is a documented cost (can't safely fix, not worth the break), it
+**graduates into a ledger entry** — so next sweep it reconciles as "known" and goes silent.
+That's how the report stays short over time. Optionally dismiss the matching Dependabot alert
+with a reason (`gh api ... -f state=dismissed -f dismissed_reason=...`) so the alert tab keeps
+reflecting reality. This (and a cost-line update from §2/§5) is the only write this runbook
+makes to the ledger; never re-frame it.
+
+## 7. Pin release-walk — the deliberate half
+
+Separate from the sweep: for every hold in the ledger, ask *can we release it yet?* This is
+work-triggered, not advisory-triggered.
+
+- **Read each blocking issue, one sentence of status.** `gh issue view <N>` for the issue a
+  hold names (#2950 motherduck, #2918 vscode-textmate, #2928 pg, #2932 bigquery, …). Many holds
+  wait on **our own** work — they won't close themselves, so this is the moment to decide to
+  pick one up. Note the cheapest if one stands out.
+- **Upstream moved?** `npm view <pkg> version` — did the awaited release ship? **Trap — version
+  math lies at a native/ESM boundary *inside* a major line.** When a hold exists because a
+  specific release crossed a native or module-format boundary mid-major (databricks pinned at
+  `1.15.0` because `1.16.0` added the native kernel; snowflake similarly), "newer version exists"
+  and "same major" both scream *cheap fix available* — while pointing straight across the very
+  boundary the hold protects. npm metadata does not show you the binary or the module format.
+  Defer to the **ledger's documented boundary**, not the version number. (Boundaries *at* the
+  major — uuid 12, @noble 2 — the major check already catches; mid-major boundaries are the trap.)
+- **Fix got cheap?** Even with the trigger unfired, a hold's fix can quietly become takeable — a
+  newly-released *genuinely*-compatible version (compatible per the ledger's boundary above,
+  **not** per npm's version math), or a dependency that stopped needing the blocker. That's not a
+  forced move, it's an *opportunity*: report it in zone `~` (§5) so you can take it early instead
+  of waiting for the trigger.
+- Where a trigger fired → propose the un-pin (loosen the range in `package.json` **and** drop the
+  `dependabot.yml` `ignore` — both surfaces) and stage it, then **stop**; pin moves are
+  deliberate. Where not → one line, "still held, <trigger> not met."
+- **Anomaly:** a hold whose two surfaces disagree (a pinned range with no `ignore`, or an
+  `ignore` with a loosened range) is a half-pin — flag it; that's how a hold silently reverts.
+
+## Report
+
+- Sweep: the four-zone block above.
+- Release-walk: which holds can move (staged, awaiting you), which are still held.
+
+Then stop.

--- a/jest.config.simple.ts
+++ b/jest.config.simple.ts
@@ -9,7 +9,7 @@ import type {Config} from 'jest';
 process.env['TZ'] = 'America/Los_Angeles';
 
 // ESM-only deps that ship plain static import/export must be transformed (not
-// ignored) so jest's CJS runtime can load them. See DEPENDENCY-MANAGEMENT.md.
+// ignored) so jest's CJS runtime can load them. See docs/dependency-management/CONTEXT.md.
 // (uuid and @noble/hashes were pinned to CJS-consumable majors, so they no longer
 // need transforming — an ESM-only runtime dep leaks downstream like a native one.)
 const transformIgnoreModules = ['@motherduck/wasm-client'].join('|');

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -4,7 +4,7 @@ process.env['TZ'] = 'America/Los_Angeles';
 
 // ESM-only deps that ship plain static import/export: jest's CJS runtime can't
 // load them as-is, so they must be transformed (not ignored). See the Class-1
-// ESM note in DEPENDENCY-MANAGEMENT.md. (uuid and @noble/hashes were here until
+// ESM note in docs/dependency-management/CONTEXT.md. (uuid and @noble/hashes were here until
 // they were pinned to CJS-consumable majors — an ESM-only runtime dep leaks
 // downstream like a native binary, so the core stays CJS.)
 const transformIgnoreModules = ['@motherduck/wasm-client'].join('|');

--- a/packages/malloy-db-snowflake/CONTEXT.md
+++ b/packages/malloy-db-snowflake/CONTEXT.md
@@ -19,7 +19,7 @@ only when every owner moves.
 
 **Revisit** when doing a deliberate `snowflake-sdk` upgrade: move the exact pin,
 run the live Snowflake suite, confirm the native chain still builds on every
-platform. The cross-cutting pin ledger is [`DEPENDENCY-MANAGEMENT.md`](../../DEPENDENCY-MANAGEMENT.md);
+platform. The cross-cutting pin ledger is [`docs/dependency-management/CONTEXT.md`](../../docs/dependency-management/CONTEXT.md);
 the Dependabot flow is in [`.github/CONTEXT.md`](../../.github/CONTEXT.md).
 
 ## `~/.snowflake/connections.toml` is read with the *driver's* schema, not Snowflake's

--- a/packages/malloy-render/CONTEXT.md
+++ b/packages/malloy-render/CONTEXT.md
@@ -26,7 +26,7 @@ bump.
 `vega-functions`, and `vega-expression` carry open advisories (high) whose only
 fix is Vega 6. These are render-owned — nothing else in the monorepo pulls them —
 so the renderer is the sole place that clears them. Recorded in the cross-cutting
-pin ledger [`DEPENDENCY-MANAGEMENT.md`](../../DEPENDENCY-MANAGEMENT.md);
+pin ledger [`docs/dependency-management/CONTEXT.md`](../../docs/dependency-management/CONTEXT.md);
 revisit when we take the Vega 5→6 upgrade.
 
 ### Public API

--- a/packages/malloy/src/model/utils.ts
+++ b/packages/malloy/src/model/utils.ts
@@ -170,7 +170,7 @@ export function makeDigest(...parts: (string | undefined)[]): string {
   const combined = parts
     .map(p => (p === undefined ? '{undefined}' : `${p.length}:${p}`))
     .join('/');
-  // @noble/hashes is pinned to v1 (v2 is ESM-only — see DEPENDENCY-MANAGEMENT.md).
+  // @noble/hashes is pinned to v1 (v2 is ESM-only — see docs/dependency-management/CONTEXT.md).
   // v1's sha256 also accepts a string directly, but we utf8-encode explicitly so the
   // digest is stable and unambiguous (and identical to the v2 form we briefly used).
   return bytesToHex(sha256(utf8ToBytes(combined)));

--- a/test/consumer-canary/CONTEXT.md
+++ b/test/consumer-canary/CONTEXT.md
@@ -42,11 +42,11 @@ downstream:
 
 - **bundle-check fails** → a runtime dep is not bundle-safe (a new native, or a
   bare native require). Externalizing it in the consumer is only a band-aid; the
-  fix is upstream — see `DEPENDENCY-MANAGEMENT.md`.
+  fix is upstream — see `docs/dependency-management/CONTEXT.md`.
 - **consumer-canary:jest fails** with "Unexpected token 'export'" / "Cannot use import
   statement outside a module" → a runtime dep went ESM-only. **Do not** add a
   transform here to silence it — pin the dep to its last CJS-consumable major, the
-  way `uuid` and `@noble/hashes` are pinned (`DEPENDENCY-MANAGEMENT.md`).
+  way `uuid` and `@noble/hashes` are pinned (`docs/dependency-management/CONTEXT.md`).
 
 ## Wiring
 

--- a/test/consumer-canary/bundle-check.mjs
+++ b/test/consumer-canary/bundle-check.mjs
@@ -51,7 +51,7 @@ try {
   console.error(
     'or a bare require of an optional native. See test/consumer-canary/CONTEXT.md'
   );
-  console.error('and DEPENDENCY-MANAGEMENT.md.\n');
+  console.error('and docs/dependency-management/CONTEXT.md.\n');
   for (const e of err.errors ?? []) {
     console.error(
       '  ' +

--- a/test/consumer-canary/jest.config.ts
+++ b/test/consumer-canary/jest.config.ts
@@ -16,7 +16,7 @@ import type {Config} from 'jest';
  * repo's own jest.config.ts does that, which is precisely why malloy's tests stay
  * green while consumers break. Adding it here would hide the leak this canary
  * exists to catch. A red canary means a runtime dep went ESM-only — pin it (see
- * DEPENDENCY-MANAGEMENT.md), don't transform it away.
+ * docs/dependency-management/CONTEXT.md), don't transform it away.
  */
 const config: Config = {
   rootDir: '.',


### PR DESCRIPTION
Dependabot's automated security updates were opening PRs that cost more than they gave. For this tree nearly every advisory is a transitive dep buried under a package we hold, which Dependabot can't fix by editing a manifest line — so it opened nothing, or worse bumped an already-safe direct dep to a breaking major. uuid #2959 is the case: it proposed our already-patched `11.1.1` → `14.0.0` (the ESM-only major we deliberately hold), fixing none of the vulnerable transitive copies. A "security fix" PR that fixes nothing and breaks downstream is worse than none.

So this turns the feature off (the `automated-security-fixes` repo setting) and removes the now-dead `security:` group from `dependabot.yml`. Security is instead swept deliberately with `npm audit --omit=dev`, reconciled against the pin ledger.

Alongside, the pin ledger moves from the repo-root `DEPENDENCY-MANAGEMENT.md` into `docs/dependency-management/CONTEXT.md`, joined by an agent-agnostic runbook for the monthly version-update pass — plain-markdown procedure any human or agent can follow, so no contributor is bound to a particular tool. The stale `/docs` ignore (a 2023 docs-migration guard, long obsolete) is removed so the tree can hold it.

First step of a dependency-management workflow; the security-sweep runbook follows once it's been run and refined.
