### PR TITLE
fix(lang): apply access modifiers to `*` expansion

### DIFF
--- a/packages/malloy/src/lang/CONTEXT.md
+++ b/packages/malloy/src/lang/CONTEXT.md
@@ -194,6 +194,19 @@ The `restrictedMode` flag flows: `ParseOptions.restrictedMode` → `MalloyTransl
 
 API-level details: [`../api/CONTEXT.md`](../api/CONTEXT.md) and the JSDoc on `ModelMaterializer.loadRestrictedQuery`.
 
+## Access modifiers
+
+`include { private: … internal: … }` (behind `##! experimental.access_modifiers`) records an `accessModifier` on the field defs of the source it produces — `ast/field-space/include-utils.ts` collects the include block, `refined-space.ts` writes the labels onto the fields as the source's `structDef` is built. The labels land when the source statement completes, which is why a `private` field is still usable in the `extend` block of the statement that declares it and not in a later one.
+
+Whether a field can be reached is a question about the *space doing the reading*, not about the field alone. Each space answers `accessProtectionLevel()`: `public` for a query segment, `internal` for a source extension. `accessAllowed(level, modifier)` in `ast/field-space/static-space.ts` decides, and `lessPermissiveAccessLevel()` narrows the level at each join hop, so reaching through a join can only lose visibility.
+
+Two code paths read fields, and both have to ask:
+
+- **By name** — `StaticSpace.lookup()`. A rejected field logs `field-not-accessible` and reports itself as not found.
+- **By `*`** — `QueryOperationSpace.wildcardExpansion()` in `ast/field-space/query-spaces.ts`. Star expansion enumerates `entries()` instead of resolving a name through `lookup()`, and **`entries()` is the raw namespace map — it has no access check in it**, so `wildcardExpansion()` is where the check goes: it narrows the level per join hop, errors on an inaccessible join named before the `*`, and drops the fields the level disallows. Dropping is silent, because an error naming the field would disclose the name the modifier exists to hide. Both `addWild()` implementations — `select:` here and `index:` in `index-field-space.ts` — get their entries from it and differ only in how they name and filter what comes back.
+
+Anything else that enumerates a namespace rather than resolving one name inherits the same obligation.
+
 ## File Organization
 
 ```

--- a/packages/malloy/src/lang/ast/field-space/index-field-space.ts
+++ b/packages/malloy/src/lang/ast/field-space/index-field-space.ts
@@ -18,13 +18,11 @@ import {
   IndexFieldReference,
   WildcardFieldReference,
 } from '../query-items/field-references';
-import type {FieldSpace} from '../types/field-space';
 import type {MalloyElement} from '../types/malloy-element';
 import type {SpaceEntry} from '../types/space-entry';
 import {SpaceField} from '../types/space-field';
 import {QueryOperationSpace} from './query-spaces';
 import {ReferenceField} from './reference-field';
-import {StructSpaceField} from './static-space';
 
 export class IndexFieldSpace extends QueryOperationSpace {
   readonly segmentType = 'index';
@@ -105,43 +103,14 @@ export class IndexFieldSpace extends QueryOperationSpace {
   addRefineFromFields(_refineThis: never) {}
 
   protected addWild(wild: WildcardFieldReference): void {
-    let current: FieldSpace = this.exprSpace;
-    const joinPath: string[] = [];
-    if (wild.joinPath) {
-      // walk path to determine namespace for *
-      for (const pathPart of wild.joinPath.list) {
-        const part = pathPart.refString;
-        joinPath.push(part);
-
-        const ent = current.entry(part);
-        if (ent) {
-          if (ent instanceof StructSpaceField) {
-            current = ent.fieldSpace;
-          } else {
-            pathPart.logError(
-              'invalid-wildcard-source',
-              `Field '${part}' does not contain rows and cannot be expanded with '*'`
-            );
-            return;
-          }
-        } else {
-          pathPart.logError(
-            'wildcard-source-not-found',
-            `No such field as '${part}'`
-          );
-          return;
-        }
-      }
+    const expansion = this.wildcardExpansion(wild, 'wildcard-source-not-found');
+    if (expansion === undefined) {
+      return;
     }
+    const {joinPath, entries} = expansion;
     const dialect = this.dialectObj();
     const expandEntries: {name: string; entry: SpaceEntry}[] = [];
-    for (const [name, entry] of current.entries()) {
-      if (wild.except.has(name)) {
-        continue;
-      }
-      if (entry.refType === 'parameter') {
-        continue;
-      }
+    for (const [name, entry] of entries) {
       const indexName = IndexFieldReference.indexOutputName([
         ...joinPath,
         name,

--- a/packages/malloy/src/lang/ast/field-space/query-spaces.ts
+++ b/packages/malloy/src/lang/ast/field-space/query-spaces.ts
@@ -20,7 +20,12 @@ import {
 } from '../query-items/field-references';
 import {RefinedSpace} from './refined-space';
 import type {LookupResult} from '../types/lookup-result';
-import {StructSpaceField} from './static-space';
+import {
+  accessAllowed,
+  accessModifierOf,
+  lessPermissiveAccessLevel,
+  StructSpaceField,
+} from './static-space';
 import {QueryInputSpace} from './query-input-space';
 import type {SpaceEntry} from '../types/space-entry';
 import type {
@@ -37,6 +42,12 @@ type TranslatedQueryField = {
   queryFieldDef: model.QueryFieldDef;
   typeDesc: model.TypeDesc;
 };
+
+/** The entries a `*` may see, and the join path written before it */
+export interface WildcardExpansion {
+  joinPath: string[];
+  entries: [string, SpaceEntry][];
+}
 
 /**
  * The output space of a query operation. It is not named "QueryOutputSpace"
@@ -144,44 +155,72 @@ export abstract class QueryOperationSpace
     return true;
   }
 
-  protected addWild(wild: WildcardFieldReference): void {
+  /**
+   * `*` expands to the fields a reference by name could have reached from
+   * here, so this runs the access checks `StaticSpace.lookup()` runs. It has
+   * to: `entries()` is the raw namespace map, with no access check in it.
+   * Returns undefined, having logged, if the join path before the `*` names
+   * something unreachable or unexpandable.
+   */
+  protected wildcardExpansion(
+    wild: WildcardFieldReference,
+    notDefined: 'wildcard-source-not-defined' | 'wildcard-source-not-found'
+  ): WildcardExpansion | undefined {
     let current: FieldSpace = this.exprSpace;
+    let accessLevel = this.exprSpace.accessProtectionLevel();
     const joinPath: string[] = [];
-    if (wild.joinPath) {
-      // walk path to determine namespace for *
-      for (const pathPart of wild.joinPath.list) {
-        const part = pathPart.refString;
-        joinPath.push(part);
+    // walk path to determine namespace for *
+    for (const pathPart of wild.joinPath?.list ?? []) {
+      const part = pathPart.refString;
+      joinPath.push(part);
 
-        const ent = current.entry(part);
-        if (ent) {
-          if (ent instanceof StructSpaceField) {
-            current = ent.fieldSpace;
-          } else {
-            pathPart.logError(
-              'invalid-wildcard-source',
-              `Field '${part}' does not contain rows and cannot be expanded with '*'`
-            );
-            return;
-          }
-        } else {
-          pathPart.logError(
-            'wildcard-source-not-defined',
-            `No such field as '${part}'`
-          );
-          return;
-        }
+      const ent = current.entry(part);
+      if (ent === undefined) {
+        pathPart.logError(notDefined, `No such field as '${part}'`);
+        return undefined;
       }
+      const modifier = accessModifierOf(ent);
+      if (modifier && !accessAllowed(accessLevel, modifier)) {
+        pathPart.logError('field-not-accessible', `'${part}' is ${modifier}`);
+        return undefined;
+      }
+      if (!(ent instanceof StructSpaceField)) {
+        pathPart.logError(
+          'invalid-wildcard-source',
+          `Field '${part}' does not contain rows and cannot be expanded with '*'`
+        );
+        return undefined;
+      }
+      current = ent.fieldSpace;
+      accessLevel = lessPermissiveAccessLevel(
+        accessLevel,
+        current.accessProtectionLevel()
+      );
     }
+    const entries = current.entries().filter(([name, entry]) => {
+      if (wild.except.has(name) || entry.refType === 'parameter') {
+        return false;
+      }
+      // Skipped rather than reported: an error naming the field would
+      // disclose the name the modifier exists to hide.
+      const modifier = accessModifierOf(entry);
+      return !modifier || accessAllowed(accessLevel, modifier);
+    });
+    return {joinPath, entries};
+  }
+
+  protected addWild(wild: WildcardFieldReference): void {
+    const expansion = this.wildcardExpansion(
+      wild,
+      'wildcard-source-not-defined'
+    );
+    if (expansion === undefined) {
+      return;
+    }
+    const {joinPath, entries} = expansion;
     const dialect = this.dialectObj();
     const expandEntries: {name: string; entry: SpaceEntry}[] = [];
-    for (const [name, entry] of current.entries()) {
-      if (wild.except.has(name)) {
-        continue;
-      }
-      if (entry.refType === 'parameter') {
-        continue;
-      }
+    for (const [name, entry] of entries) {
       if (this.entry(name)) {
         const conflict = this.expandedWild.get(name)?.path.join('.');
         wild.logError(

--- a/packages/malloy/src/lang/ast/field-space/static-space.ts
+++ b/packages/malloy/src/lang/ast/field-space/static-space.ts
@@ -11,6 +11,7 @@ import type {
   SourceDef,
   JoinFieldDef,
   AccessModifierLabel,
+  NonDefaultAccessModifierLabel,
 } from '../../../model/malloy_types';
 import {
   activeName,
@@ -291,7 +292,19 @@ export class StaticSourceSpace extends StaticSpace implements SourceFieldSpace {
   }
 }
 
-function accessAllowed(
+/**
+ * The access modifier written on the field a namespace entry stands for.
+ * Undefined when the field is public, or the entry is not a field.
+ */
+export function accessModifierOf(
+  entry: SpaceEntry
+): NonDefaultAccessModifierLabel | undefined {
+  return entry instanceof SpaceField
+    ? entry.fieldDef()?.accessModifier
+    : undefined;
+}
+
+export function accessAllowed(
   accessLevel: AccessModifierLabel,
   accessModifier: AccessModifierLabel
 ): boolean {
@@ -301,7 +314,7 @@ function accessAllowed(
   return false;
 }
 
-function lessPermissiveAccessLevel(
+export function lessPermissiveAccessLevel(
   a: AccessModifierLabel,
   b: AccessModifierLabel
 ): AccessModifierLabel {

--- a/packages/malloy/src/lang/test/query.spec.ts
+++ b/packages/malloy/src/lang/test/query.spec.ts
@@ -44,6 +44,13 @@ function getFirstSegmentFieldNames(q: Query | undefined): string[] {
   );
 }
 
+function getIndexFieldPaths(q: Query | undefined): string[] {
+  const seg = q?.pipeline[0];
+  return seg?.type === 'index'
+    ? seg.indexFields.map(f => f.path.join('.'))
+    : [];
+}
+
 describe('query:', () => {
   describe('basic query syntax', () => {
     test('run:anonymous query', () =>
@@ -981,6 +988,109 @@ describe('query:', () => {
           "Cannot expand 'ai' in '*' because a field with that name already exists (conflicts with b.ai)"
         )
       );
+    });
+    describe('star expansion and access modifiers', () => {
+      const visibleFields = (skip: string) => afields.filter(f => f !== skip);
+
+      test('star does not expand a private field', () => {
+        const m = model`
+          ##! experimental.access_modifiers
+          source: c is a include { *; private: ai }
+          run: c -> { select: * }
+        `;
+        expect(m).toTranslate();
+        const fields = getFirstSegmentFieldNames(m.translator.getQuery(0));
+        expect(fields).toEqual(visibleFields('ai'));
+      });
+      test('star does not expand an internal field in a query', () => {
+        const m = model`
+          ##! experimental.access_modifiers
+          source: c is a include { *; internal: ai }
+          run: c -> { select: * }
+        `;
+        expect(m).toTranslate();
+        const fields = getFirstSegmentFieldNames(m.translator.getQuery(0));
+        expect(fields).toEqual(visibleFields('ai'));
+      });
+      test('star in the extension declaring the modifiers sees everything', () => {
+        const m = model`
+          ##! experimental.access_modifiers
+          source: c is a include { *; private: ai } extend {
+            view: everything is { select: * }
+          }
+          run: c -> everything
+        `;
+        expect(m).toTranslate();
+        const fields = getFirstSegmentFieldNames(m.translator.getQuery(0));
+        expect(fields).toEqual(afields);
+      });
+      test('star in a later extension sees internal but not private', () => {
+        const m = model`
+          ##! experimental.access_modifiers
+          source: c is a include {
+            *
+            private: ai
+            internal: af
+          }
+          source: d is c extend {
+            view: v is { select: * }
+          }
+          run: d -> v
+        `;
+        expect(m).toTranslate();
+        const fields = getFirstSegmentFieldNames(m.translator.getQuery(0));
+        expect(fields).toEqual(visibleFields('ai'));
+      });
+      test('join dot star does not expand the joined private field', () => {
+        const m = model`
+          ##! experimental.access_modifiers
+          source: c is a include { *; private: ai }
+          source: d is a extend { join_one: c on true }
+          run: d -> { select: c.* }
+        `;
+        expect(m).toTranslate();
+        const fields = getFirstSegmentFields(m.translator.getQuery(0)).map(f =>
+          f.type === 'fieldref' ? f.path : `wrong field type ${f.type}`
+        );
+        expect(fields).toEqual(visibleFields('ai').map(f => ['c', f]));
+      });
+      test('star through an inaccessible join is an error', () => {
+        expect(markSource`
+          ##! experimental.access_modifiers
+          source: c is a
+          source: d is a extend {
+            join_one: c on true
+          } include {
+            internal: c
+          }
+          run: d -> { select: ${'c'}.* }
+        `).toLog(errorMessage("'c' is internal"));
+      });
+      test('index star does not index a private field', () => {
+        const m = model`
+          ##! experimental.access_modifiers
+          source: c is a include { *; private: ai }
+          run: c -> { index: * }
+          run: a -> { index: * }
+        `;
+        expect(m).toTranslate();
+        const withPrivate = getIndexFieldPaths(m.translator.getQuery(0));
+        const everything = getIndexFieldPaths(m.translator.getQuery(1));
+        expect(withPrivate).toEqual(everything.filter(f => f !== 'ai'));
+        expect(everything).toContain('ai');
+      });
+      test('index star through an inaccessible join is an error', () => {
+        expect(markSource`
+          ##! experimental.access_modifiers
+          source: c is a
+          source: d is a extend {
+            join_one: c on true
+          } include {
+            internal: c
+          }
+          run: d -> { index: ${'c'}.* }
+        `).toLog(errorMessage("'c' is internal"));
+      });
     });
     test('regress check extend: and star', () => {
       const m = model`run: ab->{ extend: {dimension: x is 1} select: * }`;


### PR DESCRIPTION
A field marked `private` or `internal` by an `include` block was rejected when a query named it, and returned anyway when the query wrote `*`:

    source: c is a include { *; private: ai }
    run: c -> { select: ai }   // error: 'ai' is private
    run: c -> { select: * }    // returned ai

Named references resolve through `StaticSpace.lookup()`, which compares the field's modifier against the access level of the space doing the reading. Star expansion instead walks `entries()`, the raw namespace map, which has no access check in it. Both `addWild()` implementations — `select:` in query-spaces and `index:` in index-field-space — did the same thing, so `index: *` leaked the field names *and* a sampled value range for each one.

The walk they duplicated now lives once, as `wildcardExpansion()` on `QueryOperationSpace`, and it does what `lookup()` does: start from the access level of the space the `*` was written in, narrow it at each join hop with `lessPermissiveAccessLevel`, and drop the entries that level disallows. A join named in the path before the `*` is checked too, so `select: private_join.*` is now an error. Fields are dropped silently rather than reported: an error naming the field would disclose the name the modifier exists to hide. Each `addWild()` keeps only the part that was ever different — how it names and type-filters what comes back.

One error code moves. The access check runs before the check for whether the path part can be expanded at all, so an inaccessible scalar now reports `field-not-accessible` where it reported `invalid-wildcard-source`. Reporting that a field is not expandable confirms it is there.

Unchanged: `*` written inside the statement that declares the modifiers still expands to everything, because the labels are not on the field defs until that statement completes. That is the same rule that lets the declaring statement's `extend` block name a private field.