### PR TITLE
fix(trino): move to the renamed @trinodb/trino-js-client

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -107,7 +107,7 @@ updates:
           - "@google-cloud/*"
           - "@databricks/*"
           - "@prestodb/*"
-          - "trino-client"
+          - "@trinodb/*"
           - "snowflake-sdk"
           - "@motherduck/*"
           - "mysql2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11587,6 +11587,15 @@
       "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
       "license": "MIT"
     },
+    "node_modules/@trinodb/trino-js-client": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@trinodb/trino-js-client/-/trino-js-client-0.3.2.tgz",
+      "integrity": "sha512-TNFOXkk2wp/SSgNtRdfArKZSR78ebYR7zxTobu+o01C+KJO7ELWcti90DeCw4WJDh0YbjZGT0XuXV48n7TEyoQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "axios": "1.19.0"
+      }
+    },
     "node_modules/@ts-graphviz/adapter": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@ts-graphviz/adapter/-/adapter-2.0.6.tgz",
@@ -13395,13 +13404,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
-      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.19.0.tgz",
+      "integrity": "sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
-        "form-data": "^4.0.5",
+        "form-data": "^4.0.6",
         "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
@@ -27799,26 +27808,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/trino-client": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/trino-client/-/trino-client-0.2.9.tgz",
-      "integrity": "sha512-bINcQxDH5v9DR1zqXtoNqnRJ5leYMyYzRuFZLsoqg4irWYPDh/4wBndC8c2x+QfNIOr6c35BtHKOwotelqSATg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "axios": "1.13.2"
-      }
-    },
-    "node_modules/trino-client/node_modules/axios": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.2.tgz",
-      "integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
     "node_modules/triple-beam": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
