### PR TITLE
docs: add AGENTS.md pointer to the CONTEXT.md tree

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# Agent Instructions
+
+**Read [`CONTEXT.md`](CONTEXT.md) first.** It is the root of this repo's
+context tree and orients you to the architecture, build, and test conventions.
+
+For any file you work on, walk *up* its directory tree reading each
+`CONTEXT.md` you find — from the file's own directory back to the root — to
+gather context from specific to general. Not every directory has one; read the
+ones that do.
+
+This repository follows the [CONTEXT.md convention](https://github.com/the-michael-toy/llm-context-md).


### PR DESCRIPTION
Adds a small `AGENTS.md` at the repo root that points agents at the CONTEXT.md tree.

The root `CONTEXT.md` already describes the [CONTEXT.md convention](https://github.com/the-michael-toy/llm-context-md) and the walk-up-the-tree idea, but nothing tells an agent to start there. `AGENTS.md` is the cross-tool convention filename (Codex, Cursor, Copilot, Claude Code) agents look for, so it's the natural bootstrap point.

It's deliberately a pure pointer — read `CONTEXT.md` first, walk up the tree, here's the convention — with nothing duplicated from `CONTEXT.md` so there's nothing to rot.