### PR TITLE
fix(render): drop the inert font-family that would override a host's theme

### DIFF
--- a/packages/malloy-render/src/component/render.css
+++ b/packages/malloy-render/src/component/render.css
@@ -31,11 +31,8 @@
 
 @supports (font-variation-settings: normal) {
   .malloy-render {
-    font-family:
-      InterVariable,
-      Inter,
-      system-ui sans-serif;
-
+    /* No font-family here: it belongs to --malloy-theme--font-family above, which
+       an embedding host overrides. A family in this block would win on order. */
     font-feature-settings:
       'liga' 1,
       'calt' 1;


### PR DESCRIPTION
Removes three lines of dead CSS from `render.css`. No behaviour change, in any engine, with or without a host theme.

## What is there today

`.malloy-render` sets `font-family: var(--malloy-render--font-family)` so an embedding host can theme the renderer's text. The `@supports (font-variation-settings: normal)` block just below re-declares it:

```css
@supports (font-variation-settings: normal) {
  .malloy-render {
    font-family:
      InterVariable,
      Inter,
      system-ui sans-serif;

    font-feature-settings:
      'liga' 1,
      'calt' 1;
  }
}
```

`@supports` contributes no specificity, so that later declaration would win and pin every embedding host to Inter regardless of what it passes in.

It does not win, because it is invalid. `system-ui sans-serif` is an unquoted multi-word family name, and both idents are generic-family keywords, so the identifier sequence is not a valid `<family-name>` and the whole declaration is dropped. Read back from `document.styleSheets`, that block has only ever applied `font-feature-settings`.

## Why remove it rather than leave it

Because it is a latent trap that looks exactly like a one-character typo worth tidying. Adding the comma restores the apparent intent and silently breaks font theming for every embedding host, with nothing failing to say so. Deleting the declaration makes today's actual behaviour explicit and leaves nothing to "fix".

`font-feature-settings` stays, since gating liga/calt on variable-font support is what the block is for.

Deliberately not included: preferring `InterVariable` by default. That would mean adding it to `--malloy-theme--font-family` above, which changes rendering wherever that face is available. Happy to do it as a follow-up if it is wanted, but it is a behaviour change and does not belong in a no-op cleanup.

## Verification

Rendered this file, before and after, in Chromium, Firefox and WebKit. Computed `font-family` and `font-feature-settings` are identical on both sides, both with a host theme set and without, in all three engines. The same probe confirms the comma-corrected version overrides an explicitly-set host font in all three, which is the regression this removal prevents.

`malloy-render` builds clean and its jest projects pass, 231 passed with 0 failures.

Also checked downstream rather than only in isolation: symlinked this build into a Publisher checkout and ran Publisher's own test that a host theme's font reaches renderer-drawn text (malloydata/publisher#1072). It passes, and a dashboard screenshot is unchanged from the pre-patch capture.

One caveat on that last step, for completeness: the patched build is 0.0.433 while that Publisher checkout pins 0.0.432, so it carries an unrelated minor bump. It passed, so no control run was needed.

## Unrelated, noticed while here

`packages/malloy-render`'s own `npm test` script points at `../../jest.config.js`, which does not exist; the file is `jest.config.ts`. It fails before running anything, on `main` as well as here, so I ran `npx jest --selectProjects malloy-render malloy-render-test` instead. Not touched in this PR.
