### PR TITLE
Security sweep: clear nested lodash high; ledger + runbook upkeep

### DIFF
--- a/docs/dependency-management/CONTEXT.md
+++ b/docs/dependency-management/CONTEXT.md
@@ -199,6 +199,20 @@ bumps are made deliberately, not by a lockfile range. Also `ignore`d in
 `dependabot.yml` so Dependabot stops proposing bumps (it would otherwise pull
 snowflake-sdk into the connectors group).
 
+**Judging a fix version — don't probe, defer to this boundary.** `2.3.1` is the **last
+pre-native** release; the pin is a point *inside* the 2.x line, not a semver-major cap.
+A newer 2.x (`2.4.3`, …) is on the *far* side of the native boundary — same npm major,
+wrong side of the line. npm metadata **cannot** tell you which side: the native binary
+loads via a bundled `.node` + `eval('require')` (see below), invisible to `npm view
+version`, `optionalDependencies`, `dependencies`, and install `scripts` alike — a
+security sweep once floated `2.3.1 → 2.4.3` as a "cheap same-major fix" off exactly that
+blind check. It isn't: bumping across this line is the native-chain thrash the pin
+exists to hold, so the `fast-xml-parser` critical below stays a standing cost until a
+deliberate, native-aware bump verified against live Snowflake CI. Same trap on every
+boundary pin — `@databricks/sql 1.15.0` (last pre-native), `uuid ^11` / `@noble/hashes
+^1` (last CJS): the ledger's boundary is authoritative; npm metadata won't show you the
+binary.
+
 There's also a **downstream-bundling** dimension, the same family of problem as
 Databricks: snowflake-sdk's native form loads its binary via `eval('require')`, which
 is invisible to esbuild, so it can't be bundled cleanly into the embedding apps. Part
@@ -228,8 +242,11 @@ This hold is unlike the ones above in *where* it bites: **malloy's own CI passes
 malloy uses the SDK in plain Node, which loads `.node` fine — so nothing here
 catches it. The guard lives only downstream and fires at *release time*, when the
 embedding apps run `malloy-update` + bundle. 1.15.0 is the last pure-JS (thrift)
-release. Not a security hold: 1.16.0 clears nothing 1.15.0 had (`thrift` is
-`^0.16.0` in both); the kernel is the *only* delta, and it's the problem, not a fix.
+release. The hold's *reason* is the native break, not security — but two high
+`thrift` advisories now ride on 1.15.0's `thrift@0.16.0` (see Cost). **1.16.0 clears
+neither** (still `thrift ^0.16.0`) and *adds* the native kernel — a strict regression;
+only **2.0.0** bumps thrift to `^0.23.0`, and it carries the same kernel, so the
+security fix is gated behind the very packaging work below, not a bump we can make now.
 
 The cautionary half — the two-surfaces rule's headline example: **#2888 pinned
 `package.json` to 1.15.0 but did not add the `dependabot.yml` ignore.** A pin
