### PR TITLE
fix(test): wait for mysql on TCP, not on a log line

### DIFF
--- a/test/mysql/mysql_start.sh
+++ b/test/mysql/mysql_start.sh
@@ -9,6 +9,28 @@ SCRIPTDIR=$(cd $(dirname $0); pwd)
 DATADIR=$(dirname $SCRIPTDIR)/data/mysql
 CONTAINER_NAME="mysql-malloy"
 
+# The image starts mysqld twice: a temporary server to initialize the data
+# directory, listening on the unix socket only, and then the real server on
+# 3306. Both log "mysqld: ready for connections", so the log cannot say which
+# one is up. Wait on a TCP connection, which is what the loader needs.
+wait_for_mysql() {
+  local counter=0
+  echo -n "Waiting for $CONTAINER_NAME ..."
+  until docker exec "$CONTAINER_NAME" mysqladmin ping --protocol=TCP -h127.0.0.1 -uroot --silent > /dev/null 2>&1
+  do
+    counter=$((counter+1))
+    # give up after 2 minutes
+    if [ $counter -eq 60 ]
+    then
+      echo
+      return 1
+    fi
+    echo -n .
+    sleep 2
+  done
+  echo
+}
+
 # Check for existing container
 if docker container inspect "$CONTAINER_NAME" > /dev/null 2>&1; then
   if [ "$(docker inspect -f '{{.State.Running}}' "$CONTAINER_NAME")" = "true" ]; then
@@ -17,36 +39,25 @@ if docker container inspect "$CONTAINER_NAME" > /dev/null 2>&1; then
   fi
   echo "Restarting existing $CONTAINER_NAME container..."
   docker start "$CONTAINER_NAME"
-  while ! docker logs "$CONTAINER_NAME" 2>&1 | grep -q "mysqld: ready for connections"; do
-    sleep 2
-  done
+  if ! wait_for_mysql; then
+    docker logs "$CONTAINER_NAME" >& ./.tmp/mysql-malloy.logs
+    echo "MySQL did not restart successfully, check .tmp/mysql-malloy.logs"
+    exit 1
+  fi
   echo "MySQL running on port 3306"
   exit 0
 fi
 
-docker run -p 3306:3306 -d -v $DATADIR:/init_data --name "$CONTAINER_NAME" -e MYSQL_ALLOW_EMPTY_PASSWORD=yes -d mysql:8.4.2
+docker run -p 3306:3306 -d -v $DATADIR:/init_data --name "$CONTAINER_NAME" -e MYSQL_ALLOW_EMPTY_PASSWORD=yes mysql:8.4.2
 
-# wait for server to start
-counter=0
-echo -n Starting Docker ...
-while ! docker logs "$CONTAINER_NAME" 2>&1 | grep -q "mysqld: ready for connections"
-do
-  sleep 10
-  counter=$((counter+1))
-  # if doesn't start after 2 minutes, output logs and kill process
-  if [ $counter -eq 120 ]
-  then
-    docker logs "$CONTAINER_NAME" >& ./.tmp/mysql-malloy.logs
-    docker rm -f "$CONTAINER_NAME"
-    echo "MySQL did not start successfully, check .tmp/mysql-malloy.logs"
-    exit 1
-    break
-  fi
-  echo -n ...
-done
+if ! wait_for_mysql; then
+  docker logs "$CONTAINER_NAME" >& ./.tmp/mysql-malloy.logs
+  docker rm -f "$CONTAINER_NAME"
+  echo "MySQL did not start successfully, check .tmp/mysql-malloy.logs"
+  exit 1
+fi
 
 # load the test data.
-echo
 echo Loading Test Data
 docker exec "$CONTAINER_NAME" cp /init_data/malloytest.mysql.gz /tmp
 docker exec "$CONTAINER_NAME" gunzip /tmp/malloytest.mysql.gz


### PR DESCRIPTION
`db-mysql` fails roughly one run in five, always inside `mysql_start.sh` before any
test runs.

The mysql image starts mysqld twice — a temporary server that initializes the data
directory, listening on the unix socket only, then the real server on 3306 — and both
log `mysqld: ready for connections`. The wait loop greps for that string, so it can
leave the loop while nothing is listening on TCP, and the next command is
`mysql -P3306 -h127.0.0.1`. On mysql:8.4.2 the two log lines are about 2s apart and the
loop polled every 10s. Both wait loops now poll `mysqladmin ping --protocol=TCP`, which
is the connection the loader actually needs.

Diagnosed by @jswir, while a red `db-mysql` unrelated to his change was blocking #3008.

The fresh-start deadline was `counter -eq 120` with `sleep 10` — twenty minutes, not the
two its comment claimed. It is now sixty two-second polls, and the restart path, which
had no deadline at all, shares it.
