### PR TITLE
fix(lang): one _db2_ test connection, not two

### DIFF
--- a/packages/malloy/src/lang/test/test-translator.ts
+++ b/packages/malloy/src/lang/test/test-translator.ts
@@ -189,9 +189,10 @@ export const aTableDef: TableSourceDef = {
 };
 
 /**
- * A second connection speaking the same dialect as `_db_`. This makes a
- * cross-connection reference which is not also a cross-dialect reference
- * writable in a test, isolating the connection check from the dialect check.
+ * A second connection speaking the same dialect as `_db_`. Two sources can
+ * then compile to identical SQL on different connections, which isolates the
+ * connection check from the dialect check, and is exactly the case where
+ * persistence could forget that a build target is a table on a connection.
  */
 export const db2TableDef: TableSourceDef = {
   ...aTableDef,
@@ -225,21 +226,11 @@ export const pgTableDef: SourceDef = {
  * some mocked schema definitions.
  */
 
-// A second connection of the same dialect as `_db_`, so that two sources can
-// compile to identical SQL on different connections. Persistence needs it: a
-// build target is a table on a connection, and identical SQL is exactly the
-// case where that could be forgotten.
-export const db2TableDef: TableSourceDef = {
-  ...aTableDef,
-  connection: '_db2_',
-};
-
 export const mockSchema: TableSourceDef[] = [
   aTableDef,
   db2TableDef,
   bqTableDef,
   pgTableDef,
-  db2TableDef,
   {
     type: 'table',
     name: 'carriers',
@@ -442,7 +433,6 @@ export class TestTranslator extends MalloyTranslator {
       _db2_: {type: 'connection', name: '_db2_'},
       _bq_: {type: 'connection', name: '_bq_'},
       _pg_: {type: 'connection', name: '_pg_'},
-      _db2_: {type: 'connection', name: '_db2_'},
       a: {...aTableDef, primaryKey: 'astr', name: 'a'},
       b: {...aTableDef, primaryKey: 'astr', name: 'b'},
       bq_a: {...bqTableDef, primaryKey: 'astr', name: 'bq_a'},
@@ -515,7 +505,6 @@ export class TestTranslator extends MalloyTranslator {
     this.connectionDialectZone.define('_db2_', TEST_DIALECT);
     this.connectionDialectZone.define('_bq_', 'standardsql');
     this.connectionDialectZone.define('_pg_', 'postgres');
-    this.connectionDialectZone.define('_db2_', TEST_DIALECT);
     for (const flag of options.compilerFlags ?? []) {
       this.compilerFlagSrc.push(`##! ${flag}\n`);
     }


### PR DESCRIPTION
`main` does not compile. #3032 and #3029 each added a second test
connection `_db2_` to `test-translator.ts`, at different points in the
file, so both merged cleanly and left two identical `db2TableDef`
declarations, two `_db2_` entries in `internalModel.contents`, and a
duplicate in `mockSchema` and in the dialect zone.

The surviving comment says what both connections were for, since a
future reader will otherwise add a third.