@@ -239,7 +256,14 @@ re-bumped it to 1.16.0, silently reverting #2888, and it shipped in
 fix is both surfaces: exact-pin `1.15.0` in `package.json` **and**
 `ignore: @databricks/*` in `dependabot.yml` (so the connectors group can't squat it).
 
-Cost: databricks connector held one minor behind; no security advisory rides on it.
+Cost: databricks connector held one minor behind. Two high `thrift` advisories ride
+on the held `thrift@0.16.0` — GHSA-r67j-r569-jrwp (uncontrolled recursion, `<0.23.0`)
+and GHSA-526f-jxpj-jmg2 (path traversal / request-response splitting, `<=0.22.0`) —
+both alert-only, no PR. Not a live worry: both are Thrift **server** / adversarial-peer
+surfaces (a malicious message parser, or someone hitting a Thrift *server*), and malloy
+is only a **client** over TLS to the user's own authenticated warehouse, so nothing
+attacker-controlled reaches them. Clears at 2.0.0 (thrift `^0.23.0`) — i.e. with the
+native-packaging work above, not before.
 
 Waiting for: one of two triggers — **(a)** a security advisory, direct or transitive,
 against 1.15.0 (it lights the alerts tab regardless of the ignore), or **(b)** a

--- a/docs/dependency-management/CONTEXT.md
+++ b/docs/dependency-management/CONTEXT.md
@@ -5,8 +5,8 @@ what we hold, why, what it costs, and when to revisit. The **procedures** live b
 agent-agnostic runbooks (plain markdown any human or coding agent can follow — no tool is
 imposed on contributors):
 
-- [`dependabot-monthly.md`](dependabot-monthly.md) — the monthly version-update pass.
-- [`dependabot-security.md`](dependabot-security.md) — the security-advisory sweep + pin release-walk.
+- [`dependabot-monthly.md`](dependabot-monthly.md) — the monthly Dependabot version-update pass.
+- [`npm-security-audit.md`](npm-security-audit.md) — the `npm audit`-driven security sweep + pin release-walk.
 
 ## Methodology
 

--- a/docs/dependency-management/dependabot-monthly.md
+++ b/docs/dependency-management/dependabot-monthly.md
@@ -7,8 +7,8 @@ step is unclear or wrong when you run it, fix it here.
 
 The once-a-month walk over Dependabot's **version-update PRs** (`.github/dependabot.yml`
 groups). Not the security alert tab, and not the pin ledger's release review — those are the
-security runbook (`dependabot-security.md`, still to be written), run on advisory
-publication rather than this cadence.
+npm-security-audit runbook (`npm-security-audit.md`), run on advisory publication
+rather than this cadence.
 
 The spine of this runbook is **stop if there are anomalies; don't doggedly make it happen.**
 Exactly one thing merges unattended — the minor-and-patch group, and only on green.

--- a/docs/dependency-management/npm-security-audit.md
+++ b/docs/dependency-management/npm-security-audit.md
@@ -1,4 +1,8 @@
-# Dependabot — security sweep
+# npm security audit — the shipped-dependency security sweep
+
+Driven by `npm audit`, not Dependabot — Dependabot only appears at the edges (dismissing
+an accepted alert with a reason in §6). The monthly version-update pass *is* the
+Dependabot one; this isn't, which is why it's named for its actual engine.
 
 An agent-agnostic runbook — plain procedure a human or any coding agent can follow. Bind it
 to whatever tool you use; the knowledge lives here in the tree so no contributor is forced
@@ -96,6 +100,17 @@ and can't verify locally:
 
 ```
 Security sweep — N prod findings
+
+37 vulnerabilities (4 low, 19 moderate, 13 high, 1 critical)   ← npm's own summary line
+
+Every CRITICAL and HIGH mapped to the pin it reconciles to (low/moderate stay a count):
+  critical  fast-xml-parser              → Snowflake hold (snowflake-sdk 2.3.1)
+  high      fast-xml-parser, axios       → Snowflake hold
+  high      thrift                       → Databricks hold (@databricks/sql 1.15.0)
+  high      axios, trino-client          → Trino connector maintenance
+  high      vega ×6                      → Vega v5 renderer hold (vega-lite ^5)
+  high      ws, tmp, socket.io-parser    → dev tooling, never ships (out of scope)
+
 ✓ M reconcile to documented holds / known maintenance — no action
 → K safely fixable — staged in <branch>, CI green:  open the PR?
 ~ L a hold's cost changed — ledger update, no action forced:
@@ -104,6 +119,14 @@ Security sweep — N prod findings
     <pkg>  <sev>  — <the one choice in a clause>  → <your lean>
 ```
 
