### PR TITLE
fix(presto): read EXPLAIN output from Presto versions without PlanNodeId

### DIFF
--- a/packages/malloy-db-trino/src/trino_connection.spec.ts
+++ b/packages/malloy-db-trino/src/trino_connection.spec.ts
@@ -3,8 +3,9 @@
  * SPDX-License-Identifier: MIT
  */
 
-import type {AtomicTypeDef, FieldDef} from '@malloydata/malloy';
-import {TrinoConnection, TrinoExecutor} from '.';
+import type {AtomicTypeDef, FieldDef, SQLSourceDef} from '@malloydata/malloy';
+import {TrinoDialect} from '@malloydata/malloy';
+import {PrestoConnection, TrinoConnection, TrinoExecutor} from '.';
 
 // array(varchar) is array
 const ARRAY_SCHEMA = 'array(integer)';
@@ -150,5 +151,65 @@ describe('Trino connection', () => {
         });
       });
     });
+  });
+});
+
+describe('Presto EXPLAIN schema', () => {
+  function fieldsFromPlan(plan: string): FieldDef[] {
+    const structDef: SQLSourceDef = {
+      type: 'sql_select',
+      name: 'explained',
+      connection: 'presto',
+      selectStr: 'SELECT 1 AS a',
+      dialect: 'presto',
+      fields: [],
+    };
+    PrestoConnection.schemaFromExplain(
+      {rows: [{'Query Plan': plan}], totalRows: 1},
+      structDef,
+      new TrinoDialect()
+    );
+    return structDef.fields;
+  }
+
+  it('reads a plan with a PlanNodeId group (presto >= 0.284)', () => {
+    expect(
+      fieldsFromPlan(
+        '- Output[PlanNodeId 5][a, b] => [expr:integer, expr_1:varchar]\n' +
+          '        Estimates: {rows: 1 (5B)}\n'
+      )
+    ).toEqual([
+      {name: 'a', ...intType},
+      {name: 'b', ...stringType},
+    ]);
+  });
+
+  it('reads a plan without a PlanNodeId group (presto < 0.284)', () => {
+    expect(
+      fieldsFromPlan('- Output[a, b] => [expr:integer, expr_1:varchar]\n')
+    ).toEqual([
+      {name: 'a', ...intType},
+      {name: 'b', ...stringType},
+    ]);
+  });
+
+  it('reads a field named PlanNodeId', () => {
+    expect(
+      fieldsFromPlan(
+        '- Output[PlanNodeId 5][PlanNodeId, b] => [expr:integer, expr_1:varchar]\n'
+      )
+    ).toEqual([
+      {name: 'PlanNodeId', ...intType},
+      {name: 'b', ...stringType},
+    ]);
+    expect(fieldsFromPlan('- Output[PlanNodeId] => [expr:integer]\n')).toEqual([
+      {name: 'PlanNodeId', ...intType},
+    ]);
+  });
+
+  it('reads the plan line as reported in issue #3042', () => {
+    expect(fieldsFromPlan('Output[a]=>[expr:integer]')).toEqual([
+      {name: 'a', ...intType},
+    ]);
   });
 });

--- a/packages/malloy-db-trino/src/trino_connection.ts
+++ b/packages/malloy-db-trino/src/trino_connection.ts
@@ -592,9 +592,16 @@ class TrinoPrestoSchemaParser extends TinyParser {
     });
   }
 
+  /**
+   * Presto 0.284+ writes "Output[PlanNodeId N][NAME_LIST] => ...",
+   * earlier versions write "Output[NAME_LIST] => ...".
+   */
   fieldNameList(): string[] {
-    this.skipTo(']'); // Skip to end of plan
-    this.expect('['); // Expect start of name list
+    this.skipTo('[');
+    if (this.match('id', 'id')) {
+      // [PlanNodeId N] is the only group with two adjacent ids
+      this.skipTo('[');
+    }
     const fieldNames: string[] = [];
     for (;;) {
       const nmToken = this.expect('id');


### PR DESCRIPTION
Fixes #3042. The Presto schema parser assumed the `EXPLAIN` output line always carries a `[PlanNodeId N]` group before the column list; that group only appeared in Presto 0.284, so `.sql()` sources failed against older servers.
