### PR TITLE
feat(db-databricks): add a timeoutMs setting that cancels long-running queries

### DIFF
--- a/packages/malloy-db-databricks/src/databricks_connection.ts
+++ b/packages/malloy-db-databricks/src/databricks_connection.ts
@@ -232,9 +232,9 @@ export class DatabricksConnection
     if (abortSignal?.aborted) {
       throw new Error('Databricks query was aborted before it started.');
     }
-    const operation = await this.session.executeStatement(sql, {
-      runAsync: true,
-    });
+    // The SDK always submits asynchronously and polls in fetchAll (the runAsync
+    // option is deprecated and ignored), so no execute options are needed.
+    const operation = await this.session.executeStatement(sql);
     const timeoutMs = this.resolvedTimeoutMs();
     let timer: ReturnType<typeof setTimeout> | undefined;
     let onAbort: (() => void) | undefined;
@@ -273,7 +273,16 @@ export class DatabricksConnection
     // erroring after we cancelled) so it is not an unhandled rejection.
     void fetchAll.catch(() => {});
     try {
-      return await Promise.race([fetchAll, guard]);
+      const rows = await Promise.race([fetchAll, guard]);
+      // The operation completed, so closing it is a quick round-trip.
+      await operation.close().catch(() => {});
+      return rows;
+    } catch (e) {
+      // We may be here because the connection is unresponsive (that is why the
+      // query timed out or was aborted); do not block the caller's error on a
+      // close() that could hang on that same connection.
+      void operation.close().catch(() => {});
+      throw e;
     } finally {
       if (timer !== undefined) {
         clearTimeout(timer);
@@ -281,7 +290,6 @@ export class DatabricksConnection
       if (onAbort !== undefined) {
         abortSignal?.removeEventListener('abort', onAbort);
       }
-      await operation.close().catch(() => {});
     }
   }
 

--- a/packages/malloy-db-databricks/src/databricks_connection.ts
+++ b/packages/malloy-db-databricks/src/databricks_connection.ts
@@ -120,7 +120,17 @@ export interface DatabricksConfiguration {
   defaultCatalog?: string;
   defaultSchema?: string;
   setupSQL?: string;
+  // Client-side query timeout in ms; the operation is cancelled if it runs
+  // longer. Defaults to TIMEOUT_MS (10 min); a non-positive value falls back
+  // to that default.
+  timeoutMs?: number;
 }
+
+/**
+ * Default query timeout, 10 minutes. Bounds how long the client waits for a
+ * statement before cancelling it.
+ */
+const TIMEOUT_MS = 1000 * 60 * 10;
 
 export class DatabricksConnection
   extends BaseConnection
