### PR TITLE
fix(db-bigquery): poll query results until the configured timeout

### DIFF
--- a/packages/malloy-db-bigquery/src/bigquery.spec.ts
+++ b/packages/malloy-db-bigquery/src/bigquery.spec.ts
@@ -433,6 +433,40 @@ describe('numeric value reading', () => {
   });
 });
 
+// getQueryResultsUntilComplete decides "still running" from the apiResponse's
+// jobComplete flag, which the paginator only delivers when autoPaginate is off.
+// The hermetic specs stub that callback, so they cannot notice if the real
+// client stops sending it; this pins the contract against BigQuery itself. It
+// waits for one poll of a running job, not for the query, and scans 0 bytes.
+describe('db:BigQuery getQueryResults contract', () => {
+  it('reports jobComplete false while the job is still running', async () => {
+    const sdk = new BigQuerySDK();
+    const [job] = await sdk.createQueryJob({
+      query: `SELECT COUNT(*) AS n
+              FROM UNNEST(GENERATE_ARRAY(1, 1000000)) a
+              CROSS JOIN UNNEST(GENERATE_ARRAY(1, 300)) b`,
+      useQueryCache: false,
+    });
+    try {
+      const {err, apiResponse} = await new Promise<{
+        err: Error | null;
+        apiResponse?: {jobComplete?: boolean} | null;
+      }>(resolve => {
+        job.getQueryResults(
+          {timeoutMs: 1, autoPaginate: false},
+          (err, _rows, _nextQuery, apiResponse) => resolve({err, apiResponse})
+        );
+      });
+      // An error accompanies the still-running response; what matters is that
+      // the response comes with it, not what the error says.
+      expect(err).toBeTruthy();
+      expect(apiResponse?.jobComplete).toBe(false);
+    } finally {
+      await job.cancel();
+    }
+  });
+});
+
 afterAll(async () => {
   await runtime.connection.close();
 });

--- a/packages/malloy-db-bigquery/src/bigquery_connection.ts
+++ b/packages/malloy-db-bigquery/src/bigquery_connection.ts
@@ -178,25 +178,6 @@ const TIMEOUT_MS = 1000 * 60 * 10;
  */
 const GET_QUERY_RESULTS_POLL_MS = 1000 * 60 * 2;
 
-/**
- * Resolve a connection `timeoutMs` config value (milliseconds, as a string) to a
- * number. An explicit `'0'` is preserved and means "no client-side timeout" at
- * the call sites (no poll deadline, and `jobTimeoutMs` is omitted), matching the
- * Snowflake connector. Only an unset, blank, or non-numeric value falls back to
- * `fallback` — note a whitespace-only string must be treated as blank, since
- * `Number('   ')` is `0`, not `NaN`.
- */
-export function resolveTimeoutMs(
-  configured: string | undefined,
-  fallback: number
-): number {
-  if (configured === undefined || configured.trim() === '') {
-    return fallback;
-  }
-  const parsed = Number(configured);
-  return Number.isFinite(parsed) ? parsed : fallback;
-}
-
 /** The result of a single getQueryResults poll. */
 type PollOutcome =
   | {
@@ -261,6 +242,16 @@ function pollQueryResults(
   });
 }
 
