### PR TITLE
fix(persist): quote manifest table paths per-dialect on the serve path

### DIFF
--- a/packages/malloy/src/api/foundation/persist-source-sql.spec.ts
+++ b/packages/malloy/src/api/foundation/persist-source-sql.spec.ts
@@ -30,33 +30,37 @@ function persistSourceNamed(model: Model, name: string): PersistSource {
   return source;
 }
 
+const CONN_DIGEST = 'test-conn-digest';
+
+// Compile a query on `sourceName` with a manifest whose single entry is keyed
+// by the source's build-time BuildID (makeBuildId over getSQL()) and names
+// `tableName` as the persisted table. The serve path recomputes its own
+// lookup key from the bare source SELECT (query_query.ts); on a key match the
+// FROM becomes the materialized table.
+function routedSQL(
+  model: Model,
+  sourceName: string,
+  connectionName: string,
+  tableName: string
+): string {
+  const source = persistSourceNamed(model, sourceName);
+  const buildId = source.makeBuildId(CONN_DIGEST, source.getSQL());
+  const manifest: BuildManifest = {
+    entries: {[buildId]: {tableName}},
+  };
+  return model.getPreparedQuery().getPreparedResult({
+    buildManifest: manifest,
+    connectionDigests: {[connectionName]: CONN_DIGEST},
+  }).sql;
+}
+
 describe('PersistSource build key matches serve-time manifest lookup', () => {
-  const CONN_DIGEST = 'test-conn-digest';
   const MATERIALIZED = 'MATERIALIZED_TBL';
 
   // Assert the invariant that matters — build-key == serve-key — through its
   // only observable consequence: a query routes to the materialized table.
-  // Build a manifest whose single entry is keyed by the source's build-time
-  // BuildID (makeBuildId over getSQL()), then compile a query that references
-  // the source with that manifest. The serve path recomputes its own lookup
-  // key from the bare source SELECT (query_query.ts). When the keys agree the
-  // FROM becomes the materialized table; when they diverge the lookup misses
-  // and the source is inlined instead.
-  function routedSQL(
-    model: Model,
-    sourceName: string,
-    connectionName: string
-  ): string {
-    const source = persistSourceNamed(model, sourceName);
-    const buildId = source.makeBuildId(CONN_DIGEST, source.getSQL());
-    const manifest: BuildManifest = {
-      entries: {[buildId]: {tableName: MATERIALIZED}},
-    };
-    return model.getPreparedQuery().getPreparedResult({
-      buildManifest: manifest,
-      connectionDigests: {[connectionName]: CONN_DIGEST},
-    }).sql;
-  }
+  // When the keys agree the FROM becomes the materialized table; when they
+  // diverge the lookup misses and the source is inlined instead.
 
   // Postgres is the only dialect with `hasFinalStage = true`. If getSQL()
   // finalized the query, its BuildID would be hashed over the `row_to_json`
@@ -75,7 +79,9 @@ describe('PersistSource build key matches serve-time manifest lookup', () => {
       run: pg_rollup -> { select: * }
     `);
 
-    expect(routedSQL(model, 'pg_rollup', '_pg_')).toContain(MATERIALIZED);
+    expect(routedSQL(model, 'pg_rollup', '_pg_', MATERIALIZED)).toContain(
+      MATERIALIZED
+    );
   });
 
   // duckdb has `hasFinalStage = false`, so build and serve keys agree
@@ -92,6 +98,65 @@ describe('PersistSource build key matches serve-time manifest lookup', () => {
       run: db_rollup -> { select: * }
     `);
 
-    expect(routedSQL(model, 'db_rollup', '_db_')).toContain(MATERIALIZED);
+    expect(routedSQL(model, 'db_rollup', '_db_', MATERIALIZED)).toContain(
+      MATERIALIZED
+    );
+  });
+});
+
+describe('manifest table paths are re-quoted per-dialect on the serve path', () => {
+  // The builder CREATEs the physical table with quoted (case-preserved)
+  // segments, so the serve-time FROM must quote the same way — Snowflake
+  // folds an unquoted identifier to uppercase and then can't resolve a table
+  // stored lowercase. The manifest name below is the shape a build
+  // orchestrator typically assigns: lowercase, with a lowercase-hex
+  // generation suffix.
+  const PHYSICAL = 'scratch.orders_mz__g000__ab12cd34';
+
+  function sfModel(): Model {
+    return modelOf(`
+      ##! experimental.persistence
+      #@ persist
+      source: sf_rollup is _sf_.table('aTable') -> {
+        group_by: astr
+        aggregate: n is count()
+      }
+      run: sf_rollup -> { select: * }
+    `);
+  }
+
+  test('snowflake (case-folding engine) gets double-quoted segments', () => {
+    const sql = routedSQL(sfModel(), 'sf_rollup', '_sf_', PHYSICAL);
+    expect(sql).toContain('"scratch"."orders_mz__g000__ab12cd34"');
+    // The bare path must not appear outside the quoted form: an unquoted
+    // reference is exactly the prod failure this guards against.
+    expect(sql).not.toMatch(/FROM\s+scratch\./);
+  });
+
+  test('an already-quoted manifest name gets exactly one quote layer', () => {
+    const sql = routedSQL(
+      sfModel(),
+      'sf_rollup',
+      '_sf_',
+      '"scratch"."orders_mz__g000__ab12cd34"'
+    );
+    expect(sql).toContain('"scratch"."orders_mz__g000__ab12cd34"');
+    expect(sql).not.toContain('""scratch""');
+  });
+
+  // Byte-compatibility with the builder's CREATE-side quoting on a backtick
+  // dialect: bigquery/standardsql names quote with ` per segment.
+  test('standardsql gets backtick-quoted segments', () => {
+    const model = modelOf(`
+      ##! experimental.persistence
+      #@ persist
+      source: bq_rollup is _bq_.table('aTable') -> {
+        group_by: astr
+        aggregate: n is count()
+      }
+      run: bq_rollup -> { select: * }
+    `);
+    const sql = routedSQL(model, 'bq_rollup', '_bq_', PHYSICAL);
+    expect(sql).toContain('`scratch`.`orders_mz__g000__ab12cd34`');
   });
 });

