### PR TITLE
fix(lang): wildcard expansion respects access modifiers

### DIFF
--- a/packages/malloy/src/lang/CONTEXT.md
+++ b/packages/malloy/src/lang/CONTEXT.md
@@ -194,6 +194,65 @@ The `restrictedMode` flag flows: `ParseOptions.restrictedMode` → `MalloyTransl
 
 API-level details: [`../api/CONTEXT.md`](../api/CONTEXT.md) and the JSDoc on `ModelMaterializer.loadRestrictedQuery`.
 
+## Access modifiers
+
+`private`/`internal` (behind `##! experimental.access_modifiers`) are rules
+about which **names** a model may write: `internal` may not be named in a
+query but may be named in definitions in extensions of the source, `private`
+in neither. No modifier means public — `accessModifier` only ever holds
+`'private' | 'internal'`.
+
+The labels are written onto the field defs at the end of the scope which
+declares them — one `include {} extend {}` construct — so within that scope
+there is no modifier on a field yet to deny. That is why a `private` field can
+be named in the scope which declares it and not in a later one.
+
+Reading a namespace is factored into two primitives in
+`ast/field-space/static-space.ts`, and everything that reads one goes through
+them, so a name and a `*` cannot drift apart:
+
+- `resolveNamespace(from, path, level, member)` walks a join path. Each hop is
+  a `readEntry`, and the level narrows through each join with
+  `lessPermissiveAccessLevel()`. It answers "what namespace is at the end of
+  this path, and what level does a reader arrive there with?"
+- `readEntry(space, name, level)` reads one name: records the reference, and
+  refuses the entry if the level may not see it (`field-not-accessible`).
+  `accessibleEntries(space, level)` applies that same rule to every entry.
+
+They are functions over the `FieldSpace` interface, not members of it — the
+interface has many implementors and none of them should inherit a security
+obligation.
+
+**By name** — `StaticSpace.lookup()` is `resolveNamespace` over the path
+before the name, then `readEntry` of the name. It asks "what may I, standing
+here, refer to?", so the starting level is the reading space's
+`accessProtectionLevel()`.
+
+**By `*`** — `QueryOperationSpace.wildcardExpansion()` is `resolveNamespace`
+over the path before the star, then `accessibleEntries` of what it reached. It
+asks "what will a user of the finished source see?", so the starting level is
+`public`: a `*` expands **public fields only**, and the path before it may only
+walk fields which are public too. Neither half depends on what the surrounding
+code is allowed to name, so `select: c.*` fails in a place where `select: c.ai`
+compiles. A disallowed field is dropped silently, since naming it in an error
+would disclose the name the restriction exists to hide; a disallowed path is an
+error, since the user wrote that name themselves.
+
+Inside the scope which declares restrictions they are not on the fields yet
+(see above), so a `*` there sees them all.
+
+`entries()` is the raw namespace map and never filters.
+
+`::Shape` is a second producer of modifiers: applying a type marks every column
+the shape does not list `internal` (`ast/source-elements/typed-source.ts`), so
+what a `*` does with modifiers is also what shape hiding does.
+
+`select:` and `index:` share the expansion and differ after it: each applies
+its own type filter (`select:` atomic fields, `index:` basic ones), its own
+name-conflict check, and its own bookkeeping. A `*` which matches nothing is
+`wildcard-matched-no-fields`, reported at the `*` — it names only the path the
+user wrote.
+
 ## File Organization
 
 ```

--- a/packages/malloy/src/lang/ast/field-space/def-space.ts
+++ b/packages/malloy/src/lang/ast/field-space/def-space.ts
@@ -28,6 +28,7 @@ export class DefSpace extends PassthroughSpace {
         error: {
           message: `Circular reference to '${this.circular.defineName}' in definition`,
           code: 'circular-reference-in-field-definition',
+          at: symbol[0],
         },
         found: undefined,
       };

--- a/packages/malloy/src/lang/ast/field-space/index-field-space.ts
+++ b/packages/malloy/src/lang/ast/field-space/index-field-space.ts
@@ -18,13 +18,11 @@ import {
   IndexFieldReference,
   WildcardFieldReference,
 } from '../query-items/field-references';
-import type {FieldSpace} from '../types/field-space';
 import type {MalloyElement} from '../types/malloy-element';
 import type {SpaceEntry} from '../types/space-entry';
 import {SpaceField} from '../types/space-field';
 import {QueryOperationSpace} from './query-spaces';
 import {ReferenceField} from './reference-field';
-import {StructSpaceField} from './static-space';
 
 export class IndexFieldSpace extends QueryOperationSpace {
   readonly segmentType = 'index';
@@ -105,56 +103,23 @@ export class IndexFieldSpace extends QueryOperationSpace {
   addRefineFromFields(_refineThis: never) {}
 
   protected addWild(wild: WildcardFieldReference): void {
-    let current: FieldSpace = this.exprSpace;
-    const joinPath: string[] = [];
-    if (wild.joinPath) {
-      // walk path to determine namespace for *
-      for (const pathPart of wild.joinPath.list) {
-        const part = pathPart.refString;
-        joinPath.push(part);
-
-        const ent = current.entry(part);
-        if (ent) {
-          if (ent instanceof StructSpaceField) {
-            current = ent.fieldSpace;
-          } else {
-            pathPart.logError(
-              'invalid-wildcard-source',
-              `Field '${part}' does not contain rows and cannot be expanded with '*'`
-            );
-            return;
-          }
-        } else {
-          pathPart.logError(
-            'wildcard-source-not-found',
-            `No such field as '${part}'`
-          );
-          return;
-        }
-      }
+    const entries = this.wildcardExpansion(wild);
+    if (entries === undefined) {
+      return;
     }
+    const joinPath = wild.joinPath?.path ?? [];
     const dialect = this.dialectObj();
     const expandEntries: {name: string; entry: SpaceEntry}[] = [];
-    for (const [name, entry] of current.entries()) {
-      if (wild.except.has(name)) {
-        continue;
-      }
-      if (entry.refType === 'parameter') {
-        continue;
-      }
+    for (const [name, entry] of entries) {
       const indexName = IndexFieldReference.indexOutputName([
         ...joinPath,
         name,
       ]);
       if (this.entry(indexName)) {
-        const conflict = this.expandedWild.get(indexName)?.path?.join('.');
-        wild.logError(
-          'name-conflict-in-wildcard-expansion',
-          `Cannot expand '${name}' in '${
-            wild.refString
-          }' because a field with that name already exists${
-            conflict ? ` (conflicts with ${conflict})` : ''
-          }`
+        this.logWildcardConflict(
+          wild,
+          name,
+          this.expandedWild.get(indexName)?.path?.join('.')
         );
       } else {
         const eTypeDesc = entry.typeDesc();

--- a/packages/malloy/src/lang/ast/field-space/parameter-space.ts
+++ b/packages/malloy/src/lang/ast/field-space/parameter-space.ts
@@ -56,6 +56,7 @@ export class ParameterSpace implements FieldSpace {
         error: {
           message: `\`${name}\` is not defined`,
           code: 'parameter-not-found',