@@ -203,15 +213,76 @@ export class DatabricksConnection
     }
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private async executeRaw(sql: string): Promise<any[]> {
+  /**
+   * The effective query timeout in milliseconds. A configured value that is
+   * unset, non-numeric, zero, or negative falls back to TIMEOUT_MS; only a
+   * positive number overrides the default.
+   */
+  private resolvedTimeoutMs(): number {
+    const configured = Number(this.config.timeoutMs);
+    return configured > 0 ? configured : TIMEOUT_MS;
+  }
+
+  private async executeRaw(
+    sql: string,
+    abortSignal?: AbortSignal
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ): Promise<any[]> {
     await this.ensureConnected();
+    if (abortSignal?.aborted) {
+      throw new Error('Databricks query was aborted before it started.');
+    }
     const operation = await this.session.executeStatement(sql, {
       runAsync: true,
     });
-    const result = await operation.fetchAll();
-    await operation.close();
-    return result;
+    const timeoutMs = this.resolvedTimeoutMs();
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    let onAbort: (() => void) | undefined;
+
+    // Bound the wait on the client side and cancel the operation (which cancels
+    // the statement server-side too) if it runs past timeoutMs or the caller
+    // aborts. The SDK's server-side queryTimeout is ignored on SQL Warehouses,
+    // so a client-side cancel is the portable mechanism.
+    const guard = new Promise<never>((_resolve, reject) => {
+      timer = setTimeout(() => {
+        void operation.cancel().catch(() => {});
+        reject(
+          new Error(
+            `Databricks query did not complete within the configured timeout of ${timeoutMs}ms. ` +
+              "Raise the connection's timeoutMs to allow longer-running queries."
+          )
+        );
+      }, timeoutMs);
+      if (abortSignal) {
+        onAbort = () => {
+          void operation.cancel().catch(() => {});
+          reject(
+            new Error('Databricks query was aborted before it completed.')
+          );
+        };
+        if (abortSignal.aborted) {
+          onAbort();
+        } else {
+          abortSignal.addEventListener('abort', onAbort, {once: true});
+        }
+      }
+    });
+
+    const fetchAll = operation.fetchAll();
+    // Handle a late rejection from the losing side of the race (fetchAll
+    // erroring after we cancelled) so it is not an unhandled rejection.
+    void fetchAll.catch(() => {});
+    try {
+      return await Promise.race([fetchAll, guard]);
+    } finally {
+      if (timer !== undefined) {
+        clearTimeout(timer);
+      }
+      if (onAbort !== undefined) {
+        abortSignal?.removeEventListener('abort', onAbort);
+      }
+      await operation.close().catch(() => {});
+    }
   }
 
   async manifestTemporaryTable(sqlCommand: string): Promise<string> {
@@ -228,7 +299,8 @@ export class DatabricksConnection
 
   async runSQL(sql: string, options?: RunSQLOptions): Promise<MalloyQueryData> {
     const result = await this.runRawSQL(
-      this.sqlWithQueryMetadata(sql, options?.queryMetadata)
+      this.sqlWithQueryMetadata(sql, options?.queryMetadata),
+      options?.abortSignal
     );
     if (options?.rowLimit && result.rows.length > options.rowLimit) {
       return {
@@ -338,9 +410,12 @@ export class DatabricksConnection
     }
   }
 
-  async runRawSQL(sql: string): Promise<MalloyQueryData> {
+  async runRawSQL(
+    sql: string,
+    abortSignal?: AbortSignal
+  ): Promise<MalloyQueryData> {
     try {
-      const rows = (await this.executeRaw(sql)) as QueryData;
+      const rows = (await this.executeRaw(sql, abortSignal)) as QueryData;
       return {rows, totalRows: rows.length};
     } catch (e) {
       throw new Error(`Databricks SQL error: ${e.message}`);

--- a/packages/malloy-db-databricks/src/databricks_connection.unit.spec.ts
+++ b/packages/malloy-db-databricks/src/databricks_connection.unit.spec.ts
@@ -1,0 +1,119 @@
+/*
+ * Copyright Contributors to the Malloy project
+ * SPDX-License-Identifier: MIT
+ */
+
+import {DatabricksConnection} from './databricks_connection';
+
+// A never-settling fetch, used to force the timeout/abort path.
+const never = () => new Promise<unknown[]>(() => {});
+
+// Flush enough microtasks that runRawSQL reaches its Promise.race (so the
+// timeout timer is registered) before the test advances fake time.
+const flush = async () => {
+  for (let i = 0; i < 5; i++) {
+    await Promise.resolve();
+  }
+};
+
+// A DatabricksConnection with a stubbed session/operation so runSQL drives the
+// real executeRaw timeout+cancel path without a live warehouse. A pre-set
+// session short-circuits ensureConnected, so doConnect never runs.
+function hermeticConnection(opts: {
+  timeoutMs?: number;
+  fetchAll: () => Promise<unknown[]>;
+}) {
+  const cancel = jest.fn(async () => ({}));
+  const close = jest.fn(async () => {});
+  const operation = {fetchAll: opts.fetchAll, cancel, close};
+  const executeStatement = jest.fn(async () => operation);
+  const conn = new DatabricksConnection('hermetic', {
+    host: '',
+    path: '',
+    timeoutMs: opts.timeoutMs,
+  });
+  (conn as unknown as {session: unknown}).session = {executeStatement};
+  return {conn, cancel, close, executeStatement};
+}
+
+describe('DatabricksConnection timeout + abort', () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => jest.useRealTimers());
+
+  it('cancels the operation and throws when the query exceeds timeoutMs', async () => {
+    const {conn, cancel} = hermeticConnection({
+      timeoutMs: 1000,
+      fetchAll: never,
+    });
+    const promise = conn.runRawSQL('SELECT 1');
+    promise.catch(() => {});
+    await flush();
+    expect(cancel).not.toHaveBeenCalled();
+    jest.advanceTimersByTime(1000);
+    await expect(promise).rejects.toThrow(
+      /did not complete within the configured timeout of 1000ms/
+    );
+    expect(cancel).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    ['zero', 0],
+    ['negative', -5],
+    ['unset', undefined],
+  ])(
+    'resolves a %s timeoutMs to the default (600000ms)',
+    async (_label, timeoutMs) => {
+      const {conn, cancel} = hermeticConnection({timeoutMs, fetchAll: never});
+      const promise = conn.runRawSQL('SELECT 1');
+      promise.catch(() => {});
+      await flush();
+      jest.advanceTimersByTime(599_999);
+      await flush();
+      expect(cancel).not.toHaveBeenCalled();
+      jest.advanceTimersByTime(1);
+      await expect(promise).rejects.toThrow(
+        /did not complete within the configured timeout of 600000ms/
+      );
+      expect(cancel).toHaveBeenCalledTimes(1);
+    }
+  );
+
+  it('does not cancel a query that completes within the timeout', async () => {
+    const {conn, cancel} = hermeticConnection({
+      timeoutMs: 1000,
+      fetchAll: async () => [{n: 1}],
+    });
+    const data = await conn.runRawSQL('SELECT 1');
+    expect(data.rows).toEqual([{n: 1}]);
+    expect(data.totalRows).toBe(1);
+    expect(cancel).not.toHaveBeenCalled();
+  });
+
+  it('cancels the operation when the abort signal fires', async () => {
+    const ac = new AbortController();
+    const {conn, cancel} = hermeticConnection({
+      timeoutMs: 600_000,
+      fetchAll: never,
+    });
+    const promise = conn.runSQL('SELECT 1', {abortSignal: ac.signal});
+    promise.catch(() => {});
+    await flush();
+    ac.abort();
+    await expect(promise).rejects.toThrow(/aborted/);
+    expect(cancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws without executing when the signal is already aborted', async () => {
+    const ac = new AbortController();
+    ac.abort();
+    const {conn, executeStatement, cancel} = hermeticConnection({
+      timeoutMs: 600_000,
+      fetchAll: never,
+    });
+    await expect(
+      conn.runSQL('SELECT 1', {abortSignal: ac.signal})
+    ).rejects.toThrow(/aborted/);
+    expect(executeStatement).not.toHaveBeenCalled();
+    expect(cancel).not.toHaveBeenCalled();
+  });
+});

--- a/packages/malloy-db-databricks/src/databricks_connection.unit.spec.ts
+++ b/packages/malloy-db-databricks/src/databricks_connection.unit.spec.ts
@@ -56,6 +56,24 @@ describe('DatabricksConnection timeout + abort', () => {
     expect(cancel).toHaveBeenCalledTimes(1);
   });
 
+  it('times out even if closing the operation hangs', async () => {
+    // close() over an unresponsive connection can hang; the cleanup must not be
+    // awaited on the failure path, or it would swallow the timeout.
+    const {conn, cancel, close} = hermeticConnection({
+      timeoutMs: 1000,
+      fetchAll: never,
+    });
+    close.mockImplementation(() => new Promise<void>(() => {})); // never resolves
+    const promise = conn.runRawSQL('SELECT 1');
+    promise.catch(() => {});
+    await flush();
+    jest.advanceTimersByTime(1000);
+    await expect(promise).rejects.toThrow(
+      /did not complete within the configured timeout of 1000ms/
+    );
+    expect(cancel).toHaveBeenCalledTimes(1);
+  });
+
   it.each([
     ['zero', 0],
     ['negative', -5],

--- a/packages/malloy-db-databricks/src/databricks_connection.unit.spec.ts
+++ b/packages/malloy-db-databricks/src/databricks_connection.unit.spec.ts
@@ -74,28 +74,6 @@ describe('DatabricksConnection timeout + abort', () => {
     expect(cancel).toHaveBeenCalledTimes(1);
   });
 
-  it.each([
-    ['zero', 0],
-    ['negative', -5],
-    ['unset', undefined],
-  ])(
-    'resolves a %s timeoutMs to the default (600000ms)',
-    async (_label, timeoutMs) => {
-      const {conn, cancel} = hermeticConnection({timeoutMs, fetchAll: never});
-      const promise = conn.runRawSQL('SELECT 1');
-      promise.catch(() => {});
-      await flush();
-      jest.advanceTimersByTime(599_999);
-      await flush();
-      expect(cancel).not.toHaveBeenCalled();
-      jest.advanceTimersByTime(1);
-      await expect(promise).rejects.toThrow(
-        /did not complete within the configured timeout of 600000ms/
-      );
-      expect(cancel).toHaveBeenCalledTimes(1);
-    }
-  );
-
   it('does not cancel a query that completes within the timeout', async () => {
     const {conn, cancel} = hermeticConnection({
       timeoutMs: 1000,

--- a/packages/malloy-db-databricks/src/index.ts
+++ b/packages/malloy-db-databricks/src/index.ts
@@ -37,6 +37,12 @@ registerConnectionType('databricks', {
           : undefined,
       setupSQL:
         typeof config['setupSQL'] === 'string' ? config['setupSQL'] : undefined,
+      timeoutMs:
+        typeof config['timeoutMs'] === 'number'
+          ? config['timeoutMs']
+          : typeof config['timeoutMs'] === 'string'
+            ? parseInt(config['timeoutMs'], 10)
+            : undefined,
     });
   },
   properties: [
@@ -89,6 +95,16 @@ registerConnectionType('databricks', {
       optional: true,
       advanced: true,
       description: 'SQL statements to run when the connection is established',
+    },
+    {
+      name: 'timeoutMs',
+      displayName: 'Timeout (ms)',
+      type: 'number',
+      optional: true,
+      advanced: true,
+      default: 600000,
+      description:
+        'Client-side query timeout in ms; the query is cancelled if it runs longer. Defaults to 600000 (10 min).',
     },
   ],
 });


### PR DESCRIPTION
## Summary

The Databricks connector had no query timeout: every statement was run and its
results fetched with no client-side bound and nothing to cancel a runaway query.
This adds a `timeoutMs` connection setting that bounds the wait and cancels the
operation when it is exceeded, bringing Databricks in line with the BigQuery and
Snowflake connectors. The same mechanism also honors Malloy's `abortSignal`, so
a cancelled query cancels the Databricks operation (it was previously ignored).

## Approach

All statements run through a single `executeRaw` chokepoint
(`session.executeStatement(...)` then `operation.fetchAll()`), so the wait is
bounded there:

- Race `fetchAll()` against a `timeoutMs` deadline and the caller's
  `abortSignal`. On either, best-effort `operation.cancel()` (which cancels the
  statement server-side too) and reject with an actionable error. The operation
  is closed without being awaited on the failure path, so a `close()` that hangs
  on the same unresponsive connection cannot swallow the timeout.
- Client-side cancel rather than the SDK's server-side `queryTimeout`: per the
  `@databricks/sql` docs, `queryTimeout` is "effective only with Compute
  clusters" and is ignored on SQL Warehouses, which is what this connector
  targets (the `path` is a SQL warehouse HTTP path). `operation.cancel()` works
  for both and bounds the actual client wait.
- `timeoutMs` resolves to a positive number or the default (10 min): unset,
  non-numeric, zero, or negative fall back, matching the BigQuery and Snowflake
  connectors.
- `abortSignal` is threaded `runSQL` -> `runRawSQL` -> `executeRaw`; an
  already-aborted signal fails fast before a statement is dispatched.

## Scope

Databricks-only. This is the third of the timeout follow-ups from
malloydata/malloy#3010 (BigQuery) and malloydata/malloy#3022 (Snowflake). The
server-side `STATEMENT_TIMEOUT` (the SQL Warehouse equivalent of a server-side
cap) is intentionally not set here; the client-side cancel is portable across
warehouses and clusters and already cancels the server statement.

## Tests

- `databricks_connection.unit.spec.ts` stubs the session/operation and uses fake
  timers to exercise behavior that reading the code cannot verify: a query past
  `timeoutMs` is cancelled with the actionable error; the timeout still fires
  even if closing the operation hangs; a query that finishes in time is not
  cancelled; an abort mid-flight cancels the operation; and an already-aborted
  signal throws before executing.
- The existing live integration spec (`databricks_connection.spec.ts`,
  env-gated) is unaffected.

`tsc`, `eslint`, and the unit spec pass.

## Checklist

- [x] Companion docs update: malloydata/malloydata.github.io#338 adds a
      Databricks `timeoutMs` row to `config.malloynb`.