+- **Lead with the severity breakdown.** Reproduce npm's own summary line
+  (`37 vulnerabilities (4 low, 19 moderate, 13 high, 1 critical)`), then name **every
+  critical and high** and the pin it reconciles to — group by pin, and flag the dev-only
+  ones as out of scope. This is the *receipts* for zone ✓: it proves the criticals are
+  **held, not missed**, and it's cheap because criticals/highs are few. Low and moderate
+  stay a count (they're the connector `uuid`/`bn.js`/`axios` churn under the same holds,
+  plus dev tooling). Note the count is npm's full-tree number (it includes dev); the
+  map is where you separate shipped-and-held from dev-only.
 - Zone ✓ is a **count, never a list**.
 - Zone → is **one PR to approve**.
 - Zone ~ is holds that **didn't move but whose cost description shifted**: a fix that got

--- a/package-lock.json
+++ b/package-lock.json
@@ -1807,6 +1807,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
       "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.29.7",
@@ -1821,6 +1822,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
       "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -1830,6 +1832,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
@@ -1858,6 +1861,7 @@
     },
     "node_modules/@babel/core/node_modules/semver": {
       "version": "6.3.1",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -1867,6 +1871,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
       "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.7",
@@ -1906,6 +1911,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
       "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.29.7",
@@ -1920,6 +1926,7 @@
     },
     "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
       "version": "5.1.1",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
@@ -1927,6 +1934,7 @@
     },
     "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
       "version": "6.3.1",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -1934,6 +1942,7 @@
     },
     "node_modules/@babel/helper-compilation-targets/node_modules/yallist": {
       "version": "3.1.1",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
@@ -2028,6 +2037,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
       "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -2050,6 +2060,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
       "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.29.7",
@@ -2063,6 +2074,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
       "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.29.7",
@@ -2092,6 +2104,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
       "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -2189,6 +2202,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
       "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -2211,6 +2225,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
       "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.29.7",
@@ -2278,6 +2293,7 @@
     },
     "node_modules/@babel/plugin-syntax-async-generators": {
       "version": "7.8.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -2288,6 +2304,7 @@
     },
     "node_modules/@babel/plugin-syntax-bigint": {
       "version": "7.8.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -2298,6 +2315,7 @@
     },
     "node_modules/@babel/plugin-syntax-class-properties": {
       "version": "7.12.13",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.12.13"
@@ -2372,6 +2390,7 @@
     },
     "node_modules/@babel/plugin-syntax-import-meta": {
       "version": "7.10.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
@@ -2382,6 +2401,7 @@
     },
     "node_modules/@babel/plugin-syntax-json-strings": {
       "version": "7.8.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -2394,6 +2414,7 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.24.7.tgz",
       "integrity": "sha512-6ddciUPe/mpMnOKv/U+RSd2vvVy+Yw/JfBB0ZHYjEZt9NLHmCUylNYlsbqCCS1Bffjlb0fCwC9Vqz+sBz6PsiQ==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.7"
       },
@@ -2406,6 +2427,7 @@
     },
     "node_modules/@babel/plugin-syntax-logical-assignment-operators": {
       "version": "7.10.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
@@ -2416,6 +2438,7 @@
     },
     "node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
       "version": "7.8.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -2426,6 +2449,7 @@
     },
     "node_modules/@babel/plugin-syntax-numeric-separator": {
       "version": "7.10.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
@@ -2436,6 +2460,7 @@
     },
     "node_modules/@babel/plugin-syntax-object-rest-spread": {
       "version": "7.8.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -2446,6 +2471,7 @@
     },
     "node_modules/@babel/plugin-syntax-optional-catch-binding": {
       "version": "7.8.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -2456,6 +2482,7 @@
     },
     "node_modules/@babel/plugin-syntax-optional-chaining": {
       "version": "7.8.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -2480,6 +2507,7 @@
     },
     "node_modules/@babel/plugin-syntax-top-level-await": {
       "version": "7.14.5",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
@@ -2495,6 +2523,7 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.24.7.tgz",
       "integrity": "sha512-c/+fVeJBB0FeKsFvwytYiUD+LBvhHjGSI0g446PRGdSVGZLRNArBUno2PETbAly3tpiNAQR5XaZ+JslxkotsbA==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.7"
       },
@@ -3418,6 +3447,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
       "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
@@ -3432,6 +3462,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
       "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