+          at: name,
         },
         found: undefined,
       };
@@ -67,6 +68,7 @@ export class ParameterSpace implements FieldSpace {
             .slice(1)
             .join('.')}\``,
           code: 'invalid-parameter-reference',
+          at: name,
         },
         found: undefined,
       };

--- a/packages/malloy/src/lang/ast/field-space/query-spaces.ts
+++ b/packages/malloy/src/lang/ast/field-space/query-spaces.ts
@@ -5,11 +5,7 @@
 
 import * as model from '../../../model/malloy_types';
 import {mergeFields, nameFromDef} from '../../field-utils';
-import type {
-  FieldSpace,
-  QueryFieldSpace,
-  SourceFieldSpace,
-} from '../types/field-space';
+import type {QueryFieldSpace, SourceFieldSpace} from '../types/field-space';
 import {FieldName} from '../types/field-space';
 import type {MalloyElement} from '../types/malloy-element';
 import {SpaceField} from '../types/space-field';
@@ -20,7 +16,7 @@ import {
 } from '../query-items/field-references';
 import {RefinedSpace} from './refined-space';
 import type {LookupResult} from '../types/lookup-result';
-import {StructSpaceField} from './static-space';
+import {accessibleEntries, resolveNamespace} from './static-space';
 import {QueryInputSpace} from './query-input-space';
 import type {SpaceEntry} from '../types/space-entry';
 import type {
@@ -144,53 +140,70 @@ export abstract class QueryOperationSpace
     return true;
   }
 