@@ -30900,9 +30889,9 @@
       "dependencies": {
         "@malloydata/malloy": "0.0.434",
         "@prestodb/presto-js-client": "^1.1.0",
+        "@trinodb/trino-js-client": "^0.3.2",
         "gaxios": "^4.2.0",
-        "luxon": "^3.7.2",
-        "trino-client": "^0.2.2"
+        "luxon": "^3.7.2"
       },
       "devDependencies": {
         "@types/luxon": "^3.7.2"

--- a/packages/malloy-db-trino/package.json
+++ b/packages/malloy-db-trino/package.json
@@ -25,9 +25,9 @@
   "dependencies": {
     "@malloydata/malloy": "0.0.434",
     "@prestodb/presto-js-client": "^1.1.0",
+    "@trinodb/trino-js-client": "^0.3.2",
     "gaxios": "^4.2.0",
-    "luxon": "^3.7.2",
-    "trino-client": "^0.2.2"
+    "luxon": "^3.7.2"
   },
   "devDependencies": {
     "@types/luxon": "^3.7.2"

--- a/packages/malloy-db-trino/src/test.nonspec.ts
+++ b/packages/malloy-db-trino/src/test.nonspec.ts
@@ -1,5 +1,5 @@
 export {};
-/*import {Trino, BasicAuth} from 'trino-client';
+/*import {Trino, BasicAuth} from '@trinodb/trino-js-client';
 import PrestoClient from '@prestodb/presto-js-client';
 
 // function CallPresto(client: Client, query: string ) {

--- a/packages/malloy-db-trino/src/trino_connection.ts
+++ b/packages/malloy-db-trino/src/trino_connection.ts
@@ -28,8 +28,8 @@ import {BaseConnection} from '@malloydata/malloy/connection';
 import type {PrestoClientConfig, PrestoQuery} from '@prestodb/presto-js-client';
 import {PrestoClient} from '@prestodb/presto-js-client';
 import {randomUUID} from 'crypto';
-import type {ConnectionOptions} from 'trino-client';
-import {Trino, BasicAuth} from 'trino-client';
+import type {ConnectionOptions} from '@trinodb/trino-js-client';
+import {Trino, BasicAuth} from '@trinodb/trino-js-client';
 import {resultRowToQueryRecord} from './result-to-querydata';
 
 export interface TrinoManagerOptions {
@@ -128,7 +128,7 @@ class TrinoRunner implements BaseRunner {
   client: Trino;
   constructor(config: TrinoConnectionConfiguration) {
     let server = config.server;
-    // trino-client has no separate port field — merge into the server URL
+    // the client has no separate port field — merge into the server URL
     if (server && config.port) {
       try {
         const url = new URL(server);

--- a/packages/malloy-db-trino/src/trino_query_metadata.spec.ts
+++ b/packages/malloy-db-trino/src/trino_query_metadata.spec.ts
@@ -10,7 +10,7 @@ jest.mock('@prestodb/presto-js-client', () => ({
 }));
 
 import {PrestoClient} from '@prestodb/presto-js-client';
-import {Trino} from 'trino-client';
+import {Trino} from '@trinodb/trino-js-client';
 import {PrestoConnection, TrinoConnection} from './trino_connection';
 
 const PrestoClientMock = PrestoClient as unknown as jest.Mock;

--- a/packages/malloy-render-validator/src/fake-dom.ts
+++ b/packages/malloy-render-validator/src/fake-dom.ts
@@ -130,7 +130,7 @@ export function installFakeDom(): void {
 
 /**
  * Remove the DOM globals we installed, so libraries loaded later
- * (e.g. axios via trino-client) don't think they're in a browser.
+ * (e.g. axios via @trinodb/trino-js-client) don't think they're in a browser.
  */
 export function removeFakeDom(): void {
   if (!installed) return;

--- a/packages/malloy-render-validator/src/index.ts
+++ b/packages/malloy-render-validator/src/index.ts
@@ -14,7 +14,7 @@
 // We install fake DOM globals (window, document, navigator) just long
 // enough for the renderer to load, then immediately remove them. If
 // we left them in place, any library that checks
-// `typeof window !== 'undefined'` (e.g. axios, used by trino-client)
+// `typeof window !== 'undefined'` (e.g. axios, used by @trinodb/trino-js-client)
 // would think it's in a browser and break in different ways.
 //
 // We use explicit require() instead of import because TypeScript


### PR DESCRIPTION
The Trino client was republished under the `trinodb` scope. Versions up to 0.2.9 shipped as the unscoped `trino-client`; the scoped `@trinodb/trino-js-client` starts at 0.3.0. The unscoped package is no longer maintained.

I am a Trino maintainer, and we are working through the downstream consumers of the client as part of that move.

## This also clears the axios hold

`docs/dependency-management` tracks this connector as a standing advisory hold:

> `high      axios, trino-client          → Trino connector maintenance`

The lockfile carried a nested copy pinned by the old client. After the bump it is gone and the top level moves up:

```
before:  node_modules/axios                            1.18.1
         node_modules/trino-client/node_modules/axios  1.13.2
after:   node_modules/axios                            1.19.0
```

axios 1.19.0 closes the prototype pollution fix from 1.15.1, the CR/LF header injection vector, the NO_PROXY loopback bypass from 1.16.0, and raises the form-data floor past GHSA-hmw2-7cc7-3qxx.

## Risk

Low. The declaration files of `trino-client@0.2.9` and `@trinodb/trino-js-client@0.3.2` are identical byte for byte:

```
$ npm pack trino-client@0.2.9 && tar xzf trino-client-0.2.9.tgz
$ diff -u package/dist/index.d.ts node_modules/@trinodb/trino-js-client/dist/index.d.ts
$ echo $?
0
```

So this is a rename of the dependency and its import specifiers, with no API change. Same twenty exports, same shapes.

0.3.2 contains no source changes relative to 0.3.1 either — it is a dependency-maintenance release we cut specifically so that downstream renames would carry the axios fixes rather than only a new name.

## Changes

- `packages/malloy-db-trino` — dependency and the imports in `trino_connection.ts`, `trino_query_metadata.spec.ts`, and the commented-out import in `test.nonspec.ts`
- `packages/malloy-render-validator` — two comments that name the package by its old identifier
- `.github/dependabot.yml` — the `connectors` group pattern becomes `@trinodb/*`, otherwise the old `trino-client` pattern stops matching and this connector silently drops out of the group
- `package-lock.json`

## Verification

I did not run the Trino dialect CI, which needs a live Trino. Beyond the declaration comparison above, I verified 0.3.2 against a real coordinator using a harness built from this connector's own call patterns — `Trino.create`, `BasicAuth`, the `for await` drain in `runSQL`, error handling off the result object, and session header round-tripping. All checks pass. That harness now runs in the client's CI (trinodb/trino-js-client#970).

Commits are signed off per CONTRIBUTING.md.