### PR TITLE
fix(trino): move to the renamed @trinodb/trino-js-client

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -107,7 +107,7 @@ updates:
           - "@google-cloud/*"
           - "@databricks/*"
           - "@prestodb/*"
-          - "trino-client"
+          - "@trinodb/*"
           - "snowflake-sdk"
           - "@motherduck/*"
           - "mysql2"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -56,6 +56,13 @@ updates:
       # (pg/pg-cursor/pg-query-stream move together); the real fix is issue #2928.
       - dependency-name: "pg"
       - dependency-name: "pg-query-stream"
+      # axios exact-pinned (1.19.0) at the root to match the exact pin inside
+      # @trinodb/trino-js-client. Any other version resolves a second, nested copy
+      # under the connector instead of one hoisted axios. The pin is not ours to
+      # keep: trinodb/trino-js-client#956 drops axios for native fetch in their
+      # 1.0.0, and this clears when we take that. See
+      # docs/dependency-management/CONTEXT.md.
+      - dependency-name: "axios"
       # @google-cloud/bigquery + common + paginator held at v7/v5 (a coupled set).
       # bigquery 8 -> common 6 -> google-auth-library 10 -> gaxios 7, and gaxios 7
       # does an ESM-only dynamic import() that fails under jest without

--- a/docs/dependency-management/CONTEXT.md
+++ b/docs/dependency-management/CONTEXT.md
@@ -21,7 +21,7 @@ collected into groups so a bump lands as one reviewable PR with a clear blast ra
 instead of a scatter of one-offs:
 
 - **`connectors`** — the database SDKs (`@google-cloud/*`, `@databricks/*`,
-  `trino-client`, `mysql2`, `pg`, …). Historically these have all been problematic when we update them, so we keep them in their own little corner.
+  `@trinodb/*`, `mysql2`, `pg`, …). Historically these have all been problematic when we update them, so we keep them in their own little corner.
 - **`toolchain`** — the gts / typescript / eslint / prettier cluster, majors only;
   they move together or not at all.
 - **`minor-and-patch`** — everything else's in-range minors/patches, folded into one
@@ -223,11 +223,13 @@ tied to a specific Snowflake issue — verify before acting on it.)*
 Holds open (alert-only — no PR):
 - `fast-xml-parser` — 2×critical, 4×high *(also pulled by BigQuery's
   `@google-cloud/storage`; clears only when every owner moves)*
-- `axios` — high/medium *(also via Trino's `trino-client` and the publisher)*
 - `bn.js` — 2×medium
 
+Snowflake's `axios` resolves to the tree's single hoisted copy, held at `1.19.0` by
+the Trino axios pin below. No axios advisory is open against it.
+
 Waiting for: a security advisory to force our hand (the held `fast-xml-parser` /
-`axios` / `bn.js` alerts are the standing cost, reviewed monthly), **or** Snowflake
+`bn.js` alerts are the standing cost, reviewed monthly), **or** Snowflake
 restructuring the npm package so it bundles downstream. Either way the bump is
 deliberate, verified against the live Snowflake CI env — never a lockfile float.
 
