### PR TITLE
test(render): make the drill limit query deterministic and unskip it

### DIFF
--- a/packages/malloy-render/src/drill.spec.ts
+++ b/packages/malloy-render/src/drill.spec.ts
@@ -423,10 +423,7 @@ describe('drill query', () => {
     }
   });
 
-  // Skipped: #3045. Two months tie on flight_count under these drill filters,
-  // and Malloy's default ordering does not break ties, so `limit: 1` returns
-  // either one. DuckDB answered consistently until 1.5.5.
-  test.skip('can handle drills that are already there', async () => {
+  test('can handle drills that are already there', async () => {
     const query = `
       source: flights is flights_base extend {
         view: cool_carriers is {
@@ -436,6 +433,10 @@ describe('drill query', () => {
         view: over_time is {
           group_by: dep_month is month(dep_time)
           aggregate: flight_count
+          // #3045: months 5 and 10 tie on flight_count under these drill
+          // filters, and Malloy's default ordering does not break ties, so
+          // \`limit: 1\` needs an explicit tiebreak to be deterministic.
+          order_by: flight_count desc, dep_month
           limit: 1
         }
       }


### PR DESCRIPTION
Brings back `drill query › can handle drills that are already there`, skipped in #3044.

## The failure

That test's `over_time` view takes `limit: 1` over a `group_by` whose top two rows tie — `dep_month` 5 and 10, 8 flights each under the test's drill filters. Malloy compiles the view to

```sql
GROUP BY 1
ORDER BY 2 desc NULLS LAST
LIMIT 1
```

so the cut lands inside a tie the `ORDER BY` does not break, and which row survives is up to the engine. DuckDB answered the same way every time until `@duckdb/node-api` 1.5.5, where it became thread-count dependent — which is why the test survived a single-file run and failed inside the full suite.

## The change

Give the view an explicit total order:

```malloy
view: over_time is {
  group_by: dep_month is month(dep_time)
  aggregate: flight_count
  order_by: flight_count desc, dep_month
  limit: 1
}
```

and drop the `.skip`. The `dep_month = 5` assertion is unchanged — ascending `dep_month` picks 5 out of the tie, the same answer DuckDB used to return by luck.

## Scope

This is the test-side half of #3045. The language question that issue raises — whether Malloy's default ordering should append the `group_by` keys so that *every* `limit:` is reproducible, in user models as well as tests — is untouched here; this only takes the test off that decision's critical path. If the default ordering is later made total, the explicit `order_by` becomes redundant rather than wrong.

## Verification

`MALLOY_DATABASE=duckdb npx jest --selectProjects malloy-render src/drill.spec.ts` — 155/155 pass, 10/10 suites. The un-skipped test also run 10 times in isolation, passing every time. `eslint` and `prettier --check` clean on the changed file.

---
_Generated by [Claude Code](https://claude.ai/code/session_017T5kB9u6Fbd9fAHKfGbrar)_