### PR TITLE
fix(mysql): map FLOAT/REAL to number (unblock aggregation of float columns)

### DIFF
--- a/packages/malloy-db-mysql/src/mysql_connection.spec.ts
+++ b/packages/malloy-db-mysql/src/mysql_connection.spec.ts
@@ -73,6 +73,27 @@ describeMySQL('db:MySQL', () => {
       await connection.runRawSQL('DROP TABLE `arrests-latest`');
     }
   });
+
+  it('maps FLOAT columns to number', async () => {
+    // A real FLOAT column must introspect to a Malloy number; otherwise it maps
+    // to `sql native` and can't be used in expressions (e.g. `a.sum()`).
+    await connection.runRawSQL('DROP TABLE IF EXISTS float_agg_test');
+    await connection.runRawSQL('CREATE TABLE float_agg_test (a FLOAT)');
+    try {
+      const res = await connection.fetchSchemaForTables(
+        {t: 'float_agg_test'},
+        {}
+      );
+      expect(res.errors).toEqual({});
+      expect(res.schemas['t']?.fields[0]).toEqual({
+        name: 'a',
+        type: 'number',
+        numberType: 'float',
+      });
+    } finally {
+      await connection.runRawSQL('DROP TABLE float_agg_test');
+    }
+  });
 });
 
 /**

--- a/packages/malloy/src/dialect/mysql/mysql.ts
+++ b/packages/malloy/src/dialect/mysql/mysql.ts
@@ -69,6 +69,8 @@ const mysqlToMalloyTypes: {[key: string]: BasicAtomicTypeDef} = {
   'int unsigned': {type: 'number', numberType: 'integer'},
   'bigint unsigned': {type: 'number', numberType: 'bigint'},
   'double': {type: 'number', numberType: 'float'},
+  'float': {type: 'number', numberType: 'float'},
+  'real': {type: 'number', numberType: 'float'},
   'varchar': {type: 'string'},
   'varbinary': {type: 'string'},
   'char': {type: 'string'},


### PR DESCRIPTION
## Problem

In the MySQL dialect, a real `FLOAT` column maps to an opaque `sql native` type instead of a Malloy `number`. Any expression over such a column then fails to compile:

```
Unsupported SQL native type 'float' not allowed in expression
```

Selecting/grouping the value passes through fine (the raw value is just returned), so this only bites when a real `FLOAT` **column** is used in an expression (e.g. `area.sum()`) — which is why existing tests missed it.

## Root cause

`mysqlToMalloyTypes` in `packages/malloy/src/dialect/mysql/mysql.ts` had entries for `double` and `decimal` but no `float` (or `real`). On a lookup miss, `sqlTypeToMalloyType` returns `{type:'sql native', rawType}`, which trips `sql-native-not-allowed-in-expression`.

MySQL `FLOAT` is single-precision floating point, semantically identical to `double` for Malloy's purposes. Comparable dialects already map their float spellings to `{type:'number', numberType:'float'}` (Snowflake `float`/`real`, Databricks `float`, DuckDB `FLOAT`).

## Fix

Add `float` and `real` to `mysqlToMalloyTypes`. `sqlTypeToMalloyType` already strips trailing params, so `float(10,2)` and `float unsigned` resolve to the `float` key.

## Test

Adds a schema-mapping test (in the credentials-gated `db:MySQL` suite) that creates a real `FLOAT` column and asserts it introspects to `{type:'number', numberType:'float'}` — exactly what the fix changes.

## Verification (against a live MySQL 8.4)

- Full `mysql_connection.spec` suite passes: 11/11, including the new test.
- The new test correctly catches the bug: with the fix reverted it fails, receiving `{type:'sql native', rawType:'float'}` instead of `{type:'number', numberType:'float'}`.
- End-to-end on the real failure path: `CREATE TABLE float_agg_test (a FLOAT); INSERT ... (1.5),(2.5);` then `run: mysql.table('float_agg_test') -> { aggregate: s is a.sum() }` — pre-fix errors with `Unsupported SQL native type 'float' not allowed in expression`; post-fix returns `{s: 4}`.
- Lint passes on both changed files.