@@ -6393,6 +6424,7 @@
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "camelcase": "^5.3.1",
@@ -6407,6 +6439,7 @@
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/resolve-from": {
       "version": "5.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6414,6 +6447,7 @@
     },
     "node_modules/@istanbuljs/schema": {
       "version": "0.1.3",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6808,6 +6842,7 @@
     },
     "node_modules/@jest/expect": {
       "version": "29.4.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "expect": "^29.4.3",
@@ -6821,6 +6856,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
       "integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
+      "dev": true,
       "dependencies": {
         "jest-get-type": "^29.6.3"
       },
@@ -6832,12 +6868,14 @@
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
       "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
+      "dev": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/expect/node_modules/expect": {
       "version": "29.4.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/expect-utils": "^29.4.3",
@@ -6852,6 +6890,7 @@
     },
     "node_modules/@jest/expect/node_modules/jest-get-type": {
       "version": "29.4.3",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -6859,6 +6898,7 @@
     },
     "node_modules/@jest/expect/node_modules/jest-message-util": {
       "version": "29.4.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.12.13",
@@ -7067,6 +7107,7 @@
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
       "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
       "dependencies": {
         "@sinclair/typebox": "^0.27.8"
       },
@@ -7117,6 +7158,7 @@
     },
     "node_modules/@jest/transform": {
       "version": "29.4.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.11.6",
@@ -7141,6 +7183,7 @@
     },
     "node_modules/@jest/transform/node_modules/jest-regex-util": {
       "version": "29.4.3",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -7150,6 +7193,7 @@
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
       "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
+      "dev": true,
       "dependencies": {
         "@jest/schemas": "^29.6.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -7166,6 +7210,7 @@
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -7176,6 +7221,7 @@
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
       "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -7184,6 +7230,7 @@
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -7199,6 +7246,7 @@
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -9679,7 +9727,8 @@
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
-      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA=="
+      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+      "dev": true
     },
     "node_modules/@sinonjs/commons": {
       "version": "1.8.3",
@@ -11763,6 +11812,7 @@
     },
     "node_modules/@types/babel__traverse": {
       "version": "7.18.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.3.0"
@@ -11821,6 +11871,7 @@
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.5",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -11839,10 +11890,12 @@
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
-      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w=="
+      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+      "dev": true
     },
     "node_modules/@types/istanbul-lib-report": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/istanbul-lib-coverage": "*"
@@ -11852,6 +11905,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
       "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
+      "dev": true,
       "dependencies": {
         "@types/istanbul-lib-report": "*"
       }
@@ -12016,6 +12070,7 @@
     },
     "node_modules/@types/prettier": {
       "version": "2.7.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
@@ -12080,7 +12135,8 @@
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
-      "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw=="
+      "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+      "dev": true
     },
     "node_modules/@types/tough-cookie": {
       "version": "4.0.2",
@@ -12117,6 +12173,7 @@
       "version": "17.0.35",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
       "integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -12124,6 +12181,7 @@
     },
     "node_modules/@types/yargs-parser": {
       "version": "21.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/parser": {
@@ -13029,6 +13087,7 @@
     },
     "node_modules/anymatch": {
       "version": "3.1.2",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
@@ -13163,6 +13222,7 @@
     },
     "node_modules/argparse": {
       "version": "1.0.10",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "sprintf-js": "~1.0.2"
@@ -13378,6 +13438,7 @@
     },
     "node_modules/babel-plugin-istanbul": {
       "version": "6.1.1",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.0.0",
@@ -13478,6 +13539,7 @@
     },
     "node_modules/babel-preset-current-node-syntax": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/plugin-syntax-async-generators": "^7.8.4",
@@ -13568,6 +13630,7 @@
       "version": "2.10.38",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.38.tgz",
       "integrity": "sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -13776,6 +13839,7 @@
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
       "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -13786,6 +13850,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
       "dependencies": {
         "fill-range": "^7.1.1"
       },
@@ -13817,6 +13882,7 @@
       "version": "4.28.4",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.4.tgz",
       "integrity": "sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -13859,6 +13925,7 @@
     },
     "node_modules/bser": {
       "version": "2.1.1",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "node-int64": "^0.4.0"
@@ -14141,6 +14208,7 @@
     },
     "node_modules/camelcase": {
       "version": "5.3.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -14166,6 +14234,7 @@
       "version": "1.0.30001799",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
       "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -14572,6 +14641,7 @@
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/concat-stream": {
@@ -15065,6 +15135,7 @@
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cookie": {
@@ -16080,6 +16151,7 @@
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
       "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -16239,6 +16311,7 @@
       "version": "1.5.376",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.376.tgz",
       "integrity": "sha512-cUVA7/RvbFTEuw/i3obUwDTRIXojaxkResf+ibByPFxjc6XK3VNtcQXV0NSbAlJ0FMjcJGgftVVB4Qo184EXvA==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/emittery": {
@@ -17214,6 +17287,7 @@
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
@@ -17272,6 +17346,7 @@
     },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "bser": "2.1.1"
@@ -17397,6 +17472,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -17458,6 +17534,7 @@
     },
     "node_modules/find-up": {
       "version": "4.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "locate-path": "^5.0.0",
@@ -17720,10 +17797,12 @@
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -17822,6 +17901,7 @@
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -17892,6 +17972,7 @@
     },
     "node_modules/get-package-type": {
       "version": "0.1.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
@@ -18093,6 +18174,7 @@
     },
     "node_modules/glob": {
       "version": "7.2.3",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -19197,6 +19279,7 @@
     },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