+/** Cancel a job without letting a cancel failure mask the caller's real error. */
+async function cancelJobQuietly(job: Pick<Job, 'cancel'>): Promise<void> {
+  try {
+    await job.cancel();
+  } catch {
+    // Best-effort: the job may already be finishing or gone; the caller still
+    // reports the timeout that prompted the cancel.
+  }
+}
+
 /**
  * Fetch a job's query results, polling until the job completes, `deadlineMs`
  * elapses, or the caller aborts. A single getQueryResults call cannot wait out a
@@ -270,15 +261,17 @@ function pollQueryResults(
  * running normally. So for a query that runs longer than one call's server wait
  * we re-issue getQueryResults until it finishes.
  *
- * `deadlineMs` bounds the total wait (the connection's configured timeoutMs);
- * pass `Infinity` for no deadline, i.e. poll until the job completes or the
- * caller aborts. `abortSignal` lets the loop exit promptly on cancel (the caller
- * also cancels the BigQuery job). A bounded number of retries absorbs the
- * transient access-denied error BigQuery intermittently returns on first fetch.
- * `now` is injectable for testing.
+ * `deadlineMs` bounds the total wait (the connection's configured timeoutMs).
+ * On reaching it we cancel the job before throwing: BigQuery's jobTimeoutMs
+ * should already be cancelling it server-side, but if that timeout error has not
+ * come back yet, cancelling here stops the job from running (and billing) past
+ * the point we stopped waiting. `abortSignal` lets the loop exit promptly on an
+ * external cancel (the caller cancels the job in that case). A bounded number of
+ * retries absorbs the transient access-denied error BigQuery intermittently
+ * returns on first fetch. `now` is injectable for testing.
  */
 export async function getQueryResultsUntilComplete(
-  job: Pick<Job, 'getQueryResults'>,
+  job: Pick<Job, 'getQueryResults' | 'cancel'>,
   getQueryResultsOptions: QueryResultsOptions,
   deadlineMs: number,
   {
@@ -298,6 +291,7 @@ export async function getQueryResultsUntilComplete(
     }
     const remainingMs = deadlineMs - (now() - startedAt);
     if (remainingMs <= 0) {
+      await cancelJobQuietly(job);
       throw new Error(
         `BigQuery query did not complete within the configured timeout of ${deadlineMs}ms. ` +
           "Raise the connection's timeoutMs to allow longer-running queries."
@@ -894,6 +888,16 @@ export class BigQueryConnection
     throw lastFetchError;
   }
 
+  /**
+   * The effective query timeout in milliseconds. A configured value that is
+   * unset, blank, non-numeric, or 0 falls back to TIMEOUT_MS; only a positive
+   * number overrides the default. This one value bounds both the BigQuery job
+   * (jobTimeoutMs) and how long getQueryResultsUntilComplete polls for results.
+   */
+  private resolvedTimeoutMs(): number {
+    return Number(this.config.timeoutMs) || TIMEOUT_MS;
+  }
+
   private async createBigQueryJobAndGetResults(
     sqlCommand: string,
     createQueryJobOptions?: Query,
@@ -916,8 +920,9 @@ export class BigQueryConnection
         // Poll for results until the job completes or the connection's
         // configured timeout elapses; a single getQueryResults call can't wait
         // out a long-running query (see getQueryResultsUntilComplete). The
-        // deadline is config.timeoutMs, the same knob that bounds the job
-        // timeout, defaulting to TIMEOUT_MS.
+        // deadline is the same resolved timeout that bounds the job's
+        // jobTimeoutMs, so the client stops waiting right about when BigQuery
+        // stops running the job.
         return await getQueryResultsUntilComplete(
           job,
           {
@@ -932,10 +937,7 @@ export class BigQueryConnection
             },
             ...getQueryResultsOptions,
           },
-          // A configured timeout of 0 means "no client-side limit" (matching
-          // Snowflake): no poll deadline, so poll until the job completes or the
-          // caller aborts.
-          resolveTimeoutMs(this.config.timeoutMs, TIMEOUT_MS) || Infinity,
+          this.resolvedTimeoutMs(),
           {abortSignal}
         );
       } finally {
@@ -951,15 +953,14 @@ export class BigQueryConnection
     if (options.query) {
       options.query = this.prependSetupSQL(options.query);
     }
-    const timeoutMs = resolveTimeoutMs(this.config.timeoutMs, TIMEOUT_MS);
     const [job] = await this.bigQuery.createQueryJob({
       location: this.location,
       maximumBytesBilled:
         this.config.maximumBytesBilled || MAXIMUM_BYTES_BILLED,
-      // A configured timeout of 0 means "no client-side limit" (matching
-      // Snowflake): omit jobTimeoutMs so BigQuery applies its own default rather
-      // than being told to time out at 0ms.
-      ...(timeoutMs > 0 ? {jobTimeoutMs: timeoutMs} : {}),
+      // Shadow the resolved timeout to the job's server-side limit so BigQuery
+      // cancels a runaway job on its own; getQueryResultsUntilComplete polls up
+      // to the same deadline on the client side.
+      jobTimeoutMs: this.resolvedTimeoutMs(),
       ...options,
     });
     return job;

--- a/packages/malloy-db-bigquery/src/bigquery_connection.ts
+++ b/packages/malloy-db-bigquery/src/bigquery_connection.ts
@@ -180,9 +180,11 @@ const GET_QUERY_RESULTS_POLL_MS = 1000 * 60 * 2;
 
 /**
  * Resolve a connection `timeoutMs` config value (milliseconds, as a string) to a
- * number, preserving an explicit `'0'` (fail-fast / no wait). Only an unset,
- * blank, or non-numeric value falls back to `fallback` — note a whitespace-only
- * string must be treated as blank, since `Number('   ')` is `0`, not `NaN`.
+ * number. An explicit `'0'` is preserved and means "no client-side timeout" at
+ * the call sites (no poll deadline, and `jobTimeoutMs` is omitted), matching the
+ * Snowflake connector. Only an unset, blank, or non-numeric value falls back to
+ * `fallback` — note a whitespace-only string must be treated as blank, since
+ * `Number('   ')` is `0`, not `NaN`.
  */
 export function resolveTimeoutMs(
   configured: string | undefined,
@@ -268,10 +270,12 @@ function pollQueryResults(
  * running normally. So for a query that runs longer than one call's server wait
  * we re-issue getQueryResults until it finishes.
  *
- * `deadlineMs` is the connection's configured timeoutMs. `abortSignal` lets the
- * loop exit promptly on cancel (the caller also cancels the BigQuery job). A
- * bounded number of retries absorbs the transient access-denied error BigQuery
- * intermittently returns on first fetch. `now` is injectable for testing.
+ * `deadlineMs` bounds the total wait (the connection's configured timeoutMs);
+ * pass `Infinity` for no deadline, i.e. poll until the job completes or the
+ * caller aborts. `abortSignal` lets the loop exit promptly on cancel (the caller
+ * also cancels the BigQuery job). A bounded number of retries absorbs the
+ * transient access-denied error BigQuery intermittently returns on first fetch.
+ * `now` is injectable for testing.
  */
 export async function getQueryResultsUntilComplete(
   job: Pick<Job, 'getQueryResults'>,
@@ -928,7 +932,10 @@ export class BigQueryConnection
             },
             ...getQueryResultsOptions,
           },
-          resolveTimeoutMs(this.config.timeoutMs, TIMEOUT_MS),
+          // A configured timeout of 0 means "no client-side limit" (matching
+          // Snowflake): no poll deadline, so poll until the job completes or the
+          // caller aborts.
+          resolveTimeoutMs(this.config.timeoutMs, TIMEOUT_MS) || Infinity,
           {abortSignal}
         );
       } finally {
@@ -944,11 +951,15 @@ export class BigQueryConnection
     if (options.query) {
       options.query = this.prependSetupSQL(options.query);
     }
+    const timeoutMs = resolveTimeoutMs(this.config.timeoutMs, TIMEOUT_MS);
     const [job] = await this.bigQuery.createQueryJob({
       location: this.location,
       maximumBytesBilled:
         this.config.maximumBytesBilled || MAXIMUM_BYTES_BILLED,
-      jobTimeoutMs: resolveTimeoutMs(this.config.timeoutMs, TIMEOUT_MS),
+      // A configured timeout of 0 means "no client-side limit" (matching
+      // Snowflake): omit jobTimeoutMs so BigQuery applies its own default rather
+      // than being told to time out at 0ms.
+      ...(timeoutMs > 0 ? {jobTimeoutMs: timeoutMs} : {}),
       ...options,
     });
     return job;

--- a/packages/malloy-db-bigquery/src/bigquery_connection.ts
+++ b/packages/malloy-db-bigquery/src/bigquery_connection.ts
@@ -166,10 +166,10 @@ const MAXIMUM_BYTES_BILLED = String(25 * 1024 * 1024 * 1024);
 const TIMEOUT_MS = 1000 * 60 * 10;
 
 /**
- * Per-call server-side wait for getQueryResults. BigQuery caps how long a single
- * getQueryResults call blocks near this value regardless of the requested
- * timeoutMs, so long-running queries are polled across multiple calls (see
- * getQueryResultsUntilComplete).
+ * How long each getQueryResults call asks to wait for the job to finish before
+ * returning. BigQuery returns after at most ~200s regardless of the requested
+ * value, so this is kept under that ceiling; queries that take longer are
+ * covered by polling across multiple calls (see getQueryResultsUntilComplete).
  */
 const GET_QUERY_RESULTS_POLL_MS = 1000 * 60 * 2;
 
@@ -185,12 +185,13 @@ export function isQueryStillRunningError(e: unknown): boolean {
 
 /**
  * Fetch a job's query results, polling until the job completes or `deadlineMs`
- * elapses. BigQuery caps how long one getQueryResults call blocks server-side
- * (~2 min) no matter what timeoutMs is requested, so a single long wait cannot
- * cover a long-running query (e.g. ML.GENERATE_TEXT over many rows) — it just
- * throws "The query did not complete before ...ms" while the job is still fine.
- * We poll with GET_QUERY_RESULTS_POLL_MS per call until the job finishes or the
- * caller's deadline is reached.
+ * elapses. A single getQueryResults call cannot wait out a slow query: BigQuery
+ * bounds how long one call blocks server-side (its docs note the call typically
+ * returns after ~200s even when a larger timeoutMs is requested), after which
+ * the client throws "The query did not complete before <n>ms" while the job is
+ * still running normally. So for any query that runs longer than one call's
+ * server wait, we re-issue getQueryResults (GET_QUERY_RESULTS_POLL_MS per call)
+ * until the job finishes or the caller's deadline is reached.
  *
  * Also retries a bounded number of times on the transient access-denied error
  * BigQuery intermittently returns when first fetching results (previously a
@@ -804,12 +805,10 @@ export class BigQueryConnection
 
       try {
         // Poll for results until the job completes or the connection's
-        // configured timeout elapses. A single getQueryResults call cannot wait
-        // out a long-running query — BigQuery caps its server-side wait (~2 min)
-        // regardless of the requested timeoutMs — so we loop. The deadline is
-        // config.timeoutMs (the same knob as the job timeout), defaulting to
-        // TIMEOUT_MS; getQueryResultsUntilComplete also absorbs the transient
-        // access-denied error BigQuery intermittently returns on first fetch.
+        // configured timeout elapses; a single getQueryResults call can't wait
+        // out a long-running query (see getQueryResultsUntilComplete). The
+        // deadline is config.timeoutMs, the same knob that bounds the job
+        // timeout, defaulting to TIMEOUT_MS.
         return await getQueryResultsUntilComplete(
           job,
           {

--- a/packages/malloy-db-bigquery/src/bigquery_connection.ts
+++ b/packages/malloy-db-bigquery/src/bigquery_connection.ts
@@ -178,6 +178,15 @@ const TIMEOUT_MS = 1000 * 60 * 10;
  */
 const GET_QUERY_RESULTS_POLL_MS = 1000 * 60 * 2;
 
+/**
+ * Minimum spacing between getQueryResults polls. Each call is asked to block
+ * server-side for up to GET_QUERY_RESULTS_POLL_MS, but BigQuery may return
+ * `jobComplete: false` sooner than requested; this floor keeps the loop from
+ * busy-polling in that case. Only the shortfall below it is waited out, so a
+ * poll that already blocked longer adds nothing.
+ */
+const GET_QUERY_RESULTS_MIN_POLL_INTERVAL_MS = 1000;
+
 /** The result of a single getQueryResults poll. */
 type PollOutcome =
   | {
@@ -253,6 +262,28 @@ async function cancelJobQuietly(job: Pick<Job, 'cancel'>): Promise<void> {
 }
 
 /**
+ * A delay used to space out polls; resolves early if `abortSignal` fires, and is
+ * injectable so tests need not wait real time.
+ */
+function delay(ms: number, abortSignal?: AbortSignal): Promise<void> {
+  return new Promise(resolve => {
+    if (abortSignal?.aborted) {
+      resolve();
+      return;
+    }
+    const timer = setTimeout(() => {
+      abortSignal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      resolve();
+    };
+    abortSignal?.addEventListener('abort', onAbort, {once: true});
+  });
+}
+
+/**
  * Fetch a job's query results, polling until the job completes, `deadlineMs`
  * elapses, or the caller aborts. A single getQueryResults call cannot wait out a
  * slow query: BigQuery bounds how long one call blocks server-side (its docs
@@ -268,7 +299,9 @@ async function cancelJobQuietly(job: Pick<Job, 'cancel'>): Promise<void> {
  * the point we stopped waiting. `abortSignal` lets the loop exit promptly on an
  * external cancel (the caller cancels the job in that case). A bounded number of
  * retries absorbs the transient access-denied error BigQuery intermittently
- * returns on first fetch. `now` is injectable for testing.
+ * returns on first fetch. Between polls a minimum interval is enforced so a poll
+ * that returns sooner than requested does not spin the loop. `now` and `wait`
+ * are injectable for testing.
  */
 export async function getQueryResultsUntilComplete(
   job: Pick<Job, 'getQueryResults' | 'cancel'>,
@@ -277,7 +310,12 @@ export async function getQueryResultsUntilComplete(
   {
     abortSignal,
     now = Date.now,
-  }: {abortSignal?: AbortSignal; now?: () => number} = {}
+    wait = delay,
+  }: {
+    abortSignal?: AbortSignal;
+    now?: () => number;
+    wait?: (ms: number, abortSignal?: AbortSignal) => Promise<void>;
+  } = {}
 ): Promise<
   PagedResponse<RowMetadata, Query, bigquery.IGetQueryResultsResponse>
 > {
@@ -305,6 +343,7 @@ export async function getQueryResultsUntilComplete(
       1,
       Math.min(GET_QUERY_RESULTS_POLL_MS, remainingMs)
     );
+    const polledAt = now();
     const outcome = await pollQueryResults(
       job,
       {...getQueryResultsOptions, timeoutMs: pollTimeoutMs},
@@ -313,11 +352,23 @@ export async function getQueryResultsUntilComplete(
     switch (outcome.kind) {
       case 'complete':
         return outcome.value;
-      case 'stillRunning':
-        // Keep polling; the abort/deadline checks at the top of the loop decide
-        // whether to continue. A still-running poll never consumes the
-        // transient-retry budget.
+      case 'stillRunning': {
+        // BigQuery can return `jobComplete: false` sooner than the timeoutMs we
+        // asked for; without a floor between polls the loop would busy-poll and
+        // hammer the API. Wait out only the shortfall below a minimum interval,
+        // bounded by the remaining deadline, so a poll that already blocked adds
+        // no latency. The abort/deadline checks at the top of the loop then
+        // decide whether to continue, and a still-running poll never consumes
+        // the transient-retry budget.
+        const backoffMs = Math.min(
+          GET_QUERY_RESULTS_MIN_POLL_INTERVAL_MS - (now() - polledAt),
+          deadlineMs - (now() - startedAt)
+        );
+        if (backoffMs > 0) {
+          await wait(backoffMs, abortSignal);
+        }
         continue;
+      }
       case 'aborted':
         throw new Error(
           'BigQuery getQueryResults was aborted before the query completed.'
@@ -890,12 +941,15 @@ export class BigQueryConnection
 
   /**
    * The effective query timeout in milliseconds. A configured value that is
-   * unset, blank, non-numeric, or 0 falls back to TIMEOUT_MS; only a positive
-   * number overrides the default. This one value bounds both the BigQuery job
-   * (jobTimeoutMs) and how long getQueryResultsUntilComplete polls for results.
+   * unset, blank, non-numeric, zero, or negative falls back to TIMEOUT_MS; only
+   * a positive number overrides the default. The result bounds both the
+   * BigQuery job (jobTimeoutMs) and the getQueryResultsUntilComplete poll
+   * deadline, so it must be positive: a zero or negative would make the job
+   * cancel on the first poll instead of running.
    */
   private resolvedTimeoutMs(): number {
-    return Number(this.config.timeoutMs) || TIMEOUT_MS;
+    const configured = Number(this.config.timeoutMs);
+    return configured > 0 ? configured : TIMEOUT_MS;
   }
 
   private async createBigQueryJobAndGetResults(

--- a/packages/malloy-db-bigquery/src/bigquery_connection.ts
+++ b/packages/malloy-db-bigquery/src/bigquery_connection.ts
@@ -207,9 +207,16 @@ type PollOutcome =
  * string. On the still-running path the client invokes the callback with a
  * synthetic "did not complete before ..." Error *and* an apiResponse whose
  * `jobComplete === false`; we key off that boolean, which does not drift across
- * client releases the way the message can. Resolves promptly if `abortSignal`
- * fires, so a caller's timeout/cancel is not left blocked behind BigQuery's
- * server-side wait.
+ * client releases the way the message can.
+ *
+ * `autoPaginate: false` is forced, not optional: getQueryResults is
+ * paginator-wrapped, and at the default the paginator hands the callback the
+ * error alone, dropping the apiResponse read here — so every still-running poll
+ * would be misread as a fetch error. It does not change what a completed fetch
+ * returns.
+ *
+ * Resolves promptly if `abortSignal` fires, so a caller's timeout/cancel is not
+ * left blocked behind BigQuery's server-side wait.
  */
 function pollQueryResults(
   job: Pick<Job, 'getQueryResults'>,
@@ -232,7 +239,8 @@ function pollQueryResults(
       return;
     }
     abortSignal?.addEventListener('abort', onAbort);
-    job.getQueryResults(options, (err, rows, nextQuery, apiResponse) => {
+    const pollOptions = {...options, autoPaginate: false};
+    job.getQueryResults(pollOptions, (err, rows, nextQuery, apiResponse) => {
       if (apiResponse?.jobComplete === false) {
         settle({kind: 'stillRunning'});
       } else if (err) {

--- a/packages/malloy-db-bigquery/src/bigquery_connection.ts
+++ b/packages/malloy-db-bigquery/src/bigquery_connection.ts
@@ -181,13 +181,14 @@ const GET_QUERY_RESULTS_POLL_MS = 1000 * 60 * 2;
 /**
  * Resolve a connection `timeoutMs` config value (milliseconds, as a string) to a
  * number, preserving an explicit `'0'` (fail-fast / no wait). Only an unset,
- * empty, or non-numeric value falls back to `fallback`.
+ * blank, or non-numeric value falls back to `fallback` — note a whitespace-only
+ * string must be treated as blank, since `Number('   ')` is `0`, not `NaN`.
  */
-function resolveTimeoutMs(
+export function resolveTimeoutMs(
   configured: string | undefined,
   fallback: number
 ): number {
-  if (configured === undefined || configured === '') {
+  if (configured === undefined || configured.trim() === '') {
     return fallback;
   }
   const parsed = Number(configured);

--- a/packages/malloy-db-bigquery/src/bigquery_connection.ts
+++ b/packages/malloy-db-bigquery/src/bigquery_connection.ts
@@ -165,6 +165,72 @@ const MAXIMUM_BYTES_BILLED = String(25 * 1024 * 1024 * 1024);
  */
 const TIMEOUT_MS = 1000 * 60 * 10;
 
+/**
+ * Per-call server-side wait for getQueryResults. BigQuery caps how long a single
+ * getQueryResults call blocks near this value regardless of the requested
+ * timeoutMs, so long-running queries are polled across multiple calls (see
+ * getQueryResultsUntilComplete).
+ */
+const GET_QUERY_RESULTS_POLL_MS = 1000 * 60 * 2;
+
+/**
+ * True when the BigQuery client threw because a getQueryResults call returned
+ * with the job still running (as opposed to a real failure). The client throws
+ * `Error('The query did not complete before <n>ms')` in that case and exposes
+ * no error code, so the message is the only signal we have.
+ */
+export function isQueryStillRunningError(e: unknown): boolean {
+  return e instanceof Error && /did not complete before \d+ms/.test(e.message);
+}
+
+/**
+ * Fetch a job's query results, polling until the job completes or `deadlineMs`
+ * elapses. BigQuery caps how long one getQueryResults call blocks server-side
+ * (~2 min) no matter what timeoutMs is requested, so a single long wait cannot
+ * cover a long-running query (e.g. ML.GENERATE_TEXT over many rows) — it just
+ * throws "The query did not complete before ...ms" while the job is still fine.
+ * We poll with GET_QUERY_RESULTS_POLL_MS per call until the job finishes or the
+ * caller's deadline is reached.
+ *
+ * Also retries a bounded number of times on the transient access-denied error
+ * BigQuery intermittently returns when first fetching results (previously a
+ * fixed 3-retry loop). `now` is injectable for testing.
+ */
+export async function getQueryResultsUntilComplete(
+  job: Pick<Job, 'getQueryResults'>,
+  getQueryResultsOptions: QueryResultsOptions,
+  deadlineMs: number,
+  now: () => number = Date.now
+): Promise<
+  PagedResponse<RowMetadata, Query, bigquery.IGetQueryResultsResponse>
+> {
+  const startedAt = now();
+  let transientRetries = 0;
+  for (;;) {
+    try {
+      return await job.getQueryResults({
+        timeoutMs: GET_QUERY_RESULTS_POLL_MS,
+        ...getQueryResultsOptions,
+      });
+    } catch (fetchError) {
+      const withinDeadline = now() - startedAt < deadlineMs;
+      // Job still running: keep polling until it completes or the deadline hits.
+      if (isQueryStillRunningError(fetchError)) {
+        if (withinDeadline) {
+          continue;
+        }
+        throw fetchError;
+      }
+      // Otherwise a (possibly transient) fetch error: retry a bounded number of
+      // times while within the deadline, then give up.
+      if (withinDeadline && transientRetries++ < 3) {
+        continue;
+      }
+      throw fetchError;
+    }
+  }
+}
+
 // manage access to BQ, control costs, enforce global data/API limits
 export class BigQueryConnection
   extends BaseConnection
@@ -718,9 +784,6 @@ export class BigQueryConnection
     throw lastFetchError;
   }
 
-  // TODO this needs to extend the wait for results using a timeout set by the user,
-  // and probably needs to loop to check for results - BQ docs now say that after ~2min of waiting,
-  // no matter what you set for timeoutMs, they will probably just return.
   private async createBigQueryJobAndGetResults(
     sqlCommand: string,
     createQueryJobOptions?: Query,
@@ -739,17 +802,17 @@ export class BigQueryConnection
       };
       abortSignal?.addEventListener('abort', cancel);
 
-      // TODO we should check if this is still required?
-      // We do a simple retry-loop here, as a temporary fix for a transient
-      // error in which sometimes requesting results from a job yields an
-      // access denied error. It seems that in these cases, simply trying again
-      // solves the problem. This is being currently investigated by
-      // @christopherswenson and @lloydtabb.
-      let lastFetchError;
-      for (let retries = 0; retries < 3; retries++) {
-        try {
-          return await job.getQueryResults({
-            timeoutMs: 1000 * 60 * 2, // TODO - this requires some rethinking, and is a hack to resolve some issues. talk to @bporterfield
+      try {
+        // Poll for results until the job completes or the connection's
+        // configured timeout elapses. A single getQueryResults call cannot wait
+        // out a long-running query — BigQuery caps its server-side wait (~2 min)
+        // regardless of the requested timeoutMs — so we loop. The deadline is
+        // config.timeoutMs (the same knob as the job timeout), defaulting to
+        // TIMEOUT_MS; getQueryResultsUntilComplete also absorbs the transient
+        // access-denied error BigQuery intermittently returns on first fetch.
+        return await getQueryResultsUntilComplete(
+          job,
+          {
             wrapIntegers: {
               integerTypeCastFunction: (val: string | number) => {
                 const num = Number(val);
@@ -760,14 +823,12 @@ export class BigQueryConnection
               },
             },
             ...getQueryResultsOptions,
-          });
-        } catch (fetchError) {
-          lastFetchError = fetchError;
-        } finally {
-          abortSignal?.removeEventListener('abort', cancel);
-        }
+          },
+          Number(this.config.timeoutMs) || TIMEOUT_MS
+        );
+      } finally {
+        abortSignal?.removeEventListener('abort', cancel);
       }
-      throw lastFetchError;
     } catch (e) {
       throw maybeRewriteError(e);
     }

--- a/packages/malloy-db-bigquery/src/bigquery_connection.ts
+++ b/packages/malloy-db-bigquery/src/bigquery_connection.ts
@@ -161,7 +161,12 @@ const maybeRewriteError = (e: Error | unknown): Error => {
 const MAXIMUM_BYTES_BILLED = String(25 * 1024 * 1024 * 1024);
 
 /**
- * Default timeoutMs value, 10 Mins
+ * Default connection timeoutMs, 10 minutes. Bounds both the BigQuery job
+ * (jobTimeoutMs) and, via getQueryResultsUntilComplete, how long results are
+ * polled. When this connector runs behind an HTTP layer (e.g. the Malloy
+ * Publisher), set the connection's timeoutMs below that layer's socket/request
+ * timeout so a long query is ended by this deadline with a clear error, rather
+ * than racing an opaque socket reset.
  */
 const TIMEOUT_MS = 1000 * 60 * 10;
 
@@ -174,60 +179,158 @@ const TIMEOUT_MS = 1000 * 60 * 10;
 const GET_QUERY_RESULTS_POLL_MS = 1000 * 60 * 2;
 
 /**
- * True when the BigQuery client threw because a getQueryResults call returned
- * with the job still running (as opposed to a real failure). The client throws
- * `Error('The query did not complete before <n>ms')` in that case and exposes
- * no error code, so the message is the only signal we have.
+ * Resolve a connection `timeoutMs` config value (milliseconds, as a string) to a
+ * number, preserving an explicit `'0'` (fail-fast / no wait). Only an unset,
+ * empty, or non-numeric value falls back to `fallback`.
  */
-export function isQueryStillRunningError(e: unknown): boolean {
-  return e instanceof Error && /did not complete before \d+ms/.test(e.message);
+function resolveTimeoutMs(
+  configured: string | undefined,
+  fallback: number
+): number {
+  if (configured === undefined || configured === '') {
+    return fallback;
+  }
+  const parsed = Number(configured);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+/** The result of a single getQueryResults poll. */
+type PollOutcome =
+  | {
+      kind: 'complete';
+      value: PagedResponse<
+        RowMetadata,
+        Query,
+        bigquery.IGetQueryResultsResponse
+      >;
+    }
+  | {kind: 'stillRunning'}
+  | {kind: 'aborted'}
+  | {kind: 'error'; error: unknown};
+
+/**
+ * Issue one getQueryResults call via the callback overload so we can read the
+ * structured `jobComplete` flag rather than pattern-matching the client's error
+ * string. On the still-running path the client invokes the callback with a
+ * synthetic "did not complete before ..." Error *and* an apiResponse whose
+ * `jobComplete === false`; we key off that boolean, which does not drift across
+ * client releases the way the message can. Resolves promptly if `abortSignal`
+ * fires, so a caller's timeout/cancel is not left blocked behind BigQuery's
+ * server-side wait.
+ */
+function pollQueryResults(
+  job: Pick<Job, 'getQueryResults'>,
+  options: QueryResultsOptions,
+  abortSignal?: AbortSignal
+): Promise<PollOutcome> {
+  return new Promise<PollOutcome>(resolve => {
+    let settled = false;
+    const settle = (outcome: PollOutcome) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      abortSignal?.removeEventListener('abort', onAbort);
+      resolve(outcome);
+    };
+    const onAbort = () => settle({kind: 'aborted'});
+    if (abortSignal?.aborted) {
+      settle({kind: 'aborted'});
+      return;
+    }
+    abortSignal?.addEventListener('abort', onAbort);
+    job.getQueryResults(options, (err, rows, nextQuery, apiResponse) => {
+      if (apiResponse?.jobComplete === false) {
+        settle({kind: 'stillRunning'});
+      } else if (err) {
+        settle({kind: 'error', error: err});
+      } else {
+        settle({
+          kind: 'complete',
+          value: [
+            rows ?? [],
+            nextQuery ?? null,
+            apiResponse as bigquery.IGetQueryResultsResponse,
+          ],
+        });
+      }
+    });
+  });
 }
 
 /**
- * Fetch a job's query results, polling until the job completes or `deadlineMs`
- * elapses. A single getQueryResults call cannot wait out a slow query: BigQuery
- * bounds how long one call blocks server-side (its docs note the call typically
- * returns after ~200s even when a larger timeoutMs is requested), after which
- * the client throws "The query did not complete before <n>ms" while the job is
- * still running normally. So for any query that runs longer than one call's
- * server wait, we re-issue getQueryResults (GET_QUERY_RESULTS_POLL_MS per call)
- * until the job finishes or the caller's deadline is reached.
+ * Fetch a job's query results, polling until the job completes, `deadlineMs`
+ * elapses, or the caller aborts. A single getQueryResults call cannot wait out a
+ * slow query: BigQuery bounds how long one call blocks server-side (its docs
+ * note the call typically returns after ~200s even when a larger timeoutMs is
+ * requested) and then reports `jobComplete: false` while the job is still
+ * running normally. So for a query that runs longer than one call's server wait
+ * we re-issue getQueryResults until it finishes.
  *
- * Also retries a bounded number of times on the transient access-denied error
- * BigQuery intermittently returns when first fetching results (previously a
- * fixed 3-retry loop). `now` is injectable for testing.
+ * `deadlineMs` is the connection's configured timeoutMs. `abortSignal` lets the
+ * loop exit promptly on cancel (the caller also cancels the BigQuery job). A
+ * bounded number of retries absorbs the transient access-denied error BigQuery
+ * intermittently returns on first fetch. `now` is injectable for testing.
  */
 export async function getQueryResultsUntilComplete(
   job: Pick<Job, 'getQueryResults'>,
   getQueryResultsOptions: QueryResultsOptions,
   deadlineMs: number,
-  now: () => number = Date.now
+  {
+    abortSignal,
+    now = Date.now,
+  }: {abortSignal?: AbortSignal; now?: () => number} = {}
 ): Promise<
   PagedResponse<RowMetadata, Query, bigquery.IGetQueryResultsResponse>
 > {
   const startedAt = now();
   let transientRetries = 0;
   for (;;) {
-    try {
-      return await job.getQueryResults({
-        timeoutMs: GET_QUERY_RESULTS_POLL_MS,
-        ...getQueryResultsOptions,
-      });
-    } catch (fetchError) {
-      const withinDeadline = now() - startedAt < deadlineMs;
-      // Job still running: keep polling until it completes or the deadline hits.
-      if (isQueryStillRunningError(fetchError)) {
-        if (withinDeadline) {
+    if (abortSignal?.aborted) {
+      throw new Error(
+        'BigQuery getQueryResults was aborted before the query completed.'
+      );
+    }
+    const remainingMs = deadlineMs - (now() - startedAt);
+    if (remainingMs <= 0) {
+      throw new Error(
+        `BigQuery query did not complete within the configured timeout of ${deadlineMs}ms. ` +
+          "Raise the connection's timeoutMs to allow longer-running queries."
+      );
+    }
+    // Clamp the per-poll server wait to what's left of the deadline: a short
+    // timeout then fails fast, and the overall deadline can't be overshot by a
+    // full poll interval. timeoutMs is applied last so a caller-supplied
+    // timeoutMs cannot override the poll interval.
+    const pollTimeoutMs = Math.max(
+      1,
+      Math.min(GET_QUERY_RESULTS_POLL_MS, remainingMs)
+    );
+    const outcome = await pollQueryResults(
+      job,
+      {...getQueryResultsOptions, timeoutMs: pollTimeoutMs},
+      abortSignal
+    );
+    switch (outcome.kind) {
+      case 'complete':
+        return outcome.value;
+      case 'stillRunning':
+        // Keep polling; the abort/deadline checks at the top of the loop decide
+        // whether to continue. A still-running poll never consumes the
+        // transient-retry budget.
+        continue;
+      case 'aborted':
+        throw new Error(
+          'BigQuery getQueryResults was aborted before the query completed.'
+        );
+      case 'error':
+        // A (possibly transient) fetch error — e.g. the intermittent
+        // access-denied BigQuery returns on first fetch. Retry a bounded number
+        // of times, then surface the real error.
+        if (transientRetries++ < 3) {
           continue;
         }
-        throw fetchError;
-      }
-      // Otherwise a (possibly transient) fetch error: retry a bounded number of
-      // times while within the deadline, then give up.
-      if (withinDeadline && transientRetries++ < 3) {
-        continue;
-      }
-      throw fetchError;
+        throw outcome.error;
     }
   }
 }
@@ -381,7 +484,8 @@ export class BigQueryConnection
         ? jobResult[2].totalRows
         : '0');
 
-      // TODO even though we have 10 minute timeout limit, we still should confirm that resulting metadata has "jobComplete: true"
+      // jobComplete is guaranteed here: getQueryResultsUntilComplete only
+      // returns once BigQuery reports the job complete (it polls otherwise).
       const queryCostBytes = jobResult[2]?.totalBytesProcessed;
       const data: MalloyQueryData = {
         rows: jobResult[0],
@@ -823,7 +927,8 @@ export class BigQueryConnection
             },
             ...getQueryResultsOptions,
           },
-          Number(this.config.timeoutMs) || TIMEOUT_MS
+          resolveTimeoutMs(this.config.timeoutMs, TIMEOUT_MS),
+          {abortSignal}
         );
       } finally {
         abortSignal?.removeEventListener('abort', cancel);
@@ -842,7 +947,7 @@ export class BigQueryConnection
       location: this.location,
       maximumBytesBilled:
         this.config.maximumBytesBilled || MAXIMUM_BYTES_BILLED,
-      jobTimeoutMs: Number(this.config.timeoutMs) || TIMEOUT_MS,
+      jobTimeoutMs: resolveTimeoutMs(this.config.timeoutMs, TIMEOUT_MS),
       ...options,
     });
     return job;

--- a/packages/malloy-db-bigquery/src/bigquery_connection.unit.spec.ts
+++ b/packages/malloy-db-bigquery/src/bigquery_connection.unit.spec.ts
@@ -3,32 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-import {BigQueryConnection, resolveTimeoutMs} from './bigquery_connection';
-
-describe('resolveTimeoutMs', () => {
-  const DEFAULT = 600_000;
-
-  it('falls back when unset, empty, or whitespace-only', () => {
-    expect(resolveTimeoutMs(undefined, DEFAULT)).toBe(DEFAULT);
-    expect(resolveTimeoutMs('', DEFAULT)).toBe(DEFAULT);
-    // Number('   ') is 0, not NaN, so a blank-but-not-empty value must be
-    // treated as unset rather than as a fail-fast 0.
-    expect(resolveTimeoutMs('   ', DEFAULT)).toBe(DEFAULT);
-  });
-
-  it('preserves an explicit "0" (call sites treat 0 as no-timeout)', () => {
-    expect(resolveTimeoutMs('0', DEFAULT)).toBe(0);
-  });
-
-  it('parses a numeric string, trimming surrounding whitespace', () => {
-    expect(resolveTimeoutMs('5000', DEFAULT)).toBe(5000);
-    expect(resolveTimeoutMs('  5000  ', DEFAULT)).toBe(5000);
-  });
-
-  it('falls back on a non-numeric value', () => {
-    expect(resolveTimeoutMs('abc', DEFAULT)).toBe(DEFAULT);
-  });
-});
+import {BigQueryConnection} from './bigquery_connection';
 
 // The callback overload yields (err, rows, nextQuery, apiResponse).
 type Cb = (
@@ -68,10 +43,11 @@ function hermeticConnection(steps: Step[], timeoutMs?: string) {
 }
 
 describe('BigQueryConnection.runSQL (hermetic, stubbed job)', () => {
-  it('treats config.timeoutMs "0" as no timeout: polls through, omits jobTimeoutMs', async () => {
-    // Matches Snowflake: 0 disables the client-side limit. The job is still
-    // running on the first poll, so a fail-fast reading would throw here; instead
-    // it must keep polling to completion, and must not send jobTimeoutMs: 0.
+  it('treats config.timeoutMs "0" as unset: uses the default and polls through', async () => {
+    // 0 falls back to the default (like blank or non-numeric); it means neither
+    // "wait 0ms" nor "wait forever". The job is still running on the first poll,
+    // so the loop must keep polling to completion under the default deadline,
+    // and the job is created with the default jobTimeoutMs.
     const {conn, getQueryResults, createQueryJob} = hermeticConnection(
       [stillRunning, complete([{n: 5}])],
       '0'
@@ -79,7 +55,9 @@ describe('BigQueryConnection.runSQL (hermetic, stubbed job)', () => {
     const data = await conn.runSQL('SELECT 1');
     expect(data.rows).toEqual([{n: 5}]);
     expect(getQueryResults).toHaveBeenCalledTimes(2);
-    expect(createQueryJob.mock.calls[0][0]).not.toHaveProperty('jobTimeoutMs');
+    expect(createQueryJob.mock.calls[0][0]).toMatchObject({
+      jobTimeoutMs: 600000,
+    });
   });
 
   it('passes a positive timeoutMs through to the job as jobTimeoutMs', async () => {
@@ -93,9 +71,9 @@ describe('BigQueryConnection.runSQL (hermetic, stubbed job)', () => {
     });
   });
 
-  it('treats a whitespace-only timeoutMs as unset (default), not 0', async () => {
-    // Regression guard: if "   " resolved to 0 it would be read as no-timeout and
-    // omit jobTimeoutMs; it must fall back to the default (TIMEOUT_MS, 600000ms).
+  it('treats a whitespace-only timeoutMs as the default', async () => {
+    // Number('   ') is 0, so a naive parse could go wrong here; it must fall
+    // back to the default (TIMEOUT_MS, 600000ms) like any other blank value.
     const {conn, createQueryJob} = hermeticConnection(
       [complete([{n: 1}])],
       '   '

--- a/packages/malloy-db-bigquery/src/bigquery_connection.unit.spec.ts
+++ b/packages/malloy-db-bigquery/src/bigquery_connection.unit.spec.ts
@@ -1,0 +1,103 @@
+/*
+ * Copyright Contributors to the Malloy project
+ * SPDX-License-Identifier: MIT
+ */
+
+import {BigQueryConnection, resolveTimeoutMs} from './bigquery_connection';
+
+describe('resolveTimeoutMs', () => {
+  const DEFAULT = 600_000;
+
+  it('falls back when unset, empty, or whitespace-only', () => {
+    expect(resolveTimeoutMs(undefined, DEFAULT)).toBe(DEFAULT);
+    expect(resolveTimeoutMs('', DEFAULT)).toBe(DEFAULT);
+    // Number('   ') is 0, not NaN, so a blank-but-not-empty value must be
+    // treated as unset rather than as a fail-fast 0.
+    expect(resolveTimeoutMs('   ', DEFAULT)).toBe(DEFAULT);
+  });
+
+  it('preserves an explicit "0" as fail-fast', () => {
+    expect(resolveTimeoutMs('0', DEFAULT)).toBe(0);
+  });
+
+  it('parses a numeric string, trimming surrounding whitespace', () => {
+    expect(resolveTimeoutMs('5000', DEFAULT)).toBe(5000);
+    expect(resolveTimeoutMs('  5000  ', DEFAULT)).toBe(5000);
+  });
+
+  it('falls back on a non-numeric value', () => {
+    expect(resolveTimeoutMs('abc', DEFAULT)).toBe(DEFAULT);
+  });
+});
+
+// The callback overload yields (err, rows, nextQuery, apiResponse).
+type Cb = (
+  err: unknown,
+  rows: unknown,
+  nextQuery: unknown,
+  apiResponse: unknown
+) => void;
+type Step = (cb: Cb) => void;
+
+const stillRunning: Step = cb =>
+  cb(new Error('The query did not complete before 120000ms'), null, null, {
+    jobComplete: false,
+  });
+const complete =
+  (rows: unknown[] = [{n: 1}]): Step =>
+  cb =>
+    cb(null, rows, null, {jobComplete: true, totalRows: String(rows.length)});
+
+// A BigQueryConnection with its BigQuery SDK and timeout config stubbed, so
+// runSQL drives the real createBigQueryJob -> getQueryResultsUntilComplete seam
+// (deadline wiring, and that a jobComplete:false response never surfaces as
+// data) without a live warehouse.
+function hermeticConnection(steps: Step[], timeoutMs?: string) {
+  const conn = new BigQueryConnection('hermetic');
+  let i = 0;
+  const getQueryResults = jest.fn((_options: unknown, cb: Cb) => {
+    const step = steps[Math.min(i, steps.length - 1)];
+    i++;
+    step(cb);
+  });
+  const job = {getQueryResults, cancel: jest.fn()};
+  const createQueryJob = jest.fn(async () => [job]);
+  (conn as unknown as {bigQuery: unknown}).bigQuery = {createQueryJob};
+  (conn as unknown as {config: {timeoutMs?: string}}).config = {timeoutMs};
+  return {conn, getQueryResults, createQueryJob};
+}
+
+describe('BigQueryConnection.runSQL (hermetic, stubbed job)', () => {
+  it('wires config.timeoutMs to the poll deadline: "0" fails fast', async () => {
+    // The job would still be running, but a "0" timeout means the deadline is
+    // already exceeded before the first poll is even issued.
+    const {conn, getQueryResults} = hermeticConnection([stillRunning], '0');
+    await expect(conn.runSQL('SELECT 1')).rejects.toThrow(
+      /configured timeout of 0ms/
+    );
+    expect(getQueryResults).not.toHaveBeenCalled();
+  });
+
+  it('treats a whitespace-only timeoutMs as unset, not fail-fast', async () => {
+    // Regression guard for the wiring: if "   " resolved to 0, this query would
+    // fail fast even though the job is ready. It must fall back to the default.
+    const {conn, getQueryResults} = hermeticConnection(
+      [complete([{n: 7}])],
+      '   '
+    );
+    const data = await conn.runSQL('SELECT 1');
+    expect(data.rows).toEqual([{n: 7}]);
+    expect(getQueryResults).toHaveBeenCalledTimes(1);
+  });
+
+  it('polls a still-running response rather than returning it as empty data', async () => {
+    const {conn, getQueryResults} = hermeticConnection([
+      stillRunning,
+      complete([{n: 1}, {n: 2}]),
+    ]);
+    const data = await conn.runSQL('SELECT 1');
+    expect(data.rows).toEqual([{n: 1}, {n: 2}]);
+    expect(data.totalRows).toBe(2);
+    expect(getQueryResults).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/malloy-db-bigquery/src/bigquery_connection.unit.spec.ts
+++ b/packages/malloy-db-bigquery/src/bigquery_connection.unit.spec.ts
@@ -16,7 +16,7 @@ describe('resolveTimeoutMs', () => {
     expect(resolveTimeoutMs('   ', DEFAULT)).toBe(DEFAULT);
   });
 
-  it('preserves an explicit "0" as fail-fast', () => {
+  it('preserves an explicit "0" (call sites treat 0 as no-timeout)', () => {
     expect(resolveTimeoutMs('0', DEFAULT)).toBe(0);
   });
 
@@ -61,33 +61,49 @@ function hermeticConnection(steps: Step[], timeoutMs?: string) {
     step(cb);
   });
   const job = {getQueryResults, cancel: jest.fn()};
-  const createQueryJob = jest.fn(async () => [job]);
+  const createQueryJob = jest.fn(async (_options: unknown) => [job]);
   (conn as unknown as {bigQuery: unknown}).bigQuery = {createQueryJob};
   (conn as unknown as {config: {timeoutMs?: string}}).config = {timeoutMs};
   return {conn, getQueryResults, createQueryJob};
 }
 
 describe('BigQueryConnection.runSQL (hermetic, stubbed job)', () => {
-  it('wires config.timeoutMs to the poll deadline: "0" fails fast', async () => {
-    // The job would still be running, but a "0" timeout means the deadline is
-    // already exceeded before the first poll is even issued.
-    const {conn, getQueryResults} = hermeticConnection([stillRunning], '0');
-    await expect(conn.runSQL('SELECT 1')).rejects.toThrow(
-      /configured timeout of 0ms/
-    );
-    expect(getQueryResults).not.toHaveBeenCalled();
-  });
-
-  it('treats a whitespace-only timeoutMs as unset, not fail-fast', async () => {
-    // Regression guard for the wiring: if "   " resolved to 0, this query would
-    // fail fast even though the job is ready. It must fall back to the default.
-    const {conn, getQueryResults} = hermeticConnection(
-      [complete([{n: 7}])],
-      '   '
+  it('treats config.timeoutMs "0" as no timeout: polls through, omits jobTimeoutMs', async () => {
+    // Matches Snowflake: 0 disables the client-side limit. The job is still
+    // running on the first poll, so a fail-fast reading would throw here; instead
+    // it must keep polling to completion, and must not send jobTimeoutMs: 0.
+    const {conn, getQueryResults, createQueryJob} = hermeticConnection(
+      [stillRunning, complete([{n: 5}])],
+      '0'
     );
     const data = await conn.runSQL('SELECT 1');
-    expect(data.rows).toEqual([{n: 7}]);
-    expect(getQueryResults).toHaveBeenCalledTimes(1);
+    expect(data.rows).toEqual([{n: 5}]);
+    expect(getQueryResults).toHaveBeenCalledTimes(2);
+    expect(createQueryJob.mock.calls[0][0]).not.toHaveProperty('jobTimeoutMs');
+  });
+
+  it('passes a positive timeoutMs through to the job as jobTimeoutMs', async () => {
+    const {conn, createQueryJob} = hermeticConnection(
+      [complete([{n: 7}])],
+      '300000'
+    );
+    await conn.runSQL('SELECT 1');
+    expect(createQueryJob.mock.calls[0][0]).toMatchObject({
+      jobTimeoutMs: 300000,
+    });
+  });
+
+  it('treats a whitespace-only timeoutMs as unset (default), not 0', async () => {
+    // Regression guard: if "   " resolved to 0 it would be read as no-timeout and
+    // omit jobTimeoutMs; it must fall back to the default (TIMEOUT_MS, 600000ms).
+    const {conn, createQueryJob} = hermeticConnection(
+      [complete([{n: 1}])],
+      '   '
+    );
+    await conn.runSQL('SELECT 1');
+    expect(createQueryJob.mock.calls[0][0]).toMatchObject({
+      jobTimeoutMs: 600000,
+    });
   });
 
   it('polls a still-running response rather than returning it as empty data', async () => {

--- a/packages/malloy-db-bigquery/src/bigquery_connection.unit.spec.ts
+++ b/packages/malloy-db-bigquery/src/bigquery_connection.unit.spec.ts
@@ -43,18 +43,16 @@ function hermeticConnection(steps: Step[], timeoutMs?: string) {
 }
 
 describe('BigQueryConnection.runSQL (hermetic, stubbed job)', () => {
-  it('treats config.timeoutMs "0" as unset: uses the default and polls through', async () => {
+  it('treats config.timeoutMs "0" as unset: uses the default jobTimeoutMs', async () => {
     // 0 falls back to the default (like blank or non-numeric); it means neither
-    // "wait 0ms" nor "wait forever". The job is still running on the first poll,
-    // so the loop must keep polling to completion under the default deadline,
-    // and the job is created with the default jobTimeoutMs.
-    const {conn, getQueryResults, createQueryJob} = hermeticConnection(
-      [stillRunning, complete([{n: 5}])],
+    // "wait 0ms" nor "wait forever". (Poll-through is covered separately, so
+    // this stays a single completed poll to avoid the real inter-poll wait.)
+    const {conn, createQueryJob} = hermeticConnection(
+      [complete([{n: 5}])],
       '0'
     );
     const data = await conn.runSQL('SELECT 1');
     expect(data.rows).toEqual([{n: 5}]);
-    expect(getQueryResults).toHaveBeenCalledTimes(2);
     expect(createQueryJob.mock.calls[0][0]).toMatchObject({
       jobTimeoutMs: 600000,
     });
@@ -77,6 +75,20 @@ describe('BigQueryConnection.runSQL (hermetic, stubbed job)', () => {
     const {conn, createQueryJob} = hermeticConnection(
       [complete([{n: 1}])],
       '   '
+    );
+    await conn.runSQL('SELECT 1');
+    expect(createQueryJob.mock.calls[0][0]).toMatchObject({
+      jobTimeoutMs: 600000,
+    });
+  });
+
+  it('treats a negative timeoutMs as the default', async () => {
+    // Number('-5') is -5, which is truthy, so a bare `|| TIMEOUT_MS` would let
+    // it through as jobTimeoutMs: -5 and blow the deadline on the first poll.
+    // A non-positive value must fall back to the default.
+    const {conn, createQueryJob} = hermeticConnection(
+      [complete([{n: 1}])],
+      '-5'
     );
     await conn.runSQL('SELECT 1');
     expect(createQueryJob.mock.calls[0][0]).toMatchObject({

--- a/packages/malloy-db-bigquery/src/bigquery_query_metadata.spec.ts
+++ b/packages/malloy-db-bigquery/src/bigquery_query_metadata.spec.ts
@@ -7,16 +7,28 @@ import type {QueryOptionsReader} from '@malloydata/malloy';
 import {BigQueryConnection} from './bigquery_connection';
 
 // A fake BigQuery job with just enough surface for createBigQueryJobAndGetResults.
+// getQueryResults uses the callback overload (err, rows, nextQuery, apiResponse)
+// and reports jobComplete so the connector's poll loop settles immediately.
 function fakeJob(id = 'job-abc', location = 'US') {
   return {
     id,
     location,
     cancel: () => {},
-    getQueryResults: async () => [
-      [{n: 1}],
-      null,
-      {totalRows: '1', totalBytesProcessed: '42', schema: {fields: []}},
-    ],
+    getQueryResults: (
+      _options: unknown,
+      cb: (
+        err: unknown,
+        rows: unknown,
+        nextQuery: unknown,
+        apiResponse: unknown
+      ) => void
+    ) =>
+      cb(null, [{n: 1}], null, {
+        jobComplete: true,
+        totalRows: '1',
+        totalBytesProcessed: '42',
+        schema: {fields: []},
+      }),
   };
 }
 

--- a/packages/malloy-db-bigquery/src/get_query_results_polling.spec.ts
+++ b/packages/malloy-db-bigquery/src/get_query_results_polling.spec.ts
@@ -4,91 +4,151 @@
  */
 
 import type {Job} from '@google-cloud/bigquery';
-import {
-  getQueryResultsUntilComplete,
-  isQueryStillRunningError,
-} from './bigquery_connection';
+import {getQueryResultsUntilComplete} from './bigquery_connection';
 
-// The BigQuery client throws this exact shape when a getQueryResults call
-// returns with the job still running.
-function stillRunning(ms = 120000): Error {
-  return new Error(`The query did not complete before ${ms}ms`);
-}
+// The BigQuery client's callback overload yields (err, rows, nextQuery,
+// apiResponse). Helpers build the three outcomes the client can produce.
+type Cb = (
+  err: unknown,
+  rows: unknown,
+  nextQuery: unknown,
+  resp: unknown
+) => void;
+type Step = (cb: Cb) => void;
 
-// A completed result is the [rows, nextQuery, apiResponse] tuple the client
-// resolves with; only its identity matters to these tests.
-const COMPLETE = [[{n: 1}], null, {jobComplete: true}];
+// Still running: the client passes a synthetic "did not complete" error AND an
+// apiResponse with jobComplete === false. Our code keys off the boolean.
+const stillRunning: Step = cb =>
+  cb(new Error('The query did not complete before 120000ms'), null, null, {
+    jobComplete: false,
+  });
+const complete =
+  (rows: unknown[] = [{n: 1}]): Step =>
+  cb =>
+    cb(null, rows, null, {jobComplete: true});
+const transient =
+  (message: string): Step =>
+  cb =>
+    cb(new Error(message), null, null, undefined);
+// A poll that never calls back — simulates the in-flight server-side wait.
+const pending: Step = () => {};
 
-function fakeJob(getQueryResults: jest.Mock): Pick<Job, 'getQueryResults'> {
-  return {getQueryResults} as unknown as Pick<Job, 'getQueryResults'>;
+// Build a fake job whose getQueryResults plays a scripted sequence of steps
+// (the last step repeats if called again).
+function scriptedJob(steps: Step[]): {
+  job: Pick<Job, 'getQueryResults'>;
+  getQueryResults: jest.Mock;
+} {
+  let i = 0;
+  const getQueryResults = jest.fn((_options: unknown, cb: Cb) => {
+    const step = steps[Math.min(i, steps.length - 1)];
+    i++;
+    step(cb);
+  });
+  return {
+    job: {getQueryResults} as unknown as Pick<Job, 'getQueryResults'>,
+    getQueryResults,
+  };
 }
 
 describe('getQueryResultsUntilComplete', () => {
   it('returns immediately when the job is already complete', async () => {
-    const getQueryResults = jest.fn().mockResolvedValue(COMPLETE);
-    const out = await getQueryResultsUntilComplete(
-      fakeJob(getQueryResults),
-      {},
-      600_000,
-      () => 0
-    );
-    expect(out).toBe(COMPLETE);
+    const {job, getQueryResults} = scriptedJob([complete()]);
+    const out = await getQueryResultsUntilComplete(job, {}, 600_000, {
+      now: () => 0,
+    });
+    expect(out[0]).toEqual([{n: 1}]);
     expect(getQueryResults).toHaveBeenCalledTimes(1);
   });
 
-  it('polls past "still running" timeouts until the job completes', async () => {
-    const getQueryResults = jest
-      .fn()
-      .mockRejectedValueOnce(stillRunning())
-      .mockRejectedValueOnce(stillRunning())
-      .mockResolvedValue(COMPLETE);
-    const out = await getQueryResultsUntilComplete(
-      fakeJob(getQueryResults),
-      {},
-      600_000,
-      () => 0 // always within the deadline
-    );
-    expect(out).toBe(COMPLETE);
+  it('polls past "still running" responses until the job completes', async () => {
+    const {job, getQueryResults} = scriptedJob([
+      stillRunning,
+      stillRunning,
+      complete(),
+    ]);
+    const out = await getQueryResultsUntilComplete(job, {}, 600_000, {
+      now: () => 0,
+    });
+    expect(out[0]).toEqual([{n: 1}]);
     expect(getQueryResults).toHaveBeenCalledTimes(3);
   });
 
-  it('gives up once the deadline passes while the job is still running', async () => {
-    const getQueryResults = jest.fn().mockRejectedValue(stillRunning());
-    // now() advances 100s each call: startedAt=0, then 100s (within 150s),
-    // then 200s (past the deadline) -> throw.
-    let calls = 0;
-    const now = () => calls++ * 100_000;
+  it('clamps the per-poll timeout to the remaining deadline', async () => {
+    const {job, getQueryResults} = scriptedJob([complete()]);
+    // Deadline shorter than one poll interval -> first poll asks for the
+    // remaining deadline, not the full GET_QUERY_RESULTS_POLL_MS.
+    await getQueryResultsUntilComplete(job, {}, 30_000, {now: () => 0});
+    expect(getQueryResults.mock.calls[0][0]).toMatchObject({timeoutMs: 30_000});
+  });
+
+  it('gives up with an actionable error once the deadline passes', async () => {
+    let t = 0;
+    const now = () => t;
+    const {job, getQueryResults} = scriptedJob([
+      cb => {
+        t += 100_000; // each poll advances the clock 100s
+        stillRunning(cb);
+      },
+    ]);
     await expect(
-      getQueryResultsUntilComplete(fakeJob(getQueryResults), {}, 150_000, now)
-    ).rejects.toThrow(/did not complete before/);
+      getQueryResultsUntilComplete(job, {}, 150_000, {now})
+    ).rejects.toThrow(
+      /did not complete within the configured timeout of 150000ms.*timeoutMs/s
+    );
+    // startedAt=0; polls at t=100s (within 150s) and t=200s (over) -> 2 polls.
     expect(getQueryResults).toHaveBeenCalledTimes(2);
   });
 
   it('retries a bounded number of times on a transient error, then rethrows', async () => {
-    const boom = new Error('transient access denied requesting results');
-    const getQueryResults = jest.fn().mockRejectedValue(boom);
+    const {job, getQueryResults} = scriptedJob([transient('access denied')]);
     await expect(
-      getQueryResultsUntilComplete(
-        fakeJob(getQueryResults),
-        {},
-        600_000,
-        () => 0 // always within the deadline
-      )
-    ).rejects.toThrow('transient access denied');
+      getQueryResultsUntilComplete(job, {}, 600_000, {now: () => 0})
+    ).rejects.toThrow('access denied');
     // initial attempt + 3 bounded retries
     expect(getQueryResults).toHaveBeenCalledTimes(4);
   });
-});
 
-describe('isQueryStillRunningError', () => {
-  it('matches the client job-not-complete timeout message', () => {
-    expect(isQueryStillRunningError(stillRunning())).toBe(true);
-    expect(isQueryStillRunningError(stillRunning(600000))).toBe(true);
+  it('does not reset the transient-retry budget across still-running polls', async () => {
+    // A still-running poll between each transient error must not refill the
+    // 3-retry budget: 4 transient errors total should still exhaust it.
+    const {job, getQueryResults} = scriptedJob([
+      transient('boom-1'),
+      stillRunning,
+      transient('boom-2'),
+      stillRunning,
+      transient('boom-3'),
+      stillRunning,
+      transient('boom-4'),
+    ]);
+    await expect(
+      getQueryResultsUntilComplete(job, {}, 600_000, {now: () => 0})
+    ).rejects.toThrow('boom-4');
+    expect(getQueryResults).toHaveBeenCalledTimes(7);
   });
 
-  it('does not match unrelated errors or non-errors', () => {
-    expect(isQueryStillRunningError(new Error('access denied'))).toBe(false);
-    expect(isQueryStillRunningError('did not complete before 1ms')).toBe(false);
-    expect(isQueryStillRunningError(undefined)).toBe(false);
+  it('exits promptly when the abort signal fires mid-poll', async () => {
+    const ac = new AbortController();
+    const {job, getQueryResults} = scriptedJob([pending]); // poll never returns
+    const promise = getQueryResultsUntilComplete(job, {}, 600_000, {
+      abortSignal: ac.signal,
+      now: () => 0,
+    });
+    ac.abort();
+    await expect(promise).rejects.toThrow(/aborted/);
+    expect(getQueryResults).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws without polling when the signal is already aborted', async () => {
+    const ac = new AbortController();
+    ac.abort();
+    const {job, getQueryResults} = scriptedJob([complete()]);
+    await expect(
+      getQueryResultsUntilComplete(job, {}, 600_000, {
+        abortSignal: ac.signal,
+        now: () => 0,
+      })
+    ).rejects.toThrow(/aborted/);
+    expect(getQueryResults).not.toHaveBeenCalled();
   });
 });

--- a/packages/malloy-db-bigquery/src/get_query_results_polling.spec.ts
+++ b/packages/malloy-db-bigquery/src/get_query_results_polling.spec.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright Contributors to the Malloy project
+ * SPDX-License-Identifier: MIT
+ */
+
+import type {Job} from '@google-cloud/bigquery';
+import {
+  getQueryResultsUntilComplete,
+  isQueryStillRunningError,
+} from './bigquery_connection';
+
+// The BigQuery client throws this exact shape when a getQueryResults call
+// returns with the job still running.
+function stillRunning(ms = 120000): Error {
+  return new Error(`The query did not complete before ${ms}ms`);
+}
+
+// A completed result is the [rows, nextQuery, apiResponse] tuple the client
+// resolves with; only its identity matters to these tests.
+const COMPLETE = [[{n: 1}], null, {jobComplete: true}];
+
+function fakeJob(getQueryResults: jest.Mock): Pick<Job, 'getQueryResults'> {
+  return {getQueryResults} as unknown as Pick<Job, 'getQueryResults'>;
+}
+
+describe('getQueryResultsUntilComplete', () => {
+  it('returns immediately when the job is already complete', async () => {
+    const getQueryResults = jest.fn().mockResolvedValue(COMPLETE);
+    const out = await getQueryResultsUntilComplete(
+      fakeJob(getQueryResults),
+      {},
+      600_000,
+      () => 0
+    );
+    expect(out).toBe(COMPLETE);
+    expect(getQueryResults).toHaveBeenCalledTimes(1);
+  });
+
+  it('polls past "still running" timeouts until the job completes', async () => {
+    const getQueryResults = jest
+      .fn()
+      .mockRejectedValueOnce(stillRunning())
+      .mockRejectedValueOnce(stillRunning())
+      .mockResolvedValue(COMPLETE);
+    const out = await getQueryResultsUntilComplete(
+      fakeJob(getQueryResults),
+      {},
+      600_000,
+      () => 0 // always within the deadline
+    );
+    expect(out).toBe(COMPLETE);
+    expect(getQueryResults).toHaveBeenCalledTimes(3);
+  });
+
+  it('gives up once the deadline passes while the job is still running', async () => {
+    const getQueryResults = jest.fn().mockRejectedValue(stillRunning());
+    // now() advances 100s each call: startedAt=0, then 100s (within 150s),
+    // then 200s (past the deadline) -> throw.
+    let calls = 0;
+    const now = () => calls++ * 100_000;
+    await expect(
+      getQueryResultsUntilComplete(fakeJob(getQueryResults), {}, 150_000, now)
+    ).rejects.toThrow(/did not complete before/);
+    expect(getQueryResults).toHaveBeenCalledTimes(2);
+  });
+
+  it('retries a bounded number of times on a transient error, then rethrows', async () => {
+    const boom = new Error('transient access denied requesting results');
+    const getQueryResults = jest.fn().mockRejectedValue(boom);
+    await expect(
+      getQueryResultsUntilComplete(
+        fakeJob(getQueryResults),
+        {},
+        600_000,
+        () => 0 // always within the deadline
+      )
+    ).rejects.toThrow('transient access denied');
+    // initial attempt + 3 bounded retries
+    expect(getQueryResults).toHaveBeenCalledTimes(4);
+  });
+});
+
+describe('isQueryStillRunningError', () => {
+  it('matches the client job-not-complete timeout message', () => {
+    expect(isQueryStillRunningError(stillRunning())).toBe(true);
+    expect(isQueryStillRunningError(stillRunning(600000))).toBe(true);
+  });
+
+  it('does not match unrelated errors or non-errors', () => {
+    expect(isQueryStillRunningError(new Error('access denied'))).toBe(false);
+    expect(isQueryStillRunningError('did not complete before 1ms')).toBe(false);
+    expect(isQueryStillRunningError(undefined)).toBe(false);
+  });
+});

--- a/packages/malloy-db-bigquery/src/get_query_results_polling.spec.ts
+++ b/packages/malloy-db-bigquery/src/get_query_results_polling.spec.ts
@@ -57,6 +57,10 @@ function scriptedJob(steps: Step[]): {
   };
 }
 
+// The loop spaces still-running polls by a minimum interval via wait(); tests
+// inject a no-op so they don't sleep real time.
+const noWait = async () => {};
+
 describe('getQueryResultsUntilComplete', () => {
   it('returns immediately when the job is already complete', async () => {
     const {job, getQueryResults, cancel} = scriptedJob([complete()]);
@@ -77,9 +81,52 @@ describe('getQueryResultsUntilComplete', () => {
     ]);
     const out = await getQueryResultsUntilComplete(job, {}, 600_000, {
       now: () => 0,
+      wait: noWait,
     });
     expect(out[0]).toEqual([{n: 1}]);
     expect(getQueryResults).toHaveBeenCalledTimes(3);
+  });
+
+  it('waits a minimum interval before re-polling when a poll returns early', async () => {
+    // now is constant, so the poll "returned" with no elapsed time; the loop
+    // waits the full floor before the next poll.
+    const wait = jest.fn(async (_ms: number) => {});
+    const {job} = scriptedJob([stillRunning, complete()]);
+    await getQueryResultsUntilComplete(job, {}, 600_000, {now: () => 0, wait});
+    expect(wait).toHaveBeenCalledTimes(1);
+    expect(wait.mock.calls[0][0]).toBe(1000);
+  });
+
+  it('does not wait when a poll already blocked at least the interval', async () => {
+    // The poll advances the clock past the floor, so there is no shortfall.
+    let t = 0;
+    const wait = jest.fn(async (_ms: number) => {});
+    const {job} = scriptedJob([
+      cb => {
+        t += 2000; // poll blocked 2s, longer than the 1s floor
+        stillRunning(cb);
+      },
+      complete(),
+    ]);
+    await getQueryResultsUntilComplete(job, {}, 600_000, {now: () => t, wait});
+    expect(wait).not.toHaveBeenCalled();
+  });
+
+  it('stops promptly when the signal aborts around the inter-poll wait', async () => {
+    // Abort before the loop reaches the (real) inter-poll wait: the wait must
+    // resolve immediately instead of sleeping the floor, and the loop must then
+    // exit rather than issue another poll.
+    const ac = new AbortController();
+    const {job, getQueryResults} = scriptedJob([stillRunning, complete()]);
+    const promise = getQueryResultsUntilComplete(job, {}, 600_000, {
+      abortSignal: ac.signal,
+      now: () => 0,
+    });
+    ac.abort();
+    const start = Date.now();
+    await expect(promise).rejects.toThrow(/aborted/);
+    expect(Date.now() - start).toBeLessThan(500);
+    expect(getQueryResults).toHaveBeenCalledTimes(1);
   });
 
   it('clamps the per-poll timeout to the remaining deadline', async () => {
@@ -132,7 +179,10 @@ describe('getQueryResultsUntilComplete', () => {
       transient('boom-4'),
     ]);
     await expect(
-      getQueryResultsUntilComplete(job, {}, 600_000, {now: () => 0})
+      getQueryResultsUntilComplete(job, {}, 600_000, {
+        now: () => 0,
+        wait: noWait,
+      })
     ).rejects.toThrow('boom-4');
     expect(getQueryResults).toHaveBeenCalledTimes(7);
   });

--- a/packages/malloy-db-bigquery/src/get_query_results_polling.spec.ts
+++ b/packages/malloy-db-bigquery/src/get_query_results_polling.spec.ts
@@ -36,8 +36,9 @@ const pending: Step = () => {};
 // Build a fake job whose getQueryResults plays a scripted sequence of steps
 // (the last step repeats if called again).
 function scriptedJob(steps: Step[]): {
-  job: Pick<Job, 'getQueryResults'>;
+  job: Pick<Job, 'getQueryResults' | 'cancel'>;
   getQueryResults: jest.Mock;
+  cancel: jest.Mock;
 } {
   let i = 0;
   const getQueryResults = jest.fn((_options: unknown, cb: Cb) => {
@@ -45,20 +46,27 @@ function scriptedJob(steps: Step[]): {
     i++;
     step(cb);
   });
+  const cancel = jest.fn(async () => [{}]);
   return {
-    job: {getQueryResults} as unknown as Pick<Job, 'getQueryResults'>,
+    job: {getQueryResults, cancel} as unknown as Pick<
+      Job,
+      'getQueryResults' | 'cancel'
+    >,
     getQueryResults,
+    cancel,
   };
 }
 
 describe('getQueryResultsUntilComplete', () => {
   it('returns immediately when the job is already complete', async () => {
-    const {job, getQueryResults} = scriptedJob([complete()]);
+    const {job, getQueryResults, cancel} = scriptedJob([complete()]);
     const out = await getQueryResultsUntilComplete(job, {}, 600_000, {
       now: () => 0,
     });
     expect(out[0]).toEqual([{n: 1}]);
     expect(getQueryResults).toHaveBeenCalledTimes(1);
+    // No cancel on the happy path.
+    expect(cancel).not.toHaveBeenCalled();
   });
 
   it('polls past "still running" responses until the job completes', async () => {
@@ -82,10 +90,10 @@ describe('getQueryResultsUntilComplete', () => {
     expect(getQueryResults.mock.calls[0][0]).toMatchObject({timeoutMs: 30_000});
   });
 
-  it('gives up with an actionable error once the deadline passes', async () => {
+  it('gives up with an actionable error once the deadline passes, cancelling the job', async () => {
     let t = 0;
     const now = () => t;
-    const {job, getQueryResults} = scriptedJob([
+    const {job, getQueryResults, cancel} = scriptedJob([
       cb => {
         t += 100_000; // each poll advances the clock 100s
         stillRunning(cb);
@@ -98,6 +106,8 @@ describe('getQueryResultsUntilComplete', () => {
     );
     // startedAt=0; polls at t=100s (within 150s) and t=200s (over) -> 2 polls.
     expect(getQueryResults).toHaveBeenCalledTimes(2);
+    // On its own deadline the loop cancels the job rather than leaving it running.
+    expect(cancel).toHaveBeenCalledTimes(1);
   });
 
   it('retries a bounded number of times on a transient error, then rethrows', async () => {


### PR DESCRIPTION
## Summary

The BigQuery connector could not complete any query that ran longer than about
six minutes, regardless of configuration. `runSQL` (via
`createBigQueryJobAndGetResults`) fetched results with `job.getQueryResults`
using a hardcoded 2-minute `timeoutMs`, wrapped in a fixed 3-retry loop. Each
call waits ~2 minutes and throws `The query did not complete before 120000ms`
while the job is still running fine; after 3 retries the loop gives up at
~6 minutes. The `120000ms` in the message is a single poll's window, not the
real ceiling. The connection's configured `timeoutMs` never reached this path
(it only bounded `jobTimeoutMs`), so no configuration could extend it.

This resolves the long-standing TODO in `createBigQueryJobAndGetResults`, which
already called for exactly this: "extend the wait for results using a timeout
set by the user, and probably needs to loop to check for results."

## Root cause

`getQueryResults` is a request-level wait, not a job-level one. Per the BigQuery
docs a single call returns after at most ~200s regardless of the requested
`timeoutMs`, reporting `jobComplete: false` while the job is still running; the
documented pattern is to keep calling until `jobComplete` is true. The old code
treated the incomplete response as a failure and gave up after a fixed number of
retries.

## Fix

The connection's configured `timeoutMs` now drives one resolved value that
bounds both the BigQuery job and the client-side wait, and `getQueryResults` is
polled to completion instead of being retried a fixed number of times:

- Shadow `timeoutMs` to the job's `jobTimeoutMs` so BigQuery cancels a runaway
  job server-side, and poll `getQueryResults` up to the same deadline on the
  client, totaling the wait across calls (BigQuery returns each call after ~200s
  regardless of the requested `timeoutMs`).
- Structured completion signal: "still running" is read from the callback
  overload's `apiResponse.jobComplete === false`, not a regex on the client's
  error string, so it cannot silently regress if the wording changes.
- On reaching the client deadline, cancel the job before throwing. BigQuery's
  `jobTimeoutMs` should already be cancelling it, but this covers the case where
  that timeout error has not come back yet, so the job does not keep running
  (and billing) after we have stopped waiting.
- Abort-aware: the abort signal is checked each iteration and races the in-flight
  poll, so a cancel settles the call promptly (and cancels the job) instead of
  waiting out the deadline.
- Clamped per-poll wait: `min(GET_QUERY_RESULTS_POLL_MS, remaining)`, so short
  timeouts fail fast and the deadline is not overshot by a poll.
- Minimum spacing between polls: if BigQuery returns `jobComplete: false` sooner
  than the per-poll wait we requested, the loop waits out only the shortfall
  below a 1s floor (bounded by the remaining deadline) instead of busy-polling.
- Actionable deadline error naming the configured timeout and the knob to raise.
- Bounded transient retry preserved for the intermittent access-denied error on
  first fetch, replacing the old blanket 3-retries-on-everything.
- `timeoutMs` resolves to a positive number or the default: unset, blank,
  non-numeric, zero, or negative all fall back to the 10-minute default; only a
  positive value overrides it. A non-positive value must not reach the job, or
  it would cancel on the first poll.

## Scope

BigQuery-only, by design. Among the connectors only BigQuery hand-rolls result
polling: Snowflake passes its configured timeout through, Databricks and Trino
delegate polling to their client libraries, and Postgres/MySQL/DuckDB are
synchronous. This brings BigQuery in line with the others rather than adding a
shared abstraction. Per review, two follow-ups: aligning the Snowflake
connector's `0` handling with this (open as malloydata/malloy#3022), and adding
a `timeoutMs` setting to Databricks.

## Tests

- `get_query_results_polling.spec.ts` drives the poll loop directly with a
  scripted fake job and an injected clock: immediate completion (with no cancel);
  polling past "still running" until done; the minimum inter-poll spacing
  (waiting only the shortfall when a poll returns early, and not waiting when a
  poll already blocked at least the interval); per-poll clamp to the remaining
  deadline; the actionable deadline error and that the job is cancelled on
  give-up; bounded transient retry then rethrow; that a still-running poll does
  not reset the transient-retry budget; and prompt exit on abort (mid-poll,
  already-aborted, and around the inter-poll wait).
- `bigquery_connection.unit.spec.ts` drives `runSQL` against a stubbed job to
  lock the seam: a positive `timeoutMs` is passed to the job as `jobTimeoutMs`;
  `'0'`, a whitespace-only value, and a negative value all fall back to the
  default `jobTimeoutMs`; and a `jobComplete: false` response is polled rather
  than surfaced as empty data.

`tsc`, `eslint`, and the tests all pass.

## Notes

- Config-value resolution: unset, blank, non-numeric, zero, and negative all
  resolve to the 10-minute default; only a positive value overrides it. What
  changes functionally is that the resolved timeout now actually bounds the
  results wait (previously it only bounded `jobTimeoutMs`, and the results fetch
  was capped near six minutes by a fixed retry loop).
- `timeoutMs` still defaults to 10 minutes; running longer queries requires
  raising it on the connection. When the connector runs behind an HTTP layer
  (e.g. the Malloy Publisher), keep the connection `timeoutMs` below that layer's
  socket/request timeout so a long query ends with the connector's clear error
  rather than an opaque socket reset (documented at `TIMEOUT_MS`).

## Checklist

- [x] Updated `malloydata.github.io/src/documentation/setup/config.malloynb`
      (companion PR malloydata/malloydata.github.io#336): `timeoutMs` now bounds
      the results wait as well as the job, with the 10-minute default documented.
