### PR TITLE
feat: per-query database metadata (query tags, job labels) and response query ids

### DIFF
--- a/packages/malloy-db-bigquery/src/bigquery_connection.ts
+++ b/packages/malloy-db-bigquery/src/bigquery_connection.ts
@@ -25,6 +25,7 @@ import type {
   QueryRecord,
   QueryOptionsReader,
   QueryRunStats,
+  QueryExecutionMetadata,
   RunSQLOptions,
   StreamingConnection,
   TableSourceDef,
@@ -84,6 +85,30 @@ interface BigQueryConnectionOptions extends ConnectionConfig {
   client_email?: string;
   private_key?: string;
   setupSQL?: string;
+}
+
+/** The BigQuery block of `RunSQLOptions.queryMetadata`. */
+interface BigQueryQueryMetadata {
+  jobLabels?: Record<string, string>;
+}
+
+/** Read the BigQuery job labels out of a query's metadata, if present. */
+function bigQueryJobLabels(
+  options?: RunSQLOptions
+): Record<string, string> | undefined {
+  const block = options?.queryMetadata?.bigquery as
+    BigQueryQueryMetadata | undefined;
+  const labels = block?.jobLabels;
+  return labels && typeof labels === 'object' ? labels : undefined;
+}
+
+/** Merge two label maps (the second wins per key); undefined if both empty. */
+function mergeLabels(
+  base?: Record<string, string>,
+  override?: Record<string, string>
+): Record<string, string> | undefined {
+  if (!base && !override) return undefined;
+  return {...base, ...override};
 }
 
 interface SchemaInfo {
@@ -250,14 +275,18 @@ export class BigQueryConnection
 
   private async _runSQL(
     sqlCommand: string,
-    {rowLimit, abortSignal}: RunSQLOptions = {},
+    options: RunSQLOptions = {},
     rowIndex = 0
   ): Promise<{
     data: MalloyQueryData;
     schema: bigquery.ITableFieldSchema | undefined;
   }> {
+    const {rowLimit, abortSignal} = options;
     const defaultOptions = this.readQueryOptions();
     const pageSize = rowLimit ?? defaultOptions.rowLimit;
+    // Per-call labels; the connection-default labels are merged in
+    // createBigQueryJob so they also cover runtime-internal jobs.
+    const perCallLabels = bigQueryJobLabels(options);
 
     try {
       const queryResultsOptions: QueryResultsOptions = {
@@ -265,11 +294,13 @@ export class BigQueryConnection
         startIndex: rowIndex.toString(),
       };
 
+      const capture: {jobId?: string; location?: string} = {};
       const jobResult = await this.createBigQueryJobAndGetResults(
         sqlCommand,
-        undefined,
+        perCallLabels ? {labels: perCallLabels} : undefined,
         queryResultsOptions,
-        abortSignal
+        abortSignal,
+        capture
       );
 
       const totalRows = +(jobResult[2]?.totalRows
@@ -278,11 +309,21 @@ export class BigQueryConnection
 
       // TODO even though we have 10 minute timeout limit, we still should confirm that resulting metadata has "jobComplete: true"
       const queryCostBytes = jobResult[2]?.totalBytesProcessed;
+      const executionMetadata: QueryExecutionMetadata | undefined =
+        capture.jobId
+          ? {
+              bigquery: {
+                jobId: capture.jobId,
+                ...(capture.location ? {location: capture.location} : {}),
+              },
+            }
+          : undefined;
       const data: MalloyQueryData = {
         rows: jobResult[0],
         totalRows,
         runStats: {
           queryCostBytes: queryCostBytes ? +queryCostBytes : undefined,
+          executionMetadata,
         },
       };
       const schema = jobResult[2]?.schema;
@@ -687,7 +728,8 @@ export class BigQueryConnection
     sqlCommand: string,
     createQueryJobOptions?: Query,
     getQueryResultsOptions?: QueryResultsOptions,
-    abortSignal?: AbortSignal
+    abortSignal?: AbortSignal,
+    capture?: {jobId?: string; location?: string}
   ): Promise<
     PagedResponse<RowMetadata, Query, bigquery.IGetQueryResultsResponse>
   > {
@@ -696,6 +738,12 @@ export class BigQueryConnection
         query: sqlCommand,
         ...createQueryJobOptions,
       });
+      // The warehouse-assigned job id/location, for response-side execution
+      // metadata (joins INFORMATION_SCHEMA.JOBS). Best-effort.
+      if (capture) {
+        capture.jobId = job.id ?? undefined;
+        capture.location = job.location ?? undefined;
+      }
       const cancel = () => {
         job.cancel();
       };
@@ -740,12 +788,20 @@ export class BigQueryConnection
     if (options.query) {
       options.query = this.prependSetupSQL(options.query);
     }
+    // The connection-default labels ride the query-options reader and apply to
+    // every job (including runtime-internal ones like schema fetches); any
+    // per-call labels passed in `options.labels` override them per key.
+    const labels = mergeLabels(
+      bigQueryJobLabels(this.readQueryOptions()),
+      options.labels
+    );
     const [job] = await this.bigQuery.createQueryJob({
       location: this.location,
       maximumBytesBilled:
         this.config.maximumBytesBilled || MAXIMUM_BYTES_BILLED,
       jobTimeoutMs: Number(this.config.timeoutMs) || TIMEOUT_MS,
       ...options,
+      ...(labels ? {labels} : {}),
     });
     return job;
   }

--- a/packages/malloy-db-bigquery/src/bigquery_query_metadata.spec.ts
+++ b/packages/malloy-db-bigquery/src/bigquery_query_metadata.spec.ts
@@ -56,23 +56,23 @@ describe('db-bigquery queryMetadata wiring (offline)', () => {
 
   it('applies connection-default job labels (from queryOptions) to createQueryJob', async () => {
     const {conn, spy} = makeConn({
-      queryMetadata: {bigquery: {jobLabels: {app: 'credible'}}},
+      queryMetadata: {bigquery: {jobLabels: {app: 'my-app'}}},
     });
     await conn.runSQL('SELECT 1');
-    expect(firstJobConfig(spy)['labels']).toEqual({app: 'credible'});
+    expect(firstJobConfig(spy)['labels']).toEqual({app: 'my-app'});
   });
 
   it('merges per-call labels over the connection default (per key)', async () => {
     const {conn, spy} = makeConn({
       queryMetadata: {
-        bigquery: {jobLabels: {app: 'credible', team: 'default'}},
+        bigquery: {jobLabels: {app: 'my-app', team: 'default'}},
       },
     });
     await conn.runSQL('SELECT 1', {
       queryMetadata: {bigquery: {jobLabels: {team: 'finance'}}},
     });
     expect(firstJobConfig(spy)['labels']).toEqual({
-      app: 'credible',
+      app: 'my-app',
       team: 'finance',
     });
   });

--- a/packages/malloy-db-bigquery/src/bigquery_query_metadata.spec.ts
+++ b/packages/malloy-db-bigquery/src/bigquery_query_metadata.spec.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright Contributors to the Malloy project
+ * SPDX-License-Identifier: MIT
+ */
+
+import type {QueryOptionsReader} from '@malloydata/malloy';
+import {BigQueryConnection} from './bigquery_connection';
+
+// A fake BigQuery job with just enough surface for createBigQueryJobAndGetResults.
+function fakeJob(id = 'job-abc', location = 'US') {
+  return {
+    id,
+    location,
+    cancel: () => {},
+    getQueryResults: async () => [
+      [{n: 1}],
+      null,
+      {totalRows: '1', totalBytesProcessed: '42', schema: {fields: []}},
+    ],
+  };
+}
+
+// Build a connection whose SDK createQueryJob is spied — no network, no creds.
+function makeConn(queryOptions?: QueryOptionsReader): {
+  conn: BigQueryConnection;
+  spy: jest.SpyInstance;
+} {
+  const conn = new BigQueryConnection('bq', queryOptions, {
+    projectId: 'test-proj',
+    billingProjectId: 'test-proj',
+  });
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const bq = (conn as any).bigQuery;
+  const spy = jest
+    .spyOn(bq, 'createQueryJob')
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .mockImplementation(async () => [fakeJob()] as any);
+  return {conn, spy};
+}
+
+// The job-config options passed to the SDK on the first createQueryJob call.
+function firstJobConfig(spy: jest.SpyInstance): Record<string, unknown> {
+  return spy.mock.calls[0][0] as Record<string, unknown>;
+}
+
+describe('db-bigquery queryMetadata wiring (offline)', () => {
+  afterEach(() => jest.restoreAllMocks());
+
+  it('applies per-call job labels to createQueryJob', async () => {
+    const {conn, spy} = makeConn();
+    await conn.runSQL('SELECT 1', {
+      queryMetadata: {bigquery: {jobLabels: {team: 'finance'}}},
+    });
+    expect(firstJobConfig(spy)['labels']).toEqual({team: 'finance'});
+  });
+
+  it('applies connection-default job labels (from queryOptions) to createQueryJob', async () => {
+    const {conn, spy} = makeConn({
+      queryMetadata: {bigquery: {jobLabels: {app: 'credible'}}},
+    });
+    await conn.runSQL('SELECT 1');
+    expect(firstJobConfig(spy)['labels']).toEqual({app: 'credible'});
+  });
+
+  it('merges per-call labels over the connection default (per key)', async () => {
+    const {conn, spy} = makeConn({
+      queryMetadata: {
+        bigquery: {jobLabels: {app: 'credible', team: 'default'}},
+      },
+    });
+    await conn.runSQL('SELECT 1', {
+      queryMetadata: {bigquery: {jobLabels: {team: 'finance'}}},
+    });
+    expect(firstJobConfig(spy)['labels']).toEqual({
+      app: 'credible',
+      team: 'finance',
+    });
+  });
+
+  it('sets no labels when no metadata is present', async () => {
+    const {conn, spy} = makeConn();
+    await conn.runSQL('SELECT 1');
+    expect(firstJobConfig(spy)['labels']).toBeUndefined();
+  });
+
+  it('surfaces the job id/location as runStats.executionMetadata.bigquery', async () => {
+    const {conn} = makeConn();
+    const res = await conn.runSQL('SELECT 1');
+    expect(res.runStats?.executionMetadata?.bigquery).toEqual({
+      jobId: 'job-abc',
+      location: 'US',
+    });
+  });
+});

--- a/packages/malloy-db-databricks/src/databricks_connection.ts
+++ b/packages/malloy-db-databricks/src/databricks_connection.ts
@@ -120,6 +120,34 @@ export interface DatabricksConfiguration {
   defaultCatalog?: string;
   defaultSchema?: string;
   setupSQL?: string;
+  // Session metadata applied at session open (connection-layer only in v1):
+  // query tags emitted as `SET QUERY_TAGS['<key>'] = '<value>'` and other
+  // allowlisted session settings as `SET <key> = '<value>'`.
+  queryTags?: Record<string, string>;
+  sessionSettings?: Record<string, string>;
+}
+
+// Escape a value for a single-quoted Databricks/Spark SQL string literal
+// (backslash is the escape character).
+function escapeDatabricksString(s: string): string {
+  return s.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+}
+
+// A settable session-setting key must be a bare identifier (it is not quoted).
+const SESSION_SETTING_KEY = /^[A-Za-z_][A-Za-z0-9_.]*$/;
+
+// Deterministic serialization of session settings for the connection digest.
+// Generic session settings alter session behaviour (like `setupSQL`, which the
+// digest already folds in), so they belong in connection identity; returns
+// undefined when unset so digests are unchanged for connections that omit them.
+// Pure query tags are observability-only and deliberately excluded.
+function digestSessionSettings(
+  settings?: Record<string, string>
+): string | undefined {
+  if (!settings) return undefined;
+  const keys = Object.keys(settings).sort();
+  if (keys.length === 0) return undefined;
+  return JSON.stringify(keys.map(k => [k, settings[k]]));
 }
 
 export class DatabricksConnection
@@ -184,6 +212,11 @@ export class DatabricksConnection
     // Malloy timestamps are UTC wallclock
     await this.executeRaw("SET TIME ZONE 'UTC'");
 
+    // Session metadata (query tags + allowlisted session settings)
+    for (const stmt of this.sessionMetadataStatements()) {
+      await this.executeRaw(stmt);
+    }
+
     // Set catalog and schema if configured
     if (this.config.defaultCatalog) {
       await this.executeRaw(`USE CATALOG ${this.config.defaultCatalog}`);
@@ -214,6 +247,28 @@ export class DatabricksConnection
     return result;
   }
 
+  // Build the SET statements for the connection-level query tags and session
+  // settings, run once at session open. Query tags use Databricks' dedicated
+  // associative-array grammar (`SET QUERY_TAGS['key'] = 'value'`); generic
+  // settings use `SET <key> = 'value'`. Non-identifier setting keys are
+  // skipped (the ingestion layer validates strictly; the driver stays lenient).
+  private sessionMetadataStatements(): string[] {
+    const statements: string[] = [];
+    for (const [key, value] of Object.entries(this.config.queryTags ?? {})) {
+      statements.push(
+        `SET QUERY_TAGS['${escapeDatabricksString(key)}'] = ` +
+          `'${escapeDatabricksString(value)}'`
+      );
+    }
+    for (const [key, value] of Object.entries(
+      this.config.sessionSettings ?? {}
+    )) {
+      if (!SESSION_SETTING_KEY.test(key)) continue;
+      statements.push(`SET ${key} = '${escapeDatabricksString(value)}'`);
+    }
+    return statements;
+  }
+
   async manifestTemporaryTable(sqlCommand: string): Promise<string> {
     const hash = makeDigest(sqlCommand);
     const tableName = `tt${hash.slice(0, this.dialect.maxIdentifierLength - 2)}`;
@@ -239,14 +294,17 @@ export class DatabricksConnection
 
   public getDigest(): string {
     const {host, path, defaultCatalog, defaultSchema} = this.config;
-    return makeDigest(
+    const parts: (string | undefined)[] = [
       'databricks',
       host,
       path,
       defaultCatalog,
       defaultSchema,
-      this.config.setupSQL
-    );
+      this.config.setupSQL,
+    ];
+    const sessionSettings = digestSessionSettings(this.config.sessionSettings);
+    if (sessionSettings !== undefined) parts.push(sessionSettings);
+    return makeDigest(...parts);
   }
 
   canPersist(): this is PersistSQLResults {

--- a/packages/malloy-db-databricks/src/databricks_connection.ts
+++ b/packages/malloy-db-databricks/src/databricks_connection.ts
@@ -122,7 +122,8 @@ export interface DatabricksConfiguration {
   setupSQL?: string;
   // Session metadata applied at session open (connection-layer only in v1):
   // query tags emitted as `SET QUERY_TAGS['<key>'] = '<value>'` and other
-  // allowlisted session settings as `SET <key> = '<value>'`.
+  // session settings as `SET <key> = '<value>'` (keys must be bare
+  // identifiers; which keys are permitted is enforced by the ingestion layer).
   queryTags?: Record<string, string>;
   sessionSettings?: Record<string, string>;
 }
@@ -212,7 +213,7 @@ export class DatabricksConnection
     // Malloy timestamps are UTC wallclock
     await this.executeRaw("SET TIME ZONE 'UTC'");
 
-    // Session metadata (query tags + allowlisted session settings)
+    // Session metadata (query tags + session settings)
     for (const stmt of this.sessionMetadataStatements()) {
       await this.executeRaw(stmt);
     }

--- a/packages/malloy-db-databricks/src/databricks_connection.ts
+++ b/packages/malloy-db-databricks/src/databricks_connection.ts
@@ -122,8 +122,9 @@ export interface DatabricksConfiguration {
   setupSQL?: string;
   // Session metadata applied at session open (connection-layer only in v1):
   // query tags emitted as `SET QUERY_TAGS['<key>'] = '<value>'` and other
-  // session settings as `SET <key> = '<value>'` (keys must be bare
-  // identifiers; which keys are permitted is enforced by the ingestion layer).
+  // session settings as `SET <key> = '<value>'` (setting keys must be bare
+  // identifiers; whether a setting is valid for the warehouse is the caller's
+  // responsibility).
   queryTags?: Record<string, string>;
   sessionSettings?: Record<string, string>;
 }
@@ -250,16 +251,21 @@ export class DatabricksConnection
 
   // Build the SET statements for the connection-level query tags and session
   // settings, run once at session open. Query tags use Databricks' dedicated
-  // associative-array grammar (`SET QUERY_TAGS['key'] = 'value'`); generic
-  // settings use `SET <key> = 'value'`. Non-identifier setting keys are
-  // skipped (the ingestion layer validates strictly; the driver stays lenient).
+  // associative-array grammar, all set in a single statement per the
+  // SET QUERY_TAGS reference (`SET QUERY_TAGS['k1'] = 'v1', QUERY_TAGS['k2'] =
+  // 'v2'`); generic settings use `SET <key> = 'value'`. Non-identifier setting
+  // keys are skipped so a key can't break out of its position in the emitted
+  // SQL; whether a setting is meaningful for the warehouse is the caller's
+  // responsibility.
   private sessionMetadataStatements(): string[] {
     const statements: string[] = [];
-    for (const [key, value] of Object.entries(this.config.queryTags ?? {})) {
-      statements.push(
-        `SET QUERY_TAGS['${escapeDatabricksString(key)}'] = ` +
-          `'${escapeDatabricksString(value)}'`
-      );
+    const tagAssignments = Object.entries(this.config.queryTags ?? {}).map(
+      ([key, value]) =>
+        `QUERY_TAGS['${escapeDatabricksString(key)}'] = ` +
+        `'${escapeDatabricksString(value)}'`
+    );
+    if (tagAssignments.length > 0) {
+      statements.push(`SET ${tagAssignments.join(', ')}`);
     }
     for (const [key, value] of Object.entries(
       this.config.sessionSettings ?? {}

--- a/packages/malloy-db-databricks/src/databricks_connection.ts
+++ b/packages/malloy-db-databricks/src/databricks_connection.ts
@@ -138,20 +138,6 @@ function escapeDatabricksString(s: string): string {
 // A settable session-setting key must be a bare identifier (it is not quoted).
 const SESSION_SETTING_KEY = /^[A-Za-z_][A-Za-z0-9_.]*$/;
 
-// Deterministic serialization of session settings for the connection digest.
-// Generic session settings alter session behaviour (like `setupSQL`, which the
-// digest already folds in), so they belong in connection identity; returns
-// undefined when unset so digests are unchanged for connections that omit them.
-// Pure query tags are observability-only and deliberately excluded.
-function digestSessionSettings(
-  settings?: Record<string, string>
-): string | undefined {
-  if (!settings) return undefined;
-  const keys = Object.keys(settings).sort();
-  if (keys.length === 0) return undefined;
-  return JSON.stringify(keys.map(k => [k, settings[k]]));
-}
-
 export class DatabricksConnection
   extends BaseConnection
   implements Connection, PersistSQLResults
@@ -301,17 +287,17 @@ export class DatabricksConnection
 
   public getDigest(): string {
     const {host, path, defaultCatalog, defaultSchema} = this.config;
-    const parts: (string | undefined)[] = [
+    // queryMetadata (query tags + session settings) is session metadata and is
+    // deliberately excluded from the connection digest — changing it must not
+    // re-key the connection.
+    return makeDigest(
       'databricks',
       host,
       path,
       defaultCatalog,
       defaultSchema,
-      this.config.setupSQL,
-    ];
-    const sessionSettings = digestSessionSettings(this.config.sessionSettings);
-    if (sessionSettings !== undefined) parts.push(sessionSettings);
-    return makeDigest(...parts);
+      this.config.setupSQL
+    );
   }
 
   canPersist(): this is PersistSQLResults {

--- a/packages/malloy-db-databricks/src/databricks_query_metadata.spec.ts
+++ b/packages/malloy-db-databricks/src/databricks_query_metadata.spec.ts
@@ -43,8 +43,7 @@ describe('db-databricks query metadata (offline)', () => {
     await connect(conn);
     expect(mockExecCalls).toEqual([
       "SET TIME ZONE 'UTC'",
-      "SET QUERY_TAGS['team'] = 'finance'",
-      "SET QUERY_TAGS['app'] = 'my-app'",
+      "SET QUERY_TAGS['team'] = 'finance', QUERY_TAGS['app'] = 'my-app'",
       "SET statement_timeout = '60'",
     ]);
   });

--- a/packages/malloy-db-databricks/src/databricks_query_metadata.spec.ts
+++ b/packages/malloy-db-databricks/src/databricks_query_metadata.spec.ts
@@ -1,0 +1,110 @@
+/*
+ * Copyright Contributors to the Malloy project
+ * SPDX-License-Identifier: MIT
+ */
+
+// Records every statement the session executes, so we can assert what runs at
+// session open without a live Databricks warehouse.
+const mockExecCalls: string[] = [];
+
+jest.mock('@databricks/sql', () => ({
+  LogLevel: {error: 'error'},
+  DBSQLLogger: jest.fn().mockImplementation(() => ({})),
+  DBSQLClient: jest.fn().mockImplementation(() => ({
+    connect: jest.fn(async () => {}),
+    openSession: jest.fn(async () => ({
+      executeStatement: jest.fn(async (sql: string) => {
+        mockExecCalls.push(sql);
+        return {fetchAll: async () => [], close: async () => {}};
+      }),
+    })),
+  })),
+}));
+
+import {DatabricksConnection} from './databricks_connection';
+
+const BASE = {host: 'h', path: '/sql/1.0/warehouses/w', token: 't'};
+
+const connect = (conn: DatabricksConnection): Promise<void> =>
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (conn as any).ensureConnected();
+
+describe('db-databricks query metadata (offline)', () => {
+  beforeEach(() => {
+    mockExecCalls.length = 0;
+  });
+
+  it('emits SET QUERY_TAGS and SET settings at session open, after SET TIME ZONE', async () => {
+    const conn = new DatabricksConnection('dbx', {
+      ...BASE,
+      queryTags: {team: 'finance', app: 'credible'},
+      sessionSettings: {statement_timeout: '60'},
+    });
+    await connect(conn);
+    expect(mockExecCalls).toEqual([
+      "SET TIME ZONE 'UTC'",
+      "SET QUERY_TAGS['team'] = 'finance'",
+      "SET QUERY_TAGS['app'] = 'credible'",
+      "SET statement_timeout = '60'",
+    ]);
+  });
+
+  it('emits only SET TIME ZONE when no query metadata is configured', async () => {
+    const conn = new DatabricksConnection('dbx', {...BASE});
+    await connect(conn);
+    expect(mockExecCalls).toEqual(["SET TIME ZONE 'UTC'"]);
+  });
+
+  it('uses the QUERY_TAGS associative-array grammar (not a plain SET query_tags)', async () => {
+    const conn = new DatabricksConnection('dbx', {
+      ...BASE,
+      queryTags: {'cost-center': 'abc'},
+    });
+    await connect(conn);
+    expect(mockExecCalls).toContain("SET QUERY_TAGS['cost-center'] = 'abc'");
+  });
+
+  it('escapes single quotes and backslashes in tag keys and values', async () => {
+    const conn = new DatabricksConnection('dbx', {
+      ...BASE,
+      queryTags: {"o'brien": "a'b\\c"},
+    });
+    await connect(conn);
+    expect(mockExecCalls).toContain(
+      "SET QUERY_TAGS['o\\'brien'] = 'a\\'b\\\\c'"
+    );
+  });
+
+  it('skips session-setting keys that are not bare identifiers', async () => {
+    const conn = new DatabricksConnection('dbx', {
+      ...BASE,
+      sessionSettings: {'bad key; DROP': 'x', 'good_key': 'y'},
+    });
+    await connect(conn);
+    expect(mockExecCalls).toContain("SET good_key = 'y'");
+    expect(mockExecCalls.some(s => s.includes('bad key'))).toBe(false);
+  });
+
+  describe('connection digest', () => {
+    const digest = (c: DatabricksConnection): string => c.getDigest();
+
+    it('is unchanged by query tags (observability-only)', () => {
+      expect(digest(new DatabricksConnection('dbx', BASE))).toBe(
+        digest(
+          new DatabricksConnection('dbx', {...BASE, queryTags: {team: 'fin'}})
+        )
+      );
+    });
+
+    it('differs when session settings differ (they affect the session)', () => {
+      expect(
+        digest(
+          new DatabricksConnection('dbx', {
+            ...BASE,
+            sessionSettings: {ansi_mode: 'true'},
+          })
+        )
+      ).not.toBe(digest(new DatabricksConnection('dbx', BASE)));
+    });
+  });
+});

--- a/packages/malloy-db-databricks/src/databricks_query_metadata.spec.ts
+++ b/packages/malloy-db-databricks/src/databricks_query_metadata.spec.ts
@@ -87,23 +87,21 @@ describe('db-databricks query metadata (offline)', () => {
   describe('connection digest', () => {
     const digest = (c: DatabricksConnection): string => c.getDigest();
 
-    it('is unchanged by query tags (observability-only)', () => {
-      expect(digest(new DatabricksConnection('dbx', BASE))).toBe(
+    it('excludes query metadata (both tags and session settings)', () => {
+      const base = digest(new DatabricksConnection('dbx', BASE));
+      expect(
         digest(
           new DatabricksConnection('dbx', {...BASE, queryTags: {team: 'fin'}})
         )
-      );
-    });
-
-    it('differs when session settings differ (they affect the session)', () => {
+      ).toBe(base);
       expect(
         digest(
           new DatabricksConnection('dbx', {
             ...BASE,
-            sessionSettings: {ansi_mode: 'true'},
+            sessionSettings: {some_setting: 'x'},
           })
         )
-      ).not.toBe(digest(new DatabricksConnection('dbx', BASE)));
+      ).toBe(base);
     });
   });
 });

--- a/packages/malloy-db-databricks/src/databricks_query_metadata.spec.ts
+++ b/packages/malloy-db-databricks/src/databricks_query_metadata.spec.ts
@@ -37,14 +37,14 @@ describe('db-databricks query metadata (offline)', () => {
   it('emits SET QUERY_TAGS and SET settings at session open, after SET TIME ZONE', async () => {
     const conn = new DatabricksConnection('dbx', {
       ...BASE,
-      queryTags: {team: 'finance', app: 'credible'},
+      queryTags: {team: 'finance', app: 'my-app'},
       sessionSettings: {statement_timeout: '60'},
     });
     await connect(conn);
     expect(mockExecCalls).toEqual([
       "SET TIME ZONE 'UTC'",
       "SET QUERY_TAGS['team'] = 'finance'",
-      "SET QUERY_TAGS['app'] = 'credible'",
+      "SET QUERY_TAGS['app'] = 'my-app'",
       "SET statement_timeout = '60'",
     ]);
   });

--- a/packages/malloy-db-postgres/src/postgres_connection.ts
+++ b/packages/malloy-db-postgres/src/postgres_connection.ts
@@ -154,20 +154,6 @@ function escapePostgresString(s: string): string {
 // A settable GUC key must be a bare identifier (it is not quoted).
 const POSTGRES_SETTING_KEY = /^[A-Za-z_][A-Za-z0-9_.]*$/;
 
-// Deterministic serialization of session settings for the connection digest.
-// Generic GUCs alter session behaviour (like `setupSQL`, which the digest
-// already folds in), so they belong in connection identity; returns undefined
-// when unset so digests are unchanged for connections that omit them. The
-// observability-only `application_name` is deliberately excluded.
-function digestSessionSettings(
-  settings?: Record<string, string>
-): string | undefined {
-  if (!settings) return undefined;
-  const keys = Object.keys(settings).sort();
-  if (keys.length === 0) return undefined;
-  return JSON.stringify(keys.map(k => [k, settings[k]]));
-}
-
 /**
  * Decode a canonical Postgres dotted-table path into its underlying
  * identifier strings as they appear in `information_schema`. The schema
@@ -283,18 +269,18 @@ export class PostgresConnection
     if (typeof this.configReader !== 'function') {
       const {host, port, username, databaseName, connectionString} =
         this.configReader;
-      const parts: (string | undefined)[] = [
+      // queryMetadata (application_name + session settings) is session metadata
+      // and is deliberately excluded from the connection digest — changing it
+      // must not re-key the connection.
+      return makeDigest(
         'postgres',
         host,
         port !== undefined ? String(port) : undefined,
         username,
         databaseName,
         connectionString,
-        this.setupSQL,
-      ];
-      const sessionSettings = digestSessionSettings(this.sessionSettings);
-      if (sessionSettings !== undefined) parts.push(sessionSettings);
-      return makeDigest(...parts);
+        this.setupSQL
+      );
     }
     // Fall back to connection name if config is async
     return makeDigest('postgres', this.name);

--- a/packages/malloy-db-postgres/src/postgres_connection.ts
+++ b/packages/malloy-db-postgres/src/postgres_connection.ts
@@ -90,8 +90,9 @@ interface PostgresConnectionConfiguration {
   connectionString?: string;
   setupSQL?: string;
   // Session metadata applied at session open (connection-layer only in v1):
-  // `SET application_name = '<value>'` plus allowlisted session GUCs as
-  // `SET <key> = '<value>'`. Observability-only; never data identity.
+  // `SET application_name = '<value>'` plus session GUCs as `SET <key> =
+  // '<value>'` (keys must be bare identifiers; which keys are permitted is
+  // enforced by the ingestion layer). application_name is observability-only.
   applicationName?: string;
   sessionSettings?: Record<string, string>;
   // Programmatic callers get pg's full ssl surface (incl. `checkServerIdentity`
@@ -674,7 +675,13 @@ export class PooledPostgresConnection
       this._pool.on('acquire', client => {
         client.query("SET TIME ZONE 'UTC'");
         for (const stmt of this.sessionMetadataStatements()) {
-          client.query(stmt);
+          // Fire-and-forget on the pooled acquire path: a rejected SET (e.g. an
+          // unknown GUC or a bad value) must not surface as an unhandled
+          // promise rejection, which would crash the process on every acquire.
+          // Swallow it — the checkout proceeds with that setting un-applied
+          // rather than failing the query. Strict key/value validation is the
+          // ingestion layer's responsibility.
+          client.query(stmt).catch(() => {});
         }
         if (this.setupSQL) {
           for (const stmt of this.setupSQL.split(';\n')) {

--- a/packages/malloy-db-postgres/src/postgres_connection.ts
+++ b/packages/malloy-db-postgres/src/postgres_connection.ts
@@ -91,8 +91,8 @@ interface PostgresConnectionConfiguration {
   setupSQL?: string;
   // Session metadata applied at session open (connection-layer only in v1):
   // `SET application_name = '<value>'` plus session GUCs as `SET <key> =
-  // '<value>'` (keys must be bare identifiers; which keys are permitted is
-  // enforced by the ingestion layer). application_name is observability-only.
+  // '<value>'` (GUC keys must be bare identifiers; whether a GUC is valid is
+  // the caller's responsibility). application_name is observability-only.
   applicationName?: string;
   sessionSettings?: Record<string, string>;
   // Programmatic callers get pg's full ssl surface (incl. `checkServerIdentity`
@@ -545,8 +545,9 @@ export class PostgresConnection
 
   // SET statements for the connection-level application_name and session
   // settings, run at every session open (both the non-pooled and pooled
-  // hooks). Non-identifier GUC keys are skipped — the ingestion layer
-  // validates strictly; the driver stays lenient.
+  // hooks). Non-identifier GUC keys are skipped so a key can't break out of
+  // its position in the emitted SQL; whether a GUC is meaningful is the
+  // caller's responsibility.
   protected sessionMetadataStatements(): string[] {
     const statements: string[] = [];
     if (this.applicationName !== undefined) {
@@ -679,8 +680,8 @@ export class PooledPostgresConnection
           // unknown GUC or a bad value) must not surface as an unhandled
           // promise rejection, which would crash the process on every acquire.
           // Swallow it — the checkout proceeds with that setting un-applied
-          // rather than failing the query. Strict key/value validation is the
-          // ingestion layer's responsibility.
+          // rather than failing the query. Validating that a setting is valid
+          // for the warehouse is the caller's responsibility.
           client.query(stmt).catch(() => {});
         }
         if (this.setupSQL) {

--- a/packages/malloy-db-postgres/src/postgres_connection.ts
+++ b/packages/malloy-db-postgres/src/postgres_connection.ts
@@ -89,6 +89,11 @@ interface PostgresConnectionConfiguration {
   databaseName?: string;
   connectionString?: string;
   setupSQL?: string;
+  // Session metadata applied at session open (connection-layer only in v1):
+  // `SET application_name = '<value>'` plus allowlisted session GUCs as
+  // `SET <key> = '<value>'`. Observability-only; never data identity.
+  applicationName?: string;
+  sessionSettings?: Record<string, string>;
   // Programmatic callers get pg's full ssl surface (incl. `checkServerIdentity`
   // for verify-ca). Saved/registry config is limited to the serializable
   // PostgresSSLConfig subset — see PostgresConnectionOptions.
@@ -138,6 +143,30 @@ function addTlsHint(err: unknown): unknown {
   return err;
 }
 
+// Escape a value for a single-quoted Postgres string literal (standard SQL:
+// double the single quotes; standard_conforming_strings leaves backslashes
+// literal).
+function escapePostgresString(s: string): string {
+  return s.replace(/'/g, "''");
+}
+
+// A settable GUC key must be a bare identifier (it is not quoted).
+const POSTGRES_SETTING_KEY = /^[A-Za-z_][A-Za-z0-9_.]*$/;
+
+// Deterministic serialization of session settings for the connection digest.
+// Generic GUCs alter session behaviour (like `setupSQL`, which the digest
+// already folds in), so they belong in connection identity; returns undefined
+// when unset so digests are unchanged for connections that omit them. The
+// observability-only `application_name` is deliberately excluded.
+function digestSessionSettings(
+  settings?: Record<string, string>
+): string | undefined {
+  if (!settings) return undefined;
+  const keys = Object.keys(settings).sort();
+  if (keys.length === 0) return undefined;
+  return JSON.stringify(keys.map(k => [k, settings[k]]));
+}
+
 /**
  * Decode a canonical Postgres dotted-table path into its underlying
  * identifier strings as they appear in `information_schema`. The schema
@@ -170,6 +199,8 @@ export class PostgresConnection
 {
   public readonly name: string;
   protected setupSQL: string | undefined;
+  protected applicationName: string | undefined;
+  protected sessionSettings: Record<string, string> | undefined;
   private queryOptionsReader: QueryOptionsReader = {};
   private configReader: PostgresConnectionConfigurationReader = {};
 
@@ -196,9 +227,17 @@ export class PostgresConnection
         this.configReader = configReader;
       }
     } else {
-      const {name, setupSQL, ...configReader} = arg;
+      const {
+        name,
+        setupSQL,
+        applicationName,
+        sessionSettings,
+        ...configReader
+      } = arg;
       this.name = name;
       this.setupSQL = setupSQL;
+      this.applicationName = applicationName;
+      this.sessionSettings = sessionSettings;
       this.configReader = configReader;
     }
     if (queryOptionsReader) {
@@ -243,15 +282,18 @@ export class PostgresConnection
     if (typeof this.configReader !== 'function') {
       const {host, port, username, databaseName, connectionString} =
         this.configReader;
-      return makeDigest(
+      const parts: (string | undefined)[] = [
         'postgres',
         host,
         port !== undefined ? String(port) : undefined,
         username,
         databaseName,
         connectionString,
-        this.setupSQL
-      );
+        this.setupSQL,
+      ];
+      const sessionSettings = digestSessionSettings(this.sessionSettings);
+      if (sessionSettings !== undefined) parts.push(sessionSettings);
+      return makeDigest(...parts);
     }
     // Fall back to connection name if config is async
     return makeDigest('postgres', this.name);
@@ -500,8 +542,29 @@ export class PostgresConnection
     await this.runSQL('SELECT 1');
   }
 
+  // SET statements for the connection-level application_name and session
+  // settings, run at every session open (both the non-pooled and pooled
+  // hooks). Non-identifier GUC keys are skipped — the ingestion layer
+  // validates strictly; the driver stays lenient.
+  protected sessionMetadataStatements(): string[] {
+    const statements: string[] = [];
+    if (this.applicationName !== undefined) {
+      statements.push(
+        `SET application_name = '${escapePostgresString(this.applicationName)}'`
+      );
+    }
+    for (const [key, value] of Object.entries(this.sessionSettings ?? {})) {
+      if (!POSTGRES_SETTING_KEY.test(key)) continue;
+      statements.push(`SET ${key} = '${escapePostgresString(value)}'`);
+    }
+    return statements;
+  }
+
   public async connectionSetup(client: Client): Promise<void> {
     await client.query("SET TIME ZONE 'UTC'");
+    for (const stmt of this.sessionMetadataStatements()) {
+      await client.query(stmt);
+    }
     if (this.setupSQL) {
       for (const stmt of this.setupSQL.split(';\n')) {
         const trimmed = stmt.trim();
@@ -610,6 +673,9 @@ export class PooledPostgresConnection
       this._pool = new Pool(this.buildClientConfig(await this.readConfig()));
       this._pool.on('acquire', client => {
         client.query("SET TIME ZONE 'UTC'");
+        for (const stmt of this.sessionMetadataStatements()) {
+          client.query(stmt);
+        }
         if (this.setupSQL) {
           for (const stmt of this.setupSQL.split(';\n')) {
             const trimmed = stmt.trim();

--- a/packages/malloy-db-postgres/src/postgres_query_metadata.spec.ts
+++ b/packages/malloy-db-postgres/src/postgres_query_metadata.spec.ts
@@ -69,14 +69,10 @@ describe('db-postgres query metadata (offline)', () => {
       sessionSettings?: Record<string, string>;
     }): string => new PostgresConnection({name: 'pg', ...opts}).getDigest();
 
-    it('is unchanged by application_name (observability-only)', () => {
-      expect(digest({})).toBe(digest({applicationName: 'my-app'}));
-    });
-
-    it('differs when session settings differ (they affect the session)', () => {
-      expect(digest({sessionSettings: {search_path: 'analytics'}})).not.toBe(
-        digest({})
-      );
+    it('excludes query metadata (both application_name and session settings)', () => {
+      const base = digest({});
+      expect(digest({applicationName: 'my-app'})).toBe(base);
+      expect(digest({sessionSettings: {some_setting: 'x'}})).toBe(base);
     });
   });
 });

--- a/packages/malloy-db-postgres/src/postgres_query_metadata.spec.ts
+++ b/packages/malloy-db-postgres/src/postgres_query_metadata.spec.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright Contributors to the Malloy project
+ * SPDX-License-Identifier: MIT
+ */
+
+import type {Client} from 'pg';
+import {PostgresConnection} from './postgres_connection';
+
+// A pg Client stub that records the SQL it is asked to run — no network.
+function fakeClient(): {client: Client; calls: string[]} {
+  const calls: string[] = [];
+  const client = {
+    query: (sql: string) => {
+      calls.push(sql);
+      return Promise.resolve({rows: []});
+    },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+  return {client, calls};
+}
+
+describe('db-postgres query metadata (offline)', () => {
+  it('emits SET application_name + GUCs after SET TIME ZONE at session open', async () => {
+    const conn = new PostgresConnection({
+      name: 'pg',
+      applicationName: 'credible',
+      sessionSettings: {statement_timeout: '60s'},
+    });
+    const {client, calls} = fakeClient();
+    await conn.connectionSetup(client);
+    expect(calls).toEqual([
+      "SET TIME ZONE 'UTC'",
+      "SET application_name = 'credible'",
+      "SET statement_timeout = '60s'",
+    ]);
+  });
+
+  it('emits only SET TIME ZONE when no query metadata is configured', async () => {
+    const conn = new PostgresConnection({name: 'pg'});
+    const {client, calls} = fakeClient();
+    await conn.connectionSetup(client);
+    expect(calls).toEqual(["SET TIME ZONE 'UTC'"]);
+  });
+
+  it('escapes single quotes in the application_name value', async () => {
+    const conn = new PostgresConnection({
+      name: 'pg',
+      applicationName: "cred'ible",
+    });
+    const {client, calls} = fakeClient();
+    await conn.connectionSetup(client);
+    expect(calls).toContain("SET application_name = 'cred''ible'");
+  });
+
+  it('skips GUC keys that are not bare identifiers', async () => {
+    const conn = new PostgresConnection({
+      name: 'pg',
+      sessionSettings: {'bad key; DROP': 'x', 'search_path': 'analytics'},
+    });
+    const {client, calls} = fakeClient();
+    await conn.connectionSetup(client);
+    expect(calls).toContain("SET search_path = 'analytics'");
+    expect(calls.some(s => s.includes('bad key'))).toBe(false);
+  });
+
+  describe('connection digest', () => {
+    const digest = (opts: {
+      applicationName?: string;
+      sessionSettings?: Record<string, string>;
+    }): string => new PostgresConnection({name: 'pg', ...opts}).getDigest();
+
+    it('is unchanged by application_name (observability-only)', () => {
+      expect(digest({})).toBe(digest({applicationName: 'credible'}));
+    });
+
+    it('differs when session settings differ (they affect the session)', () => {
+      expect(digest({sessionSettings: {search_path: 'analytics'}})).not.toBe(
+        digest({})
+      );
+    });
+  });
+});

--- a/packages/malloy-db-postgres/src/postgres_query_metadata.spec.ts
+++ b/packages/malloy-db-postgres/src/postgres_query_metadata.spec.ts
@@ -23,14 +23,14 @@ describe('db-postgres query metadata (offline)', () => {
   it('emits SET application_name + GUCs after SET TIME ZONE at session open', async () => {
     const conn = new PostgresConnection({
       name: 'pg',
-      applicationName: 'credible',
+      applicationName: 'my-app',
       sessionSettings: {statement_timeout: '60s'},
     });
     const {client, calls} = fakeClient();
     await conn.connectionSetup(client);
     expect(calls).toEqual([
       "SET TIME ZONE 'UTC'",
-      "SET application_name = 'credible'",
+      "SET application_name = 'my-app'",
       "SET statement_timeout = '60s'",
     ]);
   });
@@ -45,11 +45,11 @@ describe('db-postgres query metadata (offline)', () => {
   it('escapes single quotes in the application_name value', async () => {
     const conn = new PostgresConnection({
       name: 'pg',
-      applicationName: "cred'ible",
+      applicationName: "my'app",
     });
     const {client, calls} = fakeClient();
     await conn.connectionSetup(client);
-    expect(calls).toContain("SET application_name = 'cred''ible'");
+    expect(calls).toContain("SET application_name = 'my''app'");
   });
 
   it('skips GUC keys that are not bare identifiers', async () => {
@@ -70,7 +70,7 @@ describe('db-postgres query metadata (offline)', () => {
     }): string => new PostgresConnection({name: 'pg', ...opts}).getDigest();
 
     it('is unchanged by application_name (observability-only)', () => {
-      expect(digest({})).toBe(digest({applicationName: 'credible'}));
+      expect(digest({})).toBe(digest({applicationName: 'my-app'}));
     });
 
     it('differs when session settings differ (they affect the session)', () => {

--- a/packages/malloy-db-snowflake/src/snowflake_connection.ts
+++ b/packages/malloy-db-snowflake/src/snowflake_connection.ts
@@ -21,7 +21,7 @@ import type {
 import {SnowflakeDialect, sqlKey, makeDigest} from '@malloydata/malloy';
 import {BaseConnection} from '@malloydata/malloy/connection';
 
-import {SnowflakeExecutor} from './snowflake_executor';
+import {SnowflakeExecutor, snowflakeQueryTag} from './snowflake_executor';
 import {
   accumulateVariantPath,
   buildTopLevelField,
@@ -192,10 +192,14 @@ export class SnowflakeConnection
     }
     this.connOptions = connOptions ?? {};
     this.setupSQL = options?.setupSQL;
+    // The connection-level query tag (from the default queryOptions) is applied
+    // to every statement, including runtime-internal ones (schema fetches) that
+    // don't flow through runSQL's option merge.
     this.executor = new SnowflakeExecutor(
       connOptions,
       options?.poolOptions,
-      this.setupSQL
+      this.setupSQL,
+      snowflakeQueryTag(options?.queryOptions)
     );
     this.scratchSpace = options?.scratchSpace;
     this.queryOptions = options?.queryOptions ?? {};
@@ -269,11 +273,21 @@ export class SnowflakeConnection
       ...options,
     };
     const rowLimit = effectiveOptions.rowLimit;
-    let rows = await this.executor.batch(sql, effectiveOptions, this.timeoutMs);
+    const capture: {queryId?: string} = {};
+    let rows = await this.executor.batch(
+      sql,
+      effectiveOptions,
+      this.timeoutMs,
+      undefined,
+      capture
+    );
     if (rowLimit !== undefined && rows.length > rowLimit) {
       rows = rows.slice(0, rowLimit);
     }
-    return {rows, totalRows: rows.length};
+    const runStats: QueryRunStats | undefined = capture.queryId
+      ? {executionMetadata: {snowflake: {queryId: capture.queryId}}}
+      : undefined;
+    return {rows, totalRows: rows.length, runStats};
   }
 
   public async *runSQLStream(

--- a/packages/malloy-db-snowflake/src/snowflake_executor.ts
+++ b/packages/malloy-db-snowflake/src/snowflake_executor.ts
@@ -22,6 +22,24 @@ import {toAsyncGenerator} from '@malloydata/malloy';
 // Disable snowflake-sdk logging by default (issue #2565)
 snowflake.configure({logLevel: 'OFF'});
 
+/** The Snowflake block of `RunSQLOptions.queryMetadata`. */
+interface SnowflakeQueryMetadata {
+  queryTag?: string;
+}
+
+/**
+ * Resolve the Snowflake `QUERY_TAG` from a query's metadata, if present. The
+ * tag is applied per statement via `parameters.QUERY_TAG` (see `_execute`);
+ * the connection-level `connOptions.queryTag` is deliberately never set,
+ * because the SDK overwrites caller-supplied per-statement parameters whenever
+ * it is (snowflake-sdk `statement.js`).
+ */
+export function snowflakeQueryTag(options?: RunSQLOptions): string | undefined {
+  const block = options?.queryMetadata?.snowflake as
+    SnowflakeQueryMetadata | undefined;
+  return typeof block?.queryTag === 'string' ? block.queryTag : undefined;
+}
+
 export interface ConnectionConfigFile {
   // a toml file with snowflake connection settings
   // if not provided, we will try to read ~/.snowflake/config
@@ -56,15 +74,21 @@ export class SnowflakeExecutor {
 
   private pool_: Pool<Connection>;
   private setupSQL: string | undefined;
+  // Connection-level default query tag, applied to every statement (including
+  // runtime-internal ones like schema fetches) unless a per-call queryMetadata
+  // overrides it.
+  private defaultQueryTag: string | undefined;
 
   private sessionInitialized = new WeakMap<Connection, Promise<void>>();
 
   constructor(
     connOptions: ConnectionOptions,
     poolOptions?: PoolOptions,
-    setupSQL?: string
+    setupSQL?: string,
+    defaultQueryTag?: string
   ) {
     this.setupSQL = setupSQL;
+    this.defaultQueryTag = defaultQueryTag;
     this.pool_ = snowflake.createPool(connOptions, {
       ...SnowflakeExecutor.defaultPoolOptions_,
       ...(poolOptions ?? {}),
@@ -151,13 +175,18 @@ export class SnowflakeExecutor {
     conn: Connection,
     options?: RunSQLOptions,
     timeoutMs?: number,
-    binds?: Binds
+    binds?: Binds,
+    capture?: {queryId?: string}
   ): Promise<QueryData> {
     const abortSignal = options?.abortSignal;
     // Fail fast if already aborted before we even start executing
     if (abortSignal?.aborted) {
       throw new Error('Query aborted');
     }
+    // Apply the query tag per statement (never via connOptions.queryTag — the
+    // SDK clobbers per-statement parameters when that is set).
+    const queryTag = snowflakeQueryTag(options) ?? this.defaultQueryTag;
+    const parameters = queryTag ? {QUERY_TAG: queryTag} : undefined;
     let _statement: RowStatement | undefined;
     const cancel = () => {
       _statement?.cancel();
@@ -171,6 +200,7 @@ export class SnowflakeExecutor {
         _statement = conn.execute({
           sqlText,
           binds,
+          parameters,
           complete: (
             err: SnowflakeError | undefined,
             _stmt: RowStatement,
@@ -185,6 +215,15 @@ export class SnowflakeExecutor {
             if (err) {
               reject(err);
             } else {
+              // The warehouse-assigned query id, for response-side execution
+              // metadata (best-effort; never fails the query).
+              if (capture) {
+                try {
+                  capture.queryId = _stmt.getQueryId();
+                } catch {
+                  // getQueryId can throw on statements with no server id; ignore.
+                }
+              }
               // Snowflake occasionally calls complete with no rows (e.g. DDL); without this branch
               // the Promise never settles and generic-pool holds the connection forever.
               resolve(rows ?? []);
@@ -278,11 +317,21 @@ export class SnowflakeExecutor {
     sqlText: string,
     options?: RunSQLOptions,
     timeoutMs?: number,
-    binds?: Binds
+    binds?: Binds,
+    capture?: {queryId?: string}
   ): Promise<QueryData> {
     return await this.pool_.use(async (conn: Connection) => {
       await this.ensureSessionInitialized(conn, options, timeoutMs);
-      return await this._execute(sqlText, conn, options, timeoutMs, binds);
+      // Only the data statement's id is captured — session-init statements run
+      // above without a capture object.
+      return await this._execute(
+        sqlText,
+        conn,
+        options,
+        timeoutMs,
+        binds,
+        capture
+      );
     });
   }
 
@@ -345,6 +394,9 @@ export class SnowflakeExecutor {
       throw new Error('Query aborted');
     }
 
+    // Apply the query tag per statement (see _execute).
+    const queryTag = snowflakeQueryTag(options) ?? this.defaultQueryTag;
+    const parameters = queryTag ? {QUERY_TAG: queryTag} : undefined;
     // Track the statement so abort can cancel it during conn.execute()
     let _statement: RowStatement | undefined;
     const abortSignal = options?.abortSignal;
@@ -363,6 +415,7 @@ export class SnowflakeExecutor {
         _statement = conn.execute({
           sqlText,
           streamResult: true,
+          parameters,
           complete: (err: SnowflakeError | undefined, _stmt: RowStatement) => {
             if (err) {
               if (cancelFromAbort) {

--- a/packages/malloy-db-snowflake/src/snowflake_query_metadata.spec.ts
+++ b/packages/malloy-db-snowflake/src/snowflake_query_metadata.spec.ts
@@ -95,14 +95,14 @@ describe('db-snowflake queryMetadata wiring (offline)', () => {
     const {calls} = installFakeSnowflake();
     const conn = new SnowflakeConnection('sf', {
       connOptions: CONN_OPTIONS,
-      queryOptions: {queryMetadata: {snowflake: {queryTag: 'app:credible'}}},
+      queryOptions: {queryMetadata: {snowflake: {queryTag: 'app:my-app'}}},
     });
     await conn.runSQL('SELECT 1 AS T');
     // Session-init ALTER SESSION statements run before the data query; all of
     // them carry the connection-default tag.
     expect(calls.length).toBeGreaterThan(1);
     for (const c of calls) {
-      expect(c.parameters).toEqual({QUERY_TAG: 'app:credible'});
+      expect(c.parameters).toEqual({QUERY_TAG: 'app:my-app'});
     }
   });
 
@@ -110,7 +110,7 @@ describe('db-snowflake queryMetadata wiring (offline)', () => {
     const {calls} = installFakeSnowflake();
     const conn = new SnowflakeConnection('sf', {
       connOptions: CONN_OPTIONS,
-      queryOptions: {queryMetadata: {snowflake: {queryTag: 'app:credible'}}},
+      queryOptions: {queryMetadata: {snowflake: {queryTag: 'app:my-app'}}},
     });
     await conn.runSQL('SELECT 1 AS T', {
       queryMetadata: {snowflake: {queryTag: 'team:finance'}},
@@ -138,7 +138,7 @@ describe('db-snowflake queryMetadata wiring (offline)', () => {
     const {spy} = installFakeSnowflake();
     new SnowflakeConnection('sf', {
       connOptions: CONN_OPTIONS,
-      queryOptions: {queryMetadata: {snowflake: {queryTag: 'app:credible'}}},
+      queryOptions: {queryMetadata: {snowflake: {queryTag: 'app:my-app'}}},
     });
     const passedConnOptions = spy.mock.calls[0][0] as Record<string, unknown>;
     expect(passedConnOptions['queryTag']).toBeUndefined();

--- a/packages/malloy-db-snowflake/src/snowflake_query_metadata.spec.ts
+++ b/packages/malloy-db-snowflake/src/snowflake_query_metadata.spec.ts
@@ -1,0 +1,146 @@
+/*
+ * Copyright Contributors to the Malloy project
+ * SPDX-License-Identifier: MIT
+ */
+
+import snowflake from 'snowflake-sdk';
+import type {RowStatement} from 'snowflake-sdk';
+import {SnowflakeConnection} from './snowflake_connection';
+import {snowflakeQueryTag} from './snowflake_executor';
+
+// A minimal fake generic-pool + snowflake connection so runSQL / executor
+// logic runs fully offline. Records the execute options of every statement.
+interface ExecCall {
+  sqlText: string;
+  parameters?: Record<string, unknown>;
+}
+
+function installFakeSnowflake(queryId = 'q-abc-123'): {
+  calls: ExecCall[];
+  spy: jest.SpyInstance;
+} {
+  const calls: ExecCall[] = [];
+  const fakeStmt = {
+    getQueryId: () => queryId,
+    cancel: () => {},
+  } as unknown as RowStatement;
+  const fakeConn = {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    execute(opts: any): RowStatement {
+      calls.push({sqlText: opts.sqlText, parameters: opts.parameters});
+      // DDL/ALTER SESSION statements return no rows; a SELECT returns one row.
+      const rows = /^\s*select/i.test(opts.sqlText) ? [{T: 1}] : [];
+      opts.complete(undefined, fakeStmt, rows);
+      return fakeStmt;
+    },
+  };
+  const fakePool = {
+    use: (fn: (c: unknown) => Promise<unknown>) => fn(fakeConn),
+    acquire: async () => fakeConn,
+    release: async () => {},
+    drain: async () => {},
+    clear: () => {},
+  };
+  const spy = jest
+    .spyOn(snowflake, 'createPool')
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .mockReturnValue(fakePool as any);
+  return {calls, spy};
+}
+
+// Non-empty so the constructor never falls back to reading connections.toml.
+const CONN_OPTIONS = {account: 'test', username: 'test'};
+
+const lastCall = (calls: ExecCall[]): ExecCall => calls[calls.length - 1];
+
+describe('snowflakeQueryTag', () => {
+  it('reads queryMetadata.snowflake.queryTag', () => {
+    expect(
+      snowflakeQueryTag({
+        queryMetadata: {snowflake: {queryTag: 'team:finance'}},
+      })
+    ).toBe('team:finance');
+  });
+
+  it('returns undefined when the tag is absent at any level', () => {
+    expect(snowflakeQueryTag(undefined)).toBeUndefined();
+    expect(snowflakeQueryTag({})).toBeUndefined();
+    expect(snowflakeQueryTag({queryMetadata: {}})).toBeUndefined();
+    expect(snowflakeQueryTag({queryMetadata: {snowflake: {}}})).toBeUndefined();
+  });
+
+  it('ignores a non-string queryTag', () => {
+    expect(
+      snowflakeQueryTag({
+        queryMetadata: {snowflake: {queryTag: 123 as unknown as string}},
+      })
+    ).toBeUndefined();
+  });
+});
+
+describe('db-snowflake queryMetadata wiring (offline)', () => {
+  afterEach(() => jest.restoreAllMocks());
+
+  it('applies a per-call query tag as parameters.QUERY_TAG on the data statement', async () => {
+    const {calls} = installFakeSnowflake();
+    const conn = new SnowflakeConnection('sf', {connOptions: CONN_OPTIONS});
+    await conn.runSQL('SELECT 1 AS T', {
+      queryMetadata: {snowflake: {queryTag: 'team:finance'}},
+    });
+    expect(lastCall(calls).sqlText).toBe('SELECT 1 AS T');
+    expect(lastCall(calls).parameters).toEqual({QUERY_TAG: 'team:finance'});
+  });
+
+  it('applies the connection-default tag (from queryOptions) to every statement, including session init', async () => {
+    const {calls} = installFakeSnowflake();
+    const conn = new SnowflakeConnection('sf', {
+      connOptions: CONN_OPTIONS,
+      queryOptions: {queryMetadata: {snowflake: {queryTag: 'app:credible'}}},
+    });
+    await conn.runSQL('SELECT 1 AS T');
+    // Session-init ALTER SESSION statements run before the data query; all of
+    // them carry the connection-default tag.
+    expect(calls.length).toBeGreaterThan(1);
+    for (const c of calls) {
+      expect(c.parameters).toEqual({QUERY_TAG: 'app:credible'});
+    }
+  });
+
+  it('lets a per-call tag override the connection default on the data statement', async () => {
+    const {calls} = installFakeSnowflake();
+    const conn = new SnowflakeConnection('sf', {
+      connOptions: CONN_OPTIONS,
+      queryOptions: {queryMetadata: {snowflake: {queryTag: 'app:credible'}}},
+    });
+    await conn.runSQL('SELECT 1 AS T', {
+      queryMetadata: {snowflake: {queryTag: 'team:finance'}},
+    });
+    expect(lastCall(calls).parameters).toEqual({QUERY_TAG: 'team:finance'});
+  });
+
+  it('sets no parameters when no tag is present', async () => {
+    const {calls} = installFakeSnowflake();
+    const conn = new SnowflakeConnection('sf', {connOptions: CONN_OPTIONS});
+    await conn.runSQL('SELECT 1 AS T');
+    expect(lastCall(calls).parameters).toBeUndefined();
+  });
+
+  it('surfaces the warehouse query id as runStats.executionMetadata.snowflake.queryId', async () => {
+    installFakeSnowflake('01ab-2345');
+    const conn = new SnowflakeConnection('sf', {connOptions: CONN_OPTIONS});
+    const res = await conn.runSQL('SELECT 1 AS T');
+    expect(res.runStats?.executionMetadata?.snowflake).toEqual({
+      queryId: '01ab-2345',
+    });
+  });
+
+  it('never injects queryTag into the connection options (per-statement only)', () => {
+    const {spy} = installFakeSnowflake();
+    new SnowflakeConnection('sf', {
+      connOptions: CONN_OPTIONS,
+      queryOptions: {queryMetadata: {snowflake: {queryTag: 'app:credible'}}},
+    });
+    const passedConnOptions = spy.mock.calls[0][0] as Record<string, unknown>;
+    expect(passedConnOptions['queryTag']).toBeUndefined();
+  });
+});

--- a/packages/malloy-db-trino/src/trino_connection.ts
+++ b/packages/malloy-db-trino/src/trino_connection.ts
@@ -63,6 +63,14 @@ export interface TrinoConnectionConfiguration {
 
 export type TrinoConnectionOptions = ConnectionConfig;
 
+// Client tags ride in an HTTP header, comma-separated. Drop any tag containing
+// a comma (the separator) or CR/LF (which could inject a header) so a tag can't
+// corrupt the header the connector emits; whether a tag is otherwise meaningful
+// is the caller's responsibility.
+function safeClientTags(tags?: string[]): string[] {
+  return (tags ?? []).filter(t => !/[,\r\n]/.test(t));
+}
+
 export interface BaseRunner {
   runSQL(
     sql: string,
@@ -83,8 +91,9 @@ class PrestoRunner implements BaseRunner {
     const extraHeaders: Record<string, string> = {
       'X-Presto-Session': 'legacy_unnest=true',
     };
-    if (config.clientTags && config.clientTags.length > 0) {
-      extraHeaders['X-Presto-Client-Tags'] = config.clientTags.join(',');
+    const prestoTags = safeClientTags(config.clientTags);
+    if (prestoTags.length > 0) {
+      extraHeaders['X-Presto-Client-Tags'] = prestoTags.join(',');
     }
     const prestoClientConfig: PrestoClientConfig = {
       catalog: config.catalog,
@@ -150,8 +159,9 @@ class TrinoRunner implements BaseRunner {
     const extraHeaders: Record<string, string> = {
       ...(extraConfig.extraHeaders as Record<string, string> | undefined),
     };
-    if (config.clientTags && config.clientTags.length > 0) {
-      extraHeaders['X-Trino-Client-Tags'] = config.clientTags.join(',');
+    const trinoTags = safeClientTags(config.clientTags);
+    if (trinoTags.length > 0) {
+      extraHeaders['X-Trino-Client-Tags'] = trinoTags.join(',');
     }
     this.client = Trino.create({
       ...extraConfig,

--- a/packages/malloy-db-trino/src/trino_connection.ts
+++ b/packages/malloy-db-trino/src/trino_connection.ts
@@ -54,6 +54,10 @@ export interface TrinoConnectionConfiguration {
   password?: string;
   setupSQL?: string;
   source?: string;
+  // Connection-level client tags surfaced as X-Trino-Client-Tags /
+  // X-Presto-Client-Tags (visible in system.runtime.queries and usable in
+  // resource-group selectors). Connection-layer only in v1.
+  clientTags?: string[];
   extraConfig?: Partial<Record<TrinoExtraConfigKey, unknown>>;
 }
 
@@ -68,12 +72,20 @@ export interface BaseRunner {
     columns: {name: string; type: string; error?: string}[];
     error?: string;
     profilingUrl?: string;
+    // Warehouse-assigned query id, for response-side execution metadata.
+    queryId?: string;
   }>;
 }
 
 class PrestoRunner implements BaseRunner {
   client: PrestoClient;
   constructor(config: TrinoConnectionConfiguration) {
+    const extraHeaders: Record<string, string> = {
+      'X-Presto-Session': 'legacy_unnest=true',
+    };
+    if (config.clientTags && config.clientTags.length > 0) {
+      extraHeaders['X-Presto-Client-Tags'] = config.clientTags.join(',');
+    }
     const prestoClientConfig: PrestoClientConfig = {
       catalog: config.catalog,
       host: config.server,
@@ -81,7 +93,8 @@ class PrestoRunner implements BaseRunner {
       schema: config.schema,
       timezone: 'UTC',
       user: config.user || 'anyone',
-      extraHeaders: {'X-Presto-Session': 'legacy_unnest=true'},
+      source: config.source,
+      extraHeaders,
     };
     if (config.user && config.password) {
       prestoClientConfig.basicAuthentication = {
@@ -111,6 +124,7 @@ class PrestoRunner implements BaseRunner {
           ? (ret.columns as {name: string; type: string}[])
           : [],
       error,
+      queryId: ret?.queryId,
     };
   }
 }
@@ -131,8 +145,17 @@ class TrinoRunner implements BaseRunner {
         // If server isn't a parseable URL, leave it as-is
       }
     }
+    const extraConfig = (config.extraConfig ??
+      {}) as Partial<ConnectionOptions>;
+    const extraHeaders: Record<string, string> = {
+      ...(extraConfig.extraHeaders as Record<string, string> | undefined),
+    };
+    if (config.clientTags && config.clientTags.length > 0) {
+      extraHeaders['X-Trino-Client-Tags'] = config.clientTags.join(',');
+    }
     this.client = Trino.create({
-      ...(config.extraConfig as Partial<ConnectionOptions>),
+      ...extraConfig,
+      ...(Object.keys(extraHeaders).length > 0 ? {extraHeaders} : {}),
       source: config.source,
       catalog: config.catalog,
       server,
@@ -151,6 +174,8 @@ class TrinoRunner implements BaseRunner {
       };
     }
     const columns = queryResult.value.columns;
+    // The Trino query id, for response-side execution metadata.
+    const queryId = queryResult.value.id;
 
     const outputRows: unknown[][] = [];
     while (
@@ -171,7 +196,7 @@ class TrinoRunner implements BaseRunner {
     }
     // console.log(outputRows);
     // console.log(columns);
-    return {rows: outputRows, columns};
+    return {rows: outputRows, columns, queryId};
   }
 }
 
@@ -282,7 +307,7 @@ export abstract class TrinoPrestoConnection
       throw new Error(r.error);
     }
 
-    const {rows: inputRows, columns, profilingUrl} = r;
+    const {rows: inputRows, columns, profilingUrl, queryId} = r;
 
     const malloyColumns = columns.map(c =>
       mkFieldDef(this.malloyTypeFromTrinoType(c.type), c.name)
@@ -294,7 +319,16 @@ export abstract class TrinoPrestoConnection
       resultRowToQueryRecord(malloyColumns, row as unknown[], unpack)
     );
 
-    return {rows: malloyRows, totalRows: malloyRows.length, profilingUrl};
+    const runStats: QueryRunStats | undefined = queryId
+      ? {executionMetadata: {trino: {queryId}}}
+      : undefined;
+
+    return {
+      rows: malloyRows,
+      totalRows: malloyRows.length,
+      profilingUrl,
+      runStats,
+    };
   }
 
   public async runSQLBlockAndFetchResultSchema(

--- a/packages/malloy-db-trino/src/trino_query_metadata.spec.ts
+++ b/packages/malloy-db-trino/src/trino_query_metadata.spec.ts
@@ -38,14 +38,14 @@ describe('db-trino queryMetadata wiring (offline)', () => {
         .mockReturnValue({} as any);
       new TrinoConnection('t', undefined, {
         server: 'http://localhost:8080',
-        source: 'credible',
+        source: 'my-app',
         clientTags: ['team:finance', 'env:prod'],
       });
       const opts = createSpy.mock.calls[0][0] as {
         source?: string;
         extraHeaders?: Record<string, string>;
       };
-      expect(opts.source).toBe('credible');
+      expect(opts.source).toBe('my-app');
       expect(opts.extraHeaders?.['X-Trino-Client-Tags']).toBe(
         'team:finance,env:prod'
       );
@@ -67,14 +67,14 @@ describe('db-trino queryMetadata wiring (offline)', () => {
       PrestoClientMock.mockClear();
       new PrestoConnection('p', undefined, {
         server: 'localhost',
-        source: 'credible',
+        source: 'my-app',
         clientTags: ['team:finance', 'env:prod'],
       });
       const cfg = PrestoClientMock.mock.calls[0][0] as {
         source?: string;
         extraHeaders?: Record<string, string>;
       };
-      expect(cfg.source).toBe('credible');
+      expect(cfg.source).toBe('my-app');
       expect(cfg.extraHeaders?.['X-Presto-Client-Tags']).toBe(
         'team:finance,env:prod'
       );

--- a/packages/malloy-db-trino/src/trino_query_metadata.spec.ts
+++ b/packages/malloy-db-trino/src/trino_query_metadata.spec.ts
@@ -63,6 +63,21 @@ describe('db-trino queryMetadata wiring (offline)', () => {
       expect(opts.extraHeaders?.['X-Trino-Client-Tags']).toBeUndefined();
     });
 
+    it('Trino: drops client tags containing header-unsafe characters', () => {
+      const createSpy = jest
+        .spyOn(Trino, 'create')
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        .mockReturnValue({} as any);
+      new TrinoConnection('t', undefined, {
+        server: 'http://localhost:8080',
+        clientTags: ['ok', 'bad\ninject', 'has,comma'],
+      });
+      const opts = createSpy.mock.calls[0][0] as {
+        extraHeaders?: Record<string, string>;
+      };
+      expect(opts.extraHeaders?.['X-Trino-Client-Tags']).toBe('ok');
+    });
+
     it('Presto: passes source + X-Presto-Client-Tags to the client', () => {
       PrestoClientMock.mockClear();
       new PrestoConnection('p', undefined, {

--- a/packages/malloy-db-trino/src/trino_query_metadata.spec.ts
+++ b/packages/malloy-db-trino/src/trino_query_metadata.spec.ts
@@ -1,0 +1,125 @@
+/*
+ * Copyright Contributors to the Malloy project
+ * SPDX-License-Identifier: MIT
+ */
+
+// PrestoClient is mocked so we can inspect the client config the driver builds
+// (request-side client tags / source) without a live server.
+jest.mock('@prestodb/presto-js-client', () => ({
+  PrestoClient: jest.fn().mockImplementation(() => ({query: jest.fn()})),
+}));
+
+import {PrestoClient} from '@prestodb/presto-js-client';
+import {Trino} from 'trino-client';
+import type {BaseRunner} from './trino_connection';
+import {PrestoConnection, TrinoConnection} from './trino_connection';
+
+const PrestoClientMock = PrestoClient as unknown as jest.Mock;
+
+// A BaseRunner that returns a fixed result (with a query id) and no network.
+function fakeRunner(queryId?: string): BaseRunner {
+  return {
+    runSQL: async () => ({
+      rows: [['hello']],
+      columns: [{name: 'c', type: 'varchar'}],
+      queryId,
+    }),
+  };
+}
+
+describe('db-trino queryMetadata wiring (offline)', () => {
+  afterEach(() => jest.restoreAllMocks());
+
+  describe('request side — client tags / source at construction', () => {
+    it('Trino: passes source + X-Trino-Client-Tags to Trino.create', () => {
+      const createSpy = jest
+        .spyOn(Trino, 'create')
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        .mockReturnValue({} as any);
+      new TrinoConnection('t', undefined, {
+        server: 'http://localhost:8080',
+        source: 'credible',
+        clientTags: ['team:finance', 'env:prod'],
+      });
+      const opts = createSpy.mock.calls[0][0] as {
+        source?: string;
+        extraHeaders?: Record<string, string>;
+      };
+      expect(opts.source).toBe('credible');
+      expect(opts.extraHeaders?.['X-Trino-Client-Tags']).toBe(
+        'team:finance,env:prod'
+      );
+    });
+
+    it('Trino: sets no client-tags header when none are configured', () => {
+      const createSpy = jest
+        .spyOn(Trino, 'create')
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        .mockReturnValue({} as any);
+      new TrinoConnection('t', undefined, {server: 'http://localhost:8080'});
+      const opts = createSpy.mock.calls[0][0] as {
+        extraHeaders?: Record<string, string>;
+      };
+      expect(opts.extraHeaders?.['X-Trino-Client-Tags']).toBeUndefined();
+    });
+
+    it('Presto: passes source + X-Presto-Client-Tags to the client', () => {
+      PrestoClientMock.mockClear();
+      new PrestoConnection('p', undefined, {
+        server: 'localhost',
+        source: 'credible',
+        clientTags: ['team:finance', 'env:prod'],
+      });
+      const cfg = PrestoClientMock.mock.calls[0][0] as {
+        source?: string;
+        extraHeaders?: Record<string, string>;
+      };
+      expect(cfg.source).toBe('credible');
+      expect(cfg.extraHeaders?.['X-Presto-Client-Tags']).toBe(
+        'team:finance,env:prod'
+      );
+    });
+  });
+
+  describe('response side — query id into runStats.executionMetadata', () => {
+    it('Trino: surfaces the query id', async () => {
+      jest
+        .spyOn(Trino, 'create')
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        .mockReturnValue({} as any);
+      const conn = new TrinoConnection('t', undefined, {
+        server: 'http://localhost:8080',
+      });
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (conn as any).client = fakeRunner('20240101_000001_abcde');
+      const res = await conn.runSQL('SELECT 1');
+      expect(res.runStats?.executionMetadata?.trino).toEqual({
+        queryId: '20240101_000001_abcde',
+      });
+    });
+
+    it('Presto: surfaces the query id', async () => {
+      const conn = new PrestoConnection('p', undefined, {server: 'localhost'});
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (conn as any).client = fakeRunner('20240101_000002_fghij');
+      const res = await conn.runSQL('SELECT 1');
+      expect(res.runStats?.executionMetadata?.trino).toEqual({
+        queryId: '20240101_000002_fghij',
+      });
+    });
+
+    it('omits runStats when the runner reports no query id', async () => {
+      jest
+        .spyOn(Trino, 'create')
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        .mockReturnValue({} as any);
+      const conn = new TrinoConnection('t', undefined, {
+        server: 'http://localhost:8080',
+      });
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (conn as any).client = fakeRunner(undefined);
+      const res = await conn.runSQL('SELECT 1');
+      expect(res.runStats).toBeUndefined();
+    });
+  });
+});

--- a/packages/malloy/src/api/foundation/compile.ts
+++ b/packages/malloy/src/api/foundation/compile.ts
@@ -650,7 +650,7 @@ export class Malloy {
       connection = await connections.lookupConnection(connectionName);
     }
     if (sqlStruct) {
-      const data = await connection.runSQL(sqlStruct.selectStr);
+      const data = await connection.runSQL(sqlStruct.selectStr, options);
       return new Result(
         {
           structs: [sqlStruct],

--- a/packages/malloy/src/index.ts
+++ b/packages/malloy/src/index.ts
@@ -78,6 +78,7 @@ export type {
   QueryResult,
   QueryResultDef,
   QueryRunStats,
+  QueryExecutionMetadata,
   QueryScalar,
   NamedQueryDef,
   NamedModelObject,
@@ -215,7 +216,11 @@ export type {
 export type {Overlay, ConfigOverlays} from './api/foundation';
 export type {FilesystemContext, MalloyConfigOptions} from './api/foundation';
 export type {RuntimeContext} from './api/foundation';
-export type {QueryOptionsReader, RunSQLOptions} from './run_sql_options';
+export type {
+  ConnectionQueryMetadata,
+  QueryOptionsReader,
+  RunSQLOptions,
+} from './run_sql_options';
 export type {
   EventStream,
   ModelString,

--- a/packages/malloy/src/model/malloy_types.ts
+++ b/packages/malloy/src/model/malloy_types.ts
@@ -2114,9 +2114,28 @@ export function isCompoundArrayData(v: QueryValue): v is QueryData {
   );
 }
 
+/**
+ * Warehouse-assigned execution ids for the query that produced a result, keyed
+ * by connector name (e.g. Snowflake query id, BigQuery job id/location, Trino
+ * query id). Best-effort and connector-specific; absent when the connector has
+ * no durable server-side id. Reported, not declared — the response-side mirror
+ * of `ConnectionQueryMetadata`, typed loosely for the same reason.
+ */
+export type QueryExecutionMetadata = {
+  snowflake?: Record<string, unknown>;
+  bigquery?: Record<string, unknown>;
+  trino?: Record<string, unknown>;
+};
+
 /** Query execution stats. */
 export type QueryRunStats = {
   queryCostBytes?: number;
+  /**
+   * Warehouse-assigned execution identifiers for this query (Snowflake query
+   * id, BigQuery job id/location, Trino query id). Best-effort. See
+   * {@link QueryExecutionMetadata}.
+   */
+  executionMetadata?: QueryExecutionMetadata;
 };
 
 /** Returned Malloy query data */

--- a/packages/malloy/src/run_sql_options.ts
+++ b/packages/malloy/src/run_sql_options.ts
@@ -3,9 +3,30 @@
  * SPDX-License-Identifier: MIT
  */
 
+/**
+ * Session metadata (query tags, job labels, client tags, session settings)
+ * keyed by connector name. Each connector reads and narrows its own block and
+ * ignores the rest; blocks are typed loosely here so core stays
+ * connector-agnostic. Session metadata only — never affects query results or
+ * data identity.
+ */
+export interface ConnectionQueryMetadata {
+  snowflake?: Record<string, unknown>;
+  bigquery?: Record<string, unknown>;
+  databricks?: Record<string, unknown>;
+  trino?: Record<string, unknown>;
+  postgres?: Record<string, unknown>;
+}
+
 export interface RunSQLOptions {
   rowLimit?: number;
   abortSignal?: AbortSignal;
+  /**
+   * Optional per-query database metadata (query tags, job labels, session
+   * settings) applied by the connector according to its capabilities. See
+   * {@link ConnectionQueryMetadata}.
+   */
+  queryMetadata?: ConnectionQueryMetadata;
 }
 
 export type QueryOptionsReader = RunSQLOptions | (() => RunSQLOptions);

--- a/packages/malloy/src/run_sql_options.ts
+++ b/packages/malloy/src/run_sql_options.ts
@@ -4,18 +4,18 @@
  */
 
 /**
- * Session metadata (query tags, job labels, client tags, session settings)
- * keyed by connector name. Each connector reads and narrows its own block and
- * ignores the rest; blocks are typed loosely here so core stays
+ * Per-query database metadata carried on `RunSQLOptions`, keyed by connector
+ * name. Only statement/job-granular connectors read it per query — `snowflake`
+ * (query tag) and `bigquery` (job labels). Session-granular connectors (trino,
+ * databricks, postgres) take their metadata as connection configuration applied
+ * at session open, not per query, so they have no block here. Each connector
+ * narrows its own block; blocks are typed loosely so core stays
  * connector-agnostic. Session metadata only — never affects query results or
  * data identity.
  */
 export interface ConnectionQueryMetadata {
   snowflake?: Record<string, unknown>;
   bigquery?: Record<string, unknown>;
-  databricks?: Record<string, unknown>;
-  trino?: Record<string, unknown>;
-  postgres?: Record<string, unknown>;
 }
 
 export interface RunSQLOptions {


### PR DESCRIPTION
## What

Adds optional per-query database metadata to the connector layer, in two directions:

- **`RunSQLOptions.queryMetadata`** — a connector-keyed bag of session metadata (query tags, job labels, client tags, session settings), typed loosely in core and narrowed by each connector.
- **`QueryRunStats.executionMetadata`** — the response-side mirror: the warehouse-assigned execution id of the result (Snowflake query id, BigQuery job id/location, Trino query id), carried on the existing `runStats` channel.

Together these let a caller attach warehouse-side metadata to a query — so operators can attribute cost and separate workload classes in their warehouse's history/billing views — and read the warehouse's own query id back out to join an application call to the query that produced it.

## Per connector

- **snowflake** — `QUERY_TAG` applied per statement (via `parameters.QUERY_TAG`, not the connection-level option, which the SDK clobbers for per-statement params); `getQueryId()` returned as the query id. The connection-level default rides the existing `queryOptions`, so it also covers runtime-internal statements (schema fetches).
- **bigquery** — job `labels` merged into every job (connection default + per-call override); `job.id`/`location` returned.
- **trino / presto** — client tags (`X-Trino-Client-Tags` / `X-Presto-Client-Tags`) and `source` at client construction; query id lifted from the result. Tags containing a comma or CR/LF are dropped so they can't corrupt or inject the header.
- **databricks** — query tags via the dedicated `SET QUERY_TAGS['k1'] = 'v1', QUERY_TAGS['k2'] = 'v2'` grammar, plus generic session settings, at session open (connection-layer). Verified against a live Databricks SQL warehouse.
- **postgres** — `SET application_name` and session GUCs at session open, on both the pooled and non-pooled paths (connection-layer).

No work in `db-mysql` / `db-duckdb`.

## Design notes

- **Additive and optional everywhere** — no behavior change when unset; connectors ignore metadata they don't recognize. The core field is deliberately loosely typed so core stays connector-agnostic; each connector narrows its own block.
- **Two threading mechanisms, matching each connector's existing shape:** statement/job-granular connectors (snowflake, bigquery) carry it on `RunSQLOptions` (like `rowLimit`); session-granular connectors (trino, databricks, postgres) take it as connection configuration applied at session open (like `setupSQL`, following the Postgres `ssl` block precedent).
- **The connector protects the integrity of what it emits** — `SET` keys must be bare identifiers, values are quote-escaped, header-unsafe client tags are dropped. Whether a tag/label/setting is semantically valid for the warehouse is the caller's responsibility; the connector applies what it is given and does not validate warehouse-specific constraints.
- **Session metadata never affects query results or data identity.** All of it — tags, labels, client tags, `application_name`, and session settings — is excluded from the connection digest, so changing it never re-keys the connection. (`setupSQL`, which can change query semantics, stays in the digest as before.)

## Tests

Offline unit tests per connector (`*_query_metadata.spec.ts`) — no live warehouse: they assert the metadata reaches the driver call (statement params / job labels / client headers), that the query id surfaces on `runStats`, plus escaping, digest exclusion, and the header/identifier guards.

Additionally smoke-tested end-to-end against a live instance of every affected engine — confirming the metadata actually attaches (read back from the engine's own history/settings) and the execution id comes back where one exists:
- **Snowflake** — `QUERY_TAG` read back from `QUERY_HISTORY`; `queryId` returned.
- **BigQuery** — job `labels` read back from `INFORMATION_SCHEMA.JOBS`; `jobId`/`location` returned.
- **Databricks** — `SET QUERY_TAGS` grammar + escaping accepted and read back.
- **Trino** — `source` + client tags read back from `system.runtime.queries` / query-info; `queryId` returned.
- **Postgres** — `application_name` + session GUC read back via `current_setting`.

Happy to split this per-connector if smaller PRs are preferred.
