### PR TITLE
fix(persist): don't materialize an `extend`-derived reader of a persisted source

### DIFF
--- a/packages/malloy/src/api/foundation/persist-source-sql.spec.ts
+++ b/packages/malloy/src/api/foundation/persist-source-sql.spec.ts
@@ -95,3 +95,98 @@ describe('PersistSource build key matches serve-time manifest lookup', () => {
     expect(routedSQL(model, 'db_rollup', '_db_')).toContain(MATERIALIZED);
   });
 });
+
+describe('build targets exclude extend-derived readers', () => {
+  function buildTargets(model: Model): string[] {
+    return Object.values(model.getBuildPlan().sources)
+      .map(s => s.name)
+      .sort();
+  }
+
+  // The bug this guards: `#@ persist` is a Malloy annotation, so it propagates
+  // onto a source that `extend`s a persisted source. Such a reader must keep
+  // reading the pre-built table (docs: "the extension still reads from the same
+  // pre-built table"), but it must NOT be emitted as its own build target — it
+  // would materialize the base's table a second time under the inherited
+  // `name=`, colliding on one physical coordinate.
+  test('an extend of a persisted source is a reader, not a build target', () => {
+    const model = modelOf(`
+      ##! experimental.persistence
+      #@ persist name="main.base_persist"
+      source: base_persist is _db_.table('aTable') -> {
+        group_by: astr
+        aggregate: n is count()
+      }
+      source: extended_reader is base_persist extend {
+        dimension: astr_upper is upper(astr)
+      }
+    `);
+    expect(buildTargets(model)).toEqual(['base_persist']);
+  });
+
+  test('an extend reader still routes to the base pre-built table', () => {
+    const CONN_DIGEST = 'test-conn-digest';
+    const MATERIALIZED = 'MATERIALIZED_BASE';
+    const model = modelOf(`
+      ##! experimental.persistence
+      #@ persist name="main.base_persist"
+      source: base_persist is _db_.table('aTable') -> {
+        group_by: astr
+        aggregate: n is count()
+      }
+      source: extended_reader is base_persist extend {
+        dimension: astr_upper is upper(astr)
+      }
+      run: extended_reader -> { group_by: astr_upper; aggregate: tot is n.sum() }
+    `);
+    // Manifest is keyed by the ONLY build target (base_persist). Querying the
+    // extension must still route through to that materialized table.
+    const base = persistSourceNamed(model, 'base_persist');
+    const manifest: BuildManifest = {
+      entries: {
+        [base.makeBuildId(CONN_DIGEST, base.getSQL())]: {
+          tableName: MATERIALIZED,
+        },
+      },
+    };
+    const sql = model.getPreparedQuery().getPreparedResult({
+      buildManifest: manifest,
+      connectionDigests: {_db_: CONN_DIGEST},
+    }).sql;
+    expect(sql).toContain(MATERIALIZED);
+  });
+
+  test('a `#@ -persist` extension opts out and is not a build target', () => {
+    const model = modelOf(`
+      ##! experimental.persistence
+      #@ persist name="main.base_persist"
+      source: base_persist is _db_.table('aTable') -> {
+        group_by: astr
+        aggregate: n is count()
+      }
+      #@ -persist
+      source: recomputed is base_persist extend {
+        dimension: astr_upper is upper(astr)
+      }
+    `);
+    expect(buildTargets(model)).toEqual(['base_persist']);
+  });
+
+  test('an extension that DECLARES its own persist IS a distinct build target', () => {
+    const model = modelOf(`
+      ##! experimental.persistence
+      #@ persist name="main.base_persist"
+      source: base_persist is _db_.table('aTable') -> {
+        group_by: astr
+        aggregate: n is count()
+      }
+      #@ persist name="main.child_persist"
+      source: child_persist is base_persist extend {
+        dimension: astr_upper is upper(astr)
+      }
+    `);
+    // A child declaring its OWN persist (a different table) is a legitimate
+    // second materialization and must remain a build target.
+    expect(buildTargets(model)).toEqual(['base_persist', 'child_persist']);
+  });
+});

