### PR TITLE
fix(drill): filtered measures, boolean/and stable filters, and missing joins

### DIFF
--- a/packages/malloy-render/src/data_tree/drilling.ts
+++ b/packages/malloy-render/src/data_tree/drilling.ts
@@ -51,6 +51,16 @@ export function getStableDrillClauses(
   const result: Malloy.DrillOperation[] = [];
   while (current) {
     const {field} = current;
+    // The clicked leaf itself. A filtered measure (`total_sales {where: ...}`)
+    // carries its own drill_filters, and dropping them would drill to a SUPERSET
+    // of the rows behind the number that was clicked. Only the starting cell can
+    // be a leaf — every parent is an array or a record — so this runs at most
+    // once, and is disjoint from both branches below.
+    if (!field.isArray() && !field.isRecord()) {
+      const filters = field.stableDrillFilters;
+      if (filters === undefined) return undefined;
+      result.unshift(...filters.map(f => ({filter: f})));
+    }
     if (field.isArray()) {
       const filters = field.stableDrillFilters;
       if (filters === undefined) return undefined;
@@ -96,6 +106,12 @@ export function getDrillValues(cell: Cell): DrillValue[] {
   const result: DrillValue[] = [];
   while (current) {
     const field = current.field;
+    // The clicked leaf's own filters — see getStableDrillClauses. drillFilters
+    // falls back to the raw `code` when a filter has no stable form, so unlike
+    // the stable walk there is nothing to bail on here.
+    if (!field.isArray() && !field.isRecord()) {
+      result.unshift(...field.drillFilters.map(f => ({where: f})));
+    }
     if (field.isArray()) {
       const filters = field.drillFilters;
       result.unshift(...filters.map(f => ({where: f})));

--- a/packages/malloy-render/src/drill.spec.ts
+++ b/packages/malloy-render/src/drill.spec.ts
@@ -48,6 +48,136 @@ describe('drill query', () => {
     expect(row.getStableDrillQueryMalloy()).toEqual(expDrillQuery);
   });
 
+  // A filtered measure carries its own drill_filters. Drilling the CELL must
+  // include them, or the drill lands on a superset of the rows behind the
+  // number that was clicked.
+  test('filtered measure contributes its own filter', async () => {
+    const query = `
+      run: flights_base -> {
+        group_by: carriers.nickname
+        aggregate: flight_count
+        aggregate: wn_flights is flight_count { where: carrier = 'WN' }
+        limit: 1
+      }
+    `;
+    const result = await duckdb.loadModel(baseModel).loadQuery(query).run();
+    const table = getDataTree(API.util.wrapResult(result));
+    const cell = table.rows[0].column('wn_flights');
+    const expDrillQuery = `run: flights_base -> {
+  drill:
+    carriers.nickname = "Southwest",
+    carrier = "WN"
+} + { select: * }`;
+    expect(cell.getStableDrillQueryMalloy()).toEqual(expDrillQuery);
+  });
+
+  // The row-level drill must NOT pick up a sibling measure's filter — the leaf
+  // branch only fires for the clicked cell.
+  test('row drill is unaffected by a sibling filtered measure', async () => {
+    const query = `
+      run: flights_base -> {
+        group_by: carriers.nickname
+        aggregate: flight_count
+        aggregate: wn_flights is flight_count { where: carrier = 'WN' }
+        limit: 1
+      }
+    `;
+    const result = await duckdb.loadModel(baseModel).loadQuery(query).run();
+    const table = getDataTree(API.util.wrapResult(result));
+    const expDrillQuery =
+      'run: flights_base -> { drill: carriers.nickname = "Southwest" } + { select: * }';
+    expect(table.rows[0].getStableDrillQueryMalloy()).toEqual(expDrillQuery);
+  });
+
+  // A drill clause reaching through a JOIN must bring that join along, even when
+  // the view it lands on doesn't otherwise need it. Regression: the drill field's
+  // refSummary carried only the field's own usage, so the join was omitted and
+  // the SQL referenced an unjoined alias — it COMPILED, then failed at execution
+  // with a binder error. Hence this runs the query rather than matching text.
+  test('drill through a joined field pulls the join into the query', async () => {
+    const model = `
+      source: flights is flights_base extend {
+        view: by_origin is { group_by: \`Origin Code\`; aggregate: flight_count }
+        view: by_carrier is { group_by: carriers.nickname; aggregate: flight_count }
+      }
+    `;
+    const result = await duckdb
+      .loadModel(baseModel)
+      .extendModel(model)
+      .loadQuery(
+        'run: flights -> by_origin + { drill: by_carrier.nickname = "Southwest" }'
+      )
+      .run();
+    const table = getDataTree(API.util.wrapResult(result));
+    expect(table.rows.length).toBeGreaterThan(0);
+  });
+
+  // `a and b` decomposes into two independent drill clauses. Sound only for
+  // `and`, since drill clauses are conjunctive.
+  test('compound and filter decomposes into separate clauses', async () => {
+    const query = `
+      run: flights_base -> {
+        group_by: carriers.nickname
+        aggregate: flight_count
+        aggregate: wn_short is flight_count { where: carrier = 'WN' and distance = 100 }
+        limit: 1
+      }
+    `;
+    const result = await duckdb.loadModel(baseModel).loadQuery(query).run();
+    const table = getDataTree(API.util.wrapResult(result));
+    const expDrillQuery = `run: flights_base -> {
+  drill:
+    carriers.nickname = "Southwest",
+    carrier = "WN",
+    distance = 100
+} + { select: * }`;
+    expect(
+      table.rows[0].column('wn_short').getStableDrillQueryMalloy()
+    ).toEqual(expDrillQuery);
+  });
+
+  // A bare boolean is an implicit `= true`.
+  test('bare boolean filter is stable', async () => {
+    const query = `
+      run: flights_base extend { dimension: is_wn is carrier = 'WN' } -> {
+        group_by: carriers.nickname
+        aggregate: flight_count
+        aggregate: wn is flight_count { where: is_wn }
+        limit: 1
+      }
+    `;
+    const result = await duckdb.loadModel(baseModel).loadQuery(query).run();
+    const table = getDataTree(API.util.wrapResult(result));
+    const expDrillQuery = `run: flights_base -> {
+  drill:
+    carriers.nickname = "Southwest",
+    is_wn = true
+} + { select: * }`;
+    expect(table.rows[0].column('wn').getStableDrillQueryMalloy()).toEqual(
+      expDrillQuery
+    );
+  });
+
+  // `or` must NOT decompose — splitting it would widen the predicate. It stays
+  // unstable and falls back to the raw filter code.
+  test('or filter stays unstable', async () => {
+    const query = `
+      run: flights_base -> {
+        group_by: carriers.nickname
+        aggregate: flight_count
+        aggregate: wn_or_aa is flight_count { where: carrier = 'WN' or carrier = 'AA' }
+        limit: 1
+      }
+    `;
+    const result = await duckdb.loadModel(baseModel).loadQuery(query).run();
+    const table = getDataTree(API.util.wrapResult(result));
+    const cell = table.rows[0].column('wn_or_aa');
+    expect(cell.getStableDrillQueryMalloy()).toBeUndefined();
+    expect(cell.getDrillQueryMalloy()).toContain(
+      "carrier = 'WN' or carrier = 'AA'"
+    );
+  });
+
   test('can time truncation field renamed', async () => {
     const query = `
       run: flights_base -> {

--- a/packages/malloy/src/lang/ast/query-properties/drill.ts
+++ b/packages/malloy/src/lang/ast/query-properties/drill.ts
@@ -132,6 +132,14 @@ export class Drill extends Filter implements QueryPropertyInterface {
     let previousName = viewName;
     let fieldDef: AtomicFieldDef | undefined = undefined;
     let compareField: Expr | undefined = undefined;
+    // Join usage for the field the drill resolved to. When a view's field is a
+    // reference through a join (`group_by: users.full_name`), the drill's filter
+    // reads `users.first_name`/`last_name` but the field's OWN refSummary only
+    // describes usage inside `users` — it never says `users` itself is used. The
+    // query builder then omits the join and emits SQL referencing an unjoined
+    // alias. Recording the reference path here is what pulls the join in, the
+    // same way ExprIdReference does for an ordinary `where:`.
+    let compareFieldUsage: FieldUsage | undefined = undefined;
     const requiredDimensions: string[][] = [];
     const pathSoFar: string[] = [viewName.name];
     for (const name of path) {
@@ -255,6 +263,9 @@ export class Drill extends Filter implements QueryPropertyInterface {
           if (theFieldDef === undefined || isAtomic(theFieldDef)) {
             fieldDef = theFieldDef;
             compareField = {node: 'field', path: field.path};
+            // `field.path` is the reference AS WRITTEN in the view — e.g.
+            // ['users','full_name'] — so it names the joins to bring along.
+            compareFieldUsage = [{path: field.path, at: name.location}];
           } else {
             name.logError(
               'drill-field-reference-not-field',
@@ -354,7 +365,10 @@ export class Drill extends Filter implements QueryPropertyInterface {
       ...fieldDef,
       evalSpace: 'output',
       expressionType: fieldDef.expressionType ?? 'scalar',
-      refSummary: fieldDef.refSummary,
+      refSummary: mergeRefSummaries(
+        fieldDef.refSummary,
+        mkRefSummary({fieldUsage: compareFieldUsage})
+      ),
     });
     filter.has({drillField});
     const fExpression = new ExprCompare(drillField, '=', value);
@@ -380,15 +394,17 @@ export class Drill extends Filter implements QueryPropertyInterface {
         fExpr.refSummary,
         mkRefSummary({fieldUsage: collectedWhereFieldUsage})
       ),
-      stableFilter: {
-        kind: 'literal_equality',
-        expression: {
-          kind: 'field_reference',
-          name: fieldName.refString,
-          path: reference.list.slice(0, -1).map(f => f.name),
+      stableFilters: [
+        {
+          kind: 'literal_equality',
+          expression: {
+            kind: 'field_reference',
+            name: fieldName.refString,
+            path: reference.list.slice(0, -1).map(f => f.name),
+          },
+          value: value.getStableLiteral(),
         },
-        value: value.getStableLiteral(),
-      },
+      ],
     };
     return exprCond;
   }

--- a/packages/malloy/src/lang/ast/query-properties/filters.ts
+++ b/packages/malloy/src/lang/ast/query-properties/filters.ts
@@ -22,6 +22,7 @@ import type {QueryBuilder} from '../types/query-builder';
 import type {QueryPropertyInterface} from '../types/query-property-interface';
 import {LegalRefinementStage} from '../types/query-property-interface';
 import {ExprFilterExpression} from '../expressions/expr-filter-expr';
+import {ExprLogicalOp} from '../expressions/expr-logical-op';
 
 export class FilterElement extends MalloyElement {
   elementType = 'filterElement';
@@ -32,31 +33,68 @@ export class FilterElement extends MalloyElement {
     super({expr: expr});
   }
 
-  private getStableFilter(): Malloy.Filter | undefined {
+  /**
+   * The stable (drillable) form of a filter expression, or undefined when the
+   * expression has no stable representation.
+   *
+   * Returns a LIST because `a and b` decomposes into two independent filters.
+   * That is only sound for `and` — drill clauses are conjunctive, so splitting
+   * an `or` would silently widen the predicate, and `or` deliberately stays
+   * unstable.
+   */
+  private static stableFiltersOf(
+    expr: ExpressionDef
+  ): Malloy.Filter[] | undefined {
+    // `a and b` -> [a, b]; recursive, so `a and b and c` flattens.
+    if (expr instanceof ExprLogicalOp && expr.op === 'and') {
+      const left = FilterElement.stableFiltersOf(expr.left);
+      if (left === undefined) return undefined;
+      const right = FilterElement.stableFiltersOf(expr.right);
+      if (right === undefined) return undefined;
+      return [...left, ...right];
+    }
     if (
-      this.expr instanceof ExprEquality &&
-      this.expr.op === '=' &&
-      isLiteral(this.expr.right)
+      expr instanceof ExprEquality &&
+      expr.op === '=' &&
+      isLiteral(expr.right)
     ) {
-      const lhs = this.expr.left.drillExpression();
+      const lhs = expr.left.drillExpression();
       if (lhs === undefined) return undefined;
-      return {
-        kind: 'literal_equality',
-        expression: lhs,
-        value: this.expr.right.getStableLiteral(),
-      };
-    } else if (
-      this.expr instanceof ExprCompare &&
-      this.expr.op === '~' &&
-      this.expr.right instanceof ExprFilterExpression
+      return [
+        {
+          kind: 'literal_equality',
+          expression: lhs,
+          value: expr.right.getStableLiteral(),
+        },
+      ];
+    }
+    if (
+      expr instanceof ExprCompare &&
+      expr.op === '~' &&
+      expr.right instanceof ExprFilterExpression
     ) {
-      const lhs = this.expr.left.drillExpression();
+      const lhs = expr.left.drillExpression();
       if (lhs === undefined) return undefined;
-      return {
-        kind: 'filter_string',
-        expression: lhs,
-        filter: this.expr.right.filterText,
-      };
+      return [
+        {
+          kind: 'filter_string',
+          expression: lhs,
+          filter: expr.right.filterText,
+        },
+      ];
+    }
+    // A bare boolean — `where: is_domestic` means `is_domestic = true`. Only
+    // reachable once filterCondition has established the expression is boolean,
+    // so any expression with a drill reference is safe to read this way.
+    const bare = expr.drillExpression();
+    if (bare !== undefined) {
+      return [
+        {
+          kind: 'literal_equality',
+          expression: bare,
+          value: {kind: 'boolean_literal', boolean_value: true},
+        },
+      ];
     }
     return undefined;
   }
@@ -77,14 +115,14 @@ export class FilterElement extends MalloyElement {
         isSourceFilter: false,
       };
     }
-    const stableFilter = this.getStableFilter();
+    const stableFilters = FilterElement.stableFiltersOf(this.expr);
     const exprCond: FilterCondition = {
       node: 'filterCondition',
       code: this.exprSrc,
       e: exprVal.value,
       expressionType: exprVal.expressionType,
       refSummary: exprVal.refSummary,
-      stableFilter,
+      stableFilters,
       isSourceFilter: false,
     };
     return exprCond;

--- a/packages/malloy/src/model/malloy_types.ts
+++ b/packages/malloy/src/model/malloy_types.ts
@@ -163,7 +163,8 @@ export interface FilterCondition extends ExprE {
   // Attached to filters which come from a view rather than direct in the query
   // allows the renderer to know which filters should NOT be included in drill queries
   filterView?: string;
-  stableFilter?: Malloy.Filter;
+  /** Drillable form of this condition. A list because `a and b` decomposes. */
+  stableFilters?: Malloy.Filter[];
   isSourceFilter?: boolean;
 }
 

--- a/packages/malloy/src/model/query_node.ts
+++ b/packages/malloy/src/model/query_node.ts
@@ -123,8 +123,28 @@ export abstract class QueryAtomicField<
     return this.fieldDef.name !== '__distinct_key';
   }
 
+  /**
+   * Filters carried by the field's own expression — `flight_count {where: ...}`.
+   * A filtered measure compiles to a `filteredExpr` at the TOP of its expression
+   * (see getFilteredExpression in expr-props.ts); repeated filters nest, so walk
+   * the chain. Only a filter wrapping the whole expression may be hoisted: in
+   * `x + count() {where: f}` the filteredExpr is not at the top and `f` does not
+   * constrain the field's value.
+   *
+   * getResultMetadata calls this for measures only, and the result becomes the
+   * field's `drill_filters` annotation — which is how drilling a filtered measure
+   * lands on the rows behind the number rather than a superset of them.
+   */
   getFilterList(): FilterCondition[] {
-    return [];
+    const fieldDef = this.fieldDef;
+    if (!hasExpression(fieldDef)) return [];
+    const filters: FilterCondition[] = [];
+    let e = fieldDef.e;
+    while (e.node === 'filteredExpr') {
+      filters.push(...e.kids.filterList);
+      e = e.kids.e;
+    }
+    return filters;
   }
 }
 

--- a/packages/malloy/src/to_stable.ts
+++ b/packages/malloy/src/to_stable.ts
@@ -303,33 +303,43 @@ function getResultMetadataAnnotation(
 }
 
 function addDrillFiltersTag(tag: Tag, drillFilters: FilterCondition[]) {
-  for (let i = 0; i < drillFilters.length; i++) {
-    const filter = drillFilters[i];
+  // `out` is a running OUTPUT index, deliberately not the source index. Source
+  // and aggregate conditions are skipped, and one condition can fan out into
+  // several stable filters (`a and b`), so indexing by source position would
+  // leave holes — and a hole reads back as a filter with no expression, which
+  // makes the whole drill unstable.
+  let out = 0;
+  for (const filter of drillFilters) {
     if (filter.expressionType !== 'scalar' || filter.isSourceFilter) continue;
-    tag.set(['drill_filters', i, 'code'], filter.code);
     if (filter.filterView) {
-      tag.set(['drill_filters', i, 'filter_view'], filter.filterView);
+      tag.set(['drill_filters', out, 'code'], filter.code);
+      tag.set(['drill_filters', out, 'filter_view'], filter.filterView);
+      out++;
+      continue;
     }
-    if (filter.filterView === undefined && filter.stableFilter !== undefined) {
+    const stableFilters = filter.stableFilters ?? [];
+    if (stableFilters.length === 0) {
+      // No stable form. Emit the raw code so the lenient reader still has
+      // something; the strict reader treats this as undrillable.
+      tag.set(['drill_filters', out, 'code'], filter.code);
+      out++;
+      continue;
+    }
+    for (const stable of stableFilters) {
+      tag.set(['drill_filters', out, 'code'], filter.code);
       writeExpressionToTag(
         tag,
-        ['drill_filters', i, 'expression'],
-        filter.stableFilter.expression
+        ['drill_filters', out, 'expression'],
+        stable.expression
       );
-      if (filter.stableFilter.kind === 'filter_string') {
-        tag.set(['drill_filters', i, 'kind'], 'filter_expression');
-        tag.set(
-          ['drill_filters', i, 'filter_expression'],
-          filter.stableFilter.filter
-        );
+      if (stable.kind === 'filter_string') {
+        tag.set(['drill_filters', out, 'kind'], 'filter_expression');
+        tag.set(['drill_filters', out, 'filter_expression'], stable.filter);
       } else {
-        tag.set(['drill_filters', i, 'kind'], 'literal_equality');
-        writeLiteralToTag(
-          tag,
-          ['drill_filters', i, 'value'],
-          filter.stableFilter.value
-        );
+        tag.set(['drill_filters', out, 'kind'], 'literal_equality');
+        writeLiteralToTag(tag, ['drill_filters', out, 'value'], stable.value);
       }
+      out++;
     }
   }
 }


### PR DESCRIPTION
Three defects that surface when drilling a result cell into a standalone query. Each is independently reproducible; they're together because they share the drill metadata path and one masks the next.

## 1. A filtered measure drills to a superset of its own rows

`QueryAtomicField.getFilterList()` was `return []` — a stub feeding a live call site. `getResultMetadata` calls it for measures and hands the result to `addDrillFiltersTag`, so a measure like `flight_count { where: carrier = 'WN' }` never emitted `drill_filters` at all. Drilling it produced the rows for the whole group.

Concretely, `total_babies { where: gender = 'F' }` for CA reads **15,340,742**, and the drill returned all **32,042,437** rows — the user is looking at a row list twice the size of the number they clicked, with nothing to indicate it.

It now walks the `filteredExpr` chain on the field's expression. Only a filter wrapping the *whole* expression is hoisted: in `x + count() {where: f}` the `filteredExpr` isn't at the top and `f` doesn't constrain the field.

## 2. `getStableFilter` only recognized two shapes

`= literal` and `~ filter-expression`. Anything else produced no stable form, so the strict reader (`stableDrillFilters`) treated the whole drill as unstable. Added:

- **bare booleans** — `where: is_domestic` is `is_domestic = true`, representable today via `LiteralValueWithBooleanLiteral`
- **`and`** — decomposes into independent clauses, recursively, so `a and b and c` flattens

`or` deliberately stays unstable: drill clauses are conjunctive, so splitting an `or` would silently widen the predicate.

This makes `FilterCondition.stableFilter` plural (`stableFilters`). The wire format is unchanged — `drill_filters` was already an array — so the renderer needed no changes.

## 3. A drill through a joined field dropped the join

The one that produces bad SQL rather than a wrong answer. When a drill path resolves through a view whose field is a reference across a join (`group_by: users.full_name` inside a view), the `DrillField` carried only `fieldDef.refSummary` — that field's usage *inside* `users`, never that `users` itself was used. The join path lived only in `compareField.path`, which nothing read for usage.

The builder then omitted the join while the filter still referenced its alias:

```sql
FROM order_items as base
 LEFT JOIN inventory_items AS inventory_items_0 ...
WHERE ((CONCAT(UPPER(SUBSTR(users_0."first_name",1,1)), ...))='Philip Labat')
```

`users_0` is never joined. This **compiles clean** — `problems: []` — and fails at execution with `Binder Error: Referenced table not found`.

It stayed hidden because `getDrillQueryMalloy` always appends `+ { select: * }`, and `select: *` happens to drag every join in. It surfaces as soon as the drill is composed with anything narrower, e.g. `source -> some_view + { drill: … }`.

Fixed by recording the reference path as field usage, the way `ExprIdReference` does for an ordinary `where:`.

## Also

`addDrillFiltersTag` now indexes by a running **output** position. It previously used the source index while `continue`-ing past skipped conditions, leaving holes in the tag array that read back as filters with no expression — which makes an otherwise-fine drill unstable. Fan-out from `and` would have made that fire routinely.

## Tests

Six new cases in `drill.spec.ts`: filtered measure contributes its filter; row drill unaffected by a sibling filtered measure; `and` decomposes; bare boolean is stable; `or` stays unstable and falls back to raw code; and drill-through-a-join.

That last one **runs** the query rather than matching text, because the defect produced valid-looking SQL. With the fix stashed it fails with `Binder Error: Referenced table "carriers_0" not found!`.

`malloy-render` 161 passing. `malloy-core` and `db-duckdb` show 11 pre-existing failures on this base — all in the in-flight `none` filter operator (`fnumber`/`ftemporal`/`filter-expressions`), verified identical on clean `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)