-  protected addWild(wild: WildcardFieldReference): void {
-    let current: FieldSpace = this.exprSpace;
-    const joinPath: string[] = [];
-    if (wild.joinPath) {
-      // walk path to determine namespace for *
-      for (const pathPart of wild.joinPath.list) {
-        const part = pathPart.refString;
-        joinPath.push(part);
+  protected logWildcardConflict(
+    wild: WildcardFieldReference,
+    name: string,
+    conflict: string | undefined
+  ) {
+    wild.logError(
+      'name-conflict-in-wildcard-expansion',
+      `Cannot expand '${name}' in '${
+        wild.refString
+      }' because a field with that name already exists${
+        conflict ? ` (conflicts with ${conflict})` : ''
+      }`
+    );
+  }
 
-        const ent = current.entry(part);
-        if (ent) {
-          if (ent instanceof StructSpaceField) {
-            current = ent.fieldSpace;
-          } else {
-            pathPart.logError(
-              'invalid-wildcard-source',
-              `Field '${part}' does not contain rows and cannot be expanded with '*'`
-            );
-            return;
-          }
-        } else {
-          pathPart.logError(
-            'wildcard-source-not-defined',
-            `No such field as '${part}'`
-          );
-          return;
-        }
-      }
+  /**
+   * A `*` expands the fields a user of the finished source will see: it
+   * walks its path and reads the namespace at the end as a public reader,
+   * with the same walk and the same per-entry rule as a lookup by name.
+   * A disallowed path is an error, since the user wrote it; a disallowed
+   * field is dropped, since naming it would disclose it. Returns undefined,
+   * having logged, when the path fails or nothing is left to expand.
+   */
+  protected wildcardExpansion(
+    wild: WildcardFieldReference
+  ): [string, SpaceEntry][] | undefined {
+    const ns = resolveNamespace(
+      this.exprSpace,
+      wild.joinPath?.list ?? [],
+      'public',
+      '*'
+    );
+    if (ns.error) {
+      const at = ns.error.at ?? wild;
+      at.logError(ns.error.code, ns.error.message);
+      return undefined;
     }
+    const entries = accessibleEntries(ns.space, ns.accessLevel).filter(
+      ([name, entry]) => !wild.except.has(name) && entry.refType !== 'parameter'
+    );
+    if (entries.length === 0) {
+      wild.logError(
+        'wildcard-matched-no-fields',
+        `'${wild.refString}' did not match any fields`
+      );
+      return undefined;
+    }
+    return entries;
+  }
+
+  protected addWild(wild: WildcardFieldReference): void {
+    const entries = this.wildcardExpansion(wild);
+    if (entries === undefined) {
+      return;
+    }
+    const joinPath = wild.joinPath?.path ?? [];
     const dialect = this.dialectObj();
     const expandEntries: {name: string; entry: SpaceEntry}[] = [];
-    for (const [name, entry] of current.entries()) {
-      if (wild.except.has(name)) {
-        continue;
-      }
-      if (entry.refType === 'parameter') {
-        continue;
-      }
+    for (const [name, entry] of entries) {
       if (this.entry(name)) {
-        const conflict = this.expandedWild.get(name)?.path.join('.');
-        wild.logError(
-          'name-conflict-in-wildcard-expansion',
-          `Cannot expand '${name}' in '${
-            wild.refString
-          }' because a field with that name already exists${
-            conflict ? ` (conflicts with ${conflict})` : ''
-          }`
+        this.logWildcardConflict(
+          wild,
+          name,
+          this.expandedWild.get(name)?.path.join('.')
         );
       } else {
         const eType = entry.typeDesc();

--- a/packages/malloy/src/lang/ast/field-space/static-space.ts
+++ b/packages/malloy/src/lang/ast/field-space/static-space.ts
@@ -11,6 +11,7 @@ import type {
   SourceDef,
   JoinFieldDef,
   AccessModifierLabel,
+  NonDefaultAccessModifierLabel,
 } from '../../../model/malloy_types';
 import {
   activeName,
@@ -21,7 +22,7 @@ import {
 } from '../../../model/malloy_types';
 
 import type {SpaceEntry} from '../types/space-entry';
-import type {LookupResult} from '../types/lookup-result';
+import type {JoinPath, LookupError, LookupResult} from '../types/lookup-result';
 import type {
   FieldName,
   FieldSpace,
@@ -153,92 +154,25 @@ export class StaticSpace implements FieldSpace {
 
   lookup(path: FieldName[], accessLevel?: AccessModifierLabel): LookupResult {
     accessLevel ??= this.accessProtectionLevel();
-    const head = path[0];
-    const rest = path.slice(1);
-    let found = this.entry(head.refString);
-    if (!found) {
-      return {
-        error: {
-          message: `'${head}' is not defined`,
-          code: 'field-not-found',
-        },
-        found,
-      };
+    const last = path[path.length - 1];
+    const ns = resolveNamespace(
+      this,
+      path.slice(0, -1),
+      accessLevel,
+      last.refString
+    );
+    if (ns.error) {
+      return ns;
     }
-    if (found instanceof SpaceField) {
-      const definition = found.fieldDef();
-      if (definition) {
-        if (!(found instanceof StructSpaceFieldBase) && isJoined(definition)) {
-          // We have looked up a field which is a join, but not a StructSpaceField
-          // because it is someting like "dimension: joinedArray is arrayComputation"
-          // which wasn't known to be a join when the fieldspace was constructed.
-          // TODO don't make one of these every time you do a lookup
-          found = new StructSpaceField(
-            definition,
-            this.structDialect,
-            this.structConnection
-          );
-        }
-        // cswenson review todo I don't know how to count the reference properly now
-        // i tried only writing it as a join reference if there was more in the path
-        // but that failed because lookup([JOINNAME]) is called when translating JOINNAME.AGGREGATE(...)
-        // with a 1-length-path but that IS a join reference and there is a test
-        head.addReference({
-          type:
-            found instanceof StructSpaceFieldBase
-              ? 'joinReference'
-              : 'fieldReference',
-          definition: {
-            type: definition.type,
-            annotations: definition.annotations,
-            location: definition.location,
-          },
-          location: head.location,
-          text: head.refString,
-        });
-      }
-      if (definition?.accessModifier) {
-        if (!accessAllowed(accessLevel, definition.accessModifier)) {
-          return {
-            error: {
-              message: `'${head}' is ${definition?.accessModifier}`,
-              code: 'field-not-accessible',
-            },
-            found: undefined,
-          };
-        }
-      }
-    } // cswenson review todo { else this is SpaceEntry not a field which can only be a param and what is going on? }
+    const read = readEntry(ns.space, last, ns.accessLevel);
+    if (read.error) {
+      return read;
+    }
+    const found = read.found;
     const joinPath =
       found instanceof StructSpaceFieldBase
-        ? [{...found.joinPathElement, name: head.refString}]
-        : [];
-    if (rest.length) {
-      if (found instanceof StructSpaceFieldBase) {
-        const restResult = found.fieldSpace.lookup(
-          rest,
-          lessPermissiveAccessLevel(
-            accessLevel,
-            found.fieldSpace.accessProtectionLevel()
-          )
-        );
-        if (restResult.found) {
-          return {
-            ...restResult,
-            joinPath: [...joinPath, ...restResult.joinPath],
-          };
-        } else {
-          return restResult;
-        }
-      }
-      return {
-        error: {
-          message: `'${head}' cannot contain a '${rest[0]}'`,
-          code: 'invalid-property-access-in-field-reference',
-        },
-        found: undefined,
-      };
-    }
+        ? [...ns.joinPath, {...found.joinPathElement, name: last.refString}]
+        : ns.joinPath;
     return {found, error: undefined, joinPath, isOutputField: false};
   }
 
@@ -291,11 +225,154 @@ export class StaticSourceSpace extends StaticSpace implements SourceFieldSpace {
   }
 }
 
+/**
+ * A namespace reached by walking a join path, and the access level a reader
+ * who started at `accessLevel` has once they arrive there.
+ */
+export interface NamespaceRead {
+  space: FieldSpace;
+  accessLevel: AccessModifierLabel;
+  joinPath: JoinPath;
+  error: undefined;
+}
+
+/**
+ * Walk `path` from `from`, one `readEntry` per hop, narrowing the access
+ * level at each join. `lookup()` walks the path before a name with it and
+ * `*` walks the path before a star. `member` is what is about to be read from the namespace at the end
+ * of the path, a field name or `'*'`, named in the error when a hop is not a
+ * namespace.
+ */
+export function resolveNamespace(
+  from: FieldSpace,
+  path: FieldName[],
+  accessLevel: AccessModifierLabel,
+  member: string
+): NamespaceRead | LookupError {
+  let space = from;
+  const joinPath: JoinPath = [];
+  for (let i = 0; i < path.length; i++) {
+    const hop = path[i];
+    const read = readEntry(space, hop, accessLevel);
+    if (read.error) {
+      return read;
+    }
+    if (!(read.found instanceof StructSpaceFieldBase)) {
+      const next = i + 1 < path.length ? path[i + 1].refString : member;
+      const message =
+        next === '*'
+          ? `'${hop}' does not contain fields and cannot be expanded with '*'`
+          : `'${hop}' cannot contain a '${next}'`;
+      return {
+        error: {
+          message,
+          code: 'invalid-property-access-in-field-reference',
+          at: hop,
+        },
+        found: undefined,
+      };
+    }
+    joinPath.push({...read.found.joinPathElement, name: hop.refString});
+    space = read.found.fieldSpace;
+    accessLevel = lessPermissiveAccessLevel(
+      accessLevel,
+      space.accessProtectionLevel()
+    );
+  }
+  return {space, accessLevel, joinPath, error: undefined};
+}
+
+interface EntryRead {
+  found: SpaceEntry;
+  error: undefined;
+}
+
+/**
+ * Read one name from a namespace on behalf of a reader at `accessLevel`.
+ * Records the reference, and refuses the entry if the reader may not see it.
+ */
+export function readEntry(
+  space: FieldSpace,
+  name: FieldName,
+  accessLevel: AccessModifierLabel
+): EntryRead | LookupError {
+  let found = space.entry(name.refString);
+  let restriction: NonDefaultAccessModifierLabel | undefined;
+  if (!found) {
+    return {
+      error: {
+        message: `'${name}' is not defined`,
+        code: 'field-not-found',
+        at: name,
+      },
+      found: undefined,
+    };
+  }
+  if (found instanceof SpaceField) {
+    const definition = found.fieldDef();
+    restriction = definition?.accessModifier;
+    if (definition) {
+      if (!(found instanceof StructSpaceFieldBase) && isJoined(definition)) {
+        // A field which turned out to be a join after the space was built,
+        // e.g. "dimension: joinedArray is arrayComputation", so the entry
+        // is not a StructSpaceField; promote it so the path can continue.
+        found = new StructSpaceField(
+          definition,
+          space.dialectName(),
+          space.connectionName()
+        );
+      }
+      // A one-element path to a join is still a join reference:
+      // JOIN.aggregate() looks the join up on its own.
+      name.addReference({
+        type:
+          found instanceof StructSpaceFieldBase
+            ? 'joinReference'
+            : 'fieldReference',
+        definition: {
+          type: definition.type,
+          annotations: definition.annotations,
+          location: definition.location,
+        },
+        location: name.location,
+        text: name.refString,
+      });
+    }
+  }
+  if (restriction && !accessAllowed(accessLevel, restriction)) {
+    return {
+      error: {
+        message: `'${name}' is ${restriction}`,
+        code: 'field-not-accessible',
+        at: name,
+      },
+      found: undefined,
+    };
+  }
+  return {found, error: undefined};
+}
+
+/**
+ * Every entry of `space` a reader at `accessLevel` may see, by the same
+ * rule `readEntry` applies to one name.
+ */
+export function accessibleEntries(
+  space: FieldSpace,
+  accessLevel: AccessModifierLabel
+): [string, SpaceEntry][] {
+  return space.entries().filter(([, entry]) => {
+    const restriction =
+      entry instanceof SpaceField
+        ? entry.fieldDef()?.accessModifier
+        : undefined;
+    return restriction === undefined || accessAllowed(accessLevel, restriction);
+  });
+}
+
 function accessAllowed(
   accessLevel: AccessModifierLabel,
-  accessModifier: AccessModifierLabel
+  accessModifier: NonDefaultAccessModifierLabel
 ): boolean {
-  if (accessModifier === 'public') return true;
   if (accessLevel === 'internal') return accessModifier === 'internal';
   if (accessLevel === 'private') return true;
   return false;

--- a/packages/malloy/src/lang/ast/types/lookup-result.ts
+++ b/packages/malloy/src/lang/ast/types/lookup-result.ts
@@ -6,6 +6,7 @@
 import type {JoinElementType, JoinType} from '../../../model';
 import type {MessageCode} from '../../parse-log';
 import type {SpaceEntry} from './space-entry';
+import type {FieldName} from './field-space';
 
 export interface JoinPathElement {
   name: string;
@@ -21,7 +22,7 @@ export interface LookupFound {
   isOutputField: boolean;
 }
 export interface LookupError {
-  error: {message: string; code: MessageCode};
+  error: {message: string; code: MessageCode; at?: FieldName | undefined};
   found: undefined;
 }
 

--- a/packages/malloy/src/lang/parse-log.ts
+++ b/packages/malloy/src/lang/parse-log.ts
@@ -168,12 +168,10 @@ type MessageParameterTypes = {
   'top-by-non-aggregate': string;
   'definition-name-conflict': string;
   'invalid-field-in-index-query': string;
-  'invalid-wildcard-source': string;
-  'wildcard-source-not-found': string;
   'name-conflict-in-wildcard-expansion': string;
   'invalid-parameter-reference': string;
   'parameter-not-found': string;
-  'wildcard-source-not-defined': string;
+  'wildcard-matched-no-fields': string;
   'unexpected-index-segment': string;
   'accept-parameter': string;
   'except-parameter': string;

--- a/packages/malloy/src/lang/test/locations.spec.ts
+++ b/packages/malloy/src/lang/test/locations.spec.ts
@@ -276,6 +276,20 @@ describe('source references', () => {
     });
   });
 
+  test('the join named before a star is a reference', () => {
+    const source = markSource`
+      source: x is a extend { join_one: ${'b is a on true'} }
+      run: x -> { select: ${'b'}.* }
+    `;
+    const m = new TestTranslator(source.code);
+    expect(m).toTranslate();
+    expect(m.referenceAt(pos(source.locations[1]))).toMatchObject({
+      location: source.locations[1],
+      type: 'joinReference',
+      text: 'b',
+    });
+  });
+
   test('reference to query in query', () => {
     const source = markSource`
       source: t is a extend {

--- a/packages/malloy/src/lang/test/parse.spec.ts
+++ b/packages/malloy/src/lang/test/parse.spec.ts
@@ -826,7 +826,7 @@ describe('extend and refine', () => {
         expect(`
           query: q is a -> { group_by: ai }
           run: q + { join_one: b on 1 = 1 } -> { select: b.* }
-        `).toLog(errorMessage("No such field as 'b'"));
+        `).toLog(errorMessage("'b' is not defined"));
         expect(`
           query: q is a -> { group_by: ai }
           run: q + { where: 1 = 1 } -> { select: * }

--- a/packages/malloy/src/lang/test/query.spec.ts
+++ b/packages/malloy/src/lang/test/query.spec.ts
@@ -35,6 +35,13 @@ function getFirstSegmentFields(q: Query | undefined): QueryFieldDef[] {
   return qSeg?.queryFields ?? [];
 }
 
+function getIndexFieldPaths(q: Query | undefined): string[] {
+  const seg = q?.pipeline[0];
+  return seg?.type === 'index'
+    ? seg.indexFields.map(f => f.path.join('.'))
+    : [];
+}
+
 function getFirstSegmentFieldNames(q: Query | undefined): string[] {
   const qf = getFirstSegmentFields(q);
   return qf.map(f =>
@@ -949,14 +956,14 @@ describe('query:', () => {
     });
     test('star error checking', () => {
       expect(markSource`run: a->{select: ${'zzz'}.*}`).toLog(
-        errorMessage("No such field as 'zzz'")
+        errorMessage("'zzz' is not defined")
       );
       expect(markSource`run: ab->{select: b.${'zzz'}.*}`).toLog(
-        errorMessage("No such field as 'zzz'")
+        errorMessage("'zzz' is not defined")
       );
       expect(markSource`run: a->{select: ${'ai'}.*}`).toLog(
         errorMessage(
-          "Field 'ai' does not contain rows and cannot be expanded with '*'"
+          "'ai' does not contain fields and cannot be expanded with '*'"
         )
       );
       expect(markSource`run: a->{select:ai,${'*'}}`).toLog(
@@ -981,6 +988,161 @@ describe('query:', () => {
           "Cannot expand 'ai' in '*' because a field with that name already exists (conflicts with b.ai)"
         )
       );
+    });
+    describe('star expansion and access modifiers', () => {
+      const visibleFields = (...hidden: string[]) =>
+        afields.filter(f => !hidden.includes(f));
+
+      test('star does not expand a private field', () => {
+        const m = model`
+          ##! experimental.access_modifiers
+          source: c is a include { *; private: ai }
+          run: c -> { select: * }
+        `;
+        expect(m).toTranslate();
+        const fields = getFirstSegmentFieldNames(m.translator.getQuery(0));
+        expect(fields).toEqual(visibleFields('ai'));
+      });
+      test('star does not expand an internal field', () => {
+        const m = model`
+          ##! experimental.access_modifiers
+          source: c is a include { *; internal: ai }
+          run: c -> { select: * }
+        `;
+        expect(m).toTranslate();
+        const fields = getFirstSegmentFieldNames(m.translator.getQuery(0));
+        expect(fields).toEqual(visibleFields('ai'));
+      });
+      test('a name in the statement declaring the modifiers still reaches a private field', () => {
+        expect(`
+          ##! experimental.access_modifiers
+          source: c is a include { *; private: ai } extend {
+            dimension: doubled is ai + ai
+          }
+          run: c -> { group_by: doubled }
+        `).toTranslate();
+      });
+      test('star in the scope declaring the modifiers sees everything', () => {
+        const m = model`
+          ##! experimental.access_modifiers
+          source: c is a include { *; private: ai } extend {
+            view: everything is { select: * }
+          }
+          run: c -> everything
+        `;
+        expect(m).toTranslate();
+        const fields = getFirstSegmentFieldNames(m.translator.getQuery(0));
+        expect(fields).toEqual(afields);
+      });
+      test('star in a later extension is public only', () => {
+        const m = model`
+          ##! experimental.access_modifiers
+          source: c is a include {
+            *
+            private: ai
+            internal: af
+          }
+          source: d is c extend {
+            view: v is { select: * }
+          }
+          run: d -> v
+        `;
+        expect(m).toTranslate();
+        const fields = getFirstSegmentFieldNames(m.translator.getQuery(0));
+        expect(fields).toEqual(visibleFields('ai', 'af'));
+      });
+      test('join dot star does not expand the joined private field', () => {
+        const m = model`
+          ##! experimental.access_modifiers
+          source: c is a include { *; private: ai }
+          source: d is a extend { join_one: c on true }
+          run: d -> { select: c.* }
+        `;
+        expect(m).toTranslate();
+        const fields = getFirstSegmentFields(m.translator.getQuery(0)).map(f =>
+          f.type === 'fieldref' ? f.path : `wrong field type ${f.type}`
+        );
+        expect(fields).toEqual(visibleFields('ai').map(f => ['c', f]));
+      });
+      test('a star cannot walk a join it is legal to name', () => {
+        expect(markSource`
+          ##! experimental.access_modifiers
+          source: c is a
+          source: d is a extend { join_one: c on true } include { internal: c }
+          source: e is d extend {
+            dimension: byName is c.ai
+            view: v is { select: ${'c'}.* }
+          }
+        `).toLog(errorMessage("'c' is internal"));
+      });
+      test('star through an inaccessible join is an error', () => {
+        expect(markSource`
+          ##! experimental.access_modifiers
+          source: c is a
+          source: d is a extend {
+            join_one: c on true
+          } include {
+            internal: c
+          }
+          run: d -> { select: ${'c'}.* }
+        `).toLog(errorMessage("'c' is internal"));
+      });
+      test('index star does not index a private field', () => {
+        const m = model`
+          ##! experimental.access_modifiers
+          source: c is a include { *; private: ai }
+          run: c -> { index: * }
+          run: a -> { index: * }
+        `;
+        expect(m).toTranslate();
+        const withPrivate = getIndexFieldPaths(m.translator.getQuery(0));
+        const everything = getIndexFieldPaths(m.translator.getQuery(1));
+        expect(withPrivate).toEqual(everything.filter(f => f !== 'ai'));
+        expect(everything).toContain('ai');
+      });
+      test('index star through an inaccessible join is an error', () => {
+        expect(markSource`
+          ##! experimental.access_modifiers
+          source: c is a
+          source: d is a extend {
+            join_one: c on true
+          } include {
+            internal: c
+          }
+          run: d -> { index: ${'c'}.* }
+        `).toLog(errorMessage("'c' is internal"));
+      });
+      test('a star which names nothing is an error', () => {
+        expect(
+          `run: a -> { select: * { except: ${afields.join(', ')} } }`
+        ).toLog(error('wildcard-matched-no-fields'));
+      });
+      test('a star which names nothing because nothing is public is an error', () => {
+        expect(`
+          ##! experimental.access_modifiers
+          source: c is a include { private: * }
+          run: c -> { select: * }
+        `).toLog(error('wildcard-matched-no-fields'));
+      });
+      test('an index star which names nothing is an error', () => {
+        expect(`
+          ##! experimental.access_modifiers
+          source: c is a include { private: * }
+          run: c -> { index: * }
+        `).toLog(error('wildcard-matched-no-fields'));
+      });
+      test('a star which matches nothing is an error even beside a named field', () => {
+        expect(
+          `run: a -> { select: ai, * { except: ${afields.join(', ')} } }`
+        ).toLog(error('wildcard-matched-no-fields'));
+      });
+    });
+    test('a star can expand a dimension which turned out to be a join', () => {
+      const m = model`
+        source: x is a extend { dimension: copy is ais }
+        run: x -> { select: copy.* }
+      `;
+      expect(m).toTranslate();
     });
     test('regress check extend: and star', () => {
       const m = model`run: ab->{ extend: {dimension: x is 1} select: * }`;

--- a/packages/malloy/src/lang/test/user-type.spec.ts
+++ b/packages/malloy/src/lang/test/user-type.spec.ts
@@ -335,6 +335,41 @@ describe('user type shape errors', () => {
   });
 });
 
+describe('applying a shape to a source', () => {
+  test('a star names only the fields the shape declares', () => {
+    const m = userTypeModel(`
+      type: Shape is { astr :: string, ai :: number }
+      source: shaped is a :: Shape
+      run: shaped -> { select: * }
+    `);
+    expect(m).toTranslate();
+    const query = m.getQuery(0);
+    const segment = query?.pipeline[0];
+    const fields =
+      segment && segment.type === 'project'
+        ? segment.queryFields.map(f =>
+            f.type === 'fieldref' ? f.path[0] : '?'
+          )
+        : [];
+    expect(fields).toEqual(['ai', 'astr']);
+  });
+
+  test('an index star indexes only the fields the shape declares', () => {
+    const m = userTypeModel(`
+      type: Shape is { astr :: string, ai :: number }
+      source: shaped is a :: Shape
+      run: shaped -> { index: * }
+    `);
+    expect(m).toTranslate();
+    const segment = m.getQuery(0)?.pipeline[0];
+    const fields =
+      segment && segment.type === 'index'
+        ? segment.indexFields.map(f => f.path.join('.'))
+        : [];
+    expect(fields).toEqual(['ai', 'astr']);
+  });
+});
+
 describe('experimental gate', () => {
   test('user type without experimental flag', () => {
     expect(`


### PR DESCRIPTION
The initial implementation of [Access modifiers](https://docs.malloydata.dev/documentation/experiments/include) did not include specifications for how it should work with wildcards, as a result, wildcard expansion completely ignores access modifiers.

Thanks to @seckenrode for submitting #3043, and raising this as an issue that needs to be addressed.

#3043 replicated code which respects access control because that code was hidden in `lookup()` and a better approach is to refactor the FieldSpace implementation so that it is possible for the wildcard expansion to have access to the same access control primitives that `lookup()` uses.

The result of this PR is not ideal, and should not be understood as "the design of how wildcards should work with access modifiers". Like much of the experimental implementation of access modifiers, this is a minimal disturbance change while we continue to evaluate the experimental feature.

In this PR `*` in a query will enumerate the public fields, and `*` in a `view:` inside of an `extend {}` block will enumerate the fields that were public in the input of a `include {} extend {}` operation and any new fields introduced in the extend block. This is a slightly-bizzare behavior, but a sensible behavior is a larger disturbance which I judged to be inappropriate at this time.
