### PR TITLE
fix(persist): a persisted sql_select reads its built table

### DIFF
--- a/packages/malloy/src/api/foundation/build-targets.spec.ts
+++ b/packages/malloy/src/api/foundation/build-targets.spec.ts
@@ -31,7 +31,7 @@ function modelOf(src: string): Model {
 function connectionsOf(src: string): ConnectionBuild[] {
   const model = modelOf(src);
   const log: LogMessage[] = [];
-  return mkBuildTargets(resolvePersistWalk(model, log), DIGESTS);
+  return mkBuildTargets(resolvePersistWalk(model, log), DIGESTS, {});
 }
 
 function connectionNamed(
@@ -295,7 +295,7 @@ describe('what a target carries', () => {
     const model = modelOf(`${ROLLUP}\nrun: rollup -> { select: * }`);
     const walk = resolvePersistWalk(model, []);
 
-    expect(() => mkBuildTargets(walk, {})).toThrow('_db_');
+    expect(() => mkBuildTargets(walk, {}, {})).toThrow('_db_');
   });
 
   test('a model with no persist sources has no targets', () => {

--- a/packages/malloy/src/api/foundation/build_targets.ts
+++ b/packages/malloy/src/api/foundation/build_targets.ts
@@ -7,7 +7,7 @@ import type {SourceID} from '../../model';
 import type {LogMessage} from '../../lang';
 import type {PersistNode} from '../../model/persist_utils';
 import type {Model, PersistSource} from './core';
-import type {BuildTarget, ConnectionBuild} from './types';
+import type {BuildTarget, CompileQueryOptions, ConnectionBuild} from './types';
 
 /**
  * Read a key this function's own construction guarantees is present.
@@ -111,10 +111,15 @@ function addUnique(into: string[], seen: Set<string>, keys: string[]): void {
  *
  * @param walk A resolved walk from {@link resolvePersistWalk}, in order
  * @param connectionDigests One digest per connection named by a persist source
+ * @param compileOptions What the BuildID's SQL is compiled under. The compiler
+ *   recomputes the same key at serve time from `buildIdOptions()`, so anything
+ *   that changes the SQL — a `virtualMap` above all — has to be here too, or
+ *   the table is built under a key nothing looks up.
  */
 export function mkBuildTargets(
   walk: ResolvedNode[],
-  connectionDigests: Record<string, string>
+  connectionDigests: Record<string, string>,
+  compileOptions: CompileQueryOptions
 ): ConnectionBuild[] {
   const targets = new Map<string, PartialTarget>();
   // What each source hands to whoever referenced it: its own target if it is
@@ -145,7 +150,7 @@ export function mkBuildTargets(
       );
     }
 
-    const sql = source.getSQL();
+    const sql = source.getSQL(compileOptions);
     const buildId = source.makeBuildId(digest, sql);
     const key = targetKey(connectionName, buildId);
 

--- a/packages/malloy/src/api/foundation/build_targets.ts
+++ b/packages/malloy/src/api/foundation/build_targets.ts
@@ -3,11 +3,11 @@
  * SPDX-License-Identifier: MIT
  */
 
-import type {SourceID} from '../../model';
+import type {BuildIdOptions, SourceID} from '../../model';
 import type {LogMessage} from '../../lang';
 import type {PersistNode} from '../../model/persist_utils';
 import type {Model, PersistSource} from './core';
-import type {BuildTarget, CompileQueryOptions, ConnectionBuild} from './types';
+import type {BuildTarget, ConnectionBuild} from './types';
 
 /**
  * Read a key this function's own construction guarantees is present.
@@ -111,15 +111,15 @@ function addUnique(into: string[], seen: Set<string>, keys: string[]): void {
  *
  * @param walk A resolved walk from {@link resolvePersistWalk}, in order
  * @param connectionDigests One digest per connection named by a persist source
- * @param compileOptions What the BuildID's SQL is compiled under. The compiler
- *   recomputes the same key at serve time from `buildIdOptions()`, so anything
- *   that changes the SQL — a `virtualMap` above all — has to be here too, or
- *   the table is built under a key nothing looks up.
+ * @param buildIdOpts What the BuildID's SQL is compiled under. The compiler
+ *   recomputes the same key at serve time through `buildIdOptions()`; supply a
+ *   different `virtualMap` here and the table is built under a key nothing
+ *   looks up.
  */
 export function mkBuildTargets(
   walk: ResolvedNode[],
   connectionDigests: Record<string, string>,
-  compileOptions: CompileQueryOptions
+  buildIdOpts: BuildIdOptions
 ): ConnectionBuild[] {
   const targets = new Map<string, PartialTarget>();
   // What each source hands to whoever referenced it: its own target if it is
@@ -150,7 +150,7 @@ export function mkBuildTargets(
       );
     }
 
-    const sql = source.getSQL(compileOptions);
+    const sql = source.getSQL(buildIdOpts);
     const buildId = source.makeBuildId(digest, sql);
     const key = targetKey(connectionName, buildId);
 

--- a/packages/malloy/src/api/foundation/core.ts
+++ b/packages/malloy/src/api/foundation/core.ts
@@ -1813,7 +1813,11 @@ export class PersistSource implements Taggable {
    * For sql_select sources, returns the SQL string (with segment expansion).
    * For query_source sources, compiles the inner query to SQL.
    *
-   * @param options - Compile options including buildManifest for persistence.
+   * @param options - Compile options. `buildManifest` and `connectionDigests`
+   *   substitute already-built dependencies, giving the SQL to execute.
+   *   Anything that changes the SQL without them — `virtualMap` — must match
+   *   what the compiler will use, or the table is built under a key nothing
+   *   looks up.
    * @return The SQL string for this source.
    */
   getSQL(options?: CompileQueryOptions): string {
@@ -1822,7 +1826,7 @@ export class PersistSource implements Taggable {
 
     // Compile with finalize=false so this SQL is the bare source SELECT.
     // The build-time key (makeBuildId over this SQL) must equal the serve-time
-    // manifest lookup key, which query_query.ts recomputes from the same
+    // manifest lookup key, which persistedTableFor recomputes from the same
     // unfinalized SELECT; finalizing would diverge the two on dialects with a
     // final stage (Postgres) and mis-materialize the table.
     if (sd.type === 'sql_select') {

--- a/packages/malloy/src/api/foundation/runtime.ts
+++ b/packages/malloy/src/api/foundation/runtime.ts
@@ -692,7 +692,9 @@ export class Runtime {
     }
 
     return {
-      connections: mkBuildTargets(walk, connectionDigests),
+      connections: mkBuildTargets(walk, connectionDigests, {
+        virtualMap: this.virtualMap,
+      }),
       tagParseLog,
     };
   }

--- a/packages/malloy/src/doc/persist/api.md
+++ b/packages/malloy/src/doc/persist/api.md
@@ -269,14 +269,20 @@ From `target.sources[]`, or `plan.sources[sourceID]`:
 `getSQL()` answers differently depending on whether it is given a manifest, and
 a builder needs both answers:
 
-- **BuildID SQL** — `getSQL()` with no options. Fully inlined, no substitution.
-  This is what gets hashed. Because it never mentions a materialized table, the
-  BuildID is the same no matter what has been built already, so build order
-  cannot change a cache key.
+- **BuildID SQL** — `target.sql`, already computed for you. Fully inlined, no
+  substitution. This is what gets hashed. Because it never mentions a
+  materialized table, the BuildID is the same no matter what has been built
+  already, so build order cannot change a cache key.
 - **Build SQL** — `getSQL({buildManifest, connectionDigests})`. Dependencies
   already in the manifest are replaced by their table names. This is what you
   execute: it reads from the tables you just built instead of recomputing them
   inline.
+
+Anything else that changes a source's SQL has to be passed to *both* — a
+`virtualMap` above all, which decides what table a virtual source reads.
+`getBuildTargets` takes the Runtime's for the BuildID SQL; add it to the
+`getSQL()` call in step 4 as well, or you will build the wrong table under the
+right key.
 
 `getSQL()` compiles with `finalize=false`, so what comes back is the bare
 source `SELECT`. The build-time key must equal the key the compiler recomputes

--- a/packages/malloy/src/doc/persist/api.md
+++ b/packages/malloy/src/doc/persist/api.md
@@ -278,11 +278,10 @@ a builder needs both answers:
   execute: it reads from the tables you just built instead of recomputing them
   inline.
 
-Anything else that changes a source's SQL has to be passed to *both* — a
-`virtualMap` above all, which decides what table a virtual source reads.
-`getBuildTargets` takes the Runtime's for the BuildID SQL; add it to the
-`getSQL()` call in step 4 as well, or you will build the wrong table under the
-right key.
+`virtualMap` belongs in the build SQL too. `getBuildTargets` takes the
+Runtime's for the BuildID; omit it in step 4 and a virtual-backed source throws
+`runtime-virtual-map-missing`, and pass a *different* one and you build a table
+from the wrong data under a key that looks right.
 
 `getSQL()` compiles with `finalize=false`, so what comes back is the bare
 source `SELECT`. The build-time key must equal the key the compiler recomputes
@@ -327,9 +326,12 @@ referenced are pruned. A separate pass can then drop the orphaned tables.
    `connection.getDigest()` per connection name for step 4.
 4. **Build** each connection's targets in the order given. Per target: if the
    manifest already has `target.buildId`, `touch()` and move on; otherwise
-   `CREATE TABLE` from `source.getSQL({buildManifest, connectionDigests})` —
-   any of `target.sources` will do, they share the SQL — and `update()` the
-   manifest immediately, so whatever depends on it sees the table.
+   `CREATE TABLE` from
+   `source.getSQL({buildManifest, connectionDigests, virtualMap})` — any of
+   `target.sources` will do, they share the SQL — and `update()` the manifest
+   immediately, so whatever depends on it sees the table. Pass the same
+   `virtualMap` the queries will run under; omit it only if the model has no
+   virtual sources.
 5. **Write** `manifest.activeEntries`.
 
 Over several model files, keep one `Manifest` for the whole run. `touch()` and

--- a/packages/malloy/src/doc/persist/internal.md
+++ b/packages/malloy/src/doc/persist/internal.md
@@ -361,11 +361,13 @@ connection name.
 [`model/sql_compiled.ts`](../../model/sql_compiled.ts) is the lookup. It runs
 when the source is `persistent` and both `buildManifest` and
 `connectionDigests` are present. The key is `mkBuildID(connDigest, sql)`, where
-`sql` is compiled under `buildIdOptions()`: the manifest and its digests are
-dropped, so the BuildID does not depend on what is already materialized;
-`virtualMap` and `resolvedGivens` are kept, because they change the SQL and two
-different tables must not share a key. `mkBuildTargets` compiles the builder's
-side under the same options. A hit returns `entry.tableName` unquoted; manifest names are
+`sql` is compiled under `buildIdOptions()`, which returns a `BuildIdOptions` —
+a type narrow enough that it cannot carry a manifest, so the BuildID cannot
+depend on what is already materialized. It keeps `virtualMap`, which decides
+what table a virtual source reads. It drops `resolvedGivens`, which also
+changes the SQL but which only the compiler can produce; resolving on one side
+only makes the keys disagree, so neither side resolves givens (see #3041).
+`mkBuildTargets` takes the same type. A hit returns `entry.tableName` unquoted; manifest names are
 canonical. A miss under `strict` throws `runtime-manifest-strict-miss` at the
 source's location, appending `loadError` if present. It names the source's
 `sourceID` when there is one; a reference through an inline `extend` has had
@@ -386,11 +388,11 @@ Two callers:
 `QueryQueryRaw` does not look up. Its source is the `conn.sql(...)` at the run
 site, which is unnamed and so never persistent.
 
-The other half of that invariant is `PersistSource.getSQL()`, which compiles
-with `finalize=false`. On a dialect with a final stage (Postgres wraps in
+`PersistSource.getSQL()` compiles with `finalize=false` for the same reason the
+options are narrowed. On a dialect with a final stage (Postgres wraps in
 `row_to_json`) a finalized SQL would hash differently from what
-`query_query.ts` recomputes at serve time, and the table would be materialized
-under a key nothing ever looks up.
+`persistedTableFor` recomputes at serve time, and the table would be
+materialized under a key nothing ever looks up.
 
 ## Runtime manifest resolution
 

--- a/packages/malloy/src/doc/persist/internal.md
+++ b/packages/malloy/src/doc/persist/internal.md
@@ -361,13 +361,15 @@ connection name.
 [`model/sql_compiled.ts`](../../model/sql_compiled.ts) is the lookup. It runs
 when the source is `persistent` and both `buildManifest` and
 `connectionDigests` are present. The key is `mkBuildID(connDigest, sql)`, where
-`sql` is `getSourceSQL()` with no options — **the BuildID is always computed
-from manifest-ignorant SQL**, so it does not depend on what is already
-materialized. A hit returns `entry.tableName` unquoted; manifest names are
+`sql` is compiled under `buildIdOptions()`: the manifest and its digests are
+dropped, so the BuildID does not depend on what is already materialized;
+`virtualMap` and `resolvedGivens` are kept, because they change the SQL and two
+different tables must not share a key. `mkBuildTargets` compiles the builder's
+side under the same options. A hit returns `entry.tableName` unquoted; manifest names are
 canonical. A miss under `strict` throws `runtime-manifest-strict-miss` at the
-source's location, appending `loadError` if present. The compiler may have no
-path to the name the user used to invoke the source, so the error won't be
-very helpful.
+source's location, appending `loadError` if present. It names the source's
+`sourceID` when there is one; a reference through an inline `extend` has had
+that deleted, so there the error carries only a BuildID and a location.
 
 Two callers:
 
@@ -481,6 +483,7 @@ what replaced them.
 | Name | File | What |
 |---|---|---|
 | `persistedTableFor` | `model/sql_compiled.ts` | The lookup: BuildID → table, or the strict throw |
+| `buildIdOptions` | `model/sql_compiled.ts` | What a BuildID's SQL is compiled under |
 | `getStructSourceSQL` | `model/query_query.ts` | Caller: the FROM clause and joins |
 | `expandPersistableSource` | `model/sql_compiled.ts` | Caller: `%{ }` segments |
 

--- a/packages/malloy/src/doc/persist/internal.md
+++ b/packages/malloy/src/doc/persist/internal.md
@@ -357,29 +357,32 @@ connection name.
 
 ## Compiler substitution
 
-Two sites, one per persistable source type, both gated on `persistent`, both
-reached only when `buildManifest` *and* `connectionDigests` are present.
+`persistedTableFor()` in
+[`model/sql_compiled.ts`](../../model/sql_compiled.ts) is the lookup. It runs
+when the source is `persistent` and both `buildManifest` and
+`connectionDigests` are present. The key is `mkBuildID(connDigest, sql)`, where
+`sql` is `getSourceSQL()` with no options — **the BuildID is always computed
+from manifest-ignorant SQL**, so it does not depend on what is already
+materialized. A hit returns `entry.tableName` unquoted; manifest names are
+canonical. A miss under `strict` throws `runtime-manifest-strict-miss` at the
+source's location, appending `loadError` if present. The compiler may have no
+path to the name the user used to invoke the source, so the error won't be
+very helpful.
 
-**`query_source`** — in `getStructSourceSQL()`
-([`model/query_query.ts`](../../model/query_query.ts)), when the structRef is a
-query source: compile the inner query **with empty options** to get
-manifest-ignorant SQL, `mkBuildID(connDigest, sql)`, look it up. On a hit,
-return `entry.tableName` — as-is, not re-quoted, because manifest table names
-are required to be canonical and are validated on every path in. On a miss with
-`strict`, throw `runtime-manifest-strict-miss`, appending `loadError` when the
-manifest carries one. Otherwise compile normally with the real options, so
-nested dependencies can still resolve.
+Two callers:
 
-**`sql_select`** — `expandPersistableSource()` in
-[`model/sql_compiled.ts`](../../model/sql_compiled.ts) handles `%{ source }`
-segments the same way, except a hit substitutes `(SELECT * FROM <tableName>)`,
-since a segment must be usable as a subquery.
+- **`getStructSourceSQL()`**
+  ([`model/query_query.ts`](../../model/query_query.ts)) — the FROM clause and
+  joins, both persistable types. A hit is used bare, since the call site is
+  `FROM ${structSQL} as ${alias}`. On a miss a `query_source` compiles with the
+  real options and a `sql_select` is parenthesized, so nested dependencies
+  resolve.
+- **`expandPersistableSource()`**
+  ([`model/sql_compiled.ts`](../../model/sql_compiled.ts)) — `%{ }` segments. A
+  hit becomes `(SELECT * FROM <tableName>)`; a segment must work as a subquery.
 
-The invariant tying the two halves together: **the BuildID is always computed
-from manifest-ignorant SQL**. Both sites recompile with empty options rather
-than reusing whatever SQL they are about to emit, so the key a query looks up is
-the key the builder wrote — regardless of how much of the dependency tree
-happened to be materialized on either side.
+`QueryQueryRaw` does not look up. Its source is the `conn.sql(...)` at the run
+site, which is unnamed and so never persistent.
 
 The other half of that invariant is `PersistSource.getSQL()`, which compiles
 with `finalize=false`. On a dialect with a final stage (Postgres wraps in
@@ -477,8 +480,9 @@ what replaced them.
 
 | Name | File | What |
 |---|---|---|
-| `QueryQuery` | `model/query_query.ts` | Substitution for `query_source` |
-| `getCompiledSQL` | `model/sql_compiled.ts` | Substitution for `sql_select` |
+| `persistedTableFor` | `model/sql_compiled.ts` | The lookup: BuildID → table, or the strict throw |
+| `getStructSourceSQL` | `model/query_query.ts` | Caller: the FROM clause and joins |
+| `expandPersistableSource` | `model/sql_compiled.ts` | Caller: `%{ }` segments |
 
 ### Tests and samples
 

--- a/packages/malloy/src/model/index.ts
+++ b/packages/malloy/src/model/index.ts
@@ -48,7 +48,8 @@ export {
 } from './utils';
 export {getModelAnnotations} from './annotation_utils';
 export {constantExprToSQL} from './constant_expression_compiler';
-export {getCompiledSQL} from './sql_compiled';
+export {getCompiledSQL, buildIdOptions} from './sql_compiled';
+export type {BuildIdOptions} from './sql_compiled';
 export {MalloyCompileError} from './malloy_compile_error';
 export {
   mkSourceID,

--- a/packages/malloy/src/model/query_query.ts
+++ b/packages/malloy/src/model/query_query.ts
@@ -50,7 +50,6 @@ import {
   isBaseTable,
   expressionIsAnalytic,
   isTemporalType,
-  safeRecordGet,
 } from './malloy_types';
 import {
   AndChain,
@@ -80,8 +79,8 @@ import {
   sqlFullChildReference,
 } from './field_instance';
 import type * as Malloy from '@malloydata/malloy-interfaces';
-import {getCompiledSQL} from './sql_compiled';
-import {mkBuildID} from './source_def_utils';
+import type {CompileQueryCallback} from './sql_compiled';
+import {getCompiledSQL, persistedTableFor} from './sql_compiled';
 import {MalloyCompileError} from './malloy_compile_error';
 import {nestStrategy} from './nest-capability';
 
@@ -827,64 +826,33 @@ export class QueryQuery extends QueryField {
         return '{COMPOSITE SOURCE}';
       case 'finalize':
         return qs.structDef.name;
-      case 'sql_select':
+      case 'sql_select': {
+        // A hit is a table name, which is what a FROM clause wants; the
+        // inline form is a SELECT and has to be parenthesized to sit there.
+        const tableName = persistedTableFor(
+          qs.structDef,
+          qs.prepareResultOptions ?? {},
+          this.isolatedQueryCompiler()
+        );
+        if (tableName !== undefined) {
+          return tableName;
+        }
         return `(${getCompiledSQL(
           qs.structDef,
           qs.prepareResultOptions ?? {},
-          (query, opts) => {
-            // Compile query to isolated SQL (not into parent's stageWriter)
-            const ret = this.compileQueryToStages(
-              query,
-              opts ?? {},
-              undefined,
-              false
-            );
-            return ret.sql!;
-          }
+          this.isolatedQueryCompiler()
         )})`;
+      }
       case 'nest_source':
         return qs.structDef.pipeSQL;
       case 'query_source': {
-        const {buildManifest, connectionDigests} =
-          qs.prepareResultOptions ?? {};
-
-        // Check manifest for this source (only if it was marked persistent at definition time)
-        if (buildManifest && connectionDigests && qs.structDef.persistent) {
-          const connDigest = safeRecordGet(
-            connectionDigests,
-            qs.structDef.connection
-          );
-          if (connDigest) {
-            // Compile with empty opts to get manifest-ignorant SQL for BuildID
-            const fullRet = this.compileQueryToStages(
-              qs.structDef.query,
-              {},
-              undefined,
-              false
-            );
-            const buildId = mkBuildID(connDigest, fullRet.sql!);
-            const entry = buildManifest.entries[buildId];
-
-            if (entry) {
-              // Found in manifest - use persisted table.
-              // entry.tableName comes from the manifest, assumed canonical.
-              return entry.tableName;
-            }
-
-            if (buildManifest.strict) {
-              const base =
-                `Persist source '${qs.structDef.sourceID}' not found ` +
-                `in manifest (buildId: ${buildId}); strict manifest mode ` +
-                'forbids fallback to live compilation.';
-              throw new MalloyCompileError(
-                buildManifest.loadError
-                  ? `${base}\n  ${buildManifest.loadError}`
-                  : base,
-                'runtime-manifest-strict-miss',
-                qs.structDef.location
-              );
-            }
-          }
+        const tableName = persistedTableFor(
+          qs.structDef,
+          qs.prepareResultOptions ?? {},
+          this.isolatedQueryCompiler()
+        );
+        if (tableName !== undefined) {
+          return tableName;
         }
 
         // Not in manifest - compile normally
@@ -901,6 +869,16 @@ export class QueryQuery extends QueryField {
           `Cannot create SQL StageWriter from '${activeName(qs.structDef)}' type '${qs.structDef.type}`
         );
     }
+  }
+
+  /**
+   * A compile callback which writes to its own StageWriter rather than the
+   * one this query is building, so the SQL comes back as a string. Both the
+   * manifest lookup and inline expansion need a source's SQL in that form.
+   */
+  protected isolatedQueryCompiler(): CompileQueryCallback {
+    return (query, opts) =>
+      this.compileQueryToStages(query, opts ?? {}, undefined, false).sql!;
   }
 
   /**
@@ -2757,20 +2735,15 @@ class QueryQueryRaw extends QueryQuery {
         'Invalid struct for QueryQueryRaw, currently only supports SQL'
       );
     }
+    // No manifest lookup for the source itself: a raw pipeline's source is
+    // always the `conn.sql(...)` written at the run site, which is unnamed and
+    // so never persistent. Its `%{ }` dependencies do substitute, through
+    // getCompiledSQL.
     return stageWriter.addStage(
       getCompiledSQL(
         this.parent.structDef,
         this.parent.prepareResultOptions ?? {},
-        (query, opts) => {
-          // Compile query to isolated SQL (not into parent's stageWriter)
-          const ret = this.compileQueryToStages(
-            query,
-            opts ?? {},
-            undefined,
-            false
-          );
-          return ret.sql!;
-        }
+        this.isolatedQueryCompiler()
       )
     );
   }

--- a/packages/malloy/src/model/sql_compiled.ts
+++ b/packages/malloy/src/model/sql_compiled.ts
@@ -75,6 +75,58 @@ function expandSegment(
 }
 
 /**
+ * Ask the manifest what table backs a persistable source.
+ *
+ * Every place the compiler needs SQL for a persistable source goes through
+ * here, so the rule is stated once: a source marked persistent is looked up
+ * by BuildID, a hit yields the table, a miss under `strict` throws, and
+ * anything else falls through to the source's own SQL.
+ *
+ * The BuildID is always computed from manifest-ignorant SQL — `getSourceSQL`
+ * with no options — so the key a query looks up is the key the builder wrote,
+ * no matter how much of the dependency tree was materialized on either side.
+ *
+ * @return The table name, canonical SQL as the manifest supplied it, or
+ *         undefined when the caller should emit the source's own SQL.
+ */
+export function persistedTableFor(
+  source: PersistableSourceDef,
+  opts: PrepareResultOptions,
+  compileQuery: CompileQueryCallback
+): string | undefined {
+  const {buildManifest, connectionDigests} = opts;
+  if (!buildManifest || !connectionDigests || !source.persistent) {
+    return undefined;
+  }
+  const connDigest = safeRecordGet(connectionDigests, source.connection);
+  if (connDigest === undefined) {
+    return undefined;
+  }
+
+  const buildId = mkBuildID(connDigest, getSourceSQL(source, compileQuery));
+  const entry = buildManifest.entries[buildId];
+  if (entry) {
+    return entry.tableName;
+  }
+
+  if (buildManifest.strict) {
+    // Deliberately unnamed. A source reached through an inline `extend` has
+    // had its identity cleared, and the names still on the struct are the
+    // base's, which may name something else entirely in this model. The
+    // location is the reliable half.
+    const base =
+      `Persisted source not found in manifest (buildId: ${buildId}); ` +
+      'strict manifest mode forbids fallback to live compilation.';
+    throw new MalloyCompileError(
+      buildManifest.loadError ? `${base}\n  ${buildManifest.loadError}` : base,
+      'runtime-manifest-strict-miss',
+      source.location
+    );
+  }
+  return undefined;
+}
+
+/**
  * Expand a PersistableSourceDef, checking manifest for pre-built table.
  * Always returns a subquery form: (SELECT * FROM table) or (inline SQL)
  */
@@ -83,38 +135,10 @@ function expandPersistableSource(
   opts: PrepareResultOptions,
   compileQuery: CompileQueryCallback
 ): string {
-  const {buildManifest, connectionDigests} = opts;
-
-  // Try manifest lookup if we have the required info (only for persistent sources)
-  if (buildManifest && connectionDigests && source.persistent) {
-    const connDigest = safeRecordGet(connectionDigests, source.connection);
-    if (connDigest) {
-      // Get the SQL for this source to compute BuildID (no opts = full SQL)
-      const sql = getSourceSQL(source, compileQuery);
-      const buildId = mkBuildID(connDigest, sql);
-      const entry = buildManifest.entries[buildId];
-
-      if (entry) {
-        // Found in manifest - substitute with subquery from persisted table.
-        // entry.tableName is canonical SQL, supplied by the manifest builder.
-        return `(SELECT * FROM ${entry.tableName})`;
-      }
-
-      // Not in manifest
-      if (buildManifest.strict) {
-        const base =
-          `Persist source '${source.sourceID}' not found in manifest ` +
-          `(buildId: ${buildId}); strict manifest mode forbids fallback ` +
-          'to live compilation.';
-        throw new MalloyCompileError(
-          buildManifest.loadError
-            ? `${base}\n  ${buildManifest.loadError}`
-            : base,
-          'runtime-manifest-strict-miss',
-          source.location
-        );
-      }
-    }
+  // A segment has to be usable as a subquery, so a hit is wrapped.
+  const tableName = persistedTableFor(source, opts, compileQuery);
+  if (tableName !== undefined) {
+    return `(SELECT * FROM ${tableName})`;
   }
 
   // No manifest or not found - expand inline as subquery

--- a/packages/malloy/src/model/sql_compiled.ts
+++ b/packages/malloy/src/model/sql_compiled.ts
@@ -9,6 +9,7 @@ import type {
   SQLPhraseSegment,
   PersistableSourceDef,
   Query,
+  VirtualMap,
 } from './malloy_types';
 import {isSegmentSQL, isSegmentSource, safeRecordGet} from './malloy_types';
 import {mkBuildID} from './source_def_utils';
@@ -75,20 +76,34 @@ function expandSegment(
 }
 
 /**
- * The options a BuildID's SQL is compiled under.
+ * The options a BuildID's SQL is compiled under — everything the builder and
+ * the compiler must both know, and nothing else.
  *
- * Two rules pull in opposite directions and this is where they meet. The
- * BuildID must not depend on what has already been built, or build order would
- * change the key — so the manifest and its digests are dropped. But it must
- * depend on everything that changes the SQL, or two different tables would
- * share a key — so `virtualMap` and `resolvedGivens` are kept. Both sides of
- * the contract compile through here: the compiler when it looks a source up,
- * and `mkBuildTargets` when the builder is told what to build.
+ * Narrow on purpose. A BuildID must not depend on what has already been built
+ * or build order would change the key, so this type cannot express a manifest;
+ * `mkBuildTargets` takes it for the same reason.
  */
-export function buildIdOptions(
-  opts: PrepareResultOptions
-): PrepareResultOptions {
-  return {virtualMap: opts.virtualMap, resolvedGivens: opts.resolvedGivens};
+export interface BuildIdOptions {
+  virtualMap?: VirtualMap;
+}
+
+/**
+ * Project compile options down to what a BuildID is computed under.
+ *
+ * `virtualMap` decides which table a virtual source reads, so it changes the
+ * SQL and has to be in the key; the builder supplies its own.
+ *
+ * `resolvedGivens` is deliberately absent even though it also changes the SQL.
+ * The builder has no way to produce one — `Runtime.getBuildTargets` takes no
+ * givens and `PersistSource.getSQL` never resolves them — so including it makes
+ * the two sides disagree: the compiler folds `$IS_ADMIN` to a literal while the
+ * builder re-derives it from the declaration and emits `'admin'='admin'`. Both
+ * sides therefore compile givens the same way, by not resolving them. The
+ * consequence — a source whose SQL depends on a supplied given cannot be
+ * persisted, and says so badly — is #3041.
+ */
+export function buildIdOptions(opts: PrepareResultOptions): BuildIdOptions {
+  return {virtualMap: opts.virtualMap};
 }
 
 /**
@@ -145,7 +160,7 @@ export function persistedTableFor(
 }
 
 /**
- * Expand a PersistableSourceDef, checking manifest for pre-built table.
+ * Expand a PersistableSourceDef as a `%{ }` segment.
  * Always returns a subquery form: (SELECT * FROM table) or (inline SQL)
  */
 function expandPersistableSource(

--- a/packages/malloy/src/model/sql_compiled.ts
+++ b/packages/malloy/src/model/sql_compiled.ts
@@ -75,16 +75,29 @@ function expandSegment(
 }
 
 /**
+ * The options a BuildID's SQL is compiled under.
+ *
+ * Two rules pull in opposite directions and this is where they meet. The
+ * BuildID must not depend on what has already been built, or build order would
+ * change the key — so the manifest and its digests are dropped. But it must
+ * depend on everything that changes the SQL, or two different tables would
+ * share a key — so `virtualMap` and `resolvedGivens` are kept. Both sides of
+ * the contract compile through here: the compiler when it looks a source up,
+ * and `mkBuildTargets` when the builder is told what to build.
+ */
+export function buildIdOptions(
+  opts: PrepareResultOptions
+): PrepareResultOptions {
+  return {virtualMap: opts.virtualMap, resolvedGivens: opts.resolvedGivens};
+}
+
+/**
  * Ask the manifest what table backs a persistable source.
  *
  * Every place the compiler needs SQL for a persistable source goes through
  * here, so the rule is stated once: a source marked persistent is looked up
  * by BuildID, a hit yields the table, a miss under `strict` throws, and
  * anything else falls through to the source's own SQL.
- *
- * The BuildID is always computed from manifest-ignorant SQL — `getSourceSQL`
- * with no options — so the key a query looks up is the key the builder wrote,
- * no matter how much of the dependency tree was materialized on either side.
  *
  * @return The table name, canonical SQL as the manifest supplied it, or
  *         undefined when the caller should emit the source's own SQL.
@@ -103,19 +116,24 @@ export function persistedTableFor(
     return undefined;
   }
 
-  const buildId = mkBuildID(connDigest, getSourceSQL(source, compileQuery));
+  const buildId = mkBuildID(
+    connDigest,
+    getSourceSQL(source, compileQuery, buildIdOptions(opts))
+  );
   const entry = buildManifest.entries[buildId];
   if (entry) {
     return entry.tableName;
   }
 
   if (buildManifest.strict) {
-    // Deliberately unnamed. A source reached through an inline `extend` has
-    // had its identity cleared, and the names still on the struct are the
-    // base's, which may name something else entirely in this model. The
-    // location is the reliable half.
+    // `sourceID` is deleted, not inherited, when a source is modified, so it
+    // either names this source or is absent. `as` and `extends` survive a
+    // modification and would name the base, so neither stands in for it.
+    const named = source.sourceID
+      ? `Persisted source '${source.sourceID}'`
+      : 'Persisted source';
     const base =
-      `Persisted source not found in manifest (buildId: ${buildId}); ` +
+      `${named} not found in manifest (buildId: ${buildId}); ` +
       'strict manifest mode forbids fallback to live compilation.';
     throw new MalloyCompileError(
       buildManifest.loadError ? `${base}\n  ${buildManifest.loadError}` : base,

--- a/scripts/simple_builder/build.ts
+++ b/scripts/simple_builder/build.ts
@@ -63,11 +63,13 @@
  *
  *   These are two different SQL strings for the same table:
  *
- *   - **BuildID SQL** — `target.sql`, which is `source.getSQL()` with no
- *     options: fully inlined, no manifest substitution. Its hash (with the
- *     connection digest) is the BuildID. The BuildID must be stable
- *     regardless of build order, so it never includes substituted table
- *     names. `getBuildTargets` has already computed both.
+ *   - **BuildID SQL** — `target.sql`, compiled under `buildIdOptions()`:
+ *     fully inlined, no manifest substitution. Its hash (with the connection
+ *     digest) is the BuildID. The BuildID must be stable regardless of build
+ *     order, so it never includes substituted table names.
+ *     `getBuildTargets` has already computed both. A model with virtual
+ *     sources needs a `virtualMap` on the Runtime for this to compile, and
+ *     the same map in the build SQL below.
  *
  *   - **Build SQL** — `source.getSQL({buildManifest, connectionDigests})`.
  *     Dependencies that are already in the manifest are replaced with

--- a/test/src/core/persist.spec.ts
+++ b/test/src/core/persist.spec.ts
@@ -2472,12 +2472,14 @@ describe('source persistence', () => {
       """)
     `;
 
-    // A manifest holding a built table for every persist source in the model.
-    async function manifestForAll(): Promise<BuildManifest> {
+    // A manifest holding a built table for each named persist source, or for
+    // every one of them when no names are given.
+    async function manifestFor(names?: string[]): Promise<BuildManifest> {
       const model = await wrapTestModel(tstRuntime, TWO_KINDS).model.getModel();
       const digest = await getDigest();
       const manifest = createManifest();
       for (const source of Object.values(model.getBuildPlan().sources)) {
+        if (names && !names.includes(source.name)) continue;
         addManifestEntry(
           manifest,
           source.makeBuildId(digest, source.getSQL()),
@@ -2487,8 +2489,11 @@ describe('source persistence', () => {
       return manifest;
     }
 
-    async function sqlForQuery(query: string): Promise<string> {
-      const manifest = await manifestForAll();
+    async function sqlForQuery(
+      query: string,
+      built?: string[]
+    ): Promise<string> {
+      const manifest = await manifestFor(built);
       return runtimeWithManifest(manifest)
         .loadQuery(`${TWO_KINDS}\n${query}`)
         .getSQL();
@@ -2504,7 +2509,7 @@ describe('source persistence', () => {
     // manifest. The two passing tests around these are the controls: the
     // other persistable kind substitutes, and the same source substitutes
     // when interpolation reaches it, so the entry and its key are right.
-    it.skip('sql_select reads its built table', async () => {
+    it('sql_select reads its built table', async () => {
       const sql = await sqlForQuery('run: ss -> { select: * }');
       expect(sql).toContain('cached.ss_table');
       expect(sql).not.toContain('COUNT(');
@@ -2512,12 +2517,14 @@ describe('source persistence', () => {
 
     it('sql_select reached by interpolation reads its built table', async () => {
       // The manifest key and the entry are right — this path finds them.
-      const sql = await sqlForQuery('run: via_interp -> { select: * }');
+      // Only `ss` is built, so via_interp has to reach it rather than being
+      // substituted itself.
+      const sql = await sqlForQuery('run: via_interp -> { select: * }', ['ss']);
       expect(sql).toContain('cached.ss_table');
       expect(sql).not.toContain('COUNT(');
     });
 
-    it.skip('strict mode catches a missing sql_select entry', async () => {
+    it('strict mode catches a missing sql_select entry', async () => {
       // Strict mode's promise is that a persist source with no manifest entry
       // throws rather than silently compiling to inline SQL.
       const strict = createManifest();
@@ -2529,7 +2536,52 @@ describe('source persistence', () => {
       ).rejects.toThrow(/not found in manifest/);
     });
 
-    it.skip('a join of both kinds substitutes both', async () => {
+    it('reads the built table, not the SQL that built it', async () => {
+      // Substitution is only real if the rows come from the table. Build one
+      // whose contents disagree with the source's SQL: a query that reads the
+      // table says 'stale', one that recomputes says 'live'. Before #3016 the
+      // sql_select leg always said 'live' — it looked fresh because it was
+      // never reading what had been built.
+      const rwConn = new DuckDBConnection({
+        name: tstDB,
+        databasePath: ':memory:',
+        workingDirectory: 'test/data/duckdb',
+      });
+      try {
+        const modelCode = `${PERSIST_ANNOTATION}
+          #@ persist
+          source: ss is ${tstDB}.sql("""SELECT 'live' as tag""")
+
+          run: ss -> { select: * }
+        `;
+        const rwRuntime = new SingleConnectionRuntime({
+          connection: rwConn,
+          urlReader: testFileSpace,
+        });
+        const model = await rwRuntime.loadModel(modelCode).getModel();
+        const source = Object.values(model.getBuildPlan().sources)[0];
+        const buildId = source.makeBuildId(rwConn.getDigest(), source.getSQL());
+
+        await rwConn.runSQL(
+          "CREATE TABLE ss_freshness AS SELECT 'stale' as tag"
+        );
+        const manifest = createManifest();
+        addManifestEntry(manifest, buildId, 'ss_freshness');
+        rwRuntime.buildManifest = manifest;
+
+        const built = await rwRuntime.loadQuery(modelCode).run();
+        const recomputed = await rwRuntime
+          .loadQuery(modelCode, {buildManifest: EMPTY_BUILD_MANIFEST})
+          .run();
+
+        expect(built.data.toObject()).toEqual([{tag: 'stale'}]);
+        expect(recomputed.data.toObject()).toEqual([{tag: 'live'}]);
+      } finally {
+        await rwConn.close();
+      }
+    });
+
+    it('a join of both kinds substitutes both', async () => {
       const sql = await sqlForQuery(`
         run: flights extend {
           join_one: q is qs on carrier = q.carrier

--- a/test/src/core/persist.spec.ts
+++ b/test/src/core/persist.spec.ts
@@ -10,6 +10,7 @@ import type {
   BuildManifest,
   BuildPlan,
   BuildTarget,
+  VirtualMap,
 } from '@malloydata/malloy';
 import {
   ConnectionRuntime,
@@ -2593,6 +2594,60 @@ describe('source persistence', () => {
       `);
       expect(sql).toContain('cached.qs_table');
       expect(sql).toContain('cached.ss_table');
+    });
+  });
+
+  describe('BuildID SQL carries what changes the SQL', () => {
+    // The BuildID must ignore the manifest and nothing else. A virtualMap
+    // decides what table a virtual source reads, so a BuildID computed without
+    // it cannot be compiled at all — which is what both sides used to do.
+    const VIRTUAL_MODEL = `${PERSIST_ANNOTATION}
+      ##! experimental.virtual_source
+      type: ff is { carrier :: string }
+      source: vf is ${tstDB}.virtual('vflights')::ff
+
+      #@ persist
+      source: by_carrier is vf -> { group_by: carrier }
+
+      run: by_carrier -> { select: * }
+    `;
+
+    const virtualMap: VirtualMap = new Map([
+      [tstDB, new Map([['vflights', 'malloytest.flights']])],
+    ]);
+
+    function virtualRuntime() {
+      const rt = new SingleConnectionRuntime({
+        connection: tstRuntime.connection,
+        urlReader: testFileSpace,
+      });
+      rt.virtualMap = virtualMap;
+      return rt;
+    }
+
+    it('a persisted source over a virtual source can be planned', async () => {
+      const rt = virtualRuntime();
+      const model = await rt.loadModel(VIRTUAL_MODEL).getModel();
+      const {connections} = await rt.getBuildTargets(model);
+      expect(connections[0].targets[0].sql).toContain('malloytest.flights');
+    });
+
+    it('and the query finds the table the plan named', async () => {
+      // The whole point of the pair: the key the builder writes is the key the
+      // compiler recomputes. Build from getBuildTargets, then query.
+      const rt = virtualRuntime();
+      const model = await rt.loadModel(VIRTUAL_MODEL).getModel();
+      const {connections} = await rt.getBuildTargets(model);
+      const target = connections[0].targets[0];
+
+      const manifest = createManifest();
+      addManifestEntry(manifest, target.buildId, 'cached.virtual_by_carrier');
+      manifest.strict = true;
+      rt.buildManifest = manifest;
+
+      const sql = await rt.loadQuery(VIRTUAL_MODEL).getSQL();
+      expect(sql).toContain('cached.virtual_by_carrier');
+      expect(sql).not.toContain('malloytest.flights');
     });
   });
 

--- a/test/src/core/persist.spec.ts
+++ b/test/src/core/persist.spec.ts
@@ -2306,6 +2306,31 @@ describe('source persistence', () => {
       ).rejects.toThrow('not found in manifest');
     });
 
+    it('the throw names the source when it still has an identity', async () => {
+      const manifest = createManifest();
+      manifest.strict = true;
+
+      await expect(
+        runtimeWithManifest(manifest).loadQuery(strictModelCode).getSQL()
+      ).rejects.toThrow(/Persisted source 'by_carrier@/);
+    });
+
+    it('and does not guess a name when the reference has none', async () => {
+      // An inline extend has had its sourceID deleted; `as` and `extends`
+      // survive but name the base, so neither stands in for it.
+      const manifest = createManifest();
+      manifest.strict = true;
+      const inlineExtend = `${CARRIER_STATS_PERSIST_MODEL}
+        run: carrier_stats extend { dimension: loud is upper(carrier) } -> {
+          group_by: loud
+        }
+      `;
+
+      await expect(
+        runtimeWithManifest(manifest).loadQuery(inlineExtend).getSQL()
+      ).rejects.toThrow(/Persisted source not found in manifest/);
+    });
+
     it('strict manifest with loadError surfaces the load error in the throw', async () => {
       // Simulates the runtime auto-read path producing an empty manifest
       // because the file was unparseable. The strict throw should mention
@@ -2506,10 +2531,6 @@ describe('source persistence', () => {
       expect(sql).not.toContain('COUNT(');
     });
 
-    // Pending #3016 — a directly-referenced sql_select never reaches the
-    // manifest. The two passing tests around these are the controls: the
-    // other persistable kind substitutes, and the same source substitutes
-    // when interpolation reaches it, so the entry and its key are right.
     it('sql_select reads its built table', async () => {
       const sql = await sqlForQuery('run: ss -> { select: * }');
       expect(sql).toContain('cached.ss_table');
@@ -2560,7 +2581,9 @@ describe('source persistence', () => {
           urlReader: testFileSpace,
         });
         const model = await rwRuntime.loadModel(modelCode).getModel();
-        const source = Object.values(model.getBuildPlan().sources)[0];
+        const source = Object.values(model.getBuildPlan().sources).find(
+          s => s.name === 'ss'
+        )!;
         const buildId = source.makeBuildId(rwConn.getDigest(), source.getSQL());
 
         await rwConn.runSQL(
@@ -2630,6 +2653,44 @@ describe('source persistence', () => {
       const model = await rt.loadModel(VIRTUAL_MODEL).getModel();
       const {connections} = await rt.getBuildTargets(model);
       expect(connections[0].targets[0].sql).toContain('malloytest.flights');
+    });
+
+    it('a given with an inline default keeps both sides on one key', async () => {
+      // The other half of the rule: `resolvedGivens` also changes the SQL, but
+      // only the compiler can produce one, so neither side resolves givens.
+      // Resolve on one side only and this throws — the builder emits
+      // `'admin'='admin'` where the compiler folds the same expression.
+      const model = `${PERSIST_ANNOTATION}
+        ##! experimental.givens
+        given:
+          ROLE :: string is "admin"
+          inline IS_ADMIN :: boolean is $ROLE = 'admin'
+        ${FLIGHTS_SOURCE}
+
+        #@ persist
+        source: gated is flights -> {
+          where: $IS_ADMIN
+          group_by: carrier
+        }
+
+        run: gated -> { select: * }
+      `;
+      const rt = new SingleConnectionRuntime({
+        connection: tstRuntime.connection,
+        urlReader: testFileSpace,
+      });
+      const {connections} = await rt.getBuildTargets(
+        await rt.loadModel(model).getModel()
+      );
+      const target = connections[0].targets[0];
+
+      const manifest = createManifest();
+      addManifestEntry(manifest, target.buildId, 'cached.gated');
+      manifest.strict = true;
+      rt.buildManifest = manifest;
+
+      const sql = await rt.loadQuery(model).getSQL();
+      expect(sql).toContain('cached.gated');
     });
 
     it('and the query finds the table the plan named', async () => {


### PR DESCRIPTION
Fixes #3016. A persisted `sql_select` was substituted when `%{ }` interpolation
reached it, but not when it was a query's source or a join — it recompiled
inline whatever had been built, and strict mode never reported the missing
entry.

The manifest lookup is now one function, `persistedTableFor()`, called from both
reference sites. Its strict-mode error no longer names a source: by the time it
throws, a reference through an inline `extend` has had its identity cleared, and
the names still on the struct belong to the base.