--- a/packages/malloy/src/dialect/dialect.ts
+++ b/packages/malloy/src/dialect/dialect.ts
@@ -24,7 +24,7 @@ import type {
 import {isRawCast, isBasicAtomic, TD, isDateUnit} from '../model/malloy_types';
 import type {DialectFunctionOverloadDef} from './functions';
 import type {ValidateTablePathResult} from './table-path';
-import {validateDottedTablePath} from './table-path';
+import {decodeDottedTablePath, validateDottedTablePath} from './table-path';
 
 interface DialectField {
   typeDef: AtomicTypeDef;
@@ -444,6 +444,42 @@ export abstract class Dialect {
       bareIdentRegex: this.tablePathBareIdentRegex,
       dialectName: this.name,
     });
+  }
+
+  /**
+   * Render a dotted table path with every segment quoted for this
+   * dialect. A table created with quoted (case-preserved) segments can
+   * only be read back with quoted segments on a case-folding engine —
+   * Snowflake folds unquoted identifiers to uppercase — so any path
+   * whose producer quoted at CREATE time must be quoted here at read
+   * time, byte-compatibly.
+   *
+   * Accepts bare (`a.b`), quoted (`"a"."b"`), or mixed input: segments
+   * are decoded (delimiters stripped, escapes unescaped) and re-quoted,
+   * so the result carries exactly one quote layer regardless of input
+   * form. A path that doesn't parse as dotted segments for this dialect
+   * (e.g. a DuckDB file path) is returned verbatim — those grammars are
+   * already canonical SQL and have no segments to fold.
+   */
+  sqlQuoteTablePath(tablePath: string): string {
+    if (
+      this.identifierEscapeStyle !== EscapeStyle.Doubled &&
+      this.identifierEscapeStyle !== EscapeStyle.Backslash
+    ) {
+      return tablePath;
+    }
+    const result = decodeDottedTablePath(tablePath, {
+      quoteChar: this.identifierQuoteChar,
+      escapeStyle: this.identifierEscapeStyle,
+      bareIdentRegex: this.tablePathBareIdentRegex,
+      dialectName: this.name,
+    });
+    if (!result.ok) {
+      return tablePath;
+    }
+    return result.segments
+      .map(segment => this.sqlQuoteIdentifier(segment.value))
+      .join('.');
   }
 
   // returns an table that is a 0 based array of numbers