@@ -19212,6 +19295,7 @@
     },
     "node_modules/inflight": {
       "version": "1.0.6",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "once": "^1.3.0",
@@ -19626,6 +19710,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
       "engines": {
         "node": ">=0.12.0"
       }
@@ -19793,6 +19878,7 @@
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.0",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=8"
@@ -19800,6 +19886,7 @@
     },
     "node_modules/istanbul-lib-instrument": {
       "version": "5.2.1",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@babel/core": "^7.12.3",
@@ -19814,6 +19901,7 @@
     },
     "node_modules/istanbul-lib-instrument/node_modules/semver": {
       "version": "6.3.1",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -20620,6 +20708,7 @@
     },
     "node_modules/jest-haste-map": {
       "version": "29.4.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.4.3",
@@ -20643,6 +20732,7 @@
     },
     "node_modules/jest-haste-map/node_modules/jest-regex-util": {
       "version": "29.4.3",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -20672,6 +20762,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
       "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
+      "dev": true,
       "dependencies": {
         "chalk": "^4.0.0",
         "jest-diff": "^29.7.0",
@@ -20686,6 +20777,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
       "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
+      "dev": true,
       "dependencies": {
         "chalk": "^4.0.0",
         "diff-sequences": "^29.6.3",
@@ -20700,6 +20792,7 @@
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
       "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
+      "dev": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
@@ -21160,6 +21253,7 @@
     },
     "node_modules/jest-snapshot": {
       "version": "29.4.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.11.6",
@@ -21193,6 +21287,7 @@
     },
     "node_modules/jest-snapshot/node_modules/expect": {
       "version": "29.4.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/expect-utils": "^29.4.3",
@@ -21207,6 +21302,7 @@
     },
     "node_modules/jest-snapshot/node_modules/jest-diff": {
       "version": "29.4.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.0.0",
@@ -21220,6 +21316,7 @@
     },
     "node_modules/jest-snapshot/node_modules/jest-get-type": {
       "version": "29.4.3",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -21227,6 +21324,7 @@
     },
     "node_modules/jest-snapshot/node_modules/jest-message-util": {
       "version": "29.4.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.12.13",
@@ -21247,6 +21345,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
       "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.6.3",
@@ -21264,6 +21363,7 @@
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
       "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -21330,6 +21430,7 @@
     },
     "node_modules/jest-worker": {
       "version": "29.4.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -21343,6 +21444,7 @@
     },
     "node_modules/jest-worker/node_modules/supports-color": {
       "version": "8.1.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -21367,12 +21469,14 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
       "version": "3.14.2",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
       "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -21581,6 +21685,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
       "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
@@ -22869,6 +22974,7 @@
     },
     "node_modules/locate-path": {
       "version": "5.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-locate": "^4.1.0"
@@ -23149,6 +23255,7 @@
     },
     "node_modules/makeerror": {
       "version": "1.0.12",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "tmpl": "1.0.5"
@@ -23339,6 +23446,7 @@
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/merge2": {
@@ -23353,6 +23461,7 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
       "dependencies": {
         "braces": "^3.0.3",
         "picomatch": "^2.3.1"
@@ -23413,6 +23522,7 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -23790,6 +23900,7 @@
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/ncp": {
@@ -23959,6 +24070,7 @@
       "version": "2.0.48",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.48.tgz",
       "integrity": "sha512-1uz8041X6LoI6ZSdZacM9lVY28vuzDlSKitnpbSNK0RfKoIJkX29NBPVEFXhnuSuEOA9Ww0xnPJ+ILWbGAv8DA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -24013,6 +24125,7 @@
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -24412,6 +24525,7 @@
     },
     "node_modules/p-limit": {
       "version": "2.3.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-try": "^2.0.0"
@@ -24425,6 +24539,7 @@
     },
     "node_modules/p-locate": {
       "version": "4.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-limit": "^2.2.0"
@@ -24512,6 +24627,7 @@
     },
     "node_modules/p-try": {
       "version": "2.2.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -24915,6 +25031,7 @@
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -24922,6 +25039,7 @@
     },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -25128,6 +25246,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -25150,6 +25269,7 @@
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.6.tgz",
       "integrity": "sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==",
+      "dev": true,
       "engines": {
         "node": ">= 6"
       }
@@ -25413,6 +25533,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
       "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
       "dependencies": {
         "@jest/schemas": "^29.6.3",
         "ansi-styles": "^5.0.0",
@@ -25426,6 +25547,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -25835,7 +25957,8 @@
     "node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true
     },
     "node_modules/react-is-18": {
       "name": "react-is",
@@ -26616,6 +26739,7 @@
     },
     "node_modules/slash": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -26851,6 +26975,7 @@
     },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/sql-escaper": {
@@ -26903,6 +27028,7 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
       "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+      "dev": true,
       "dependencies": {
         "escape-string-regexp": "^2.0.0"
       },
@@ -26912,6 +27038,7 @@
     },
     "node_modules/stack-utils/node_modules/escape-string-regexp": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -27363,6 +27490,7 @@
     },
     "node_modules/test-exclude": {
       "version": "6.0.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "@istanbuljs/schema": "^0.1.2",
@@ -27562,12 +27690,14 @@
     },
     "node_modules/tmpl": {
       "version": "1.0.5",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -28006,6 +28136,7 @@
     },
     "node_modules/type-detect": {
       "version": "4.0.8",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -28789,6 +28920,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
       "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -29765,6 +29897,7 @@
     },
     "node_modules/walker": {
       "version": "1.0.8",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "makeerror": "1.0.12"
@@ -29985,6 +30118,7 @@
     },
     "node_modules/write-file-atomic": {
       "version": "4.0.2",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "imurmurhash": "^0.1.4",
@@ -32225,7 +32359,6 @@
       "version": "0.0.424",
       "license": "MIT",
       "dependencies": {
-        "@jest/globals": "^29.4.3",
         "@malloydata/db-bigquery": "0.0.424",
         "@malloydata/db-duckdb": "0.0.424",
         "@malloydata/db-postgres": "0.0.424",
@@ -32241,6 +32374,7 @@
         "madge": "^8.0.0"
       },
       "devDependencies": {
+        "@jest/globals": "^29.4.3",
         "@types/jsdom": "^21.1.1",
         "@types/luxon": "^3.7.2"
       },
@@ -32250,6 +32384,7 @@
     },
     "test/node_modules/@jest/environment": {
       "version": "29.4.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/fake-timers": "^29.4.3",
@@ -32263,6 +32398,7 @@
     },
     "test/node_modules/@jest/fake-timers": {
       "version": "29.4.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.4.3",
@@ -32278,6 +32414,7 @@
     },
     "test/node_modules/@jest/globals": {
       "version": "29.4.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/environment": "^29.4.3",
@@ -32308,6 +32445,7 @@
     },
     "test/node_modules/@sinonjs/commons": {
       "version": "2.0.0",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "type-detect": "4.0.8"
@@ -32315,6 +32453,7 @@
     },
     "test/node_modules/@sinonjs/fake-timers": {
       "version": "10.0.2",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^2.0.0"
@@ -32351,6 +32490,7 @@
     },
     "test/node_modules/jest-message-util": {
       "version": "29.4.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.12.13",
@@ -32369,6 +32509,7 @@
     },
     "test/node_modules/jest-mock": {
       "version": "29.4.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.4.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22878,9 +22878,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.camelcase": {
@@ -31676,12 +31676,6 @@
         "@esbuild/win32-x64": "0.28.1"
       }
     },
