### PR TITLE
fix(mysql): survery and correct mysql-to-malloy type mapping

### DIFF
--- a/packages/malloy-db-mysql/src/mysql_connection.spec.ts
+++ b/packages/malloy-db-mysql/src/mysql_connection.spec.ts
@@ -73,6 +73,73 @@ describeMySQL('db:MySQL', () => {
       await connection.runRawSQL('DROP TABLE `arrests-latest`');
     }
   });
+
+  // The unit spec (packages/malloy/src/dialect/mysql/mysql_types.spec.ts)
+  // pins what each reported spelling means. This pins that these are the
+  // spellings a live server reports -- including the ones MySQL rewrites on
+  // the way in, which is why the declared and reported columns differ here.
+  //
+  // Declared columns are the point, so this is the one case a SELECT cannot
+  // stand in for. The table is TEMPORARY, which scopes it to this connection
+  // and leaves parallel workers alone.
+  it('reads the declared types a live server reports', async () => {
+    await connection.runRawSQL('DROP TEMPORARY TABLE IF EXISTS type_survey');
+    await connection.runRawSQL(`CREATE TEMPORARY TABLE type_survey (
+      c_tinyint    TINYINT,
+      c_boolean    BOOLEAN,
+      c_tinyint_u  TINYINT UNSIGNED,
+      c_int_u      INT UNSIGNED,
+      c_bigint_u   BIGINT UNSIGNED,
+      c_serial     SERIAL,
+      c_float      FLOAT,
+      c_real       REAL,
+      c_dec_scaled DECIMAL(10,2),
+      c_dec_small  DECIMAL(15,0),
+      c_dec_big    DECIMAL(16,0),
+      c_longtext   LONGTEXT,
+      c_mediumtext MEDIUMTEXT,
+      c_tinytext   TINYTEXT,
+      c_varbinary  VARBINARY(20),
+      c_enum       ENUM('a','b'),
+      c_year       YEAR
+    )`);
+    try {
+      const res = await connection.fetchSchemaForTables({t: 'type_survey'}, {});
+      expect(res.errors).toEqual({});
+      const byName = Object.fromEntries(
+        (res.schemas['t']?.fields ?? []).map(f => [f.name, f])
+      );
+      const num = (numberType: string) => ({type: 'number', numberType});
+      expect(byName).toMatchObject({
+        // TINYINT is not a boolean: BOOLEAN is only a spelling of TINYINT(1),
+        // the (1) is a display width, and the column accepts 42.
+        'c_tinyint': num('integer'),
+        'c_boolean': num('integer'),
+        // `unsigned` never changes the Malloy type.
+        'c_tinyint_u': num('integer'),
+        'c_int_u': num('integer'),
+        'c_bigint_u': num('bigint'),
+        'c_serial': num('bigint'),
+        // REAL is reported as double; FLOAT is its own spelling.
+        'c_float': num('float'),
+        'c_real': num('float'),
+        // Scale decides float vs exact; precision decides whether an exact
+        // value survives a JS double.
+        'c_dec_scaled': num('float'),
+        'c_dec_small': num('integer'),
+        'c_dec_big': num('bigint'),
+        'c_longtext': {type: 'string'},
+        'c_mediumtext': {type: 'string'},
+        'c_tinytext': {type: 'string'},
+        // Deliberately opaque.
+        'c_varbinary': {type: 'sql native', rawType: 'varbinary'},
+        'c_enum': {type: 'sql native', rawType: 'enum'},
+        'c_year': {type: 'sql native', rawType: 'year'},
+      });
+    } finally {
+      await connection.runRawSQL('DROP TEMPORARY TABLE type_survey');
+    }
+  });
 });
 
 /**
@@ -108,6 +175,47 @@ describeMySQL('numeric value reading', () => {
       await expect(`
         run: mysql.sql("select 1") -> { select: d is ${largeInt} }
       `).toMatchResult(testModel, {d: largeInt});
+    });
+
+    // MySQL returns SUM() of an integer column as a DECIMAL, so a sum is not
+    // covered by supportBigNumbers the way the column itself is. Reading the
+    // column has always worked; summing it silently rounded to the nearest
+    // even above 2^53 until DECIMAL stopped being converted on arrival.
+    it('preserves precision when summing above 2^53', async () => {
+      const half = BigInt('9007199254740993'); // 2^53 + 1
+      await expect(`
+        run: mysql.sql("""
+          SELECT CAST(${half} AS SIGNED) as v
+          UNION ALL SELECT CAST(${half} AS SIGNED)
+        """) -> { aggregate: s is v.sum() }
+      `).toMatchResult(testModel, {s: half * BigInt(2)});
+    });
+
+    // A sum across a join_many is computed symmetrically, in a fixed-point
+    // domain wide enough to hold the join key's hash -- DECIMAL(55,10). Its
+    // result therefore carries a ten-place fraction that BigInt() rejects
+    // unless the driver strips it.
+    it('preserves precision when summing above 2^53 across a join', async () => {
+      const half = BigInt('9007199254740993'); // 2^53 + 1
+      await expect(`
+        run: mysql.sql("""
+          SELECT 1 as id, CAST(${half} AS SIGNED) as v
+          UNION ALL SELECT 2, CAST(${half} AS SIGNED)
+        """) extend {
+          join_many: kid is mysql.sql("""
+            SELECT 1 as parent_id
+            UNION ALL SELECT 1
+            UNION ALL SELECT 1
+            UNION ALL SELECT 2
+            UNION ALL SELECT 2
+          """) on id = kid.parent_id
+        } -> {
+          aggregate: s is v.sum()
+          // Referencing the join is what keeps it from being elided, which is
+          // what makes the sum symmetric.
+          aggregate: kids is kid.count()
+        }
+      `).toMatchResult(testModel, {s: half * BigInt(2), kids: 5});
     });
   });
 

--- a/packages/malloy-db-mysql/src/mysql_connection.spec.ts
+++ b/packages/malloy-db-mysql/src/mysql_connection.spec.ts
@@ -154,6 +154,8 @@ describeMySQL('numeric value reading', () => {
     await connection.close();
   });
 
+  const half = BigInt('9007199254740993'); // 2^53 + 1
+
   describe('integer types', () => {
     // MySQL infers int for values <= 2^31-1, bigint for larger
     it('reads int correctly', async () => {
@@ -178,11 +180,8 @@ describeMySQL('numeric value reading', () => {
     });
 
     // MySQL returns SUM() of an integer column as a DECIMAL, so a sum is not
-    // covered by supportBigNumbers the way the column itself is. Reading the
-    // column has always worked; summing it silently rounded to the nearest
-    // even above 2^53 until DECIMAL stopped being converted on arrival.
+    // covered by supportBigNumbers the way the column itself is.
     it('preserves precision when summing above 2^53', async () => {
-      const half = BigInt('9007199254740993'); // 2^53 + 1
       await expect(`
         run: mysql.sql("""
           SELECT CAST(${half} AS SIGNED) as v
@@ -196,7 +195,6 @@ describeMySQL('numeric value reading', () => {
     // result therefore carries a ten-place fraction that BigInt() rejects
     // unless the driver strips it.
     it('preserves precision when summing above 2^53 across a join', async () => {
-      const half = BigInt('9007199254740993'); // 2^53 + 1
       await expect(`
         run: mysql.sql("""
           SELECT 1 as id, CAST(${half} AS SIGNED) as v

--- a/packages/malloy-db-mysql/src/mysql_connection.ts
+++ b/packages/malloy-db-mysql/src/mysql_connection.ts
@@ -80,7 +80,6 @@ function castMySQLValue(
     }
     return digits;
   }
-  // Every other type keeps the driver's own decoding.
   return next();
 }
 
@@ -341,9 +340,8 @@ export class MySQLConnection
     typeMap: {[name: string]: string}
   ) {
     for (const fieldName in typeMap) {
-      // Hand the dialect the type exactly as MySQL reported it. Truncating
-      // here would hide DECIMAL's precision and scale, which decide its
-      // Malloy type.
+      // The dialect needs the full reported spelling: DECIMAL's parameters
+      // decide its Malloy type.
       const malloyType = this.dialect.sqlTypeToMalloyType(typeMap[fieldName]);
       // no arrays or records exist in mysql
       structDef.fields.push({...malloyType, name: fieldName});

--- a/packages/malloy-db-mysql/src/mysql_connection.ts
+++ b/packages/malloy-db-mysql/src/mysql_connection.ts
@@ -52,6 +52,38 @@ export class MySQLExecutor {
   }
 }
 
+/**
+ * MySQL renders a DECIMAL at its declared scale, so trailing zeros after the
+ * point are formatting rather than data and stripping them is lossless.
+ *
+ * This matters because every aggregate of an integer column comes back as a
+ * DECIMAL: SUM() of a BIGINT arrives as `18014398509481986.0000000000`, and
+ * Malloy reads a bigint-typed cell with BigInt(), which rejects any fractional
+ * spelling. A value with a real fraction is left alone.
+ *
+ * mysql2 delivers DECIMAL as a string, which is what preserves digits above
+ * 2^53 -- its `decimalNumbers` option parses them into a double instead, and
+ * must stay off. This hook is the last point at which a cell's MySQL type is
+ * known; by the time a row reaches Malloy it is gone.
+ */
+function castMySQLValue(
+  field: MYSQL.TypeCastField,
+  next: MYSQL.TypeCastNext
+): unknown {
+  if (field.type === 'DECIMAL' || field.type === 'NEWDECIMAL') {
+    const digits = next();
+    if (typeof digits === 'string') {
+      const whole = digits.match(/^([+-]?\d+)\.0+$/);
+      if (whole) {
+        return whole[1];
+      }
+    }
+    return digits;
+  }
+  // Every other type keeps the driver's own decoding.
+  return next();
+}
+
 export class MySQLConnection
   extends BaseConnection
   implements Connection, PersistSQLResults