@@ -274,6 +276,41 @@ per-platform `@databricks/databricks-sql-kernel-*` `.node` binaries, `approve-na
 them in each — then take 1.16.0+ and verify against the live Databricks CI env. Until
 then it's supported-or-rots: the connector is welded to the embedding apps' bundlers,
 so it can't float.
+
+### Trino — `axios` pinned exactly at `1.19.0` to match the connector's own pin
+Owned by the **root** `package.json`. `@trinodb/trino-js-client` declares `axios` as
+an exact version, not a range; no upstream rationale is recorded. npm hoists one
+`axios` only while the root resolves to that same version. At any other value — a
+routine in-range float to `1.20.0` included — a **second copy** nests under
+`node_modules/@trinodb/trino-js-client`, and the advisories land on it.
+
+Both surfaces: exact `1.19.0` in the root `package.json` **and** `ignore: axios` in
+`dependabot.yml`.
+
+**The connector is exact-pinned too — `@trinodb/trino-js-client` at `0.3.2` in
+`packages/malloy-db-trino` — and the two move together.** Upstream ships releases
+whose only change is the axios pin (`0.3.0`/`0.3.1` carried `1.13.2`; `0.3.2` carries
+`1.19.0` and nothing else). Under a caret, such a release lands a connector whose
+exact axios no longer matches the root, npm nests a second copy, and the `ignore`
+above guarantees nothing ever proposes re-converging it. **Any `@trinodb` bump must
+move the root `axios` pin to that release's exact axios, in the same PR.**
+
+Deliberately *not* in the `ignore` list: it stays in the `connectors` group so their
+`1.0.0` still arrives as a standalone PR. The group is the notification; the rule
+above is the guard.
+
+The publisher declares `axios ^1.19.0` — a floor, not a pin. `malloy-db-publisher`
+is published, so its range is what downstream consumers resolve; the floor keeps them
+above the advisory range rather than inheriting it. `1.19.0` satisfies it here, so the
+hoisted copy still serves it and there is nothing extra to unwind.
+
+Cost: axios security fixes arrive on the connector's release cadence, not npm's. An
+advisory against `1.19.0` is answered by a `@trinodb/trino-js-client` release
+carrying a newer pin, not by bumping axios here.
+
+Waiting for: **trinodb/trino-js-client#956** — drops axios for native `fetch` +
+`undici`, public API unchanged, targeted at their `1.0.0` (their #982). Taking that
+release ends the constraint and the root returns to a caret.
 
 ### uuid + @noble/hashes — held below their ESM-only majors
 Owned by `packages/malloy` (core, published as `@malloydata/malloy`). **uuid 12+ and
@@ -338,9 +375,9 @@ here only because the rule is "everything ignored is written down."
 
 ## Not pins — context, so this list stays short
 
-- **Connector SDKs other than Snowflake and Databricks** (`trino-client`,
+- **Connector SDKs other than Snowflake and Databricks** (`@trinodb/*`,
   `@google-cloud/*`, `mysql2`, …) aren't pinned — just not-yet-upgraded.
-  Their transitive advisories (`axios`, `thrift`, `fast-xml-parser`, `uuid`) clear
+  Their transitive advisories (`thrift`, `fast-xml-parser`, `uuid`) clear
   by a deliberate per-dialect SDK bump, each verified against that dialect's live
   CI env. They're collected into the `connectors` group in `dependabot.yml` so a
   bump lands as its own deliberate PR instead of riding the routine minor/patch

--- a/docs/dependency-management/npm-security-audit.md
+++ b/docs/dependency-management/npm-security-audit.md
@@ -105,9 +105,8 @@ Security sweep — N prod findings
 
 Every CRITICAL and HIGH mapped to the pin it reconciles to (low/moderate stay a count):
   critical  fast-xml-parser              → Snowflake hold (snowflake-sdk 2.3.1)
-  high      fast-xml-parser, axios       → Snowflake hold
+  high      fast-xml-parser              → Snowflake hold
   high      thrift                       → Databricks hold (@databricks/sql 1.15.0)
-  high      axios, trino-client          → Trino connector maintenance
   high      vega ×6                      → Vega v5 renderer hold (vega-lite ^5)
   high      ws, tmp, socket.io-parser    → dev tooling, never ships (out of scope)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@types/jest": "^29.0.3",
         "@types/node": "^22.20.0",
         "@types/yargs": "^17.0.33",
-        "axios": "^1.12.0",
+        "axios": "1.19.0",
         "babel-jest": "^29.3.1",
         "cross-os": "^1.5.0",
         "csv-stringify": "^5.6.5",
@@ -30611,7 +30611,7 @@
       "license": "MIT",
       "dependencies": {
         "@malloydata/malloy": "0.0.434",
-        "axios": "^1.6.7"
+        "axios": "^1.19.0"
       },
       "devDependencies": {
         "@openapitools/openapi-generator-cli": "^2.39.1"
@@ -30889,7 +30889,7 @@
       "dependencies": {
         "@malloydata/malloy": "0.0.434",
         "@prestodb/presto-js-client": "^1.1.0",
-        "@trinodb/trino-js-client": "^0.3.2",
+        "@trinodb/trino-js-client": "0.3.2",
         "gaxios": "^4.2.0",
         "luxon": "^3.7.2"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -11587,6 +11587,15 @@
       "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
       "license": "MIT"
     },
+    "node_modules/@trinodb/trino-js-client": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@trinodb/trino-js-client/-/trino-js-client-0.3.2.tgz",
+      "integrity": "sha512-TNFOXkk2wp/SSgNtRdfArKZSR78ebYR7zxTobu+o01C+KJO7ELWcti90DeCw4WJDh0YbjZGT0XuXV48n7TEyoQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "axios": "1.19.0"
+      }
+    },
     "node_modules/@ts-graphviz/adapter": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@ts-graphviz/adapter/-/adapter-2.0.6.tgz",
@@ -13395,13 +13404,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
-      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.19.0.tgz",
+      "integrity": "sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
-        "form-data": "^4.0.5",
+        "form-data": "^4.0.6",
         "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
@@ -27799,26 +27808,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/trino-client": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/trino-client/-/trino-client-0.2.9.tgz",
-      "integrity": "sha512-bINcQxDH5v9DR1zqXtoNqnRJ5leYMyYzRuFZLsoqg4irWYPDh/4wBndC8c2x+QfNIOr6c35BtHKOwotelqSATg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "axios": "1.13.2"
-      }
-    },
-    "node_modules/trino-client/node_modules/axios": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.2.tgz",
-      "integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
     "node_modules/triple-beam": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
@@ -30900,9 +30889,9 @@
       "dependencies": {
         "@malloydata/malloy": "0.0.434",
         "@prestodb/presto-js-client": "^1.1.0",
+        "@trinodb/trino-js-client": "^0.3.2",
         "gaxios": "^4.2.0",
-        "luxon": "^3.7.2",
-        "trino-client": "^0.2.2"
+        "luxon": "^3.7.2"
       },
       "devDependencies": {
         "@types/luxon": "^3.7.2"

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "@types/jest": "^29.0.3",
     "@types/node": "^22.20.0",
     "@types/yargs": "^17.0.33",
-    "axios": "^1.12.0",
+    "axios": "1.19.0",
     "babel-jest": "^29.3.1",
     "cross-os": "^1.5.0",
     "csv-stringify": "^5.6.5",

--- a/packages/malloy-db-publisher/package.json
+++ b/packages/malloy-db-publisher/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@malloydata/malloy": "0.0.434",
-    "axios": "^1.6.7"
+    "axios": "^1.19.0"
   },
   "devDependencies": {
     "@openapitools/openapi-generator-cli": "^2.39.1"

--- a/packages/malloy-db-publisher/scripts/patch-common.js
+++ b/packages/malloy-db-publisher/scripts/patch-common.js
@@ -6,6 +6,7 @@
  * This ensures that:
  * 1. configuration.baseOptions (including timeout) is merged into axios requests in common.ts
  * 2. RawAxiosRequestConfig is exported from index.ts
+ * 3. createRequestFunction declares its return type in common.ts
  *
  */
 
