### PR TITLE
fix(simple_builder): create the flights table with OR REPLACE

### DIFF
--- a/scripts/simple_builder/build.ts
+++ b/scripts/simple_builder/build.ts
@@ -157,8 +157,12 @@ async function runBuild(
 ): Promise<void> {
   const {modelFile, manifestFile, sqlFile, logDir} = opts;
 
+  // OR REPLACE because a build may not be the first thing to touch this
+  // database: two DuckDB connections built with the same options share one
+  // instance, `:memory:` included, so a second build -- or a caller which
+  // made its own connection the same way -- finds the table already there.
   await connection.runSQL(
-    "CREATE TABLE flights AS SELECT * FROM parquet_scan('test/data/malloytest-parquet/flights.parquet')"
+    "CREATE OR REPLACE TABLE flights AS SELECT * FROM parquet_scan('test/data/malloytest-parquet/flights.parquet')"
   );
 
   // Convert with pathToFileURL/fileURLToPath, never by concatenation: a path

--- a/scripts/simple_builder/simple_builder.spec.ts
+++ b/scripts/simple_builder/simple_builder.spec.ts
@@ -381,7 +381,7 @@ test('runtime queries with and without manifest', async () => {
     // The sample writes a SQL script rather than executing it, so materialize
     // its output here to query against.
     await connection.runSQL(
-      `CREATE TABLE flights AS SELECT * FROM parquet_scan('${FLIGHTS_PARQUET}')`
+      `CREATE OR REPLACE TABLE flights AS SELECT * FROM parquet_scan('${FLIGHTS_PARQUET}')`
     );
     const buildSql = await readFile(SQL_FILE, 'utf-8');
     for (const stmt of buildSql.split(';\n').filter(s => s.trim())) {


### PR DESCRIPTION
Two DuckDB connections built with the same options share one instance,
`:memory:` included. The simple_builder sample and its test each make a
connection that way and each create a `flights` table, so whichever runs
second can find the table already there. Creating it with `OR REPLACE` also
lets the sample be run twice.