@@ -88,9 +120,10 @@ export class MySQLConnection
         password: this.config.password,
         database: this.config.database,
         multipleStatements: true,
-        decimalNumbers: true,
+        // A BIGINT too wide for a double arrives as an exact string.
         supportBigNumbers: true,
         timezone: '+00:00',
+        typeCast: castMySQLValue,
       });
       await this.connection.query(
         // LTNOTE: Need to make the group_concat_max_len configurable.
@@ -308,9 +341,10 @@ export class MySQLConnection
     typeMap: {[name: string]: string}
   ) {
     for (const fieldName in typeMap) {
-      let mySqlType = typeMap[fieldName].toLocaleLowerCase();
-      mySqlType = mySqlType.trim().split('(')[0];
-      const malloyType = this.dialect.sqlTypeToMalloyType(mySqlType);
+      // Hand the dialect the type exactly as MySQL reported it. Truncating
+      // here would hide DECIMAL's precision and scale, which decide its
+      // Malloy type.
+      const malloyType = this.dialect.sqlTypeToMalloyType(typeMap[fieldName]);
       // no arrays or records exist in mysql
       structDef.fields.push({...malloyType, name: fieldName});
     }

--- a/packages/malloy/src/dialect/mysql/mysql.ts
+++ b/packages/malloy/src/dialect/mysql/mysql.ts
@@ -56,38 +56,68 @@ const inSeconds: Record<string, number> = {
   week: 7 * 24 * 3600,
 };
 
+/**
+ * MySQL reports a column type as
+ *
+ *     base [ '(' params ')' ] [ 'unsigned' ] [ 'zerofill' ]
+ *
+ * and normalizes every alias away before reporting, so a schema read only
+ * ever produces canonical base names. A raw cast reaches this map without
+ * that normalization, and any alias it spells -- REAL, INTEGER, NUMERIC --
+ * falls through to `sql native`.
+ *
+ * No modifier changes the Malloy type: `unsigned` only widens the range, and
+ * the sole type whose range crosses a Malloy boundary is bigint, which is
+ * already `bigint`; `zerofill` is presentation. So the map is keyed on the
+ * base name alone. DECIMAL is not in the map because its Malloy type depends
+ * on its parameters.
+ */
 const mysqlToMalloyTypes: {[key: string]: BasicAtomicTypeDef} = {
-  // TODO: This assumes tinyint is always going to be a boolean.
-  'tinyint': {type: 'boolean'},
+  'tinyint': {type: 'number', numberType: 'integer'},
   'smallint': {type: 'number', numberType: 'integer'},
   'mediumint': {type: 'number', numberType: 'integer'},
   'int': {type: 'number', numberType: 'integer'},
   'bigint': {type: 'number', numberType: 'bigint'},
-  'tinyint unsigned': {type: 'number', numberType: 'integer'},
-  'smallint unsigned': {type: 'number', numberType: 'integer'},
-  'mediumint unsigned': {type: 'number', numberType: 'integer'},
-  'int unsigned': {type: 'number', numberType: 'integer'},
-  'bigint unsigned': {type: 'number', numberType: 'bigint'},
+  'float': {type: 'number', numberType: 'float'},
   'double': {type: 'number', numberType: 'float'},
-  'varchar': {type: 'string'},
-  'varbinary': {type: 'string'},
   'char': {type: 'string'},
+  'varchar': {type: 'string'},
+  'tinytext': {type: 'string'},
   'text': {type: 'string'},
+  'mediumtext': {type: 'string'},
+  'longtext': {type: 'string'},
   'date': {type: 'date'},
   'datetime': {type: 'timestamp'},
   'timestamp': {type: 'timestamp'},
   'time': {type: 'string'},
-  'decimal': {type: 'number', numberType: 'float'},
-  // TODO: Check if we need special handling for boolean.
-  'tinyint(1)': {type: 'boolean'},
 };
+
+/**
+ * Split a reported type into its base name and numeric parameters.
+ *
+ * Only numeric parameter lists are read. ENUM and SET carry quoted value
+ * lists whose quoting rules a regex should not chase, and nothing needs
+ * their values -- both map to `sql native`.
+ */
+function parseMySQLType(sqlType: string): {base: string; params: number[]} {
+  const text = sqlType.trim().toLowerCase();
+  const base = text.match(/^\w+/)?.[0] ?? text;
+  const params = text.match(/^\w+\s*\((\d+(?:\s*,\s*\d+)*)\)/);
+  return {
+    base,
+    params: params ? params[1].split(',').map(p => parseInt(p, 10)) : [],
+  };
+}
 
 function malloyTypeToJSONTableType(malloyType: AtomicTypeDef): string {
   switch (malloyType.type) {
     case 'number':
-      if (malloyType.numberType === 'integer') {
-        return 'INT';
-      } else if (malloyType.numberType === 'bigint') {
+      // BIGINT for both: JSON_TABLE turns an out-of-range value into NULL
+      // without warning, and `integer` is not bounded at 32 bits.
+      if (
+        malloyType.numberType === 'integer' ||
+        malloyType.numberType === 'bigint'
+      ) {
         return 'BIGINT';
       } else {
         return 'DOUBLE';
@@ -95,7 +125,8 @@ function malloyTypeToJSONTableType(malloyType: AtomicTypeDef): string {
     case 'string':
       return 'CHAR(255)'; // JSON_TABLE needs a length
     case 'boolean':
-      return 'INT'; // or TINYINT(1) if you prefer
+      // MySQL has no boolean; TINYINT(1) is only a spelling of TINYINT.
+      return 'INT';
     case 'record':
     case 'array':
       return 'JSON';
@@ -175,12 +206,25 @@ export class MySQLDialect extends Dialect {
   }
 
   sqlTypeToMalloyType(sqlType: string): BasicAtomicTypeDef {
-    // Remove trailing params
-    const baseSqlType = sqlType.match(/^(\w+)/)?.at(0) ?? sqlType;
+    const {base, params} = parseMySQLType(sqlType);
+    if (base === 'decimal') {
+      // DECIMAL is exact, so scale 0 is an integer rather than a float. Above
+      // 15 digits it no longer survives a JS double and must be carried as a
+      // bigint. MySQL reports precision and scale on every decimal; the
+      // defaults match its own when a bare DECIMAL is declared.
+      const [precision, scale] = [params[0] ?? 10, params[1] ?? 0];
+      if (scale > 0) {
+        return {type: 'number', numberType: 'float'};
+      }
+      return {
+        type: 'number',
+        numberType: precision <= 15 ? 'integer' : 'bigint',
+      };
+    }
     return (
-      mysqlToMalloyTypes[baseSqlType.toLowerCase()] || {
+      mysqlToMalloyTypes[base] || {
         type: 'sql native',
-        rawType: baseSqlType,
+        rawType: base,
       }
     );
   }

--- a/packages/malloy/src/dialect/mysql/mysql_types.spec.ts
+++ b/packages/malloy/src/dialect/mysql/mysql_types.spec.ts
@@ -1,0 +1,159 @@
+/*
+ * Copyright Contributors to the Malloy project
+ * SPDX-License-Identifier: MIT
+ */
+
+import type {BasicAtomicTypeDef} from '../../model/malloy_types';
+import {MySQLDialect} from './mysql';
+
+const dialect = new MySQLDialect();
+
+const integer: BasicAtomicTypeDef = {type: 'number', numberType: 'integer'};
+const bigint: BasicAtomicTypeDef = {type: 'number', numberType: 'bigint'};
+const float: BasicAtomicTypeDef = {type: 'number', numberType: 'float'};
+const string: BasicAtomicTypeDef = {type: 'string'};
+const native = (rawType: string): BasicAtomicTypeDef => ({
+  type: 'sql native',
+  rawType,
+});
+
+/**
+ * Every distinct type spelling MySQL 8.4.2 was observed to report, from
+ * `DESCRIBE` on declared columns and from `CREATE TABLE ... AS SELECT` on
+ * expression results -- the two shapes `fetchTableSchema` and
+ * `fetchSelectSchema` read. `DESCRIBE.Type` and
+ * `information_schema.COLUMN_TYPE` agree byte-for-byte on all of them.
+ *
+ * These are the *reported* spellings, not the declarable ones. MySQL rewrites
+ * every alias on write -- INTEGER to int, DEC/NUMERIC/FIXED to decimal, REAL
+ * and DOUBLE PRECISION to double, BOOL/BOOLEAN to tinyint(1), SERIAL to
+ * bigint unsigned, NCHAR to char -- so no alias can reach this map from a
+ * schema read, and none is listed here.
+ */
+const reportedTypes: [string, BasicAtomicTypeDef][] = [
+  // Integers. No modifier changes the type: `unsigned` only widens the range,
+  // and the one type whose range crosses a Malloy boundary is already bigint.
+  ['tinyint', integer],
+  ['tinyint unsigned', integer],
+  ['tinyint(1)', integer],
+  ['tinyint(1) unsigned zerofill', integer],
+  ['tinyint(3) unsigned zerofill', integer],
+  ['smallint', integer],
+  ['smallint unsigned', integer],
+  ['mediumint', integer],
+  ['mediumint unsigned', integer],
+  ['int', integer],
+  ['int unsigned', integer],
+  ['int(10) unsigned zerofill', integer],
+  ['bigint', bigint],
+  ['bigint unsigned', bigint],
+  ['bigint(20) unsigned zerofill', bigint],
+
+  // Approximate numerics.
+  ['float', float],
+  ['float unsigned', float],
+  ['float unsigned zerofill', float],
+  ['float(10,2)', float],
+  ['double', float],
+  ['double unsigned', float],
+
+  // DECIMAL is exact, so its scale decides whether it is a float, and its
+  // precision decides whether it survives a JS double. decimal(23,0) is what
+  // SUM() of an integer column reports.
+  ['decimal(10,2)', float],
+  ['decimal(10,2) unsigned', float],
+  ['decimal(10,2) unsigned zerofill', float],
+  ['decimal(2,1)', float],
+  ['decimal(5,4)', float],
+  ['decimal(8,3)', float],
+  ['decimal(10,0)', integer],
+  ['decimal(15,0)', integer],
+  ['decimal(16,0)', bigint],
+  ['decimal(23,0)', bigint],
+  ['decimal(65,0)', bigint],
+
+  // Text. longtext is what JSON_UNQUOTE(JSON_EXTRACT(...)) reports.
+  ['char(1)', string],
+  ['char(10)', string],
+  ['varchar(20)', string],
+  ['tinytext', string],
+  ['text', string],
+  ['mediumtext', string],
+  ['longtext', string],
+
+  // Temporal. datetime is a wall clock and timestamp a session-rendered
+  // instant, but the UTC session pin makes them coincide; they split when
+  // Malloy gets a datetime type. Nothing carries fractional-second precision.
+  ['date', {type: 'date'}],
+  ['datetime', {type: 'timestamp'}],
+  ['datetime(6)', {type: 'timestamp'}],
+  ['timestamp', {type: 'timestamp'}],
+  ['timestamp(6)', {type: 'timestamp'}],
+  ['time', string],
+  ['time(3)', string],
+
+  // Bytes. Malloy has no bytes type and the driver returns a Buffer, so the
+  // whole family stays opaque -- varbinary included.
+  ['binary(1)', native('binary')],
+  ['varbinary(20)', native('varbinary')],
+  ['tinyblob', native('tinyblob')],
+  ['blob', native('blob')],
+  ['mediumblob', native('mediumblob')],
+  ['longblob', native('longblob')],
+
+  // Deliberately opaque. `enum` orders by declaration index but aggregates
+  // lexically, so calling it a string would make order_by silently mean
+  // something else. `set` is a comma-joined multi-value. `bit` cannot be
+  // told from bit(8). `year` has a 0000 value with no Malloy spelling. `json`
+  // is opaque on seven of eight dialects, and unnestColumns reads its
+  // rawType to pick the JSON_TABLE column type.
+  ["enum('a','b')", native('enum')],
+  ["set('x','y')", native('set')],
+  ['bit(1)', native('bit')],
+  ['bit(8)', native('bit')],
+  ['year', native('year')],
+  ['json', native('json')],
+
+  // Spatial.
+  ['geometry', native('geometry')],
+  ['point', native('point')],
+  ['linestring', native('linestring')],
+  ['polygon', native('polygon')],
+  ['multipoint', native('multipoint')],
+  ['multilinestring', native('multilinestring')],
+  ['multipolygon', native('multipolygon')],
+  ['geomcollection', native('geomcollection')],
+];
+
+describe('mysql schema types', () => {
+  test.each(reportedTypes)('%s', (sqlType, expected) => {
+    expect(dialect.sqlTypeToMalloyType(sqlType)).toEqual(expected);
+  });
+
+  test('an unrecognized type is opaque, keyed on the base name', () => {
+    expect(dialect.sqlTypeToMalloyType('nosuchtype(3) unsigned')).toEqual(
+      native('nosuchtype')
+    );
+  });
+
+  test('the reported spelling may be any case', () => {
+    expect(dialect.sqlTypeToMalloyType('BIGINT UNSIGNED')).toEqual(bigint);
+    expect(dialect.sqlTypeToMalloyType('DECIMAL(20,0)')).toEqual(bigint);
+  });
+});
+
+describe('mysql JSON_TABLE column types', () => {
+  // JSON_TABLE silently returns NULL for a value its declared column type
+  // cannot hold, so an integer must not be declared INT -- Malloy's `integer`
+  // is not bounded at 32 bits, and MySQL's INT is.
+  test.each([
+    [integer, 'BIGINT'],
+    [bigint, 'BIGINT'],
+    [float, 'DOUBLE'],
+  ])('%p unnests as %s', (typeDef, expected) => {
+    const unnest = dialect.unnestColumns([
+      {typeDef, sqlExpression: 'x', rawName: 'x', sqlOutputName: 'x'},
+    ]);
+    expect(unnest).toContain(expected);
+  });
+});

--- a/packages/malloy/src/dialect/mysql/mysql_types.spec.ts
+++ b/packages/malloy/src/dialect/mysql/mysql_types.spec.ts
@@ -110,9 +110,9 @@ const reportedTypes: [string, BasicAtomicTypeDef][] = [
   // Deliberately opaque. `enum` orders by declaration index but aggregates
   // lexically, so calling it a string would make order_by silently mean
   // something else. `set` is a comma-joined multi-value. `bit` cannot be
-  // told from bit(8). `year` has a 0000 value with no Malloy spelling. `json`
-  // is opaque on seven of eight dialects, and unnestColumns reads its
-  // rawType to pick the JSON_TABLE column type.
+  // told from bit(8). `year` has a 0000 value with no Malloy spelling.
+  // `unnestColumns` reads `json`'s rawType to pick the JSON_TABLE column
+  // type, so typing it would have to change with that.
   ["enum('a','b')", native('enum')],
   ["set('x','y')", native('set')],
   ['bit(1)', native('bit')],

--- a/packages/malloy/src/dialect/mysql/mysql_types.spec.ts
+++ b/packages/malloy/src/dialect/mysql/mysql_types.spec.ts
@@ -58,8 +58,7 @@ const reportedTypes: [string, BasicAtomicTypeDef][] = [
   ['double unsigned', float],
 
   // DECIMAL is exact, so its scale decides whether it is a float, and its
-  // precision decides whether it survives a JS double. decimal(23,0) is what
-  // SUM() of an integer column reports.
+  // precision decides whether it survives a JS double.
   ['decimal(10,2)', float],
   ['decimal(10,2) unsigned', float],
   ['decimal(10,2) unsigned zerofill', float],
@@ -71,6 +70,13 @@ const reportedTypes: [string, BasicAtomicTypeDef][] = [
   ['decimal(16,0)', bigint],
   ['decimal(23,0)', bigint],
   ['decimal(65,0)', bigint],
+
+  // Aggregates of an integer column are reported as DECIMAL, which is why the
+  // rows above are reachable without anyone declaring a DECIMAL column.
+  ['decimal(41,0)', bigint], // SUM(bigint)
+  ['decimal(42,0)', bigint], // SUM(CAST(x AS SIGNED))
+  ['decimal(43,0)', bigint], // SUM(CAST(x AS UNSIGNED))
+  ['decimal(23,4)', float], // AVG(bigint)
 
   // Text. longtext is what JSON_UNQUOTE(JSON_EXTRACT(...)) reports.
   ['char(1)', string],


### PR DESCRIPTION
When the MySQL dialect was added, it was done quickly without taking time to do a full and careful survey of how the various MySQL data types should work in Malloy.

There are over 70 different ways to write types in MySQL and they result in about 20 different actual types which could appear in a schema. This PR makes an informed and intentional call on what to do with each of those types.

For #3009 this now handles the previously un-mapped `float` type in a schema.
For #3049 this now correctly maps the various integer sub-types.

TODO AFTER LANDING
- [ ] Update docs page with the exact map