@@ -53,9 +54,52 @@ if (fs.existsSync(commonTsPath)) {
         } else {
             console.error('✗ Could not find the expected pattern in common.ts');
             console.error('The file format may have changed. Please check manually.');
+            // A missed patch here still compiles — it silently drops
+            // configuration.baseOptions, so per-connection timeoutMs stops being
+            // applied. Fail loudly rather than report success.
+            process.exitCode = 1;
         }
     } else {
         console.log('✓ common.ts already patched, skipping...');
+    }
+} else {
+    console.log('⚠ common.ts not found, skipping...');
+}
+
+// Patch common.ts: give createRequestFunction a nameable return type.
+//
+// axios >= 1.19 defaults request()'s R to a non-exported `unique symbol` and
+// resolves the response through a conditional on it. With the generated
+// `request<T, R>` call, R stays a type parameter, so that conditional never
+// reduces: tsc cannot name the inferred return type (TS2527), and naming it
+// Promise<R> does not type-check either (TS2322).
+//
+// Dropping R and letting request() use its own default makes the response
+// concrete — Promise<AxiosResponse<T>>. Nothing passes R explicitly; all call
+// sites in api.ts infer through the enclosing AxiosPromise<...> return type,
+// which binds T just as well.
+console.log('Patching common.ts to give createRequestFunction a nameable return type...');
+
+if (fs.existsSync(commonTsPath)) {
+    let content = fs.readFileSync(commonTsPath, 'utf8');
+
+    if (!content.includes('BASE_PATH): Promise<AxiosResponse<T>> =>')) {
+        const signature = /return <T = unknown, R = AxiosResponse<T>>\((axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH)\) =>/;
+        const call = /return axios\.request<T, R>\(axiosRequestArgs\);/;
+
+        if (signature.test(content) && call.test(content)) {
+            content = content.replace(signature, 'return <T = unknown>($1): Promise<AxiosResponse<T>> =>');
+            content = content.replace(call, 'return axios.request<T>(axiosRequestArgs);');
+            fs.writeFileSync(commonTsPath, content, 'utf8');
+            console.log('✓ Successfully annotated createRequestFunction');
+            patched = true;
+        } else {
+            console.error('✗ Could not find createRequestFunction in common.ts');
+            console.error('The file format may have changed. Please check manually.');
+            process.exitCode = 1;
+        }
+    } else {
+        console.log('✓ createRequestFunction already annotated, skipping...');
     }
 } else {
     console.log('⚠ common.ts not found, skipping...');

--- a/packages/malloy-db-publisher/src/client/common.ts
+++ b/packages/malloy-db-publisher/src/client/common.ts
@@ -143,12 +143,12 @@ export const toPathString = function (url: URL) {
  * @export
  */
 export const createRequestFunction = function (axiosArgs: RequestArgs, globalAxios: AxiosInstance, BASE_PATH: string, configuration?: Configuration) {
-    return <T = unknown, R = AxiosResponse<T>>(axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
+    return <T = unknown>(axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH): Promise<AxiosResponse<T>> => {
         const axiosRequestArgs = {
         ...configuration?.baseOptions,
         ...axiosArgs.options,
         url: (axios.defaults.baseURL ? '' : configuration?.basePath ?? basePath) + axiosArgs.url
         };
-        return axios.request<T, R>(axiosRequestArgs);
+        return axios.request<T>(axiosRequestArgs);
     };
 }

--- a/packages/malloy-db-trino/package.json
+++ b/packages/malloy-db-trino/package.json
@@ -25,9 +25,9 @@
   "dependencies": {
     "@malloydata/malloy": "0.0.434",
     "@prestodb/presto-js-client": "^1.1.0",
+    "@trinodb/trino-js-client": "^0.3.2",
     "gaxios": "^4.2.0",
-    "luxon": "^3.7.2",
-    "trino-client": "^0.2.2"
+    "luxon": "^3.7.2"
   },
   "devDependencies": {
     "@types/luxon": "^3.7.2"

--- a/packages/malloy-db-trino/package.json
+++ b/packages/malloy-db-trino/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@malloydata/malloy": "0.0.434",
     "@prestodb/presto-js-client": "^1.1.0",
-    "@trinodb/trino-js-client": "^0.3.2",
+    "@trinodb/trino-js-client": "0.3.2",
     "gaxios": "^4.2.0",
     "luxon": "^3.7.2"
   },

--- a/packages/malloy-db-trino/src/test.nonspec.ts
+++ b/packages/malloy-db-trino/src/test.nonspec.ts
@@ -1,5 +1,5 @@
 export {};
-/*import {Trino, BasicAuth} from 'trino-client';
+/*import {Trino, BasicAuth} from '@trinodb/trino-js-client';
 import PrestoClient from '@prestodb/presto-js-client';
 
 // function CallPresto(client: Client, query: string ) {

--- a/packages/malloy-db-trino/src/trino_connection.ts
+++ b/packages/malloy-db-trino/src/trino_connection.ts
@@ -28,8 +28,8 @@ import {BaseConnection} from '@malloydata/malloy/connection';
 import type {PrestoClientConfig, PrestoQuery} from '@prestodb/presto-js-client';
 import {PrestoClient} from '@prestodb/presto-js-client';
 import {randomUUID} from 'crypto';
-import type {ConnectionOptions} from 'trino-client';
-import {Trino, BasicAuth} from 'trino-client';
+import type {ConnectionOptions} from '@trinodb/trino-js-client';
+import {Trino, BasicAuth} from '@trinodb/trino-js-client';
 import {resultRowToQueryRecord} from './result-to-querydata';
 
 export interface TrinoManagerOptions {
@@ -128,7 +128,7 @@ class TrinoRunner implements BaseRunner {
   client: Trino;
   constructor(config: TrinoConnectionConfiguration) {
     let server = config.server;
-    // trino-client has no separate port field — merge into the server URL
+    // the client has no separate port field — merge into the server URL
     if (server && config.port) {
       try {
         const url = new URL(server);

--- a/packages/malloy-db-trino/src/trino_query_metadata.spec.ts
+++ b/packages/malloy-db-trino/src/trino_query_metadata.spec.ts
@@ -10,7 +10,7 @@ jest.mock('@prestodb/presto-js-client', () => ({
 }));
 
 import {PrestoClient} from '@prestodb/presto-js-client';
-import {Trino} from 'trino-client';
+import {Trino} from '@trinodb/trino-js-client';
 import {PrestoConnection, TrinoConnection} from './trino_connection';
 
 const PrestoClientMock = PrestoClient as unknown as jest.Mock;

--- a/packages/malloy-render-validator/src/fake-dom.ts
+++ b/packages/malloy-render-validator/src/fake-dom.ts
@@ -130,7 +130,7 @@ export function installFakeDom(): void {
 
 /**
  * Remove the DOM globals we installed, so libraries loaded later
- * (e.g. axios via trino-client) don't think they're in a browser.
+ * (e.g. axios via @trinodb/trino-js-client) don't think they're in a browser.
  */
 export function removeFakeDom(): void {
   if (!installed) return;

--- a/packages/malloy-render-validator/src/index.ts
+++ b/packages/malloy-render-validator/src/index.ts
@@ -14,7 +14,7 @@
 // We install fake DOM globals (window, document, navigator) just long
 // enough for the renderer to load, then immediately remove them. If
 // we left them in place, any library that checks
-// `typeof window !== 'undefined'` (e.g. axios, used by trino-client)
+// `typeof window !== 'undefined'` (e.g. axios, used by @trinodb/trino-js-client)
 // would think it's in a browser and break in different ways.
 //
 // We use explicit require() instead of import because TypeScript

--- a/packages/malloy/src/connection/CONTEXT.md
+++ b/packages/malloy/src/connection/CONTEXT.md
@@ -180,7 +180,7 @@ Factory extracts `name`, `setupSQL`, `timeoutMs`, and the three pool fields; pas
 
 **Trino** (`displayName: "Trino"`):
 `server` (string), `port` (number), `catalog` (string), `schema` (string), `user` (string), `password` (password), `setupSQL` (text, advanced), `source` (string, advanced), `ssl` (json, advanced), `session` (json, advanced), `extraCredential` (json, advanced), `extraHeaders` (json, advanced)
-The json-typed properties pass through to `trino-client`'s `ConnectionOptions` via `extraConfig`.
+The json-typed properties pass through to `@trinodb/trino-js-client`'s `ConnectionOptions` via `extraConfig`.
 
 **Presto** (`displayName: "Presto"`):
 `server` (string), `port` (number), `catalog` (string), `schema` (string), `user` (string), `password` (password), `setupSQL` (text, advanced)


### PR DESCRIPTION
Thanks to @mosabua for #3065 — the rename here is his commit.

We couldn't take it on its own. Moving to `@trinodb/trino-js-client` pulls axios
forward, which breaks our generated publisher client, and the client pins axios
exactly, so we have to pin axios to match: `1.19.0`, with the connector held at
`0.3.2` so the two can't drift apart. trinodb/trino-js-client#956 drops axios for
native `fetch` and retires both pins.