--- a/packages/malloy/src/dialect/table-path-quoting.spec.ts
+++ b/packages/malloy/src/dialect/table-path-quoting.spec.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright Contributors to the Malloy project
+ * SPDX-License-Identifier: MIT
+ */
+
+// Dialect.sqlQuoteTablePath: render a manifest table path with every
+// segment quoted for the target dialect. A table CREATEd with quoted
+// (case-preserved) segments can only be read back quoted on a
+// case-folding engine — Snowflake folds unquoted identifiers to
+// uppercase — so the serve path must quote byte-compatibly with the
+// builder. See the persist routing assertions in
+// api/foundation/persist-source-sql.spec.ts for the end-to-end contract.
+
+import {getDialect} from './dialect_map';
+
+describe('sqlQuoteTablePath', () => {
+  const snowflake = getDialect('snowflake');
+  const standardsql = getDialect('standardsql');
+  const postgres = getDialect('postgres');
+  const duckdb = getDialect('duckdb');
+
+  test('quotes each segment of a bare path (snowflake)', () => {
+    expect(
+      snowflake.sqlQuoteTablePath('scratch.orders_mz__g000__ab12cd34')
+    ).toBe('"scratch"."orders_mz__g000__ab12cd34"');
+  });
+
+  test('is idempotent: a quoted path keeps exactly one quote layer', () => {
+    expect(snowflake.sqlQuoteTablePath('"scratch"."orders_mz"')).toBe(
+      '"scratch"."orders_mz"'
+    );
+  });
+
+  test('normalizes a mixed bare/quoted path to fully quoted', () => {
+    expect(snowflake.sqlQuoteTablePath('scratch."MiXed Case"')).toBe(
+      '"scratch"."MiXed Case"'
+    );
+  });
+
+  test('re-escapes an embedded quote (doubled style)', () => {
+    expect(postgres.sqlQuoteTablePath('"we""ird".t')).toBe('"we""ird"."t"');
+  });
+
+  test('uses backticks on a backtick dialect (standardsql)', () => {
+    expect(standardsql.sqlQuoteTablePath('proj.dataset.orders__g003')).toBe(
+      '`proj`.`dataset`.`orders__g003`'
+    );
+  });
+
+  test('quotes a hyphenated BigQuery project id segment', () => {
+    // `-` is in standardsql's bare-segment charset, so this parses bare and
+    // comes back quoted — the quoted form is what a hyphenated id requires.
+    expect(standardsql.sqlQuoteTablePath('my-proj.ds.t')).toBe(
+      '`my-proj`.`ds`.`t`'
+    );
+  });
+
+  test('returns a non-dotted-path input verbatim (duckdb file path)', () => {
+    // DuckDB file paths are canonical as single-quoted string literals, not
+    // dotted identifier paths; they have no segments to case-fold, so the
+    // helper must pass them through untouched.
+    expect(duckdb.sqlQuoteTablePath("'data/local.parquet'")).toBe(
+      "'data/local.parquet'"
+    );
+  });
+
+  test('quotes a duckdb physical (dotted) table path', () => {
+    expect(duckdb.sqlQuoteTablePath('main.order_summary_mz')).toBe(
+      '"main"."order_summary_mz"'
+    );
+  });
+});

--- a/packages/malloy/src/lang/test/test-translator.ts
+++ b/packages/malloy/src/lang/test/test-translator.ts
@@ -210,6 +210,18 @@ export const pgTableDef: SourceDef = {
   fields: baseFields,
 };
 