--- a/packages/malloy/src/lang/ast/statements/define-source.ts
+++ b/packages/malloy/src/lang/ast/statements/define-source.ts
@@ -10,7 +10,10 @@ import {
   isSourceDef,
 } from '../../../model/malloy_types';
 import {mkSourceID} from '../../../model/source_def_utils';
-import {checkPersistAnnotation} from '../../../model/persist_utils';
+import {
+  checkPersistAnnotation,
+  checkPersistDeclaredOnOwn,
+} from '../../../model/persist_utils';
 import {ErrorFactory} from '../error-factory';
 import type {HasParameter} from '../parameters/has-parameter';
 import type {DocStatement, Document} from '../types/malloy-element';
@@ -80,7 +83,17 @@ export class DefineSource
       // which DynamicSpace cleared).
       entry.sourceID = mkSourceID(this.name, this.location?.url);
       if (isPersistableSourceDef(entry)) {
+        // `persistent` folds the whole annotation chain (own + inherited via
+        // `extend`) — correct for read routing. `persistDeclared` is computed
+        // from the OWN annotation alone, so only a source that declares persist
+        // itself is treated as a build target; an `extend`-derived reader
+        // inherits `persistent` (reads the pre-built table) but is not rebuilt.
+        // `this.ownAnnotation` is undefined for a plain extension, and for a
+        // modified/extended source `entry.annotations` is a pass-through of the
+        // base's — so the own annotation is the only reliable declared-here
+        // signal here.
         entry.persistent = checkPersistAnnotation(entry).persist;
+        entry.persistDeclared = checkPersistDeclaredOnOwn(this.ownAnnotation);
       }
     }
     entry.partitionComposite =

--- a/packages/malloy/src/lang/ast/statements/define-source.ts
+++ b/packages/malloy/src/lang/ast/statements/define-source.ts
@@ -83,15 +83,12 @@ export class DefineSource
       // which DynamicSpace cleared).
       entry.sourceID = mkSourceID(this.name, this.location?.url);
       if (isPersistableSourceDef(entry)) {
-        // `persistent` folds the whole annotation chain (own + inherited via
-        // `extend`) — correct for read routing. `persistDeclared` is computed
-        // from the OWN annotation alone, so only a source that declares persist
-        // itself is treated as a build target; an `extend`-derived reader
-        // inherits `persistent` (reads the pre-built table) but is not rebuilt.
-        // `this.ownAnnotation` is undefined for a plain extension, and for a
+        // `persistent` folds the whole annotation chain (read routing);
+        // `persistDeclared` uses the OWN annotation alone (the build-target
+        // signal — see PersistableSourceProperties.persistDeclared).
+        // `this.ownAnnotation` is the only reliable declared-here signal: for a
         // modified/extended source `entry.annotations` is a pass-through of the
-        // base's — so the own annotation is the only reliable declared-here
-        // signal here.
+        // base's, and it is undefined for a plain extension.
         entry.persistent = checkPersistAnnotation(entry).persist;
         entry.persistDeclared = checkPersistDeclaredOnOwn(this.ownAnnotation);
       }