-    "packages/malloy-render/node_modules/lodash": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-      "license": "MIT"
-    },
     "packages/malloy-render/node_modules/vega": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/vega/-/vega-6.2.0.tgz",
@@ -32213,12 +32207,6 @@
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
-    },
-    "packages/malloy/node_modules/lodash": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-      "license": "MIT"
     },
     "profiler": {
       "name": "@malloydata/malloy-profiler",

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
   },
   "dependencies": {},
   "overrides": {
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "lodash": "^4.18.1"
   }
 }

--- a/test/package.json
+++ b/test/package.json
@@ -20,7 +20,6 @@
     "malloyc": "ts-node ../scripts/malloy-to-json"
   },
   "dependencies": {
-    "@jest/globals": "^29.4.3",
     "@malloydata/db-bigquery": "0.0.424",
     "@malloydata/db-duckdb": "0.0.424",
     "@malloydata/db-postgres": "0.0.424",
@@ -36,6 +35,7 @@
     "madge": "^8.0.0"
   },
   "devDependencies": {
+    "@jest/globals": "^29.4.3",
     "@types/jsdom": "^21.1.1",
     "@types/luxon": "^3.7.2"
   },


### PR DESCRIPTION
A periodic `npm audit` security sweep of the shipped dependency tree, reconciled against the pin ledger. Almost every advisory maps to an existing hold and needs nothing — this PR is the residue that didn't.

