### PR TITLE
fix(render): contain plugin render-time failures instead of masking them

### DIFF
--- a/packages/malloy-render/src/api/malloy-viz.tsx
+++ b/packages/malloy-render/src/api/malloy-viz.tsx
@@ -138,15 +138,24 @@ export class MalloyViz {
   setResult(malloyResult: Malloy.Result): void {
     this.result = malloyResult;
     if (this.result) {
+      const installErrorPlugin = (
+        error: Error,
+        plugins: RenderPluginInstance[]
+      ) => {
+        const errorPlugin = ErrorPlugin.create(error.message);
+        plugins.push(errorPlugin);
+      };
       this.metadata = new RenderFieldMetadata(
         this.result,
         this.pluginRegistry,
         this.options.pluginOptions ?? {},
-        (error, _factory, _field, plugins) => {
-          const errorPlugin = ErrorPlugin.create(error.message);
-          plugins.push(errorPlugin);
-        },
-        this.logCollector
+        (error, _factory, _field, plugins) =>
+          installErrorPlugin(error, plugins),
+        this.logCollector,
+        // A plugin that throws from beforeRender/getStyleOverrides is replaced
+        // the same way a plugin that fails to construct is, so the field shows
+        // the real reason rather than a half-initialized chart.
+        (error, _plugin, _field, plugins) => installErrorPlugin(error, plugins)
       );
     }
   }

--- a/packages/malloy-render/src/component/render.tsx
+++ b/packages/malloy-render/src/component/render.tsx
@@ -153,8 +153,7 @@ export function MalloyRenderInner(props: {
   });
 
   const metadata = createMemo(() => {
-    // TODO Do we even need this anymore...
-    const resultMetadata = getResultMetadata(rootCell().field, {
+    const options = {
       renderFieldMetadata: props.renderFieldMetadata,
       getVegaConfigOverride: props.vegaConfigOverride,
       parentSize: {
@@ -163,33 +162,17 @@ export function MalloyRenderInner(props: {
       },
       useVegaInterpreter: props.useVegaInterpreter,
       explicitTheme: props.theme,
-    });
+    };
 
-    // Collect style overrides from plugins
-    const styleOverrides: Record<string, string> = {};
-    props.renderFieldMetadata?.getAllFields().forEach(field => {
-      const plugins =
-        props.renderFieldMetadata?.getPluginsForField(field.key) ?? [];
-      plugins.forEach(plugin => {
-        plugin.beforeRender?.(resultMetadata, {
-          renderFieldMetadata: props.renderFieldMetadata,
-          getVegaConfigOverride: props.vegaConfigOverride,
-          parentSize: {
-            width: parentSize().width - CHART_SIZE_BUFFER,
-            height: parentSize().height - CHART_SIZE_BUFFER,
-          },
-          useVegaInterpreter: props.useVegaInterpreter,
-          explicitTheme: props.theme,
-        });
+    // TODO Do we even need this anymore...
+    const resultMetadata = getResultMetadata(rootCell().field, options);
 
-        // Collect style overrides from plugin
-        if (plugin.getStyleOverrides) {
-          Object.assign(styleOverrides, plugin.getStyleOverrides());
-        }
-      });
-    });
-
-    resultMetadata.styleOverrides = styleOverrides;
+    // Runs the plugins' beforeRender hooks and collects their style overrides.
+    // Guarded inside RenderFieldMetadata: nothing a plugin does may throw out
+    // of this memo, because every reader of metadata() (style(), showRendering(),
+    // _setParentSize) would then see it as undefined and report the failure as a
+    // styleOverrides TypeError instead of the plugin's actual error.
+    props.renderFieldMetadata?.runPluginsBeforeRender(resultMetadata, options);
 
     return resultMetadata;
   });

--- a/packages/malloy-render/src/render-field-metadata.ts
+++ b/packages/malloy-render/src/render-field-metadata.ts
@@ -10,6 +10,10 @@ import type {
   RenderFieldRegistry,
 } from '@/registry/types';
 import {RenderLogCollector} from '@/component/render-log-collector';
+import type {
+  GetResultMetadataOptions,
+  RenderMetadata,
+} from '@/component/render-result-metadata';
 import type {Tag} from '@malloydata/malloy-tag';
 import {resolveBuiltInTags} from '@/component/tag-configs';
 import {getBuiltInRendererValidationSpec} from '@/component/renderer-validation-specs';
@@ -24,6 +28,19 @@ export type OnPluginCreateError = (
   plugins: RenderPluginInstance[]
 ) => void;
 
+/**
+ * Called when an already-created plugin throws from a render-time hook
+ * (`beforeRender` / `getStyleOverrides`). The `plugins` array is the field's
+ * plugin list with the failed plugin already removed — push a replacement onto
+ * it (an error renderer) to have the field report the failure in place.
+ */
+export type OnPluginRenderError = (
+  error: Error,
+  plugin: RenderPluginInstance,
+  field: Field,
+  plugins: RenderPluginInstance[]
+) => void;
+
 export class RenderFieldMetadata {
   private registry: RenderFieldRegistry;
   private rootField: RootField;
@@ -34,7 +51,8 @@ export class RenderFieldMetadata {
     private pluginRegistry: RenderPluginFactory[] = [],
     private pluginOptions: Record<string, unknown> = {},
     private onPluginCreateError?: OnPluginCreateError,
-    logCollector?: RenderLogCollector
+    logCollector?: RenderLogCollector,
+    private onPluginRenderError?: OnPluginRenderError
   ) {
     this.logCollector = logCollector ?? new RenderLogCollector();
     this.registry = new Map();
@@ -177,6 +195,69 @@ export class RenderFieldMetadata {
 
   getFieldEntry(fieldKey: string): RenderFieldRegistryEntry | undefined {
     return this.registry.get(fieldKey);
+  }
+
+  /**
+   * Run every plugin's `beforeRender` hook and collect the style overrides they
+   * publish onto `resultMetadata`.
+   *
+   * Both hooks run behind a guard, mirroring how plugin *creation* failures are
+   * contained in `instantiatePluginsForField`. A plugin that throws is logged
+   * and dropped from its field, and `onPluginRenderError` gets a chance to put
+   * a replacement (an error renderer) in its place, so the failure is reported
+   * on that field instead of taking down the whole render.
+   *
+   * This containment is load-bearing for the caller: this runs inside the
+   * renderer's `metadata` memo, and an escaping throw left that memo undefined,
+   * so every render-time plugin failure surfaced as
+   * `Cannot read properties of undefined (reading 'styleOverrides')` from the
+   * next read of the memo — discarding the real reason, which was never logged.
+   */
+  runPluginsBeforeRender(
+    resultMetadata: RenderMetadata,
+    options: GetResultMetadataOptions
+  ): void {
+    const styleOverrides: Record<string, string> = {};
+
+    for (const field of this.getAllFields()) {
+      // Snapshot: handlePluginRenderError rewrites the field's plugin list.
+      for (const plugin of [...this.getPluginsForField(field.key)]) {
+        try {
+          plugin.beforeRender?.(resultMetadata, options);
+          if (plugin.getStyleOverrides) {
+            Object.assign(styleOverrides, plugin.getStyleOverrides());
+          }
+        } catch (error) {
+          this.handlePluginRenderError(error, plugin, field);
+        }
+      }
+    }
+
+    resultMetadata.styleOverrides = styleOverrides;
+  }
+
+  private handlePluginRenderError(
+    error: unknown,
+    plugin: RenderPluginInstance,
+    field: Field
+  ): void {
+    const msg = error instanceof Error ? error.message : String(error);
+    this.logCollector.error(
+      `Plugin ${plugin.name} failed for field '${field.key}': ${msg}`
+    );
+
+    const entry = this.registry.get(field.key);
+    if (!entry) return;
+
+    // Drop the failed plugin before offering a replacement: applyRenderer reads
+    // plugins.at(0), so leaving it in place would keep rendering the broken one.
+    const plugins = entry.plugins.filter(p => p !== plugin);
+    this.onPluginRenderError?.(error as Error, plugin, field, plugins);
+
+    entry.plugins = plugins;
+    // Goes through setPlugins so the field's cached renderAs is recomputed for
+    // whatever replaced the plugin (or for having no plugin at all).
+    field.setPlugins(plugins);
   }
 
   /**

--- a/packages/malloy-render/src/render-plugin-render-error.spec.ts
+++ b/packages/malloy-render/src/render-plugin-render-error.spec.ts
@@ -1,0 +1,217 @@
+/*
+ * Copyright Contributors to the Malloy project
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+ * Containment of render-time plugin failures (`beforeRender` /
+ * `getStyleOverrides`).
+ *
+ * Compile-only harness per docs/testing.md: the behavior is a function of the
+ * result schema plus the plugin registry, so no query run, no Vega, no DOM.
+ * The renderer calls runPluginsBeforeRender from inside a Solid memo; a throw
+ * escaping it left that memo undefined and every failure surfaced to users as
+ * `Cannot read properties of undefined (reading 'styleOverrides')`, with the
+ * plugin's real error never logged.
+ */
+
+import {DuckDBConnection} from '@malloydata/db-duckdb';
+import {SingleConnectionRuntime} from '@malloydata/malloy';
+import {RenderFieldMetadata} from './render-field-metadata';
+import type {OnPluginRenderError} from './render-field-metadata';
+import {getResultMetadata} from './component/render-result-metadata';
+import type {RenderMetadata} from './component/render-result-metadata';
+import type {
+  RenderPluginFactory,
+  RenderPluginInstance,
+} from './api/plugin-types';
+
+let connection: DuckDBConnection;
+let runtime: SingleConnectionRuntime;
+
+beforeAll(async () => {
+  connection = new DuckDBConnection('duckdb');
+  await connection.connecting;
+  runtime = new SingleConnectionRuntime({connection});
+});
+
+afterAll(async () => {
+  await connection.close();
+});
+
+const SOURCE = `
+  source: airings is duckdb.sql("""
+    SELECT 'ESPN' AS network, 10 AS reach
+  """)
+`;
+
+const BOOM = 'plugin exploded during beforeRender';
+
+const POLITE_OVERRIDE = {'--malloy-render--table-body-color': 'teal'};
+
+/** Minimal plugin matching a tag, optionally throwing from one render hook. */
+function fakeFactory(
+  name: string,
+  opts: {
+    throwFrom?: 'beforeRender' | 'getStyleOverrides';
+    styleOverrides?: Record<string, string>;
+  } = {}
+): RenderPluginFactory {
+  return {
+    name,
+    matches: (_field, fieldTag) => fieldTag.has(name),
+    create: (field): RenderPluginInstance => ({
+      name,
+      field,
+      renderMode: 'solidjs',
+      sizingStrategy: 'fill',
+      getMetadata: () => ({}),
+      renderComponent: () => null,
+      beforeRender: () => {
+        if (opts.throwFrom === 'beforeRender') throw new Error(BOOM);
+      },
+      getStyleOverrides: () => {
+        if (opts.throwFrom === 'getStyleOverrides') throw new Error(BOOM);
+        return opts.styleOverrides ?? {};
+      },
+    }),
+  };
+}
+
+const boomFactory = (throwFrom: 'beforeRender' | 'getStyleOverrides') =>
+  fakeFactory('boom', {throwFrom});
+
+/** A well-behaved plugin, to prove one bad plugin doesn't starve the others. */
+const politeFactory = fakeFactory('polite', {
+  styleOverrides: POLITE_OVERRIDE,
+});
+
+async function setup(
+  query: string,
+  plugins: RenderPluginFactory[],
+  onPluginRenderError?: OnPluginRenderError
+) {
+  const pr = await runtime
+    .loadModel(`${SOURCE}\n${query}`)
+    .loadQueryByName('q')
+    .getPreparedResult();
+  const rfm = new RenderFieldMetadata(
+    pr.toStableResult(),
+    plugins,
+    {},
+    undefined,
+    undefined,
+    onPluginRenderError
+  );
+  const root = rfm.getRootField();
+  const resultMetadata: RenderMetadata = getResultMetadata(root, {
+    renderFieldMetadata: rfm,
+    parentSize: {width: 400, height: 300},
+  });
+  return {rfm, root, resultMetadata};
+}
+
+const BOOM_QUERY = `
+  # boom
+  query: q is airings -> { group_by: network }
+`;
+
+describe('runPluginsBeforeRender contains plugin failures', () => {
+  test('a throwing beforeRender does not propagate to the caller', async () => {
+    const {rfm, resultMetadata} = await setup(BOOM_QUERY, [
+      boomFactory('beforeRender'),
+    ]);
+
+    expect(() =>
+      rfm.runPluginsBeforeRender(resultMetadata, {
+        renderFieldMetadata: rfm,
+        parentSize: {width: 400, height: 300},
+      })
+    ).not.toThrow();
+
+    // The guarantee the render path depends on: metadata is still usable, and
+    // styleOverrides is an object rather than undefined.
+    expect(resultMetadata.styleOverrides).toEqual({});
+  });
+
+  test('a throwing getStyleOverrides is contained the same way', async () => {
+    const {rfm, resultMetadata} = await setup(BOOM_QUERY, [
+      boomFactory('getStyleOverrides'),
+    ]);
+
+    expect(() =>
+      rfm.runPluginsBeforeRender(resultMetadata, {
+        renderFieldMetadata: rfm,
+        parentSize: {width: 400, height: 300},
+      })
+    ).not.toThrow();
+    expect(resultMetadata.styleOverrides).toEqual({});
+  });
+
+  test("the plugin's real error is logged, not swallowed", async () => {
+    const {rfm, resultMetadata} = await setup(BOOM_QUERY, [
+      boomFactory('beforeRender'),
+    ]);
+    rfm.runPluginsBeforeRender(resultMetadata, {
+      renderFieldMetadata: rfm,
+      parentSize: {width: 400, height: 300},
+    });
+
+    const errors = rfm.logCollector
+      .getLogs()
+      .filter(l => l.severity === 'error');
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toContain(BOOM);
+    expect(errors[0].message).toContain('Plugin boom failed for field');
+  });
+
+  test('the failed plugin is dropped and a replacement can take its place', async () => {
+    const replacement = {
+      name: 'error',
+      field: {},
+      renderMode: 'solidjs',
+      sizingStrategy: 'fill',
+      getMetadata: () => ({}),
+      renderComponent: () => null,
+    } as unknown as RenderPluginInstance;
+
+    const {rfm, root, resultMetadata} = await setup(
+      BOOM_QUERY,
+      [boomFactory('beforeRender')],
+      (_error, _plugin, _field, plugins) => plugins.push(replacement)
+    );
+    expect(root.getPlugins().map(p => p.name)).toEqual(['boom']);
+
+    rfm.runPluginsBeforeRender(resultMetadata, {
+      renderFieldMetadata: rfm,
+      parentSize: {width: 400, height: 300},
+    });
+
+    // Dropped from both views of the field's plugin list, and replaced.
+    expect(root.getPlugins().map(p => p.name)).toEqual(['error']);
+    expect(rfm.getPluginsForField(root.key).map(p => p.name)).toEqual([
+      'error',
+    ]);
+    // applyRenderer dispatches on renderAs, which setPlugins recomputes.
+    expect(root.renderAs()).toBe('error');
+  });
+
+  test('a failing plugin does not suppress a healthy one', async () => {
+    const {rfm, resultMetadata} = await setup(
+      `
+      # boom
+      # polite
+      query: q is airings -> { group_by: network }
+      `,
+      [boomFactory('beforeRender'), politeFactory]
+    );
+
+    rfm.runPluginsBeforeRender(resultMetadata, {
+      renderFieldMetadata: rfm,
+      parentSize: {width: 400, height: 300},
+    });
+
+    // The healthy plugin's override still lands, and only it.
+    expect(resultMetadata.styleOverrides).toEqual(POLITE_OVERRIDE);
+  });
+});


### PR DESCRIPTION
## The bug

A plugin that throws from `beforeRender` or `getStyleOverrides` escaped the `metadata` memo in `MalloyRenderInner`. That left the memo undefined, so the next reader — `style()` — failed on `metadata().styleOverrides`, and **every** render-time plugin failure reached users as:

```
Cannot read properties of undefined (reading 'styleOverrides')
```

Two things made this worse than a bad message:

- **The real reason was never logged.** Plugin *create* failures log `Plugin bar failed for field '["trend"]': …` and the render survives. A `beforeRender` failure logged nothing at all — `getLogs()` is meant to be read from the `onReady` callback, and a crash means `onReady` never fires. Users got the message above and no breadcrumb.
- **One bad field took down the whole result.** The `ErrorBoundary` is at the root of `MalloyRender`, so a single failing chart replaced the entire rendered result with that one misleading tile.

Reproduced with a plugin whose `beforeRender` throws:

```
before   errors:      onError: Cannot read properties of undefined (reading 'styleOverrides')
         html:        <div class="malloy-error-message">Cannot read properties of undefined…
         render logs: none                             ← cause destroyed

after    errors:      none
         html:        <div class="malloy-render" …>     ← result renders
         render logs: [error] Plugin boom failed for field '[]': <the plugin's real error>
```

## The fix

Plugin *creation* failures were already contained — `instantiatePluginsForField` catches them, logs them, and lets the embedder swap in a replacement. This gives the render-time hooks the same treatment.

- **`RenderFieldMetadata.runPluginsBeforeRender`** (new) owns the loop with a per-plugin guard. A plugin that throws is logged with its real message, dropped from its field, and offered to a new `onPluginRenderError` callback.
- **`render.tsx`** — the memo now delegates to that method, shrinking from ~40 lines to two calls. The options object was being built twice with identical contents, so it is hoisted.
- **`MalloyViz`** wires `onPluginRenderError` to the same `ErrorPlugin` it already installs for create failures, so the failure is reported on the field that caused it while the rest of the result renders.

Two details worth a reviewer's eye:

- **`field.setPlugins()`, not in-place array mutation.** `setPlugins` also recomputes the field's cached `_renderAs` via `shouldRenderAs`, and `applyRenderer` dispatches on it — mutating `entry.plugins` alone would leave `renderAs` pointing at the dead plugin and the replacement tile would never show. Pinned by a test asserting `renderAs() === 'error'`.
- **The failed plugin is removed *before* the callback runs.** `applyRenderer` reads `plugins.at(0)`, so the create path's "just push a replacement" is not enough here: at render time the broken plugin already occupies index 0.

Behavior for embedders that pass no `onPluginRenderError` is still strictly better than before — the throw is contained and logged rather than taking down the render.

## Tests

New `render-plugin-render-error.spec.ts`, at the compile-only layer per `docs/testing.md` (schema only — no query run, no Vega, no DOM), covering: a throwing `beforeRender` does not propagate; a throwing `getStyleOverrides` is contained the same way; the real error is logged; the failed plugin is dropped from both views of the plugin list and a replacement takes its place with `renderAs` recomputed; and a failing plugin does not suppress a healthy one's style overrides.

`npx jest --selectProjects malloy-render` → **123 passed**. Type-check and lint are clean for `packages/malloy-render`.

One note on local verification: 4 suites in that project (`drill.spec.ts` and the three chart vega-spec specs) fail to resolve `@malloydata/db-snowflake` via `test/src/runtimes.ts`, and `npm run build` reports 14 type errors in sibling db packages. Both reproduce identically on unmodified `main` in my workspace — unbuilt sibling packages, not this change — but it does mean the chart spec-generation layer is unverified locally and I am relying on CI for it.

## Related

Not overlapping, but #2874 edits the same `ErrorBoundary` fallback in `render.tsx` (coercing `errorProps` to a string). That change makes the *wrong* message display more reliably; this one stops it being produced. Worth sequencing if both land.