### PR TITLE
Bump @duckdb/node-api to 1.5.5-r.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3806,37 +3806,37 @@
       "license": "MIT"
     },
     "node_modules/@duckdb/node-api": {
-      "version": "1.5.3-r.2",
-      "resolved": "https://registry.npmjs.org/@duckdb/node-api/-/node-api-1.5.3-r.2.tgz",
-      "integrity": "sha512-xjn6W9n8Sn9PaYmzrB6ayidNLQHpqNKdaRz4gx3yVoLUkrsIebQC1M1jV3BR8KqXj5P0RX4wLs8Tg/fK2ZQmNA==",
+      "version": "1.5.5-r.4",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-api/-/node-api-1.5.5-r.4.tgz",
+      "integrity": "sha512-8v0CZNo7aM6GQCNUHERGTrZWIfss8xKzZPF3ACNhPdMMrt7UjkNI5nRQ9FTFO7Yx8ghxYxVpdotmBBMQ5vXUOA==",
       "license": "MIT",
       "dependencies": {
-        "@duckdb/node-bindings": "1.5.3-r.2"
+        "@duckdb/node-bindings": "1.5.5-r.4"
       }
     },
     "node_modules/@duckdb/node-bindings": {
-      "version": "1.5.3-r.2",
-      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings/-/node-bindings-1.5.3-r.2.tgz",
-      "integrity": "sha512-bveKx+LfqRazcH8/MuCkMsbLVQKqr/EyuYRzaKpBcEvRYenw/TqK5+1N4fkMyoTv8ZukA4UYobymNYHqJUpdOA==",
+      "version": "1.5.5-r.4",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings/-/node-bindings-1.5.5-r.4.tgz",
+      "integrity": "sha512-n+4hEfjp4vny3BuWn5p1Gh5CzHaPRxoI8TzTytxL1GMlIKKrXcg/o6sSAjrsROUXGAM4WQCiWPLKnPsjJJSggg==",
       "license": "MIT",
       "dependencies": {
         "detect-libc": "^2.1.2"
       },
       "optionalDependencies": {
-        "@duckdb/node-bindings-darwin-arm64": "1.5.3-r.2",
-        "@duckdb/node-bindings-darwin-x64": "1.5.3-r.2",
-        "@duckdb/node-bindings-linux-arm64": "1.5.3-r.2",
-        "@duckdb/node-bindings-linux-arm64-musl": "1.5.3-r.2",
-        "@duckdb/node-bindings-linux-x64": "1.5.3-r.2",
-        "@duckdb/node-bindings-linux-x64-musl": "1.5.3-r.2",
-        "@duckdb/node-bindings-win32-arm64": "1.5.3-r.2",
-        "@duckdb/node-bindings-win32-x64": "1.5.3-r.2"
+        "@duckdb/node-bindings-darwin-arm64": "1.5.5-r.4",
+        "@duckdb/node-bindings-darwin-x64": "1.5.5-r.4",
+        "@duckdb/node-bindings-linux-arm64": "1.5.5-r.4",
+        "@duckdb/node-bindings-linux-arm64-musl": "1.5.5-r.4",
+        "@duckdb/node-bindings-linux-x64": "1.5.5-r.4",
+        "@duckdb/node-bindings-linux-x64-musl": "1.5.5-r.4",
+        "@duckdb/node-bindings-win32-arm64": "1.5.5-r.4",
+        "@duckdb/node-bindings-win32-x64": "1.5.5-r.4"
       }
     },
     "node_modules/@duckdb/node-bindings-darwin-arm64": {
-      "version": "1.5.3-r.2",
-      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-darwin-arm64/-/node-bindings-darwin-arm64-1.5.3-r.2.tgz",
-      "integrity": "sha512-5RQ3+fUZn+OvIJEfa1i/KngJHo5d6ilpjunsHfHdQy5F7r5pewDkPxRQno4xInPqGukMibKDoMdpzCKnymFJtw==",
+      "version": "1.5.5-r.4",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-darwin-arm64/-/node-bindings-darwin-arm64-1.5.5-r.4.tgz",
+      "integrity": "sha512-4OdO3pkoJzAZDnZ2iyehi67XL4+WqHPCGYWbyAsYyhGJS+WscGrAnFhMhHudMM2XF8pIEM2tuOKMmwWnTNN2wQ==",
       "cpu": [
         "arm64"
       ],
@@ -3847,9 +3847,9 @@
       ]
     },
     "node_modules/@duckdb/node-bindings-darwin-x64": {
-      "version": "1.5.3-r.2",
-      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-darwin-x64/-/node-bindings-darwin-x64-1.5.3-r.2.tgz",
-      "integrity": "sha512-E7Pc+do8kj82+hHXkp4mxfw9Kqfe6V5FUT2EMoRsacbvhuoM1AeZxOj9jknh23IoNxPtn3S2tKnD1krL0v0I7A==",
+      "version": "1.5.5-r.4",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-darwin-x64/-/node-bindings-darwin-x64-1.5.5-r.4.tgz",
+      "integrity": "sha512-WHg3E+TupdujG31LGujMMcmtPIdW6rqRHeihlKgJR8EMetHycoYkwYxRud0niitJvS+uV0du/6pdemzs3HG9GQ==",
       "cpu": [
         "x64"
       ],
@@ -3860,9 +3860,9 @@
       ]
     },
     "node_modules/@duckdb/node-bindings-linux-arm64": {
-      "version": "1.5.3-r.2",
-      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-linux-arm64/-/node-bindings-linux-arm64-1.5.3-r.2.tgz",
-      "integrity": "sha512-R8RKkNgVL4kHodot1krfbB4XQ+bA90LPsnN1Lm5J03QJlFgNlezul0H2U1UuvEaKUBPWDQj8g9Yt4hhKKKX0zw==",
+      "version": "1.5.5-r.4",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-linux-arm64/-/node-bindings-linux-arm64-1.5.5-r.4.tgz",
+      "integrity": "sha512-VIeHMpYAKpGiWZ4QYsOhODAHDEcXcn089aKty0MFsMEKaEfRJWixKwnwXy/ba2/wwFmnPiSFhKNqygj2BrQbqw==",
       "cpu": [
         "arm64"
       ],
@@ -3876,9 +3876,9 @@
       ]
     },
     "node_modules/@duckdb/node-bindings-linux-arm64-musl": {
-      "version": "1.5.3-r.2",
-      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-linux-arm64-musl/-/node-bindings-linux-arm64-musl-1.5.3-r.2.tgz",
-      "integrity": "sha512-P9lTyML8M6pS300fJbnMNFSBhojC0xJcvGvuR44xd//NqaHk9EwcPIs4+r2ek4LP5uugm7konVZ3VMr0BOKujw==",
+      "version": "1.5.5-r.4",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-linux-arm64-musl/-/node-bindings-linux-arm64-musl-1.5.5-r.4.tgz",
+      "integrity": "sha512-Tswnf+/XWpOcFJNUUu1fkFIX/su4tMcnNz0ZV0Nru3/CkJKIMwBh+VL4SM9YV4zPK90GC4Lm8gzafjc1qDmfyQ==",
       "cpu": [
         "arm64"
       ],
@@ -3892,9 +3892,9 @@
       ]
     },
     "node_modules/@duckdb/node-bindings-linux-x64": {
-      "version": "1.5.3-r.2",
-      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-linux-x64/-/node-bindings-linux-x64-1.5.3-r.2.tgz",
-      "integrity": "sha512-6vYTXgIqnWEjlNZX/AveTU7EzicuGATOdy8ncUbBIDxoC9cIrjoIqQc37COKEyT5IHjLIt25MllJtags96vvxA==",
+      "version": "1.5.5-r.4",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-linux-x64/-/node-bindings-linux-x64-1.5.5-r.4.tgz",
+      "integrity": "sha512-EY+CL/4h8MQZd9MxTBq+98m3U9osmvHBwhE9b5fMWQGt2I6p1j8fvX0SXiwy9KBfQIbjVUOf5XvGdXncI54KSg==",
       "cpu": [
         "x64"
       ],
@@ -3908,9 +3908,9 @@
       ]
     },
     "node_modules/@duckdb/node-bindings-linux-x64-musl": {
-      "version": "1.5.3-r.2",
-      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-linux-x64-musl/-/node-bindings-linux-x64-musl-1.5.3-r.2.tgz",
-      "integrity": "sha512-V9kPvbMoJENvPo82LOzfhZ+KilFe1K8TKrksFmHe1Sy2pduNUVnxC+T4OQuOu4sqyCCVqVYRXe3pqTzKa/hCYg==",
+      "version": "1.5.5-r.4",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-linux-x64-musl/-/node-bindings-linux-x64-musl-1.5.5-r.4.tgz",
+      "integrity": "sha512-h0ixrgGHtHh+C/Fu1eAL9hX4iCf8yuyJN6Y24Gh8axXXP8UuSh0rQRAQUQTYarQ8pm2qSG/67ZYjyYYydD+J/w==",
       "cpu": [
         "x64"
       ],
@@ -3924,9 +3924,9 @@
       ]
     },
     "node_modules/@duckdb/node-bindings-win32-arm64": {
-      "version": "1.5.3-r.2",
-      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-win32-arm64/-/node-bindings-win32-arm64-1.5.3-r.2.tgz",
-      "integrity": "sha512-CjKqTI0WfRxwLgz8FV4fej/wkijPQnRgDk93aQlWQ+/+EwB9EnwQW3yfUy4Rs8cFjQkxkwlL5azoSR973l8U6w==",
+      "version": "1.5.5-r.4",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-win32-arm64/-/node-bindings-win32-arm64-1.5.5-r.4.tgz",
+      "integrity": "sha512-uorAnySIMwWkRDuUhM1yTDxWIislnX8mndhFIw6r4VKhVW61HEOOMX5oAgkSQFII4RNWpC5PCcUAEhSATgNvVQ==",
       "cpu": [
         "arm64"
       ],
@@ -3937,9 +3937,9 @@
       ]
     },
     "node_modules/@duckdb/node-bindings-win32-x64": {
-      "version": "1.5.3-r.2",
-      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-win32-x64/-/node-bindings-win32-x64-1.5.3-r.2.tgz",
-      "integrity": "sha512-/oxN8ZFf2LxhForL+Uc+lEqnzHNvhSEsu3blnk3zu73rKTbD/WvPYIecrenb1ysApRK9ElGxitIYFx8PBuVKxg==",
+      "version": "1.5.5-r.4",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-win32-x64/-/node-bindings-win32-x64-1.5.5-r.4.tgz",
+      "integrity": "sha512-X9XGcWQ10P3mvUIaMXXk2bi94Cow7b/ziTPMKxJ0U8U3wQPxsLzEUP7D7C/KrBWINl5am2k+5SkDVyA/THUgPg==",
       "cpu": [
         "x64"
       ],
@@ -30527,7 +30527,7 @@
       "license": "MIT",
       "dependencies": {
         "@duckdb/duckdb-wasm": "1.33.1-dev45.0",
-        "@duckdb/node-api": "1.5.3-r.2",
+        "@duckdb/node-api": "1.5.5-r.4",
         "@malloydata/malloy": "0.0.430",
         "@motherduck/wasm-client": "0.6.6",
         "apache-arrow": "^17.0.0",

--- a/packages/malloy-db-duckdb/package.json
+++ b/packages/malloy-db-duckdb/package.json
@@ -60,7 +60,7 @@
   },
   "dependencies": {
     "@duckdb/duckdb-wasm": "1.33.1-dev45.0",
-    "@duckdb/node-api": "1.5.3-r.2",
+    "@duckdb/node-api": "1.5.5-r.4",
     "@malloydata/malloy": "0.0.430",
     "@motherduck/wasm-client": "0.6.6",
     "apache-arrow": "^17.0.0",


### PR DESCRIPTION
Moves the DuckDB engine in `malloy-db-duckdb` from 1.5.3 to 1.5.5 (patch-level), and the node bindings from 1.5.3-r.2 to 1.5.5-r.4.

## Why

- DuckDB 1.5.4/1.5.5 are fix-only patch releases: several out-of-bounds-read security fixes, storage/checkpoint correctness fixes (`DROP COLUMN` metadata bookkeeping, row-group stats), and concurrency fixes (`TemporaryMemoryManager` deadlock, concurrent `ALTER`+`INSERT` crash). Release notes: [v1.5.4](https://github.com/duckdb/duckdb/releases/tag/v1.5.4), [v1.5.5](https://github.com/duckdb/duckdb/releases/tag/v1.5.5).
- Community extensions are built per DuckDB version, and the v1.5.3 builds are frozen at older extension code. Concretely, the `gcs` community extension's v1.5.3 build predates its `DirectoryExists` implementation, which DuckLake needs for `DATA_PATH` on GCS — so DuckLake-on-GCS via that extension only works on a 1.5.5 engine.
- The bindings delta (r.2 → r.4) is additive: engine tracking, list child-vector capacity fix, clearer MAP errors, N-API reference-lifetime fixes, and a new table-function API. No breaking TS API changes.

## Verification

- `npm run build`, `npm run typecheck`, and the full `npm run test-duckdb` suite (118 suites / 3,994 tests across malloy-core, render, db-duckdb, db-duckdb-core, simple-builder) pass unchanged.
- A downstream consumer (malloy-publisher) was built and tested against these exact packages via a local overlay: typecheck, unit suites, DuckDB extension bake (httpfs, aws, azure, postgres, ducklake, excel, bigquery, snowflake all load on 1.5.5), and its end-to-end scenario harness (real Postgres + DuckLake + booted server) — all green.

The lockfile diff touches only the `@duckdb/node-api` / `@duckdb/node-bindings` family.

🤖 Generated with [Claude Code](https://claude.com/claude-code)