**Two code changes.** A nested `lodash@4.17.23` (the `_.template` code-injection high) survived under `@creditkarma/thrift-server-core` even though our own copies were already on the patched `4.18.1`; a same-major `overrides` lifts every copy. Separately, `@malloydata/malloy-tests` declared `@jest/globals` as a runtime dependency, but nothing on its published entry path imports it (only a `.spec.` file does) — so it was pulling jest for nothing and, because the package publishes and `--omit=dev` walks workspace deps, leaking a jest→js-yaml advisory into the shipped audit. Moved to `devDependencies`. `consumer-canary` and precheck confirm neither disturbed anything.

**Ledger honesty.** The Databricks entry said "no security advisory rides on it" — two high `thrift` advisories now do. Recorded as a standing cost: it clears only with the `2.0.0` bump the hold already blocks on, not `1.16.0` (which keeps the vulnerable `thrift` and adds the native break). Snowflake gains a caution I earned by getting it wrong mid-sweep — a newer `2.x` is past the native boundary the pin exists to hold *despite* being the same major, and npm metadata can't see the `eval('require')` binary, so defer to the documented boundary.

**Runbook.** Renamed `dependabot-security.md` → `npm-security-audit.md`: the sweep is `npm audit`-driven, not Dependabot (which only appears at the edges, dismissing an accepted alert). Its report now leads with npm's severity line, mapping every high and critical to the pin it reconciles to.

Left for a separate decision: the `thrift` bump itself.