--- a/packages/malloy/src/model/malloy_types.ts
+++ b/packages/malloy/src/model/malloy_types.ts
@@ -1626,7 +1626,28 @@ export function isSourceRegistryReference(
 
 export interface PersistableSourceProperties {
   extends?: SourceID;
+  /**
+   * Whether this source USES a persisted table — true when `#@ persist` is in
+   * effect after folding the whole annotation chain (own + inherited via
+   * `extend`), unless overridden by `#@ -persist`. Drives read routing
+   * (query_query.ts / sql_compiled.ts): a source with `persistent === true`
+   * reads the pre-built table. An `extend`-derived reader that only inherited
+   * the directive is `persistent === true` (it reads the base's table) — which
+   * is why this flag alone cannot say who OWNS the materialization; see
+   * `persistDeclared`.
+   */
   persistent?: boolean;
+  /**
+   * Whether `#@ persist` is DECLARED on this source's own annotation (not merely
+   * inherited via `extend`). Distinct from `persistent`: only a source that
+   * declares persist is a build TARGET (a table to materialize). An
+   * `extend`-derived reader inherits `persistent` (so it reads the pre-built
+   * table) but has `persistDeclared !== true`, so the build-plan enumeration
+   * excludes it instead of emitting a duplicate materialization of the same
+   * table. Computed at define time from the source's OWN annotation only (see
+   * DefineSource.execute); `#@ -persist` in the own annotation reports false.
+   */
+  persistDeclared?: boolean;
 }
 
 export interface SQLSourceDef

--- a/packages/malloy/src/model/malloy_types.ts
+++ b/packages/malloy/src/model/malloy_types.ts
@@ -1708,8 +1708,8 @@ export function isSourceDef(sd: NamedModelObject | FieldDef): sd is SourceDef {
  * - mkQuerySourceDef(base, ...) - create QuerySourceDef from base
  *
  * These factories explicitly copy only safe fields, dropping the identity
- * fields (sourceID/referenceID/extends/persistent) so they are not propagated
- * onto a freshly built source. In the translator, by contrast, object spread is
+ * fields (sourceID/referenceID/extends/persistent/persistDeclared) so they are
+ * not propagated onto a freshly built source. In the translator, by contrast, object spread is
  * used deliberately to *carry* sourceID/referenceID through an unmodified
  * reference; DefineSource then sets them, and DynamicSpace clears referenceID
  * on the modification path.

--- a/packages/malloy/src/model/persist_utils.ts
+++ b/packages/malloy/src/model/persist_utils.ts
@@ -4,6 +4,7 @@
  */
 
 import type {
+  AnnotationsDef,
   ModelDef,
   SourceDef,
   SQLPhraseSegment,
@@ -46,6 +47,32 @@ export function checkPersistAnnotation(source: SourceDef): {
   if (!source.annotations) return {persist: false, log: []};
   const {tag, log} = new Annotations(source.annotations).parseAsTag('@');
   return {persist: tag.has('persist'), log};
+}
+
+/**
+ * Whether `#@ persist` is DECLARED on a source's OWN annotation, as opposed to
+ * merely inherited from a source it `extend`s.
+ *
+ * `checkPersistAnnotation` folds the entire annotation chain (including
+ * `inherits`), which is correct for the read/recompute decision (`persistent`):
+ * an `extend`-derived reader SHOULD read the parent's pre-built table. But a
+ * reader is NOT a build target — materializing it would duplicate the parent's
+ * table under the same inherited `name=`. This checks the own annotation alone
+ * (the block/line notes written on this source, with any inherited bundle
+ * dropped) so that only a source that declares persist itself is treated as a
+ * thing to build. `#@ -persist` in the own annotation deletes the key and so
+ * reports false. Errors are not re-logged here — the folded
+ * `checkPersistAnnotation` on the same source already surfaces them.
+ */
+export function checkPersistDeclaredOnOwn(
+  own: AnnotationsDef | undefined
+): boolean {
+  if (!own) return false;
+  const {tag} = new Annotations({
+    notes: own.notes,
+    blockNotes: own.blockNotes,
+  }).parseAsTag('@');
+  return tag.has('persist');
 }
 
 /**
@@ -123,9 +150,17 @@ export function findPersistentDependencies(
     }
 
     const childDeps = processSourceDef(sourceDef);
+    // Compute `persistent` for its side effects (registry cache + tag-parse-error
+    // logging), but gate inclusion on `persistDeclared`: a source is a build
+    // TARGET only if it DECLARES `#@ persist` itself. An `extend`-derived reader
+    // is `persistent` (it reads the parent's pre-built table) but declares
+    // nothing, so — like a non-persistent source — it flattens out, bubbling its
+    // real persisted dependency (the parent) up in its place. Without this, the
+    // reader would be emitted as a second build target that materializes the
+    // parent's table again under the same inherited `name=`, colliding.
     const persistent = isPersistent(sourceID, modelDef, tagParseLog);
 
-    if (persistent) {
+    if (persistent && sourceDef.persistDeclared === true) {
       return [{sourceID, dependsOn: childDeps}];
     } else {
       return childDeps;

--- a/packages/malloy/src/model/persist_utils.ts
+++ b/packages/malloy/src/model/persist_utils.ts
@@ -50,18 +50,12 @@ export function checkPersistAnnotation(source: SourceDef): {
 }
 
 /**
- * Whether `#@ persist` is DECLARED on a source's OWN annotation, as opposed to
- * merely inherited from a source it `extend`s.
- *
- * `checkPersistAnnotation` folds the entire annotation chain (including
- * `inherits`), which is correct for the read/recompute decision (`persistent`):
- * an `extend`-derived reader SHOULD read the parent's pre-built table. But a
- * reader is NOT a build target — materializing it would duplicate the parent's
- * table under the same inherited `name=`. This checks the own annotation alone
- * (the block/line notes written on this source, with any inherited bundle
- * dropped) so that only a source that declares persist itself is treated as a
- * thing to build. `#@ -persist` in the own annotation deletes the key and so
- * reports false. Errors are not re-logged here — the folded
+ * Whether `#@ persist` is DECLARED on a source's OWN annotation (the block/line
+ * notes on this source, with any inherited bundle dropped) rather than inherited
+ * from a source it `extend`s. This is the build-target signal — see
+ * `PersistableSourceProperties.persistDeclared`. Unlike `checkPersistAnnotation`,
+ * which folds the whole chain for read routing, this reads the own notes only;
+ * `#@ -persist` there reports false. Errors are not re-logged — the folded
  * `checkPersistAnnotation` on the same source already surfaces them.
  */
 export function checkPersistDeclaredOnOwn(
@@ -151,13 +145,10 @@ export function findPersistentDependencies(
 
     const childDeps = processSourceDef(sourceDef);
     // Compute `persistent` for its side effects (registry cache + tag-parse-error
-    // logging), but gate inclusion on `persistDeclared`: a source is a build
-    // TARGET only if it DECLARES `#@ persist` itself. An `extend`-derived reader
-    // is `persistent` (it reads the parent's pre-built table) but declares
-    // nothing, so — like a non-persistent source — it flattens out, bubbling its
-    // real persisted dependency (the parent) up in its place. Without this, the
-    // reader would be emitted as a second build target that materializes the
-    // parent's table again under the same inherited `name=`, colliding.
+    // logging), but gate build-target inclusion on `persistDeclared`: only a
+    // source that declares `#@ persist` itself is a target. An inherited-only
+    // reader flattens out, bubbling its real persisted dependency up in its place
+    // (see PersistableSourceProperties.persistDeclared).
     const persistent = isPersistent(sourceID, modelDef, tagParseLog);
 
     if (persistent && sourceDef.persistDeclared === true) {

--- a/packages/malloy/src/model/source_def_utils.ts
+++ b/packages/malloy/src/model/source_def_utils.ts
@@ -101,6 +101,7 @@ export function mkQuerySourceDef(
     // referenceID: undefined,
     // extends: undefined,
     // persistent: undefined,
+    // persistDeclared: undefined,
   };
 }
 
@@ -153,6 +154,7 @@ export function mkSQLSourceDef(
     // referenceID: undefined,
     // extends: undefined,
     // persistent: undefined,
+    // persistDeclared: undefined,
   };
 }
 

--- a/test/src/core/persist.spec.ts
+++ b/test/src/core/persist.spec.ts
@@ -1286,7 +1286,7 @@ describe('source persistence', () => {
       );
     });
 
-    it('detects persistent base through non-persistent imported extend chain', async () => {
+    it('collapses an inherited-persist imported extend chain to the single declaring build target', async () => {
       // Model 1: defines persist source A
       const model1 = `${PERSIST_ANNOTATION}
         ${FLIGHTS_SOURCE}
@@ -1328,32 +1328,21 @@ describe('source persistence', () => {
 
       const plan = model.getBuildPlan();
 
-      // Persistence is inherited through extends chain, so all three sources
-      // are persistent. source_c is the root (nothing depends on it).
-      // All three will generate the same SQL and use the same build artifact.
+      // Only source_a DECLARES `#@ persist`, so it is the single build target.
+      // source_b and source_c inherit `persistent` via `extend` (their reads
+      // still route to source_a's materialized table), but an inherited-only
+      // reader is not itself a build target — materializing it would duplicate
+      // source_a's table. So the chain collapses to one node: source_a.
       expect(plan.graphs).toHaveLength(1);
       const graph = plan.graphs[0];
 
-      // Build graph has 1 level with the root node (source_c)
-      // Dependencies are nested in dependsOn
+      // One build level holding the single declaring target.
       expect(graph.nodes).toHaveLength(1);
       expect(graph.nodes[0]).toHaveLength(1);
 
-      // Root: source_c
-      const source_c = graph.nodes[0][0];
-      expect(source_c.sourceID).toContain('source_c');
-
-      // source_c depends on source_b
-      expect(source_c.dependsOn).toHaveLength(1);
-      const source_b = source_c.dependsOn[0];
-      expect(source_b.sourceID).toContain('source_b');
-
-      // source_b depends on source_a
-      expect(source_b.dependsOn).toHaveLength(1);
-      const source_a = source_b.dependsOn[0];
+      // Root and only target: source_a, with no dependents.
+      const source_a = graph.nodes[0][0];
       expect(source_a.sourceID).toContain('source_a');
-
-      // source_a has no dependencies
       expect(source_a.dependsOn).toHaveLength(0);
     });
 


### PR DESCRIPTION
## Problem

`#@ persist` is a Malloy annotation, so it propagates onto a source that `extend`s a persisted source. `Model.getBuildPlan()` enumerates build targets from `findPersistentDependencies`, gated on the folded `persistent` flag — which is `true` for an `extend`-derived reader (correctly, since it must read the pre-built table). As a result the reader was emitted as a **second build target**, materializing the base's table again under the same inherited `name=`.

Minimal repro (DuckDB dialect):

```malloy
##! experimental.persistence
#@ persist name="main.base_persist"
source: base_persist is duckdb.table('t') -> {
  group_by: astr
  aggregate: n is count()
}

// no #@ persist of its own — just adds a computed field
source: extended_reader is base_persist extend {
  dimension: astr_upper is upper(astr)
}
```

`getBuildPlan().sources` returned **both** `base_persist` and `extended_reader` (with the reader as the graph root and `base_persist` nested under `dependsOn`), so a consumer materializes one physical table twice.

Per the [persistence docs](https://docs.malloydata.dev/documentation/experiments/persistence), extending a persistent source should **read** the pre-built table, not re-materialize it (`#@ -persist` is the opt-out to recompute).

## Fix

Distinguish "uses a persisted table" from "declares the materialization":

- Add `persistDeclared` to `PersistableSourceProperties`, computed at define time (`DefineSource.execute`) from the source's **own** annotation only (via `checkPersistDeclaredOnOwn`), so an inherited `#@ persist` doesn't count and an own `#@ -persist` reports false.
- Gate build-target inclusion in `findPersistentDependencies` on `persistDeclared`. An inherited-only reader keeps `persistent === true` (so it still routes to the pre-built table) but is no longer a build target — it flattens to its real persisted dependency, exactly like a non-persistent source.

The folded `persistent` flag and the serve/read path are unchanged.

## Tests

`persist-source-sql.spec.ts`:
- an `extend` of a persisted source is a reader, not a build target
- an `extend` reader still routes to the base's materialized table
- a `#@ -persist` extension opts out (not a build target)
- an extension that declares its **own** persist name stays a distinct build target

Typecheck clean; existing persist/annotation/import/sql-block/runtime unit suites pass.