+// Snowflake table definition — Snowflake folds unquoted identifiers to
+// UPPERCASE, so it is the dialect that exercises per-dialect quoting of
+// manifest table paths on the persist serve path (Dialect.sqlQuoteTablePath).
+export const sfTableDef: SourceDef = {
+  type: 'table',
+  name: 'aTable',
+  dialect: 'snowflake',
+  tablePath: 'aTable',
+  connection: '_sf_',
+  fields: baseFields,
+};
+
 /**
  * A TestTranlator never actually talks to connection, instead uses
  * some mocked schema definitions.
@@ -219,6 +231,7 @@ export const mockSchema: TableSourceDef[] = [
   aTableDef,
   bqTableDef,
   pgTableDef,
+  sfTableDef,
   {
     type: 'table',
     name: 'carriers',
@@ -416,6 +429,7 @@ export class TestTranslator extends MalloyTranslator {
       _db_: {type: 'connection', name: '_db_'},
       _bq_: {type: 'connection', name: '_bq_'},
       _pg_: {type: 'connection', name: '_pg_'},
+      _sf_: {type: 'connection', name: '_sf_'},
       a: {...aTableDef, primaryKey: 'astr', name: 'a'},
       b: {...aTableDef, primaryKey: 'astr', name: 'b'},
       bq_a: {...bqTableDef, primaryKey: 'astr', name: 'bq_a'},
@@ -487,6 +501,7 @@ export class TestTranslator extends MalloyTranslator {
     this.connectionDialectZone.define('_db_', TEST_DIALECT);
     this.connectionDialectZone.define('_bq_', 'standardsql');
     this.connectionDialectZone.define('_pg_', 'postgres');
+    this.connectionDialectZone.define('_sf_', 'snowflake');
     for (const flag of options.compilerFlags ?? []) {
       this.compilerFlagSrc.push(`##! ${flag}\n`);
     }

--- a/packages/malloy/src/model/malloy_types.ts
+++ b/packages/malloy/src/model/malloy_types.ts
@@ -2391,6 +2391,13 @@ export function mergeUniqueKeyRequirement(
 
 /**
  * Entry in a BuildManifest for a persisted table.
+ *
+ * `tableName` is a logical dotted table path (bare or quoted segments,
+ * validated by `requireCanonicalTablePathAnyDialect` at ingestion). It is
+ * NOT pasted into SQL verbatim: the render sites re-quote every segment
+ * for the target dialect (`Dialect.sqlQuoteTablePath`), because the
+ * builder creates the table with quoted, case-preserved segments and a
+ * case-folding engine (Snowflake) cannot resolve the bare form.
  */
 export interface BuildManifestEntry {
   tableName: string;

--- a/packages/malloy/src/model/query_query.ts
+++ b/packages/malloy/src/model/query_query.ts
@@ -866,9 +866,12 @@ export class QueryQuery extends QueryField {
             const entry = buildManifest.entries[buildId];
 
             if (entry) {
-              // Found in manifest - use persisted table.
-              // entry.tableName comes from the manifest, assumed canonical.
-              return entry.tableName;
+              // Found in manifest - use persisted table. The manifest name is
+              // a logical dotted path; it must be re-quoted per-dialect here
+              // because the builder CREATEd it with quoted (case-preserved)
+              // segments, and a case-folding engine (Snowflake uppercases
+              // unquoted identifiers) can't resolve it bare.
+              return qs.dialect.sqlQuoteTablePath(entry.tableName);
             }
 
             if (buildManifest.strict) {

--- a/packages/malloy/src/model/sql_compiled.ts
+++ b/packages/malloy/src/model/sql_compiled.ts
@@ -13,6 +13,7 @@ import type {
 import {isSegmentSQL, isSegmentSource, safeRecordGet} from './malloy_types';
 import {mkBuildID} from './source_def_utils';
 import {MalloyCompileError} from './malloy_compile_error';
+import {getDialect} from '../dialect';
 
 /**
  * Callback type for compiling a Query to SQL.
@@ -96,8 +97,14 @@ function expandPersistableSource(
 
       if (entry) {
         // Found in manifest - substitute with subquery from persisted table.
-        // entry.tableName is canonical SQL, supplied by the manifest builder.
-        return `(SELECT * FROM ${entry.tableName})`;
+        // The manifest name is a logical dotted path; re-quote it
+        // per-dialect because the builder CREATEd it with quoted
+        // (case-preserved) segments, and a case-folding engine (Snowflake
+        // uppercases unquoted identifiers) can't resolve it bare.
+        const quoted = getDialect(source.dialect).sqlQuoteTablePath(
+          entry.tableName
+        );
+        return `(SELECT * FROM ${quoted})`;
       }
 
       // Not in manifest

--- a/test/src/core/persist.spec.ts
+++ b/test/src/core/persist.spec.ts
@@ -273,7 +273,7 @@ describe('source persistence', () => {
           connectionDigests: {[tstDB]: connectionDigest},
         });
 
-        expect(sql).toContain('my_schema.persisted_carrier_stats');
+        expect(sql).toContain('"my_schema"."persisted_carrier_stats"');
         expect(sql).not.toContain('COUNT(');
       });
 
@@ -365,7 +365,7 @@ describe('source persistence', () => {
           connectionDigests: {[tstDB]: connectionDigest},
         });
 
-        expect(sql).toContain('cached.carrier_stats_table');
+        expect(sql).toContain('"cached"."carrier_stats_table"');
         expect(sql).not.toContain('COUNT(');
       });
     });
@@ -1144,7 +1144,7 @@ describe('source persistence', () => {
         connectionDigests: {[tstDB]: connectionDigest},
       });
 
-      expect(sql).toContain('cache.carrier_stats_built');
+      expect(sql).toContain('"cache"."carrier_stats_built"');
       expect(sql).not.toContain('COUNT(');
     });
   });
@@ -1222,7 +1222,7 @@ describe('source persistence', () => {
         connectionDigests: {[tstDB]: connectionDigest},
       });
 
-      expect(wrapperSQL).toContain('build_cache.carrier_stats_v1');
+      expect(wrapperSQL).toContain('"build_cache"."carrier_stats_v1"');
       expect(wrapperSQL).toContain('flight_count > 100');
 
       const wrapperBuildId = wrapper.makeBuildId(connectionDigest, wrapperSQL);
@@ -1460,7 +1460,7 @@ describe('source persistence', () => {
       );
 
       const sql = await getModel2SQL(manifest);
-      expect(sql).toContain('cached.carrier_stats_table');
+      expect(sql).toContain('"cached"."carrier_stats_table"');
       expect(sql).not.toContain('COUNT(');
     });
 
@@ -1499,7 +1499,7 @@ describe('source persistence', () => {
       );
 
       const sql = await getModel2SQL(manifest);
-      expect(sql).toContain('cached.carrier_stats_table');
+      expect(sql).toContain('"cached"."carrier_stats_table"');
       expect(sql).not.toContain('COUNT(');
     });
 
@@ -1519,7 +1519,7 @@ describe('source persistence', () => {
       );
 
       const sql = await getModel2SQL(manifest);
-      expect(sql).toContain('cached.carrier_stats_table');
+      expect(sql).toContain('"cached"."carrier_stats_table"');
       expect(sql).not.toContain('COUNT(');
     });
 
@@ -1803,7 +1803,7 @@ describe('source persistence', () => {
       const sqlWithManifest = await rt
         .loadQuery(BY_CARRIER_QUERY_MODEL)
         .getSQL();
-      expect(sqlWithManifest).toMatch(/FROM\s+by_carrier\s/);
+      expect(sqlWithManifest).toMatch(/FROM\s+"by_carrier"\s/);
 
       // Override with empty manifest — SQL should NOT reference the table
       const sqlWithoutManifest = await rt
@@ -1811,7 +1811,7 @@ describe('source persistence', () => {
           buildManifest: EMPTY_BUILD_MANIFEST,
         })
         .getSQL();
-      expect(sqlWithoutManifest).not.toMatch(/FROM\s+by_carrier\s/);
+      expect(sqlWithoutManifest).not.toMatch(/FROM\s+"by_carrier"\s/);
     });
 
     it('query results match with and without manifest', async () => {
@@ -2007,14 +2007,14 @@ describe('source persistence', () => {
       const sqlBefore = await runtime
         .loadQuery(BY_CARRIER_QUERY_MODEL)
         .getSQL();
-      expect(sqlBefore).not.toMatch(/FROM\s+by_carrier\s/);
+      expect(sqlBefore).not.toMatch(/FROM\s+"by_carrier"\s/);
 
       // Set manifest via setter
       runtime.buildManifest = manifest;
 
       // Now SQL SHOULD reference the table
       const sqlAfter = await runtime.loadQuery(BY_CARRIER_QUERY_MODEL).getSQL();
-      expect(sqlAfter).toMatch(/FROM\s+by_carrier\s/);
+      expect(sqlAfter).toMatch(/FROM\s+"by_carrier"\s/);
     });
   });
 
@@ -2076,7 +2076,7 @@ describe('source persistence', () => {
       const resultSQL = await runtimeWithManifest(manifest)
         .loadQuery(strictModelCode)
         .getSQL();
-      expect(resultSQL).toContain('cached.by_carrier');
+      expect(resultSQL).toContain('"cached"."by_carrier"');
     });
 
     it('non-strict manifest falls through when persist source is missing', async () => {
@@ -2130,7 +2130,7 @@ describe('source persistence', () => {
       const sql = await runtimeWithManifest(manifest)
         .loadQuery(modelCode)
         .getSQL();
-      expect(sql).toContain('cached.by_carrier');
+      expect(sql).toContain('"cached"."by_carrier"');
     });
 
     it('strict manifest ignores named non-persistent source used as join', async () => {
@@ -2176,7 +2176,7 @@ describe('source persistence', () => {
       const sql = await runtimeWithManifest(manifest)
         .loadQuery(modelCode)
         .getSQL();
-      expect(sql).toContain('cached.by_carrier');
+      expect(sql).toContain('"cached"."by_carrier"');
     });
   });
 });


### PR DESCRIPTION
## The bug

A query on a `#@ persist` source over **Snowflake** fails with
`SQL compilation error: Object 'DB.SCHEMA.TABLE__G000__AB12CD34' does not exist or not authorized`
even though the materialized table exists and holds correct data.

The build side CREATEs the physical table with **quoted, case-preserved** segments, so a lowercase-assigned name (`scratch.orders_mz__g000__ab12cd34`) is stored case-sensitively lowercase. The serve side pasted the build-manifest `tableName` into `FROM` **verbatim and unquoted** (`query_query.ts` `query_source` case, and `sql_compiled.ts` `expandPersistableSource`). Snowflake folds unquoted identifiers to UPPERCASE, so the read can never resolve the table. Postgres folds down (matches a lowercase name) and BigQuery doesn't fold, which is why the write/read quoting asymmetry went unnoticed — the two warehouses the existing tests exercise both mask it.

## The fix

- New `Dialect.sqlQuoteTablePath(tablePath)` on the base dialect, composed from the existing primitives: `decodeDottedTablePath` (strips any existing quote layer per segment) + `sqlQuoteIdentifier` per segment, joined with `.`.
  - **Idempotent**: bare (`a.b`), quoted (`\"a\".\"b\"`), or mixed input all come out with exactly one properly-escaped quote layer.
  - **Non-breaking fallback**: input that doesn't parse as dotted identifier segments for the dialect (e.g. a DuckDB file path, which is canonical as a string literal) is returned verbatim — prior behavior preserved.
- Both manifest render sites now call it. Manifest entries are already validated at ingestion (`requireCanonicalTablePathAnyDialect`), so a validated entry always takes the quoting path.
- User-authored `.table()` paths are untouched: they render via the separate, translator-validated `'table'` case, so nothing gets double-quoted.

## Tests

- `dialect/table-path-quoting.spec.ts`: per-dialect quoting (snowflake double quotes, standardsql backticks, postgres doubled-quote escaping), idempotence, mixed-form normalization, hyphenated BigQuery project ids, DuckDB file-path passthrough.
- `api/foundation/persist-source-sql.spec.ts`: adds a snowflake test connection (`_sf_`) and routing assertions pinning the quoted `FROM` on snowflake (the case-folding engine, i.e. the test that would have caught this) and standardsql (backtick byte-compatibility with the build side).
- `test/src/core/persist.spec.ts`: existing routing assertions updated to pin the quoted form.

Verified: `malloy-core` and `db-all`/`db-duckdb`/`db-duckdb-core` jest projects green. Not verified here: a live Snowflake round-trip (the failure was reproduced and root-caused against a production Snowflake deployment; a follow-up will confirm end-to-end once this is consumable downstream).